### PR TITLE
Make tmux mode the default, remove --tmux flag

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,7 +16,6 @@ import (
 
 // NewRootCmd creates the root fleet command.
 func NewRootCmd() *cobra.Command {
-	var useTmux bool
 	var runDoctor bool
 
 	root := &cobra.Command{
@@ -27,14 +26,10 @@ func NewRootCmd() *cobra.Command {
 			if runDoctor {
 				return doctor.Run()
 			}
-			if useTmux {
-				return relaunchInTmux()
-			}
-			return tui.Run()
+			return relaunchInTmux()
 		},
 	}
 
-	root.Flags().BoolVar(&useTmux, "tmux", false, "launch fleet inside a tmux session (enables split pane mode)")
 	root.Flags().BoolVar(&runDoctor, "doctor", false, "launch a coding agent to diagnose and fix your setup")
 
 	root.AddCommand(
@@ -71,7 +66,7 @@ func relaunchInTmux() error {
 
 	tmuxBin, err := exec.LookPath("tmux")
 	if err != nil {
-		return fmt.Errorf("tmux not found: %w", err)
+		return fmt.Errorf("tmux is required but was not found on PATH. Install it via your package manager (apt/dnf/brew install tmux) and re-run fleet")
 	}
 
 	// exec into: tmux new-session -s fleet -- <self>

--- a/internal/deps/check.go
+++ b/internal/deps/check.go
@@ -17,6 +17,13 @@ type Dependency struct {
 func Check() []Dependency {
 	deps := []Dependency{
 		{
+			Name:        "tmux",
+			Binary:      "tmux",
+			Required:    true,
+			InstallURL:  "https://github.com/tmux/tmux/wiki/Installing",
+			Description: "Terminal multiplexer — fleet runs its TUI inside a tmux session.",
+		},
+		{
 			Name:       "devcontainer CLI",
 			Binary:     "devcontainer",
 			Required:   true,

--- a/internal/tui/page_settings.go
+++ b/internal/tui/page_settings.go
@@ -413,7 +413,7 @@ func (sp *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.Cmd {
 				return nil
 			}
 			if item == settingsItemUpdate {
-				return performUpdateCmd(m.inHostTmux)
+				return performUpdateCmd()
 			}
 			if item == settingsItemDoctor {
 				cmd, err := doctor.Command()

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -71,18 +71,14 @@ func checkUpdateCmd() tea.Cmd {
 
 // performUpdateCmd runs the install script via tea.ExecProcess and, on
 // success, signals Run() (via updateInstalledMsg) to quit the TUI and
-// exec-replace this process with the new fleet binary. If inHostTmux
-// is true the --tmux flag is preserved on the replacement argv.
-func performUpdateCmd(inHostTmux bool) tea.Cmd {
+// exec-replace this process with the new fleet binary.
+func performUpdateCmd() tea.Cmd {
 	self, err := os.Executable()
 	if err != nil {
 		self = "fleet"
 	}
 
 	args := []string{self}
-	if inHostTmux {
-		args = append(args, "--tmux")
-	}
 
 	return tea.ExecProcess(
 		updateShellCmd(),

--- a/skills/DOCTOR.md
+++ b/skills/DOCTOR.md
@@ -207,9 +207,9 @@ cat "${CODER_CONFIG_DIR:-$HOME/.config/coderv2}/url" 2>/dev/null || echo "URL fi
 
 ---
 
-## 7. tmux (optional but recommended)
+## 7. tmux (required)
 
-tmux enables split-pane mode in the TUI where the fleet list and instance shell appear side by side.
+tmux is required — fleet always runs its TUI inside a tmux session. Without tmux, `fleet` will refuse to start.
 
 ```bash
 command -v tmux && tmux -V
@@ -219,13 +219,12 @@ command -v tmux && tmux -V
   ```bash
   sudo apt-get update && sudo apt-get install -y tmux
   ```
-- **Note:** To use split-pane mode, launch fleet with `fleet --tmux`.
 
 ---
 
-## 8. Terminal Emulators (optional)
+## 8. Terminal Emulators (legacy fallback)
 
-When not running inside tmux, fleet-man tries to open instance shells in a new terminal window. It probes for these emulators in order:
+Fleet always runs inside tmux now, so instance shells open as tmux split panes. The terminal-emulator probe below is only relevant if tmux support has been disabled or removed in a fork.
 
 1. ptyxis
 2. gnome-terminal
@@ -242,8 +241,6 @@ for t in ptyxis gnome-terminal konsole xfce4-terminal alacritty kitty xterm; do
   fi
 done
 ```
-
-- **Fix:** Install at least one terminal emulator, or use tmux mode (`fleet --tmux`) instead.
 
 ---
 


### PR DESCRIPTION
## Summary
- Always launch fleet inside a tmux session; removes the opt-in `--tmux` flag
- Adds tmux to the required deps check so the first-run dep page and `--doctor` both flag it when missing
- Upgrades the missing-tmux error to an actionable install hint

Closes #17

## Test plan
- [ ] `fleet` launches into a tmux session with no flags
- [ ] `fleet --doctor` still launches the diagnostic agent
- [ ] With tmux uninstalled, running `fleet` prints the new install-hint error and exits cleanly
- [ ] First-run deps page lists tmux as required when missing
- [ ] In-TUI update path (settings → update) still exec-replaces correctly and lands back in tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)