### PR TITLE
Add integration test suite for devcontainer backend

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,36 @@
+name: Integration Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install devcontainer CLI
+        run: npm install -g @devcontainers/cli
+
+      - name: Verify docker
+        run: |
+          docker version
+          docker info
+
+      - name: Build fleet binary
+        run: go build -o /usr/local/bin/fleet ./cmd/fleet
+
+      - name: Run integration tests
+        env:
+          FLEET_BIN: /usr/local/bin/fleet
+        run: ./integration/run.sh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,24 +4,18 @@ on:
   pull_request:
     branches: [main]
 
-# Opt every JavaScript-based action (checkout / setup-go / setup-node)
-# into the Node.js 24 runtime. Suppresses the deprecation warning and
-# the forced flip is scheduled for 2026-06-02 anyway.
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   integration:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Install devcontainer CLI
         run: npm install -g @devcontainers/cli
 
+      - name: Install tmux (used by TUI tests)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y tmux
+          tmux -V
+
       - name: Verify docker
         run: |
           docker version

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches: [main]
 
+# Opt every JavaScript-based action (checkout / setup-go / setup-node)
+# into the Node.js 24 runtime. Suppresses the deprecation warning and
+# the forced flip is scheduled for 2026-06-02 anyway.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   integration:
     runs-on: ubuntu-latest

--- a/integration/README.md
+++ b/integration/README.md
@@ -14,13 +14,23 @@ integration/
 │   └── .devcontainer/
 │       └── devcontainer.json
 └── tests/
-    ├── 010_up_and_ls.sh
-    ├── 020_exec.sh
-    ├── 030_stop_start.sh
-    ├── 040_status.sh
-    ├── 050_down.sh
-    └── 060_destroy.sh
+    ├── 010_up_and_ls.sh        # CLI — up + ls
+    ├── 020_exec.sh             # CLI — exec
+    ├── 030_stop_start.sh       # CLI — stop / start
+    ├── 040_status.sh           # CLI — status
+    ├── 050_down.sh             # CLI — down
+    ├── 060_destroy.sh          # CLI — destroy
+    ├── 100_tui_startup.sh      # TUI — launch + render
+    ├── 110_tui_collapse.sh     # TUI — space collapses / expands fleet
+    ├── 120_tui_stop_start.sh   # TUI — s toggles instance status
+    ├── 130_tui_delete_cancel.sh# TUI — d opens dialog, n cancels
+    ├── 140_tui_quit.sh         # TUI — q exits cleanly
+    └── 150_tui_refresh.sh      # TUI — r re-reads state
 ```
+
+TUI tests drive the real `fleet` binary inside a detached `tmux` session
+using `send-keys` and read back rendered state via `capture-pane` —
+see `common.sh` `tui_*` helpers.
 
 ## Contract
 
@@ -43,6 +53,7 @@ state so the next test starts clean.
 - Go toolchain (for building `fleet`)
 - Docker daemon reachable (`docker info` works)
 - `devcontainer` CLI (`npm install -g @devcontainers/cli`)
+- `tmux` (used by the TUI tests as a headless terminal)
 
 ## Running
 

--- a/integration/README.md
+++ b/integration/README.md
@@ -34,16 +34,37 @@ see `common.sh` `tui_*` helpers.
 
 ## Contract
 
-Every test file is standalone:
+Every test file is standalone and owns its own result row. Adding a new
+test means dropping a file in `tests/` — nothing to edit elsewhere.
 
-1. Declare a short description in the header as `# Description: <text>` —
-   `run.sh` greps this out and includes it in the Actions step summary.
-2. `source common.sh` at the top.
-3. Call `setup_test` first — this wipes `~/.fleet` and re-creates a fresh
-   git fixture repo at `${FIXTURE_REPO_DIR}`.
-4. Drive the CLI with `"${FLEET_BIN}"` (set by `run.sh`) and assert with
-   the `assert_*` helpers.
-5. `exit 0` on success. `fail` helpers `exit 1`.
+A test file follows this shape:
+
+```bash
+#!/usr/bin/env bash
+# Description: <one-line description shown in the Actions summary>
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }   # optional — only if the test needs cleanup
+itest_begin
+
+setup_test
+# ...drive fleet / TUI, run assert_* / tui_assert_*...
+pass "short summary"
+```
+
+1. `# Description:` — grepped straight out of the file.
+2. `itest_cleanup` — optional hook, runs before the result row is emitted.
+3. `itest_begin` — records start time and installs an EXIT trap that
+   writes `name|status|duration|description` to the shared results file.
+4. `setup_test` — wipes `~/.fleet` and re-creates the fixture git repo.
+5. `pass` / `fail` — print and emit the row; test exits. If the script
+   crashes before either fires, the EXIT trap emits a `fail` row so the
+   runner never silently loses a test.
+
+`run.sh` does not judge results — it just runs each file, then
+aggregates the rows into a terminal summary and the `$GITHUB_STEP_SUMMARY`
+markdown table.
 
 `run.sh` calls `teardown_test` after every test to nuke containers and
 state so the next test starts clean.

--- a/integration/README.md
+++ b/integration/README.md
@@ -26,12 +26,14 @@ integration/
 
 Every test file is standalone:
 
-1. `source common.sh` at the top.
-2. Call `setup_test` first — this wipes `~/.fleet` and re-creates a fresh
+1. Declare a short description in the header as `# Description: <text>` —
+   `run.sh` greps this out and includes it in the Actions step summary.
+2. `source common.sh` at the top.
+3. Call `setup_test` first — this wipes `~/.fleet` and re-creates a fresh
    git fixture repo at `${FIXTURE_REPO_DIR}`.
-3. Drive the CLI with `"${FLEET_BIN}"` (set by `run.sh`) and assert with
+4. Drive the CLI with `"${FLEET_BIN}"` (set by `run.sh`) and assert with
    the `assert_*` helpers.
-4. `exit 0` on success. `fail` helpers `exit 1`.
+5. `exit 0` on success. `fail` helpers `exit 1`.
 
 `run.sh` calls `teardown_test` after every test to nuke containers and
 state so the next test starts clean.

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,0 +1,60 @@
+# fleet-man integration tests
+
+End-to-end tests exercising the `fleet` CLI against the devcontainer
+backend. Each test drives the real binary against a fixture repo and a
+real docker daemon.
+
+## Layout
+
+```
+integration/
+├── run.sh              # driver: builds binary, runs every test, teardown between
+├── common.sh           # shared helpers: assertions, setup/teardown, fleet_up
+├── fixture/            # minimal devcontainer fixture cloned via file:// per test
+│   └── .devcontainer/
+│       └── devcontainer.json
+└── tests/
+    ├── 010_up_and_ls.sh
+    ├── 020_exec.sh
+    ├── 030_stop_start.sh
+    ├── 040_status.sh
+    ├── 050_down.sh
+    └── 060_destroy.sh
+```
+
+## Contract
+
+Every test file is standalone:
+
+1. `source common.sh` at the top.
+2. Call `setup_test` first — this wipes `~/.fleet` and re-creates a fresh
+   git fixture repo at `${FIXTURE_REPO_DIR}`.
+3. Drive the CLI with `"${FLEET_BIN}"` (set by `run.sh`) and assert with
+   the `assert_*` helpers.
+4. `exit 0` on success. `fail` helpers `exit 1`.
+
+`run.sh` calls `teardown_test` after every test to nuke containers and
+state so the next test starts clean.
+
+## Prerequisites
+
+- Go toolchain (for building `fleet`)
+- Docker daemon reachable (`docker info` works)
+- `devcontainer` CLI (`npm install -g @devcontainers/cli`)
+
+## Running
+
+```
+./integration/run.sh
+```
+
+Use a prebuilt binary:
+
+```
+FLEET_BIN=/path/to/fleet ./integration/run.sh
+```
+
+## CI
+
+`.github/workflows/integration.yml` runs this suite on every PR to
+`main`.

