### PR TITLE
test: expand TUI coverage with 8 more integration tests

### DIFF
--- a/integration/tests/170_tui_new_fleet_cancel.sh
+++ b/integration/tests/170_tui_new_fleet_cancel.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Description: TUI new-fleet dialog cancel with esc does not create a fleet
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+
+info "spawning TUI on empty fleet list"
+tui_spawn
+tui_wait_for "No instances" 15
+
+info "opening new-fleet dialog with 'n'"
+tui_send n
+tui_wait_for "git@github.com" 5
+tui_assert_contains "New fleet" "new-fleet dialog title missing"
+
+info "cancelling dialog with Escape"
+tui_send Escape
+tui_wait_for_absent "git@github.com" 5
+tui_wait_for_absent "New fleet" 5
+
+info "verifying empty state persists and no fleet was created"
+tui_assert_contains "No instances" "empty state should persist after cancel"
+
+ls_out=$("${FLEET_BIN}" ls || true)
+assert_not_contains "${ls_out}" "${FIXTURE_REPO_NAME}" "no fleet should exist after cancel"
+
+pass "TUI new-fleet dialog cancel (esc)"

--- a/integration/tests/180_tui_new_instance_cancel.sh
+++ b/integration/tests/180_tui_new_instance_cancel.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Description: TUI 'a' on fleet header opens new-instance dialog; 'esc' cancels without creating instance
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+info "spawning TUI"
+tui_spawn
+tui_wait_for "alpha" 15
+
+info "pressing 'a' on fleet header to open new-instance dialog"
+tui_send a
+tui_wait_for "instance-name" 5
+tui_assert_contains "New instance" "new-instance dialog title missing"
+
+info "pressing Escape to cancel the dialog"
+tui_send Escape
+tui_wait_for_absent "instance-name" 5
+tui_wait_for_absent "New instance" 5
+
+info "verifying original alpha instance is still intact"
+tui_assert_contains "alpha" "alpha should still be visible after cancel"
+tui_assert_contains "running" "alpha should still be running after cancel"
+
+info "verifying via CLI ls that no spurious instance was created"
+ls_out=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+assert_contains "${ls_out}" "alpha" "CLI ls should still list alpha after cancel"
+assert_not_contains "${ls_out}" "instance-name" "CLI ls should not contain placeholder 'instance-name' (no stray instance)"
+
+pass "TUI new-instance dialog cancel (esc)"

--- a/integration/tests/190_tui_nav_wrap.sh
+++ b/integration/tests/190_tui_nav_wrap.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Description: TUI cursor navigation with j/k wraps around top/bottom of list
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+tui_spawn
+tui_wait_for "alpha" 15
+tui_wait_for "running" 5
+
+# Step 3: cursor starts on the fleet header — verify via Space toggling collapse.
+tui_assert_contains "▼ itest-fleet" "fleet should start expanded"
+info "collapsing fleet to confirm cursor starts on header"
+tui_send Space
+tui_wait_for "▶ itest-fleet" 5
+info "re-expanding fleet"
+tui_send Space
+tui_wait_for "▼ itest-fleet" 5
+
+# Step 4: press j three times — should wrap back to the fleet header.
+info "pressing j three times to wrap back to header"
+tui_send j
+sleep 0.2
+tui_send j
+sleep 0.2
+tui_send j
+sleep 0.2
+tui_send Space
+tui_wait_for "▶ itest-fleet" 5
+info "j wrapped back to header (collapse succeeded)"
+tui_send Space
+tui_wait_for "▼ itest-fleet" 5
+
+# Step 5: press k once from header — should wrap up to settings row.
+info "pressing k once to wrap up to settings row"
+tui_send k
+sleep 0.2
+tui_send Enter
+tui_wait_for "Tmux vim keys" 5
+info "k wrapped up to settings row (settings page rendered)"
+
+# Step 6: return to the fleet list.
+tui_send Escape
+tui_wait_for "alpha" 5
+
+pass "TUI cursor navigation wraps with j/k"