--- a/integration/common.sh
+++ b/integration/common.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Shared helpers for fleet-man integration tests.
+#
+# Each test file sources this, calls `setup_test`, runs assertions, and
+# exits 0 on pass. `run.sh` invokes teardown between tests so state does
+# not bleed across runs.
+
+set -euo pipefail
+
+# Colors (only when stdout is a tty)
+if [ -t 1 ]; then
+  C_RED='\033[0;31m'
+  C_GREEN='\033[0;32m'
+  C_YELLOW='\033[0;33m'
+  C_RESET='\033[0m'
+else
+  C_RED=''
+  C_GREEN=''
+  C_YELLOW=''
+  C_RESET=''
+fi
+
+# Paths resolved relative to this file's directory.
+INTEGRATION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${INTEGRATION_DIR}/.." && pwd)"
+FIXTURE_SRC="${INTEGRATION_DIR}/fixture"
+
+# Test scratch dir created fresh per test.
+TEST_SCRATCH_DIR="${TEST_SCRATCH_DIR:-/tmp/fleet-man-itest}"
+
+# The fleet binary under test. run.sh builds it and exports FLEET_BIN.
+FLEET_BIN="${FLEET_BIN:-fleet}"
+
+# Fleet name is derived from the repo URL basename. We clone the fixture
+# into a dir named "itest-fleet" so resolve.go sees fleet "itest-fleet".
+FIXTURE_REPO_NAME="itest-fleet"
+FIXTURE_REPO_DIR="${TEST_SCRATCH_DIR}/${FIXTURE_REPO_NAME}"
+FIXTURE_REPO_URL="file://${FIXTURE_REPO_DIR}"
+
+# === Logging ===
+
+info()  { printf "%b[info]%b  %s\n" "${C_YELLOW}" "${C_RESET}" "$*"; }
+pass()  { printf "%b[pass]%b  %s\n" "${C_GREEN}"  "${C_RESET}" "$*"; }
+fail()  { printf "%b[fail]%b  %s\n" "${C_RED}"    "${C_RESET}" "$*" >&2; exit 1; }
+
+# === Assertions ===
+
+# assert_equals <expected> <actual> <message>
+assert_equals() {
+  local expected="$1"; local actual="$2"; local msg="${3:-values not equal}"
+  if [ "$expected" != "$actual" ]; then
+    fail "${msg}: expected=[${expected}] actual=[${actual}]"
+  fi
+}
+
+# assert_contains <haystack> <needle> <message>
+assert_contains() {
+  local haystack="$1"; local needle="$2"; local msg="${3:-substring not found}"
+  if ! printf '%s' "${haystack}" | grep -qF -- "${needle}"; then
+    fail "${msg}: needle=[${needle}] haystack=[${haystack}]"
+  fi
+}
+
+# assert_not_contains <haystack> <needle> <message>
+assert_not_contains() {
+  local haystack="$1"; local needle="$2"; local msg="${3:-substring unexpectedly found}"
+  if printf '%s' "${haystack}" | grep -qF -- "${needle}"; then
+    fail "${msg}: needle=[${needle}] haystack=[${haystack}]"
+  fi
+}
+
+# assert_file_exists <path>
+assert_file_exists() {
+  [ -e "$1" ] || fail "expected path to exist: $1"
+}
+
+# assert_file_absent <path>
+assert_file_absent() {
+  [ ! -e "$1" ] || fail "expected path to be absent: $1"
+}
+
+# === Setup / teardown ===
+
+# setup_test prepares a clean environment:
+#   1. removes ~/.fleet
+#   2. recreates the fixture git repo at $FIXTURE_REPO_DIR
+# Called at the top of each test.
+setup_test() {
+  # 1. Wipe fleet state.
+  rm -rf "${HOME}/.fleet"
+
+  # 2. Re-create the fixture repo from the committed fixture template.
+  rm -rf "${TEST_SCRATCH_DIR}"
+  mkdir -p "${FIXTURE_REPO_DIR}"
+  cp -r "${FIXTURE_SRC}/." "${FIXTURE_REPO_DIR}/"
+
+  (
+    cd "${FIXTURE_REPO_DIR}"
+    git init -q -b main
+    git config user.email "itest@fleet-man.local"
+    git config user.name  "Fleet Integration Test"
+    git add -A
+    git commit -q -m "fixture: initial commit"
+  )
+}
+
+# teardown_test best-effort cleans up any containers spawned by a test.
+# It tears down every fleet in state, then wipes state files. Called by
+# run.sh after each test whether it passed or failed.
+teardown_test() {
+  # Tear down containers. Best effort — a test that never reached
+  # "up" will have no fleets; a test that left state in a weird place
+  # is recovered by the fallback docker sweep below.
+  if [ -f "${HOME}/.fleet/state.json" ]; then
+    # Iterate fleet names out of state.json without jq (not guaranteed on
+    # the runner). Grep the top-level keys under "fleets".
+    local fleets
+    fleets=$(grep -oE '"[a-zA-Z0-9._-]+":\s*\{' "${HOME}/.fleet/state.json" 2>/dev/null \
+      | grep -v '"fleets"' \
+      | sed -E 's/"([^"]+)".*/\1/' \
+      | sort -u || true)
+    for f in ${fleets}; do
+      "${FLEET_BIN}" destroy "${f}" >/dev/null 2>&1 || true
+    done
+  fi
+
+  # Fallback: remove any devcontainer created from the fixture workspace.
+  # The devcontainer CLI labels containers with the workspace folder path.
+  if command -v docker >/dev/null 2>&1; then
+    local stale
+    stale=$(docker ps -aq --filter "label=devcontainer.local_folder=${HOME}/.fleet/workspaces" 2>/dev/null || true)
+    if [ -n "${stale}" ]; then
+      docker rm -f ${stale} >/dev/null 2>&1 || true
+    fi
+  fi
+
+  rm -rf "${HOME}/.fleet"
+  rm -rf "${TEST_SCRATCH_DIR}"
+}
+
+# fleet_up spawns an instance against the fixture repo. Uses --repo so
+# the test does not depend on cwd being a git repo. Streams output to
+# the caller's stdout/stderr.
+fleet_up() {
+  local name="$1"
+  "${FLEET_BIN}" up "${name}" --repo "${FIXTURE_REPO_URL}"
+}

--- a/integration/common.sh
+++ b/integration/common.sh
@@ -42,11 +42,85 @@ TUI_SESSION="${TUI_SESSION:-fleetman-itest}"
 TUI_WIDTH="${TUI_WIDTH:-140}"
 TUI_HEIGHT="${TUI_HEIGHT:-40}"
 
-# === Logging ===
+# === Logging / result emission ===
+#
+# Each test is responsible for emitting its OWN result row — not the
+# runner. `itest_begin` is called at the top of every test: it records
+# the start time and installs an EXIT trap so a row is always emitted,
+# even if the script crashes or `set -e` trips.
+#
+# `pass` / `fail` both print and emit the row explicitly. The EXIT trap
+# only emits if neither was reached (catch-all for unexpected bash exits).
+# The row format written to ${FLEET_ITEST_RESULTS} is:
+#   <name>|<pass|fail>|<duration_s>|<description>
+# run.sh aggregates this file into the final table. No central list
+# needs editing when a new test is added.
 
 info()  { printf "%b[info]%b  %s\n" "${C_YELLOW}" "${C_RESET}" "$*"; }
-pass()  { printf "%b[pass]%b  %s\n" "${C_GREEN}"  "${C_RESET}" "$*"; }
-fail()  { printf "%b[fail]%b  %s\n" "${C_RED}"    "${C_RESET}" "$*" >&2; exit 1; }
+
+pass()  {
+  printf "%b[pass]%b  %s\n" "${C_GREEN}"  "${C_RESET}" "$*"
+  _itest_emit pass
+  exit 0
+}
+
+fail()  {
+  printf "%b[fail]%b  %s\n" "${C_RED}" "${C_RESET}" "$*" >&2
+  _itest_emit fail
+  exit 1
+}
+
+# itest_cleanup is a hook tests can override to run cleanup (e.g. kill a
+# tmux session) before the EXIT trap emits the result row. Default: no-op.
+itest_cleanup() { :; }
+
+# itest_begin: call once per test, right after sourcing common.sh and
+# before the test body. Records metadata and installs the result-emit
+# EXIT trap.
+itest_begin() {
+  TEST_NAME="$(basename "$0" .sh)"
+  TEST_DESCRIPTION="$(grep -m1 -E '^# Description:' "$0" 2>/dev/null \
+    | sed -E 's/^# Description: *//')"
+  if [ -z "${TEST_DESCRIPTION}" ]; then
+    TEST_DESCRIPTION="(no description)"
+  fi
+  TEST_START="$(date +%s)"
+  TEST_EMITTED=""
+  trap _itest_exit_handler EXIT
+}
+
+# Internal: runs on EXIT. Calls itest_cleanup, then emits a row if the
+# test did not already do so via pass/fail.
+_itest_exit_handler() {
+  local rc=$?
+  itest_cleanup || true
+  if [ -z "${TEST_EMITTED:-}" ]; then
+    local status="fail"
+    [ "${rc}" -eq 0 ] && status="pass"
+    _itest_emit "${status}"
+  fi
+  # Preserve the original exit code.
+  exit "${rc}"
+}
+
+# Internal: append one row to the shared results file. Safe to call
+# outside a runner (just becomes a no-op when FLEET_ITEST_RESULTS is unset).
+_itest_emit() {
+  TEST_EMITTED=1
+  local status="$1"
+  local dur=0
+  if [ -n "${TEST_START:-}" ]; then
+    dur=$(( $(date +%s) - TEST_START ))
+  fi
+  if [ -n "${FLEET_ITEST_RESULTS:-}" ]; then
+    printf '%s|%s|%s|%s\n' \
+      "${TEST_NAME:-unknown}" \
+      "${status}" \
+      "${dur}" \
+      "${TEST_DESCRIPTION:-(no description)}" \
+      >> "${FLEET_ITEST_RESULTS}"
+  fi
+}
 
 # === Assertions ===
 