--- a/integration/tests/200_tui_settings.sh
+++ b/integration/tests/200_tui_settings.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Description: TUI settings page opens from fleet list and closes with esc and q
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+tui_spawn
+tui_wait_for "alpha" 15
+
+tui_assert_contains "settings" "settings row missing"
+
+# Move cursor up from header, wrapping to the last row (settings), then Enter.
+tui_send k
+sleep 0.3
+tui_send Enter
+
+# Settings page should render.
+tui_wait_for "Tmux vim keys" 5
+tui_assert_contains "General" "General section missing"
+tui_assert_contains "Show help text" "Show help text row missing"
+
+# Close with Escape; fleet list should come back.
+tui_send Escape
+tui_wait_for "alpha" 5
+tui_wait_for_absent "Tmux vim keys" 5
+
+# Re-open settings and close with q this time.
+tui_send k
+sleep 0.3
+tui_send Enter
+tui_wait_for "Tmux vim keys" 5
+
+tui_send q
+tui_wait_for "alpha" 5
+tui_wait_for_absent "Tmux vim keys" 5
+
+pass "TUI settings page open + close (esc and q)"

--- a/integration/tests/200_tui_settings.sh
+++ b/integration/tests/200_tui_settings.sh
@@ -10,31 +10,51 @@ setup_test
 fleet_up alpha
 
 tui_spawn
+# Wait for a fully-hydrated row (○ idle agent indicator), not just "alpha".
+# The initial render can show "alpha" before buildRows/stats settle, and
+# keystrokes landing during that window are unreliable.
 tui_wait_for "alpha" 15
+tui_wait_for "○ idle" 60
 
 tui_assert_contains "settings" "settings row missing"
 
-# Move cursor up from header, wrapping to the last row (settings), then Enter.
-tui_send k
-sleep 0.3
-tui_send Enter
+# Verify the cursor is on the fleet header by toggling collapse. Space on
+# the header flips the ▼/▶ arrow; if cursor were elsewhere Space would do
+# something else entirely. This also protects us against any transient
+# cursor clamping during TUI startup.
+info "verifying cursor is on the fleet header via Space-collapse toggle"
+tui_assert_contains "▼ itest-fleet" "fleet should start expanded"
+tui_send Space
+tui_wait_for "▶ itest-fleet" 5
+tui_send Space
+tui_wait_for "▼ itest-fleet" 5
 
-# Settings page should render.
-tui_wait_for "Tmux vim keys" 5
+# From the header, two 'j' presses walk deterministically down through
+# rows [header, alpha, settings] → cursor on settings.
+info "moving cursor to the settings row with j j"
+tui_send j
+sleep 0.5
+tui_send j
+sleep 0.5
+
+info "opening Settings with Enter"
+tui_send Enter
+tui_wait_for "Tmux vim keys" 10
 tui_assert_contains "General" "General section missing"
 tui_assert_contains "Show help text" "Show help text row missing"
 
-# Close with Escape; fleet list should come back.
+info "closing Settings with Escape"
 tui_send Escape
 tui_wait_for "alpha" 5
 tui_wait_for_absent "Tmux vim keys" 5
 
-# Re-open settings and close with q this time.
-tui_send k
-sleep 0.3
+# On return from Settings, cursor remains on the settings row (buildRows
+# preserves wasOnSettings). Pressing Enter re-opens the page directly.
+info "re-opening Settings (cursor remains on settings row)"
 tui_send Enter
-tui_wait_for "Tmux vim keys" 5
+tui_wait_for "Tmux vim keys" 10
 
+info "closing Settings with q"
 tui_send q
 tui_wait_for "alpha" 5
 tui_wait_for_absent "Tmux vim keys" 5

--- a/integration/tests/210_tui_tag_instance.sh
+++ b/integration/tests/210_tui_tag_instance.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Description: TUI tag instance — save tag via Enter, cancel via Esc, verify persistence
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+tui_spawn
+tui_wait_for "alpha" 15
+tui_wait_for "running" 5
+
+# Move cursor to alpha instance row
+tui_send j
+sleep 0.3
+
+# Open the tag dialog
+tui_send t
+tui_wait_for "Tag instance" 5
+tui_assert_contains "itest-fleet/alpha" "tag dialog should show instance key"
+
+# Type a tag and submit
+tui_send_text "important"
+sleep 0.3
+tui_send Enter
+
+# Expect success message and dialog close
+tui_wait_for "Tagged itest-fleet/alpha: important" 5
+tui_wait_for_absent "Tag instance" 5
+
+# Re-open dialog to test cancel; defensively re-settle cursor on alpha
+tui_send j
+sleep 0.2
+tui_send k
+sleep 0.2
+tui_send t
+tui_wait_for "Tag instance" 5
+
+# Cancel with Escape
+tui_send Escape
+tui_wait_for "Cancelled" 5
+tui_wait_for_absent "Tag instance" 5
+
+# Verify tag persisted in state.json
+tag_value=$(grep -oE '"tag"[[:space:]]*:[[:space:]]*"[^"]*"' "${HOME}/.fleet/state.json" | head -1 || true)
+assert_contains "${tag_value}" "important" "tag should persist in state.json after save"
+
+pass "TUI tag instance — save + cancel"

--- a/integration/tests/220_tui_multi_instance.sh
+++ b/integration/tests/220_tui_multi_instance.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Description: TUI creates a fleet and two instances; verifies header count and both rows
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+
+# ===========================================
+# Spawn TUI and wait for empty state
+# ===========================================
+tui_spawn
+tui_wait_for "No instances" 15
+
+# ===========================================
+# Create the fleet via `n`
+# ===========================================
+info "Creating fleet via TUI"
+tui_send n
+tui_wait_for "git@github.com" 5
+tui_send_text "${FIXTURE_REPO_URL}"
+sleep 0.3
+tui_send Enter
+tui_wait_for "Added fleet ${FIXTURE_REPO_NAME}" 5
+tui_wait_for "${FIXTURE_REPO_NAME}" 5
+
+# Cursor may have landed on the settings row after fleet creation;
+# re-seat on the fleet header.
+tui_send k
+sleep 0.3
+
+# ===========================================
+# Create the first instance "alpha"
+# ===========================================
+info "Creating first instance: alpha"
+tui_send a
+tui_wait_for "instance-name" 5
+tui_send_text "alpha"
+sleep 0.3
+tui_send Enter
+
+# Devcontainer build can take a while; wait for idle agent indicator.
+tui_wait_for "○ idle" 180
+tui_assert_contains "alpha" "alpha row missing after create"
+
+# ===========================================
+# Move cursor back to the fleet header
+# ===========================================
+# At this point rows are [header, alpha, settings]; pressing `k` three
+# times from any row lands us on the fleet header (wraps if needed).
+tui_send k
+sleep 0.3
+tui_send k
+sleep 0.3
+tui_send k
+sleep 0.3
+
+# ===========================================
+# Create the second instance "beta"
+# ===========================================
+info "Creating second instance: beta"
+tui_send a
+tui_wait_for "instance-name" 5
+tui_send_text "beta"
+sleep 0.3
+tui_send Enter
+
+# Creation toast may flash past; allow it to be optional.
+tui_wait_for "Creating ${FIXTURE_REPO_NAME}/beta" 10 || true
+
+# beta row should appear quickly in a "creating" state
+tui_wait_for "beta" 15
+
+# Both rows should be present while beta hydrates
+tui_assert_contains "alpha" "alpha missing after beta create"
+tui_assert_contains "beta" "beta row missing"
+
+# The header count updating to (2) is the most reliable signal that
+# both instances are registered in fleet state.
+tui_wait_for "${FIXTURE_REPO_NAME} (2)" 180
+
+# ===========================================
+# Final screen assertions
+# ===========================================
+tui_assert_contains "${FIXTURE_REPO_NAME} (2)" "fleet header should show count of 2 instances"
+tui_assert_contains "alpha" "alpha row missing"
+tui_assert_contains "beta" "beta row missing"
+
+# ===========================================
+# Verify via CLI as well
+# ===========================================
+info "Verifying via 'fleet ls'"
+ls_out=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+assert_contains "${ls_out}" "alpha" "CLI ls should list alpha"
+assert_contains "${ls_out}" "beta" "CLI ls should list beta"
+
+pass "TUI multi-instance fleet (2 instances created via TUI)"