--- a/integration/common.sh
+++ b/integration/common.sh
@@ -37,6 +37,11 @@ FIXTURE_REPO_NAME="itest-fleet"
 FIXTURE_REPO_DIR="${TEST_SCRATCH_DIR}/${FIXTURE_REPO_NAME}"
 FIXTURE_REPO_URL="file://${FIXTURE_REPO_DIR}"
 
+# Default tmux session name used by TUI tests. Overridable per-test.
+TUI_SESSION="${TUI_SESSION:-fleetman-itest}"
+TUI_WIDTH="${TUI_WIDTH:-140}"
+TUI_HEIGHT="${TUI_HEIGHT:-40}"
+
 # === Logging ===
 
 info()  { printf "%b[info]%b  %s\n" "${C_YELLOW}" "${C_RESET}" "$*"; }
@@ -108,6 +113,12 @@ setup_test() {
 # It tears down every fleet in state, then wipes state files. Called by
 # run.sh after each test whether it passed or failed.
 teardown_test() {
+  # Kill any TUI tmux session left over from a TUI test. Safe if there
+  # is none. Done first so nothing else is holding the state file open.
+  if command -v tmux >/dev/null 2>&1; then
+    tmux kill-session -t "${TUI_SESSION}" >/dev/null 2>&1 || true
+  fi
+
   # Tear down containers. Best effort — a test that never reached
   # "up" will have no fleets; a test that left state in a weird place
   # is recovered by the fallback docker sweep below.
@@ -144,4 +155,113 @@ teardown_test() {
 fleet_up() {
   local name="$1"
   "${FLEET_BIN}" up "${name}" --repo "${FIXTURE_REPO_URL}"
+}
+
+# === TUI helpers ===
+#
+# The fleet TUI is a bubbletea app. Tests drive it the same way a human
+# would: launch `fleet` inside a detached tmux session of fixed size,
+# then send keys + capture the rendered screen.
+
+# tui_spawn [session] [args...]
+# Start the TUI inside a detached tmux session. Any extra arguments are
+# passed through to the fleet binary.
+tui_spawn() {
+  local session="${1:-${TUI_SESSION}}"
+  shift || true
+  tmux kill-session -t "${session}" >/dev/null 2>&1 || true
+
+  # Force TERM to something tmux+lipgloss render predictably on CI.
+  tmux new-session -d -s "${session}" -x "${TUI_WIDTH}" -y "${TUI_HEIGHT}" \
+    "env TERM=xterm-256color ${FLEET_BIN} $*"
+}
+
+# tui_capture [session]
+# Print the current visible screen of the tmux session to stdout.
+tui_capture() {
+  local session="${1:-${TUI_SESSION}}"
+  tmux capture-pane -t "${session}" -p
+}
+
+# tui_send <key> [session]
+# Send a single key / chord to the session. Use tmux key names: j, k,
+# Enter, Escape, Space, C-c, etc.
+tui_send() {
+  local key="$1"
+  local session="${2:-${TUI_SESSION}}"
+  tmux send-keys -t "${session}" "${key}"
+}
+
+# tui_wait_for <needle> [timeout_s] [session]
+# Poll capture-pane for up to timeout seconds waiting for `needle` (plain
+# substring) to appear. Default timeout 10s. Returns 0 on match, 1 on
+# timeout. On timeout also dumps the final screen to stderr.
+tui_wait_for() {
+  local needle="$1"
+  local timeout="${2:-10}"
+  local session="${3:-${TUI_SESSION}}"
+  local deadline=$(( $(date +%s) + timeout ))
+  local screen=""
+  while [ "$(date +%s)" -lt "${deadline}" ]; do
+    screen=$(tui_capture "${session}" || true)
+    if printf '%s' "${screen}" | grep -qF -- "${needle}"; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  printf '%b[fail]%b tui_wait_for timed out after %ss waiting for: %s\n' \
+    "${C_RED}" "${C_RESET}" "${timeout}" "${needle}" >&2
+  printf -- '--- final screen ---\n%s\n--- end screen ---\n' "${screen}" >&2
+  return 1
+}
+
+# tui_wait_for_absent <needle> [timeout_s] [session]
+# Inverse of tui_wait_for — poll until the needle disappears from screen.
+tui_wait_for_absent() {
+  local needle="$1"
+  local timeout="${2:-10}"
+  local session="${3:-${TUI_SESSION}}"
+  local deadline=$(( $(date +%s) + timeout ))
+  local screen=""
+  while [ "$(date +%s)" -lt "${deadline}" ]; do
+    screen=$(tui_capture "${session}" || true)
+    if ! printf '%s' "${screen}" | grep -qF -- "${needle}"; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  printf '%b[fail]%b tui_wait_for_absent timed out after %ss waiting for: %s\n' \
+    "${C_RED}" "${C_RESET}" "${timeout}" "${needle}" >&2
+  printf -- '--- final screen ---\n%s\n--- end screen ---\n' "${screen}" >&2
+  return 1
+}
+
+# tui_kill [session]
+# Kill the tmux session if it is still around. Safe to call multiple times.
+tui_kill() {
+  local session="${1:-${TUI_SESSION}}"
+  tmux kill-session -t "${session}" >/dev/null 2>&1 || true
+}
+
+# tui_assert_contains <needle> [message]
+# Fails the test if the current screen does NOT contain needle.
+tui_assert_contains() {
+  local needle="$1"; local msg="${2:-screen missing expected text}"
+  local screen
+  screen=$(tui_capture)
+  if ! printf '%s' "${screen}" | grep -qF -- "${needle}"; then
+    printf -- '--- screen ---\n%s\n--- end ---\n' "${screen}" >&2
+    fail "${msg}: needle=[${needle}]"
+  fi
+}
+
+# tui_assert_not_contains <needle> [message]
+tui_assert_not_contains() {
+  local needle="$1"; local msg="${2:-screen unexpectedly contains text}"
+  local screen
+  screen=$(tui_capture)
+  if printf '%s' "${screen}" | grep -qF -- "${needle}"; then
+    printf -- '--- screen ---\n%s\n--- end ---\n' "${screen}" >&2
+    fail "${msg}: needle=[${needle}]"
+  fi
 }

--- a/integration/common.sh
+++ b/integration/common.sh
@@ -165,8 +165,12 @@ assert_file_absent() {
 #   2. recreates the fixture git repo at $FIXTURE_REPO_DIR
 # Called at the top of each test.
 setup_test() {
-  # 1. Wipe fleet state.
+  # 1. Wipe fleet state. Leave an empty ~/.fleet behind — its presence
+  #    suppresses the first-launch deps-check splash, which is not what
+  #    these tests are trying to exercise and would otherwise block key
+  #    input to the fleet list page.
   rm -rf "${HOME}/.fleet"
+  mkdir -p "${HOME}/.fleet"
 
   # 2. Re-create the fixture repo from the committed fixture template.
   rm -rf "${TEST_SCRATCH_DIR}"
@@ -239,7 +243,8 @@ fleet_up() {
 
 # tui_spawn [session] [args...]
 # Start the TUI inside a detached tmux session. Any extra arguments are
-# passed through to the fleet binary.
+# passed through to the fleet binary. The TMUX env var is implicitly set
+# by running inside tmux, which the TUI uses to enable split pane mode.
 tui_spawn() {
   local session="${1:-${TUI_SESSION}}"
   shift || true
@@ -248,6 +253,80 @@ tui_spawn() {
   # Force TERM to something tmux+lipgloss render predictably on CI.
   tmux new-session -d -s "${session}" -x "${TUI_WIDTH}" -y "${TUI_HEIGHT}" \
     "env TERM=xterm-256color ${FLEET_BIN} $*"
+}
+
+# tui_send_text <text> [session]
+# Type a string literally into the TUI (safe for URLs / names that
+# contain tmux-reserved key words).
+tui_send_text() {
+  local text="$1"
+  local session="${2:-${TUI_SESSION}}"
+  tmux send-keys -t "${session}" -l "${text}"
+}
+
+# tui_send_pane <pane_index> <key> [session]
+# Send a key to a specific pane by its visible index (0 = TUI, 1 = first
+# split, 2 = second split, ...). Needed once a split pane is open and
+# we want to talk to the shell rather than the TUI.
+tui_send_pane() {
+  local pane="$1"; local key="$2"; local session="${3:-${TUI_SESSION}}"
+  tmux send-keys -t "${session}:.${pane}" "${key}"
+}
+
+# tui_send_pane_text <pane_index> <text> [session]
+tui_send_pane_text() {
+  local pane="$1"; local text="$2"; local session="${3:-${TUI_SESSION}}"
+  tmux send-keys -t "${session}:.${pane}" -l "${text}"
+}
+
+# tui_capture_pane <pane_index> [session]
+# Capture the visible contents of a specific pane, scrolled from the
+# history so we see output that has already scrolled off-screen.
+tui_capture_pane() {
+  local pane="$1"; local session="${2:-${TUI_SESSION}}"
+  tmux capture-pane -t "${session}:.${pane}" -p -S -200
+}
+
+# tui_pane_count [session] — number of panes in the active window.
+tui_pane_count() {
+  local session="${1:-${TUI_SESSION}}"
+  tmux list-panes -t "${session}" 2>/dev/null | wc -l
+}
+
+# tui_wait_for_pane <expected_count> [timeout_s] [session]
+# Wait until the tmux window has `expected_count` panes (e.g. 2 after a
+# split opens, 1 after it's closed).
+tui_wait_for_pane() {
+  local expected="$1"; local timeout="${2:-10}"
+  local session="${3:-${TUI_SESSION}}"
+  local deadline=$(( $(date +%s) + timeout ))
+  while [ "$(date +%s)" -lt "${deadline}" ]; do
+    [ "$(tui_pane_count "${session}")" -eq "${expected}" ] && return 0
+    sleep 0.25
+  done
+  printf '%b[fail]%b tui_wait_for_pane timed out — expected %s panes, have %s\n' \
+    "${C_RED}" "${C_RESET}" "${expected}" "$(tui_pane_count "${session}")" >&2
+  return 1
+}
+
+# tui_wait_for_in_pane <pane_index> <needle> [timeout_s] [session]
+# Poll a specific pane's capture for a substring.
+tui_wait_for_in_pane() {
+  local pane="$1"; local needle="$2"; local timeout="${3:-10}"
+  local session="${4:-${TUI_SESSION}}"
+  local deadline=$(( $(date +%s) + timeout ))
+  local screen=""
+  while [ "$(date +%s)" -lt "${deadline}" ]; do
+    screen=$(tui_capture_pane "${pane}" "${session}" || true)
+    if printf '%s' "${screen}" | grep -qF -- "${needle}"; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  printf '%b[fail]%b timed out after %ss waiting in pane %s for: %s\n' \
+    "${C_RED}" "${C_RESET}" "${timeout}" "${pane}" "${needle}" >&2
+  printf -- '--- pane %s ---\n%s\n--- end ---\n' "${pane}" "${screen}" >&2
+  return 1
 }
 
 # tui_capture [session]

--- a/integration/fixture/.devcontainer/devcontainer.json
+++ b/integration/fixture/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "name": "fleet-man integration fixture",
+  "image": "mcr.microsoft.com/devcontainers/base:debian-12"
+}

--- a/integration/fixture/.devcontainer/devcontainer.json
+++ b/integration/fixture/.devcontainer/devcontainer.json
@@ -1,4 +1,5 @@
 {
   "name": "fleet-man integration fixture",
-  "image": "mcr.microsoft.com/devcontainers/base:debian-12"
+  "image": "mcr.microsoft.com/devcontainers/base:debian-12",
+  "postCreateCommand": "sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends tmux"
 }

--- a/integration/fixture/README.md
+++ b/integration/fixture/README.md
@@ -1,0 +1,8 @@
+# fleet-man integration fixture
+
+Minimal devcontainer fixture used by the integration test suite.
+
+The suite copies this directory into a throwaway git repo and points
+`fleet up --repo file://<path>` at it. A lightweight debian-base image
+keeps test runs fast compared to booting the full fleet-man devcontainer
+(which pulls Go + node + docker-in-docker features).

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -61,24 +61,11 @@ if [ "${#tests[@]}" -eq 0 ]; then
   exit 2
 fi
 
-passed=0
-failed=0
-failed_tests=()
-# Per-test result rows for the step summary: "<name>|<status>|<duration>s|<description>"
-result_rows=()
-
-# Pull a short test description out of a "# Description: ..." header line,
-# or fall back to "(no description)" if the file does not declare one.
-test_description() {
-  local file="$1"
-  local desc
-  desc=$(grep -m1 -E '^# Description: *' "${file}" 2>/dev/null | sed -E 's/^# Description: *//')
-  if [ -z "${desc}" ]; then
-    echo "(no description)"
-  else
-    echo "${desc}"
-  fi
-}
+# Shared results file — tests append one row each via common.sh helpers.
+# run.sh does NOT judge results; it only aggregates this file at the end.
+FLEET_ITEST_RESULTS="$(mktemp)"
+export FLEET_ITEST_RESULTS
+trap 'rm -f "${FLEET_ITEST_RESULTS}"' EXIT
 
 # Sourced common.sh in tests provides teardown_test — we need it here too.
 # shellcheck disable=SC1091
@@ -86,27 +73,45 @@ source "${INTEGRATION_DIR}/common.sh"
 
 for test_file in "${tests[@]}"; do
   test_name=$(basename "${test_file}" .sh)
-  test_desc=$(test_description "${test_file}")
   printf "\n"
-  say "${BOLD}RUN${RESET}  ${test_name} — ${test_desc}"
-  t_start=$(date +%s)
-  if bash "${test_file}"; then
-    t_end=$(date +%s)
-    dur=$((t_end - t_start))
-    printf "%b==>%b %bPASS%b ${test_name} (%ds)\n" "${BOLD}" "${RESET}" "${GREEN}" "${RESET}" "${dur}"
-    passed=$((passed + 1))
-    result_rows+=("${test_name}|pass|${dur}|${test_desc}")
-  else
-    t_end=$(date +%s)
-    dur=$((t_end - t_start))
-    printf "%b==>%b %bFAIL%b ${test_name} (%ds)\n" "${BOLD}" "${RESET}" "${RED}" "${RESET}" "${dur}"
-    failed=$((failed + 1))
-    failed_tests+=("${test_name}")
-    result_rows+=("${test_name}|fail|${dur}|${test_desc}")
-  fi
-
+  say "${BOLD}RUN${RESET}  ${test_name}"
+  bash "${test_file}" || true
   say "teardown ${test_name}"
   teardown_test || true
+done
+
+# Aggregate the per-test rows.
+passed=0
+failed=0
+failed_tests=()
+result_rows=()
+if [ -s "${FLEET_ITEST_RESULTS}" ]; then
+  while IFS='|' read -r name status dur desc; do
+    [ -z "${name}" ] && continue
+    result_rows+=("${name}|${status}|${dur}|${desc}")
+    if [ "${status}" = "pass" ]; then
+      passed=$((passed + 1))
+    else
+      failed=$((failed + 1))
+      failed_tests+=("${name}")
+    fi
+  done < "${FLEET_ITEST_RESULTS}"
+fi
+
+# Any test file that did not emit a row at all is an unexplained crash
+# (e.g. syntax error before itest_begin ran). Surface it as a failure.
+declare -A seen_names
+for row in "${result_rows[@]}"; do
+  IFS='|' read -r n _ _ _ <<< "${row}"
+  seen_names["${n}"]=1
+done
+for test_file in "${tests[@]}"; do
+  n=$(basename "${test_file}" .sh)
+  if [ -z "${seen_names[${n}]:-}" ]; then
+    failed=$((failed + 1))
+    failed_tests+=("${n}")
+    result_rows+=("${n}|fail|0|(test did not emit a result — crashed before itest_begin?)")
+  fi
 done
 
 printf "\n%b==>%b Summary: %b%d passed%b, %b%d failed%b\n" \

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -64,6 +64,8 @@ fi
 passed=0
 failed=0
 failed_tests=()
+# Per-test result rows for the step summary: "<name>|<status>|<duration>s"
+result_rows=()
 
 # Sourced common.sh in tests provides teardown_test — we need it here too.
 # shellcheck disable=SC1091
@@ -76,13 +78,17 @@ for test_file in "${tests[@]}"; do
   t_start=$(date +%s)
   if bash "${test_file}"; then
     t_end=$(date +%s)
-    printf "%b==>%b %bPASS%b ${test_name} (%ds)\n" "${BOLD}" "${RESET}" "${GREEN}" "${RESET}" "$((t_end - t_start))"
+    dur=$((t_end - t_start))
+    printf "%b==>%b %bPASS%b ${test_name} (%ds)\n" "${BOLD}" "${RESET}" "${GREEN}" "${RESET}" "${dur}"
     passed=$((passed + 1))
+    result_rows+=("${test_name}|pass|${dur}")
   else
     t_end=$(date +%s)
-    printf "%b==>%b %bFAIL%b ${test_name} (%ds)\n" "${BOLD}" "${RESET}" "${RED}" "${RESET}" "$((t_end - t_start))"
+    dur=$((t_end - t_start))
+    printf "%b==>%b %bFAIL%b ${test_name} (%ds)\n" "${BOLD}" "${RESET}" "${RED}" "${RESET}" "${dur}"
     failed=$((failed + 1))
     failed_tests+=("${test_name}")
+    result_rows+=("${test_name}|fail|${dur}")
   fi
 
   say "teardown ${test_name}"
@@ -93,6 +99,36 @@ printf "\n%b==>%b Summary: %b%d passed%b, %b%d failed%b\n" \
   "${BOLD}" "${RESET}" \
   "${GREEN}" "${passed}" "${RESET}" \
   "${RED}"   "${failed}" "${RESET}"
+
+# Emit a GitHub Actions step summary if running inside a workflow.
+# GITHUB_STEP_SUMMARY is a file path the runner publishes as markdown on
+# the job summary page. Outside Actions this env var is unset and we skip.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  total=$((passed + failed))
+  if [ "${failed}" -eq 0 ]; then
+    overall="✅ all green"
+  else
+    overall="❌ ${failed} failing"
+  fi
+  {
+    printf '## Integration Tests — %s\n\n' "${overall}"
+    printf '**%d passed**, **%d failed** out of %d.\n\n' "${passed}" "${failed}" "${total}"
+    printf '| Test | Status | Duration |\n'
+    printf '| --- | --- | ---: |\n'
+    for row in "${result_rows[@]}"; do
+      IFS='|' read -r name status dur <<< "${row}"
+      if [ "${status}" = "pass" ]; then
+        icon="✅ pass"
+      else
+        icon="❌ fail"
+      fi
+      printf '| `%s` | %s | %ss |\n' "${name}" "${icon}" "${dur}"
+    done
+    if [ "${failed}" -gt 0 ]; then
+      printf '\n**Failed:** %s\n' "${failed_tests[*]}"
+    fi
+  } >> "${GITHUB_STEP_SUMMARY}"
+fi
 
 if [ "${failed}" -gt 0 ]; then
   printf "Failed: %s\n" "${failed_tests[*]}"

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -64,8 +64,21 @@ fi
 passed=0
 failed=0
 failed_tests=()
-# Per-test result rows for the step summary: "<name>|<status>|<duration>s"
+# Per-test result rows for the step summary: "<name>|<status>|<duration>s|<description>"
 result_rows=()
+
+# Pull a short test description out of a "# Description: ..." header line,
+# or fall back to "(no description)" if the file does not declare one.
+test_description() {
+  local file="$1"
+  local desc
+  desc=$(grep -m1 -E '^# Description: *' "${file}" 2>/dev/null | sed -E 's/^# Description: *//')
+  if [ -z "${desc}" ]; then
+    echo "(no description)"
+  else
+    echo "${desc}"
+  fi
+}
 
 # Sourced common.sh in tests provides teardown_test — we need it here too.
 # shellcheck disable=SC1091
@@ -73,22 +86,23 @@ source "${INTEGRATION_DIR}/common.sh"
 
 for test_file in "${tests[@]}"; do
   test_name=$(basename "${test_file}" .sh)
+  test_desc=$(test_description "${test_file}")
   printf "\n"
-  say "${BOLD}RUN${RESET}  ${test_name}"
+  say "${BOLD}RUN${RESET}  ${test_name} — ${test_desc}"
   t_start=$(date +%s)
   if bash "${test_file}"; then
     t_end=$(date +%s)
     dur=$((t_end - t_start))
     printf "%b==>%b %bPASS%b ${test_name} (%ds)\n" "${BOLD}" "${RESET}" "${GREEN}" "${RESET}" "${dur}"
     passed=$((passed + 1))
-    result_rows+=("${test_name}|pass|${dur}")
+    result_rows+=("${test_name}|pass|${dur}|${test_desc}")
   else
     t_end=$(date +%s)
     dur=$((t_end - t_start))
     printf "%b==>%b %bFAIL%b ${test_name} (%ds)\n" "${BOLD}" "${RESET}" "${RED}" "${RESET}" "${dur}"
     failed=$((failed + 1))
     failed_tests+=("${test_name}")
-    result_rows+=("${test_name}|fail|${dur}")
+    result_rows+=("${test_name}|fail|${dur}|${test_desc}")
   fi
 
   say "teardown ${test_name}"
@@ -113,16 +127,16 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
   {
     printf '## Integration Tests — %s\n\n' "${overall}"
     printf '**%d passed**, **%d failed** out of %d.\n\n' "${passed}" "${failed}" "${total}"
-    printf '| Test | Status | Duration |\n'
-    printf '| --- | --- | ---: |\n'
+    printf '| Test | Status | Duration | Description |\n'
+    printf '| --- | --- | ---: | --- |\n'
     for row in "${result_rows[@]}"; do
-      IFS='|' read -r name status dur <<< "${row}"
+      IFS='|' read -r name status dur desc <<< "${row}"
       if [ "${status}" = "pass" ]; then
         icon="✅ pass"
       else
         icon="❌ fail"
       fi
-      printf '| `%s` | %s | %ss |\n' "${name}" "${icon}" "${dur}"
+      printf '| `%s` | %s | %ss | %s |\n' "${name}" "${icon}" "${dur}" "${desc}"
     done
     if [ "${failed}" -gt 0 ]; then
       printf '\n**Failed:** %s\n' "${failed_tests[*]}"

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Integration test driver for fleet-man.
+#
+# - Builds the fleet binary to a temp location (unless FLEET_BIN is set).
+# - Runs every test in integration/tests in alphabetical order.
+# - Between tests: runs teardown to kill any leftover containers / state.
+# - Exits 0 only if every test passes.
+
+set -euo pipefail
+
+INTEGRATION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${INTEGRATION_DIR}/.." && pwd)"
+
+# Colors
+if [ -t 1 ]; then
+  BOLD='\033[1m'; GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[0;33m'; RESET='\033[0m'
+else
+  BOLD=''; GREEN=''; RED=''; YELLOW=''; RESET=''
+fi
+
+say() { printf "%b==>%b %s\n" "${BOLD}" "${RESET}" "$*"; }
+
+# 1. Build fleet binary unless caller provided one.
+if [ -z "${FLEET_BIN:-}" ]; then
+  build_dir="$(mktemp -d)"
+  FLEET_BIN="${build_dir}/fleet"
+  say "Building fleet -> ${FLEET_BIN}"
+  (cd "${REPO_ROOT}" && go build -o "${FLEET_BIN}" ./cmd/fleet)
+fi
+export FLEET_BIN
+say "Using fleet binary: ${FLEET_BIN}"
+"${FLEET_BIN}" --help >/dev/null || { printf "%b[fatal]%b fleet binary failed to run\n" "${RED}" "${RESET}" >&2; exit 2; }
+
+# 2. Preflight: docker + devcontainer CLI must be available and usable.
+if ! command -v docker >/dev/null 2>&1; then
+  printf "%b[fatal]%b docker CLI not on PATH\n" "${RED}" "${RESET}" >&2
+  exit 2
+fi
+if ! docker info >/dev/null 2>&1; then
+  printf "%b[fatal]%b docker daemon not reachable\n" "${RED}" "${RESET}" >&2
+  exit 2
+fi
+if ! command -v devcontainer >/dev/null 2>&1; then
+  printf "%b[fatal]%b devcontainer CLI not on PATH (npm i -g @devcontainers/cli)\n" "${RED}" "${RESET}" >&2
+  exit 2
+fi
+
+# 3. Pre-pull the fixture image once so each test is not waiting on image pulls.
+fixture_image=$(grep -oE '"image":\s*"[^"]+"' "${INTEGRATION_DIR}/fixture/.devcontainer/devcontainer.json" | sed -E 's/.*"([^"]+)"$/\1/')
+if [ -n "${fixture_image}" ]; then
+  say "Pre-pulling fixture image: ${fixture_image}"
+  docker pull -q "${fixture_image}" >/dev/null || true
+fi
+
+# 4. Iterate tests.
+shopt -s nullglob
+tests=("${INTEGRATION_DIR}"/tests/*.sh)
+shopt -u nullglob
+if [ "${#tests[@]}" -eq 0 ]; then
+  printf "%b[fatal]%b no tests found in %s\n" "${RED}" "${RESET}" "${INTEGRATION_DIR}/tests" >&2
+  exit 2
+fi
+
+passed=0
+failed=0
+failed_tests=()
+
+# Sourced common.sh in tests provides teardown_test — we need it here too.
+# shellcheck disable=SC1091
+source "${INTEGRATION_DIR}/common.sh"
+
+for test_file in "${tests[@]}"; do
+  test_name=$(basename "${test_file}" .sh)
+  printf "\n"
+  say "${BOLD}RUN${RESET}  ${test_name}"
+  t_start=$(date +%s)
+  if bash "${test_file}"; then
+    t_end=$(date +%s)
+    printf "%b==>%b %bPASS%b ${test_name} (%ds)\n" "${BOLD}" "${RESET}" "${GREEN}" "${RESET}" "$((t_end - t_start))"
+    passed=$((passed + 1))
+  else
+    t_end=$(date +%s)
+    printf "%b==>%b %bFAIL%b ${test_name} (%ds)\n" "${BOLD}" "${RESET}" "${RED}" "${RESET}" "$((t_end - t_start))"
+    failed=$((failed + 1))
+    failed_tests+=("${test_name}")
+  fi
+
+  say "teardown ${test_name}"
+  teardown_test || true
+done
+
+printf "\n%b==>%b Summary: %b%d passed%b, %b%d failed%b\n" \
+  "${BOLD}" "${RESET}" \
+  "${GREEN}" "${passed}" "${RESET}" \
+  "${RED}"   "${failed}" "${RESET}"
+
+if [ "${failed}" -gt 0 ]; then
+  printf "Failed: %s\n" "${failed_tests[*]}"
+  exit 1
+fi

--- a/integration/tests/010_up_and_ls.sh
+++ b/integration/tests/010_up_and_ls.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
+itest_begin
 
 setup_test
 

--- a/integration/tests/010_up_and_ls.sh
+++ b/integration/tests/010_up_and_ls.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verifies `fleet up` creates a running instance and `fleet ls` reports it.
+# Description: `fleet up` creates a running container and `fleet ls` reports it.
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"

--- a/integration/tests/010_up_and_ls.sh
+++ b/integration/tests/010_up_and_ls.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Verifies `fleet up` creates a running instance and `fleet ls` reports it.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+
+setup_test
+
+info "fleet up alpha"
+fleet_up alpha
+
+info "fleet ls"
+ls_out=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+printf '%s\n' "${ls_out}"
+
+assert_contains "${ls_out}" "${FIXTURE_REPO_NAME}" "fleet name missing from ls output"
+assert_contains "${ls_out}" "alpha"               "instance name missing from ls output"
+assert_contains "${ls_out}" "running"             "instance status should be 'running'"
+
+# state.json must exist and list the instance.
+assert_file_exists "${HOME}/.fleet/state.json"
+state=$(cat "${HOME}/.fleet/state.json")
+assert_contains "${state}" "\"name\": \"alpha\""  "state.json missing instance entry"
+assert_contains "${state}" "\"status\": \"running\"" "state.json instance not running"
+
+pass "up + ls"

--- a/integration/tests/020_exec.sh
+++ b/integration/tests/020_exec.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
+itest_begin
 
 setup_test
 fleet_up alpha

--- a/integration/tests/020_exec.sh
+++ b/integration/tests/020_exec.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Verifies `fleet exec` runs a command inside the container and returns
+# its stdout to the caller.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+
+setup_test
+fleet_up alpha
+
+info "fleet exec alpha -- uname -s"
+uname_out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- uname -s)
+assert_equals "Linux" "${uname_out}" "uname -s inside container"
+
+info "fleet exec alpha -- sh -c 'echo hello-from-container'"
+hello_out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- sh -c "echo hello-from-container")
+assert_equals "hello-from-container" "${hello_out}" "echo output"
+
+# A non-zero exit inside the container should propagate.
+info "fleet exec alpha -- sh -c 'exit 7' should fail"
+set +e
+"${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- sh -c "exit 7" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "${rc}" -eq 0 ]; then
+  fail "expected non-zero exit from 'exit 7', got 0"
+fi
+
+pass "exec"

--- a/integration/tests/020_exec.sh
+++ b/integration/tests/020_exec.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Verifies `fleet exec` runs a command inside the container and returns
-# its stdout to the caller.
+# Description: `fleet exec` runs commands inside the container and propagates exit codes.
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"

--- a/integration/tests/030_stop_start.sh
+++ b/integration/tests/030_stop_start.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
+itest_begin
 
 setup_test
 fleet_up alpha

--- a/integration/tests/030_stop_start.sh
+++ b/integration/tests/030_stop_start.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Verifies the stop -> start lifecycle: status transitions are persisted
-# and the underlying docker container is actually stopped/started.
+# Description: `fleet stop`/`start` transition state and the underlying docker container correctly.
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"

--- a/integration/tests/030_stop_start.sh
+++ b/integration/tests/030_stop_start.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Verifies the stop -> start lifecycle: status transitions are persisted
+# and the underlying docker container is actually stopped/started.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+
+setup_test
+fleet_up alpha
+
+# Grab the container ID from state so we can independently verify docker state.
+container_id=$(grep -oE '"container_id":\s*"[^"]+"' "${HOME}/.fleet/state.json" | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
+[ -n "${container_id}" ] || fail "could not read container_id from state.json"
+info "container id: ${container_id}"
+
+# --- stop ---
+info "fleet stop alpha"
+stop_out=$("${FLEET_BIN}" stop "${FIXTURE_REPO_NAME}/alpha")
+printf '%s\n' "${stop_out}"
+assert_contains "${stop_out}" "stopped" "stop output should mention stopped"
+
+# docker reports the container as exited/created, not running.
+docker_state=$(docker inspect -f '{{.State.Status}}' "${container_id}")
+info "docker state after stop: ${docker_state}"
+if [ "${docker_state}" = "running" ]; then
+  fail "expected container to not be running after stop, got: ${docker_state}"
+fi
+
+ls_after_stop=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+assert_contains "${ls_after_stop}" "stopped" "ls should report stopped status"
+
+# Second stop is a no-op.
+info "fleet stop alpha (already stopped)"
+stop_again=$("${FLEET_BIN}" stop "${FIXTURE_REPO_NAME}/alpha")
+assert_contains "${stop_again}" "already stopped" "repeated stop should be a no-op"
+
+# --- start ---
+info "fleet start alpha"
+start_out=$("${FLEET_BIN}" start "${FIXTURE_REPO_NAME}/alpha")
+printf '%s\n' "${start_out}"
+assert_contains "${start_out}" "started" "start output should mention started"
+
+docker_state=$(docker inspect -f '{{.State.Status}}' "${container_id}")
+assert_equals "running" "${docker_state}" "container should be running after start"
+
+ls_after_start=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+assert_contains "${ls_after_start}" "running" "ls should report running status"
+
+# exec works again after start.
+echo_out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- sh -c "echo back-online")
+assert_equals "back-online" "${echo_out}" "exec after start"
+
+pass "stop + start"

--- a/integration/tests/040_status.sh
+++ b/integration/tests/040_status.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verifies `fleet status` reports fleet / instance counts correctly.
+# Description: `fleet status` reports fleet and instance running/stopped counts.
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"

--- a/integration/tests/040_status.sh
+++ b/integration/tests/040_status.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Verifies `fleet status` reports fleet / instance counts correctly.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+
+setup_test
+
+# Empty state.
+info "fleet status (no fleets)"
+empty_out=$("${FLEET_BIN}" status)
+assert_contains "${empty_out}" "No fleets" "empty status should say 'No fleets'"
+
+# One running instance.
+fleet_up alpha
+info "fleet status (1 running)"
+s1=$("${FLEET_BIN}" status)
+printf '%s\n' "${s1}"
+assert_contains "${s1}" "${FIXTURE_REPO_NAME}" "fleet name missing"
+assert_contains "${s1}" "1 running" "should report 1 running"
+
+# Stop it — counts should shift.
+"${FLEET_BIN}" stop "${FIXTURE_REPO_NAME}/alpha" >/dev/null
+info "fleet status (1 stopped)"
+s2=$("${FLEET_BIN}" status)
+printf '%s\n' "${s2}"
+assert_contains "${s2}" "0 running" "should report 0 running"
+assert_contains "${s2}" "1 stopped" "should report 1 stopped"
+
+pass "status"

--- a/integration/tests/040_status.sh
+++ b/integration/tests/040_status.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
+itest_begin
 
 setup_test
 

--- a/integration/tests/050_down.sh
+++ b/integration/tests/050_down.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
+itest_begin
 
 setup_test
 fleet_up alpha

--- a/integration/tests/050_down.sh
+++ b/integration/tests/050_down.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Verifies `fleet down` removes the container, wipes the workspace dir,
+# and drops the instance from state.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+
+setup_test
+fleet_up alpha
+
+container_id=$(grep -oE '"container_id":\s*"[^"]+"' "${HOME}/.fleet/state.json" | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
+# Fleet clones into <fleet>/<instance>/<fleet> so the leaf dir contains the
+# workspace; `fleet down` wipes that leaf.
+workspace_dir="${HOME}/.fleet/workspaces/${FIXTURE_REPO_NAME}/alpha/${FIXTURE_REPO_NAME}"
+[ -n "${container_id}" ] || fail "could not read container_id"
+assert_file_exists "${workspace_dir}"
+
+info "fleet down alpha"
+down_out=$("${FLEET_BIN}" down "${FIXTURE_REPO_NAME}/alpha")
+printf '%s\n' "${down_out}"
+assert_contains "${down_out}" "removed" "down should mention removed"
+
+# Docker container gone.
+if docker inspect "${container_id}" >/dev/null 2>&1; then
+  fail "container ${container_id} still exists after down"
+fi
+
+# Workspace clone gone.
+assert_file_absent "${workspace_dir}"
+
+# State no longer has the instance.
+state=$(cat "${HOME}/.fleet/state.json")
+assert_not_contains "${state}" "\"name\": \"alpha\"" "instance should be removed from state"
+
+# `ls` no longer lists it.
+ls_out=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+assert_not_contains "${ls_out}" "alpha" "ls should not list removed instance"
+
+pass "down"

--- a/integration/tests/050_down.sh
+++ b/integration/tests/050_down.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Verifies `fleet down` removes the container, wipes the workspace dir,
-# and drops the instance from state.
+# Description: `fleet down` removes the container, wipes the workspace, and drops the state entry.
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"

--- a/integration/tests/060_destroy.sh
+++ b/integration/tests/060_destroy.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
+itest_begin
 
 setup_test
 fleet_up alpha

--- a/integration/tests/060_destroy.sh
+++ b/integration/tests/060_destroy.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Verifies `fleet destroy` removes every instance in a fleet and the
+# fleet record itself. Creates two instances to prove it handles more
+# than one.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+
+setup_test
+fleet_up alpha
+fleet_up beta
+
+# Collect container IDs for both instances.
+mapfile -t container_ids < <(grep -oE '"container_id":\s*"[^"]+"' "${HOME}/.fleet/state.json" | sed -E 's/.*"([^"]+)"$/\1/')
+[ "${#container_ids[@]}" -eq 2 ] || fail "expected 2 container ids in state, got ${#container_ids[@]}"
+info "container ids: ${container_ids[*]}"
+
+ls_before=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+assert_contains "${ls_before}" "alpha" "alpha missing before destroy"
+assert_contains "${ls_before}" "beta"  "beta missing before destroy"
+
+info "fleet destroy ${FIXTURE_REPO_NAME}"
+destroy_out=$("${FLEET_BIN}" destroy "${FIXTURE_REPO_NAME}")
+printf '%s\n' "${destroy_out}"
+assert_contains "${destroy_out}" "destroyed" "destroy should mention destroyed"
+assert_contains "${destroy_out}" "2 instances removed" "destroy should remove both instances"
+
+# All containers gone.
+for cid in "${container_ids[@]}"; do
+  if docker inspect "${cid}" >/dev/null 2>&1; then
+    fail "container ${cid} still exists after destroy"
+  fi
+done
+
+# Fleet removed from state.
+state=$(cat "${HOME}/.fleet/state.json")
+assert_not_contains "${state}" "\"${FIXTURE_REPO_NAME}\"" "fleet should be removed from state"
+
+# `ls` shows no instances from this fleet.
+ls_after=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}" || true)
+assert_not_contains "${ls_after}" "alpha" "alpha should be gone"
+assert_not_contains "${ls_after}" "beta"  "beta should be gone"
+
+pass "destroy"

--- a/integration/tests/060_destroy.sh
+++ b/integration/tests/060_destroy.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-# Verifies `fleet destroy` removes every instance in a fleet and the
-# fleet record itself. Creates two instances to prove it handles more
-# than one.
+# Description: `fleet destroy` removes every instance in a fleet and the fleet record itself.
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"

--- a/integration/tests/100_tui_startup.sh
+++ b/integration/tests/100_tui_startup.sh
@@ -3,8 +3,8 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
-
-trap 'tui_kill' EXIT
+itest_cleanup() { tui_kill; }
+itest_begin
 
 setup_test
 fleet_up alpha

--- a/integration/tests/100_tui_startup.sh
+++ b/integration/tests/100_tui_startup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Description: TUI launches, renders the logo, fleet name, and running instance.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+
+trap 'tui_kill' EXIT
+
+setup_test
+fleet_up alpha
+
+info "Spawning TUI"
+tui_spawn
+
+info "Waiting for fleet header to render"
+tui_wait_for "itest-fleet" 15
+
+# Logo strips to the "fleet" word as text — the gradient lettering
+# uses block chars so just assert on the fleet/instance fragments.
+tui_assert_contains "itest-fleet"           "fleet header missing"
+tui_assert_contains "alpha"                 "instance row missing"
+tui_assert_contains "running"               "instance status missing"
+tui_assert_contains "settings"              "settings row missing"
+
+pass "TUI startup renders fleet list"

--- a/integration/tests/110_tui_collapse.sh
+++ b/integration/tests/110_tui_collapse.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Description: Pressing space on the fleet header collapses / expands the instance list.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+
+trap 'tui_kill' EXIT
+
+setup_test
+fleet_up alpha
+
+tui_spawn
+tui_wait_for "alpha" 15
+# Cursor starts on the fleet header. Expanded marker = ▼, collapsed = ▶.
+tui_assert_contains "▼ itest-fleet" "fleet should start expanded"
+tui_assert_contains "alpha"         "instance should be visible when expanded"
+
+info "Collapse with space"
+tui_send Space
+tui_wait_for "▶ itest-fleet" 5
+
+# alpha should disappear from the screen while collapsed.
+tui_wait_for_absent "alpha" 5 || fail "instance still visible after collapse"
+
+info "Expand with space again"
+tui_send Space
+tui_wait_for "▼ itest-fleet" 5
+tui_wait_for "alpha" 5
+
+pass "TUI collapse / expand via space"

--- a/integration/tests/110_tui_collapse.sh
+++ b/integration/tests/110_tui_collapse.sh
@@ -3,8 +3,8 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
-
-trap 'tui_kill' EXIT
+itest_cleanup() { tui_kill; }
+itest_begin
 
 setup_test
 fleet_up alpha

--- a/integration/tests/120_tui_stop_start.sh
+++ b/integration/tests/120_tui_stop_start.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Description: Pressing `s` on a running instance toggles its status to stopped and back.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+
+trap 'tui_kill' EXIT
+
+setup_test
+fleet_up alpha
+
+tui_spawn
+tui_wait_for "running" 15
+
+info "Move cursor down to the alpha instance"
+tui_send j
+sleep 0.5
+
+info "Press 's' to stop"
+tui_send s
+# Message shown below the list on completion.
+tui_wait_for "Stopped itest-fleet/alpha" 20
+tui_wait_for "stopped" 5
+
+info "Press 's' again to start"
+tui_send s
+tui_wait_for "Started itest-fleet/alpha" 20
+tui_wait_for "running" 5
+
+pass "TUI stop / start via s"

--- a/integration/tests/120_tui_stop_start.sh
+++ b/integration/tests/120_tui_stop_start.sh
@@ -3,8 +3,8 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
-
-trap 'tui_kill' EXIT
+itest_cleanup() { tui_kill; }
+itest_begin
 
 setup_test
 fleet_up alpha

--- a/integration/tests/130_tui_delete_cancel.sh
+++ b/integration/tests/130_tui_delete_cancel.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Description: Pressing `d` opens the delete dialog; pressing `n` cancels without removing.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+
+trap 'tui_kill' EXIT
+
+setup_test
+fleet_up alpha
+
+tui_spawn
+tui_wait_for "alpha" 15
+
+info "Move to alpha and open delete dialog"
+tui_send j
+sleep 0.3
+tui_send d
+tui_wait_for "Delete instance" 5
+tui_assert_contains "Remove itest-fleet/alpha" "delete confirmation body missing"
+tui_assert_contains "[y] Yes"                  "delete dialog hint missing"
+
+info "Cancel with n"
+tui_send n
+tui_wait_for "Cancelled" 5
+tui_wait_for_absent "Delete instance" 5
+
+# Instance must still exist after cancel.
+tui_assert_contains "alpha"   "instance should still be listed after cancel"
+tui_assert_contains "running" "instance should still be running after cancel"
+
+ls_out=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+assert_contains "${ls_out}" "alpha"   "CLI ls should still list instance after cancel"
+assert_contains "${ls_out}" "running" "CLI ls should still show running after cancel"
+
+pass "TUI delete dialog cancel"

--- a/integration/tests/130_tui_delete_cancel.sh
+++ b/integration/tests/130_tui_delete_cancel.sh
@@ -3,8 +3,8 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
-
-trap 'tui_kill' EXIT
+itest_cleanup() { tui_kill; }
+itest_begin
 
 setup_test
 fleet_up alpha

--- a/integration/tests/140_tui_quit.sh
+++ b/integration/tests/140_tui_quit.sh
@@ -3,8 +3,8 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
-
-trap 'tui_kill' EXIT
+itest_cleanup() { tui_kill; }
+itest_begin
 
 setup_test
 fleet_up alpha

--- a/integration/tests/140_tui_quit.sh
+++ b/integration/tests/140_tui_quit.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Description: Pressing `q` exits the TUI and the tmux session dies.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+
+trap 'tui_kill' EXIT
+
+setup_test
+fleet_up alpha
+
+tui_spawn
+tui_wait_for "alpha" 15
+
+info "Quit with q"
+tui_send q
+
+# The fleet binary exits → the tmux session terminates. Poll for the
+# session to be gone. `has-session` returns non-zero once it is killed.
+deadline=$(( $(date +%s) + 10 ))
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  if ! tmux has-session -t "${TUI_SESSION}" 2>/dev/null; then
+    pass "TUI quit via q"
+    exit 0
+  fi
+  sleep 0.25
+done
+fail "tmux session ${TUI_SESSION} still alive after 'q'"

--- a/integration/tests/150_tui_refresh.sh
+++ b/integration/tests/150_tui_refresh.sh
@@ -3,8 +3,8 @@
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
-
-trap 'tui_kill' EXIT
+itest_cleanup() { tui_kill; }
+itest_begin
 
 setup_test
 fleet_up alpha

--- a/integration/tests/150_tui_refresh.sh
+++ b/integration/tests/150_tui_refresh.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Description: Pressing `r` refreshes state and surfaces new instances created via the CLI.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+
+trap 'tui_kill' EXIT
+
+setup_test
+fleet_up alpha
+
+tui_spawn
+tui_wait_for "alpha" 15
+tui_assert_not_contains "beta" "beta should not exist yet"
+
+info "Create 'beta' via CLI while the TUI is running"
+fleet_up beta >/dev/null
+
+# Initially the TUI has not re-read state.json. Press `r` to refresh.
+info "Press 'r' to refresh"
+tui_send r
+tui_wait_for "Refreshed" 5
+tui_wait_for "beta" 5
+
+pass "TUI refresh picks up new instance"

--- a/integration/tests/160_tui_full_lifecycle.sh
+++ b/integration/tests/160_tui_full_lifecycle.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Description: Full TUI lifecycle — create fleet, create instance, shell in (split pane), run cmd, delete instance.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+# Fresh state — no fleets, no instances. The TUI will build it from scratch.
+setup_test
+
+info "Spawn the TUI with no fleets"
+tui_spawn
+tui_wait_for "No instances" 15
+
+# ---------------------------------------------------------------------------
+# Step 1 — create the fleet via `n`.
+# ---------------------------------------------------------------------------
+info "Press 'n' to open the new-fleet dialog"
+tui_send n
+tui_wait_for "git@github.com" 5   # placeholder visible in the dialog
+
+info "Type the fixture repo URL"
+tui_send_text "${FIXTURE_REPO_URL}"
+sleep 0.3
+tui_send Enter
+tui_wait_for "Added fleet ${FIXTURE_REPO_NAME}" 5
+tui_wait_for "${FIXTURE_REPO_NAME}" 5
+
+# ---------------------------------------------------------------------------
+# Step 2 — create an instance via `a`.
+# ---------------------------------------------------------------------------
+info "Move cursor to the fleet header (j/k wraps) and press 'a'"
+# After 'n' the cursor may have stayed on the settings row; press k
+# once so we land on the freshly-added fleet header.
+tui_send k
+sleep 0.3
+tui_send a
+tui_wait_for "instance-name" 5
+
+info "Name the instance 'alpha' and submit"
+tui_send_text "alpha"
+sleep 0.3
+tui_send Enter
+
+info "Wait for the instance to finish provisioning"
+# The transitional "creating" status resolves to "running" when devcontainer
+# up completes. Wait for the hydrated row — the `○ idle` agent indicator
+# only appears once the post-start poll has reported the row as running.
+# (Just waiting for "running" can match the one-shot status message that
+# fires a beat before the row itself transitions.)
+tui_wait_for "Creating ${FIXTURE_REPO_NAME}/alpha" 5 || true   # may flash past
+tui_wait_for "○ idle" 120
+tui_assert_contains "alpha" "instance row missing after create"
+
+# ---------------------------------------------------------------------------
+# Step 3 — shell into the instance via `enter` (opens split pane).
+# ---------------------------------------------------------------------------
+info "Move cursor to the alpha instance and press enter to open a split pane"
+tui_send j
+sleep 0.3
+tui_send Enter
+
+# A second pane should appear in the tmux window.
+tui_wait_for_pane 2 20
+
+# ---------------------------------------------------------------------------
+# Step 4 — run a shell command in the split pane and verify the output.
+# ---------------------------------------------------------------------------
+# The inner pane runs tmux-inside-the-container. Give its shell a moment
+# to become ready (tmux session attach + container shell spawn).
+sleep 3
+SENTINEL="hello-from-splitpane-$(date +%s)"
+info "Run 'echo ${SENTINEL}' inside the split pane"
+tui_send_pane_text 1 "echo ${SENTINEL}"
+tui_send_pane 1 Enter
+
+info "Verify the output appeared in the pane"
+tui_wait_for_in_pane 1 "${SENTINEL}" 15
+
+# Also confirm we are actually inside the container (not the host shell)
+# by checking the working directory reflects the mounted workspace.
+tui_send_pane_text 1 "pwd"
+tui_send_pane 1 Enter
+tui_wait_for_in_pane 1 "/workspaces/${FIXTURE_REPO_NAME}" 10
+
+# ---------------------------------------------------------------------------
+# Step 5 — close the split pane and delete the instance via `d` + `y`.
+# ---------------------------------------------------------------------------
+info "Close the split pane so we can interact with the TUI again"
+# We could send Ctrl+Q (bound by fleet to kill-pane -a), but tmux
+# send-keys bypasses key bindings — the C-q character flows straight
+# into the TUI's own "quit" handler, exiting the TUI. Kill the pane
+# directly via tmux instead, which is what the C-q binding does anyway.
+tmux kill-pane -t "${TUI_SESSION}:.1" 2>/dev/null || true
+tui_wait_for_pane 1 5
+
+info "Move back to alpha (cursor should still be on it) and press 'd'"
+# Ensure cursor is on alpha. Building rows may have reordered; press k
+# once to move up from settings row just in case, then j to re-seat.
+tui_send k
+sleep 0.2
+tui_send j
+sleep 0.2
+tui_send d
+tui_wait_for "Delete instance" 5
+tui_wait_for "Remove ${FIXTURE_REPO_NAME}/alpha" 5
+
+info "Confirm deletion with 'y'"
+tui_send y
+# Async deletion: transitions to "deleting", then the row disappears and
+# the fleet header's instance count drops to 0. The word "alpha" itself
+# still appears transiently in the "Removed itest-fleet/alpha" status
+# message, so assert on the empty-fleet header / success message instead.
+tui_wait_for "Removed ${FIXTURE_REPO_NAME}/alpha" 30
+tui_wait_for "${FIXTURE_REPO_NAME} (0)" 10
+
+# Verify via CLI that state actually reflects the removal.
+ls_out=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}" || true)
+assert_not_contains "${ls_out}" "alpha" "CLI ls should not list alpha after TUI delete"
+
+pass "TUI full lifecycle (create fleet → instance → shell → verify → delete)"


### PR DESCRIPTION
## Summary

- New scripted integration test suite under `/integration` exercising the core devcontainer workflow end-to-end against the real `fleet` CLI and docker daemon.
- Each test is standalone — `setup_test` wipes `~/.fleet` and rebuilds a fresh fixture git repo; `run.sh` calls `teardown_test` between tests to remove any leftover containers and state.
- New GitHub Actions workflow (`.github/workflows/integration.yml`) runs the suite on every PR to `main` so regressions in the core flow fail the check before merge.

## Tests

| # | File | Covers |
|---|------|--------|
| 1 | `010_up_and_ls.sh` | `fleet up` creates container, `ls` shows running instance |
| 2 | `020_exec.sh` | `fleet exec` runs commands inside container, exit code propagates |
| 3 | `030_stop_start.sh` | Stop/start lifecycle + docker state verification |
| 4 | `040_status.sh` | `fleet status` reports running/stopped counts |
| 5 | `050_down.sh` | `fleet down` removes container, workspace, and state entry |
| 6 | `060_destroy.sh` | `fleet destroy` removes every instance in a fleet |

## Test plan

- [x] All 6 tests pass locally (`./integration/run.sh`)
- [ ] CI check passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)