--- a/integration/tests/230_tui_fleet_delete_empty.sh
+++ b/integration/tests/230_tui_fleet_delete_empty.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Description: TUI delete on empty fleet uses single-confirm path (no warn dialog)
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+
+tui_spawn
+tui_wait_for "No instances" 15
+
+# Create an empty fleet via TUI (no instances added)
+tui_send n
+tui_wait_for "git@github.com" 5
+tui_send_text "${FIXTURE_REPO_URL}"
+sleep 0.3
+tui_send Enter
+tui_wait_for "Added fleet ${FIXTURE_REPO_NAME}" 5
+tui_wait_for "${FIXTURE_REPO_NAME} (0)" 5
+
+# Move cursor back to the fleet header (may be on settings row after creation)
+tui_send k
+sleep 0.3
+
+# Open delete dialog
+tui_send d
+tui_wait_for "Delete fleet" 5
+tui_assert_contains "[y] Yes" "delete dialog hint missing"
+tui_assert_contains "Remove fleet ${FIXTURE_REPO_NAME}" "delete body missing fleet name"
+
+# Confirm with y — empty fleet should take the single-confirm path
+tui_send y
+tui_wait_for "Removed fleet ${FIXTURE_REPO_NAME}" 5
+tui_assert_not_contains "!! WARNING !!" "empty-fleet delete should not show warn dialog"
+
+# Fleet should be gone — the status message contains the fleet name, so assert empty state instead
+tui_wait_for "No instances" 10
+
+# Verify via CLI
+ls_out=$("${FLEET_BIN}" ls || true)
+assert_not_contains "${ls_out}" "${FIXTURE_REPO_NAME}" "fleet should be absent from CLI ls after delete"
+
+pass "TUI delete empty fleet (single confirm)"

--- a/integration/tests/240_tui_fleet_delete_warn.sh
+++ b/integration/tests/240_tui_fleet_delete_warn.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Description: TUI fleet delete double-confirm warn dialog (cancel + destroy paths)
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+tui_spawn
+tui_wait_for "alpha" 15
+tui_wait_for "running" 5
+
+# ------------------------------------------------------------
+# Path 1: cancel at the warn dialog - fleet + instance survive
+# ------------------------------------------------------------
+info "opening first-confirm delete dialog"
+tui_send d
+tui_wait_for "Delete fleet" 5
+tui_assert_contains "Remove fleet ${FIXTURE_REPO_NAME}" "first-confirm body missing"
+
+info "pressing y should advance to warn dialog (fleet has running instance)"
+tui_send y
+tui_wait_for "!! WARNING !!" 5
+tui_assert_contains "You are about to destroy fleet ${FIXTURE_REPO_NAME}" "warn dialog body missing"
+tui_assert_contains "[y] Confirm destroy" "warn hint missing"
+
+info "pressing n at warn should cancel without deleting"
+tui_send n
+tui_wait_for "Cancelled" 5
+tui_wait_for_absent "!! WARNING !!" 5
+
+tui_assert_contains "alpha" "alpha should still be present after warn-cancel"
+tui_assert_contains "running" "alpha should still be running after warn-cancel"
+
+# ------------------------------------------------------------
+# Path 2: confirm at warn dialog - fleet + instance destroyed
+# ------------------------------------------------------------
+info "re-opening first-confirm delete dialog"
+tui_send d
+tui_wait_for "Delete fleet" 5
+
+info "pressing y advances to warn dialog"
+tui_send y
+tui_wait_for "!! WARNING !!" 5
+
+info "pressing y at warn dialog destroys fleet + instances"
+tui_send y
+tui_wait_for "Removed fleet ${FIXTURE_REPO_NAME}" 60
+tui_wait_for "No instances" 15
+
+info "verifying via CLI that fleet is gone"
+ls_out=$("${FLEET_BIN}" ls || true)
+assert_not_contains "${ls_out}" "${FIXTURE_REPO_NAME}" "fleet should not appear in CLI ls after destroy"
+
+pass "TUI fleet delete — warn path cancel + destroy"

--- a/integration/tests/250_tui_session_create.sh
+++ b/integration/tests/250_tui_session_create.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Description: TUI creates a tmux session inside an instance via the New session dialog
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+info "spawning TUI"
+tui_spawn
+
+info "waiting for TUI to hydrate before any keypress"
+tui_wait_for "alpha" 15
+tui_wait_for "○ idle" 60
+
+info "moving cursor to alpha instance row"
+tui_send j
+sleep 0.5
+
+info "expanding the instance session list"
+tui_send Space
+tui_wait_for "+ new session" 15
+
+info "opening the New session dialog"
+tui_send a
+tui_wait_for "session-name (or empty for auto)" 5
+tui_assert_contains "itest-fleet/alpha" "dialog should show instance key"
+
+info "submitting a session name"
+tui_send_text "mysession"
+sleep 0.3
+tui_send Enter
+
+info "waiting for Session created status"
+tui_wait_for "Session created" 15
+
+info "waiting for the new session row to appear"
+tui_wait_for "○ mysession" 15
+tui_assert_contains "mysession" "new session row missing"
+
+pass "TUI create tmux session inside instance"

--- a/integration/tests/260_tui_session_rename.sh
+++ b/integration/tests/260_tui_session_rename.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Description: TUI rename tmux session (esc-cancel + rename end-to-end)
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+info "spawning TUI"
+tui_spawn
+
+# Stabilize render before sending keys to avoid keypress-during-hydration races.
+tui_wait_for "alpha" 15
+tui_wait_for "○ idle" 60
+
+info "navigating to alpha and expanding"
+tui_send j
+sleep 0.5
+tui_send Space
+tui_wait_for "+ new session" 15
+
+info "creating session 'origname'"
+tui_send a
+tui_wait_for "session-name (or empty for auto)" 5
+tui_send_text "origname"
+sleep 0.3
+tui_send Enter
+tui_wait_for "Session created" 15
+tui_wait_for "origname" 15
+
+info "moving cursor to the session row"
+# After create, cursor is still on the alpha instance row.
+# Rows now: [header, alpha, origname-row, new-session, settings].
+tui_send j
+sleep 0.5
+
+info "opening rename dialog"
+tui_send r
+tui_wait_for "Rename session" 5
+tui_assert_contains "Current:" "rename dialog missing Current label"
+tui_assert_contains "origname" "rename dialog should reference original name"
+
+info "testing esc-cancel on rename dialog"
+tui_send Escape
+tui_wait_for "Cancelled" 5
+tui_wait_for_absent "Rename session" 5
+tui_assert_contains "origname" "session should still exist after cancel"
+
+info "re-opening rename dialog (defensively re-settle cursor)"
+tui_send j
+sleep 0.2
+tui_send k
+sleep 0.2
+tui_send r
+tui_wait_for "Rename session" 5
+
+info "submitting new name 'renamed'"
+tui_send_text "renamed"
+sleep 0.3
+tui_send Enter
+
+# renameGroupCmd emits "Renamed session alpha~origname → alpha~renamed"
+tui_wait_for "Renamed session" 15
+tui_wait_for "renamed" 15
+
+info "verifying renamed session appears on screen"
+tui_assert_contains "renamed" "renamed session row missing"
+# Note: we intentionally do NOT assert absence of "origname" because the
+# status message "Renamed session alpha~origname → alpha~renamed" contains it.
+
+pass "TUI rename tmux session"

--- a/integration/tests/270_tui_session_delete.sh
+++ b/integration/tests/270_tui_session_delete.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Description: TUI delete tmux session - exercises both cancel and confirm paths
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+tui_spawn
+
+# Stabilize TUI before any keypress
+tui_wait_for "alpha" 15
+tui_wait_for "○ idle" 60
+
+# Navigate to alpha and expand
+info "expanding alpha instance"
+tui_send j
+sleep 0.5
+tui_send Space
+tui_wait_for "+ new session" 15
+
+# Create session named tokill
+info "creating session 'tokill'"
+tui_send a
+tui_wait_for "session-name (or empty for auto)" 5
+tui_send_text "tokill"
+sleep 0.3
+tui_send Enter
+tui_wait_for "Session created" 15
+tui_wait_for "tokill" 15
+
+# Move cursor to the session row (was on instance after create)
+info "moving cursor to session row"
+tui_send j
+sleep 0.5
+
+# --- CANCEL PATH ---
+info "testing cancel path"
+tui_send d
+tui_wait_for "Delete session" 5
+tui_assert_contains "itest-fleet/alpha" "delete dialog should reference instance"
+tui_assert_contains "[y] Yes" "delete dialog hint missing"
+
+tui_send n
+tui_wait_for "Cancelled" 5
+tui_wait_for_absent "Delete session" 5
+tui_assert_contains "tokill" "session should still be present after cancel"
+
+# --- CONFIRM PATH ---
+info "testing confirm path"
+# Defensively re-settle cursor on the session row
+tui_send j
+sleep 0.2
+tui_send k
+sleep 0.2
+
+tui_send d
+tui_wait_for "Delete session" 5
+
+tui_send y
+tui_wait_for "Deleted session" 15
+
+# Wait for re-render; the status message contains "tokill" so we can't
+# immediately assert absence. Let the status message clear first.
+tui_wait_for "+ new session" 15
+sleep 3
+tui_assert_not_contains "tokill" "session row should be gone after delete"
+
+pass "TUI delete tmux session — cancel + confirm"

--- a/integration/tests/270_tui_session_delete.sh
+++ b/integration/tests/270_tui_session_delete.sh
@@ -63,10 +63,11 @@ tui_wait_for "Delete session" 5
 tui_send y
 tui_wait_for "Deleted session" 15
 
-# Wait for re-render; the status message contains "tokill" so we can't
-# immediately assert absence. Let the status message clear first.
-tui_wait_for "+ new session" 15
-sleep 3
-tui_assert_not_contains "tokill" "session row should be gone after delete"
+# Wait for re-render. The status message "Deleted session alpha~tokill"
+# contains "tokill" and is not auto-cleared by time — it's only cleared
+# on the next keypress that triggers updateNormal. So check for the
+# ROW format "○ tokill" (with the session icon) which won't match the
+# status message text.
+tui_wait_for_absent "○ tokill" 15
 
 pass "TUI delete tmux session — cancel + confirm"


### PR DESCRIPTION
## Summary
- Adds 8 new integration tests under \`integration/tests/\` targeting previously-uncovered TUI behavior:
  - \`170\` new-fleet dialog cancel (esc)
  - \`180\` new-instance dialog cancel (esc)
  - \`190\` cursor navigation wraps with j/k
  - \`200\` settings page open/close (esc and q)
  - \`210\` tag instance — save via Enter, cancel via Esc, state.json persistence check
  - \`220\` multi-instance fleet (creates 2 instances via TUI, verifies header count shows \`(2)\`)
  - \`230\` fleet delete (empty) — single-confirm path, no warn dialog
  - \`240\` fleet delete (with instances) — double-confirm warn dialog (cancel path + destroy path)
- All devcontainer-backend only; coder/codespaces backends intentionally excluded.

## Test plan
- [ ] CI \`Integration Tests\` workflow runs all 21 tests green
- [ ] Summary table in GitHub Actions shows all 8 new tests with pass status