### PR TITLE
feat: allow renaming instances via DisplayName

### DIFF
--- a/integration/tests/215_tui_rename_instance.sh
+++ b/integration/tests/215_tui_rename_instance.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Description: TUI edit instance — rename via display_name through the edit dialog, verify persistence
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+tui_spawn
+tui_wait_for "alpha" 15
+tui_wait_for "running" 5
+
+# Move cursor to alpha instance row
+tui_send j
+sleep 0.3
+
+# Open the edit dialog via 'e' — cursor lands on the Name row with the
+# current display name prefilled.
+tui_send e
+tui_wait_for "Edit instance" 5
+tui_assert_contains "itest-fleet" "edit dialog should show fleet name"
+
+# Clear the prefilled name by sending backspaces, then type a new one.
+for _ in 1 2 3 4 5; do tui_send BSpace; done
+tui_send_text "auth-fix"
+sleep 0.3
+tui_send Enter
+
+# Expect the dialog to close and the new label to appear in the list.
+tui_wait_for_absent "Edit instance" 5
+tui_wait_for "auth-fix" 5
+
+# Verify DisplayName persisted in state.json and the underlying Name is untouched.
+display_value=$(grep -oE '"display_name"[[:space:]]*:[[:space:]]*"[^"]*"' "${HOME}/.fleet/state.json" | head -1 || true)
+assert_contains "${display_value}" "auth-fix" "display_name should persist in state.json after save"
+name_value=$(grep -oE '"name"[[:space:]]*:[[:space:]]*"alpha"' "${HOME}/.fleet/state.json" | head -1 || true)
+assert_contains "${name_value}" "alpha" "underlying name should remain unchanged after rename"
+
+pass "TUI edit instance — rename via display_name"

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -65,6 +65,7 @@ func newUpCmd() *cobra.Command {
 			wsDir := filepath.Join(state.WorkspacesDir(), target.Fleet, target.Instance, target.Fleet)
 			inst := &fleet.Instance{
 				Name:         target.Instance,
+				DisplayName:  target.Instance,
 				Config:       ".devcontainer/devcontainer.json",
 				WorkspaceDir: wsDir,
 				CreatedAt:    time.Now(),

--- a/internal/fleet/instance.go
+++ b/internal/fleet/instance.go
@@ -23,16 +23,32 @@ const (
 	BackendCodespaces   BackendType = "codespaces"
 )
 
+// Instance represents a single devcontainer workspace in a fleet.
+//
+// Name is the stable identifier used for container names, workspace paths,
+// tmux session prefixes, and CLI lookups — it never changes after creation.
+// DisplayName is the user-facing label shown in the TUI; it may be edited
+// freely without touching any underlying resources.
 type Instance struct {
-	Name        string         `json:"name"`
-	ContainerID string         `json:"container_id"`
-	Config      string         `json:"config"`
-	WorkspaceDir string        `json:"workspace_dir"`
-	CreatedAt   time.Time      `json:"created_at"`
-	Status      InstanceStatus `json:"status"`
-	Error       string         `json:"error,omitempty"`
-	Backend     BackendType    `json:"backend,omitempty"`
-	Tag         string         `json:"tag,omitempty"`
-	Color       string         `json:"color,omitempty"`
-	Branch      string         `json:"branch,omitempty"`
+	Name         string         `json:"name"`
+	DisplayName  string         `json:"display_name,omitempty"`
+	ContainerID  string         `json:"container_id"`
+	Config       string         `json:"config"`
+	WorkspaceDir string         `json:"workspace_dir"`
+	CreatedAt    time.Time      `json:"created_at"`
+	Status       InstanceStatus `json:"status"`
+	Error        string         `json:"error,omitempty"`
+	Backend      BackendType    `json:"backend,omitempty"`
+	Tag          string         `json:"tag,omitempty"`
+	Color        string         `json:"color,omitempty"`
+	Branch       string         `json:"branch,omitempty"`
+}
+
+// GetDisplayName returns the user-facing label for the instance. Legacy
+// instances persisted before DisplayName existed fall back to Name.
+func (i *Instance) GetDisplayName() string {
+	if i.DisplayName == "" {
+		return i.Name
+	}
+	return i.DisplayName
 }

--- a/internal/fleet/instance_test.go
+++ b/internal/fleet/instance_test.go
@@ -1,0 +1,37 @@
+package fleet
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestInstanceGetDisplayNameFallsBackToName(t *testing.T) {
+	inst := &Instance{Name: "agent-1"}
+	if got := inst.GetDisplayName(); got != "agent-1" {
+		t.Fatalf("GetDisplayName() = %q, want %q (fallback to Name)", got, "agent-1")
+	}
+}
+
+func TestInstanceGetDisplayNameReturnsDisplayNameWhenSet(t *testing.T) {
+	inst := &Instance{Name: "agent-1", DisplayName: "auth-fix"}
+	if got := inst.GetDisplayName(); got != "auth-fix" {
+		t.Fatalf("GetDisplayName() = %q, want %q", got, "auth-fix")
+	}
+}
+
+// TestInstanceUnmarshalLegacyHasNoDisplayName verifies that Instance records
+// persisted before DisplayName existed deserialize cleanly with an empty
+// DisplayName, so GetDisplayName falls back to Name.
+func TestInstanceUnmarshalLegacyHasNoDisplayName(t *testing.T) {
+	legacy := []byte(`{"name":"agent-1","container_id":"abc","config":"x","workspace_dir":"/tmp","status":"running"}`)
+	var inst Instance
+	if err := json.Unmarshal(legacy, &inst); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if inst.DisplayName != "" {
+		t.Fatalf("DisplayName = %q, want empty for legacy state", inst.DisplayName)
+	}
+	if got := inst.GetDisplayName(); got != "agent-1" {
+		t.Fatalf("GetDisplayName() = %q, want %q", got, "agent-1")
+	}
+}

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -185,8 +185,10 @@ const (
 )
 
 // openEditInstanceDialog opens the add-instance dialog in edit mode for
-// the currently selected instance. Name and deploy target are disabled;
-// only the color is editable.
+// the currently selected instance. The user-facing Name (stored as
+// DisplayName) and color are editable; the underlying identifier, branch,
+// and deploy target are immutable — they describe how the workspace was
+// originally provisioned.
 func (fp *fleetPage) openEditInstanceDialog(m *model) tea.Cmd {
 	f, inst := fp.selectedInstance(m)
 	if inst == nil || f == nil {
@@ -206,12 +208,11 @@ func (fp *fleetPage) openEditInstanceDialog(m *model) tea.Cmd {
 	if fp.dialogColor == "" {
 		fp.dialogColor = instanceColorWhite
 	}
-	fp.dialogRow = addInstanceRowColor
-	fp.textInput.SetValue(inst.Name)
-	fp.textInput.Blur()
+	fp.dialogRow = addInstanceRowName
+	fp.textInput.SetValue(inst.GetDisplayName())
 	fp.branchInput.SetValue(inst.Branch)
-	fp.branchInput.Blur()
-	return nil
+	fp.syncAddInstanceFocus()
+	return fp.textInput.Cursor.BlinkCmd()
 }
 
 // updateAddInstance handles the add-instance dialog.
@@ -259,6 +260,7 @@ func (fp *fleetPage) updateAddInstance(m *model, msg tea.Msg) tea.Cmd {
 			wsDir := filepath.Join(state.WorkspacesDir(), fleetName, name, fleetName)
 			inst := &fleet.Instance{
 				Name:         name,
+				DisplayName:  name,
 				Config:       ".devcontainer/devcontainer.json",
 				WorkspaceDir: wsDir,
 				CreatedAt:    time.Now(),
@@ -362,9 +364,10 @@ func (fp *fleetPage) updateAddInstance(m *model, msg tea.Msg) tea.Cmd {
 
 // syncAddInstanceFocus focuses the text input of the currently selected
 // row so the cursor visually reflects the current focus. In edit mode
-// the name and branch are immutable so focus is never granted to them.
+// the branch input is immutable so it never receives focus; the name
+// input edits DisplayName and stays focusable.
 func (fp *fleetPage) syncAddInstanceFocus() {
-	nameFocus := fp.dialogRow == addInstanceRowName && !fp.dialogEditing
+	nameFocus := fp.dialogRow == addInstanceRowName
 	branchFocus := fp.dialogRow == addInstanceRowBranch && !fp.dialogEditing
 
 	if nameFocus {
@@ -381,14 +384,14 @@ func (fp *fleetPage) syncAddInstanceFocus() {
 }
 
 // addInstanceRowEnabled reports whether a given row is selectable in the
-// current dialog mode. Name, branch, and deploy are locked while editing
-// because they describe how the workspace was originally provisioned and
-// cannot be retroactively changed without recreating the instance.
+// current dialog mode. Branch and deploy are locked while editing because
+// they describe how the workspace was originally provisioned and cannot
+// be retroactively changed without recreating the instance.
 func (fp *fleetPage) addInstanceRowEnabled(row int) bool {
 	if !fp.dialogEditing {
 		return true
 	}
-	return row == addInstanceRowColor
+	return row == addInstanceRowName || row == addInstanceRowColor
 }
 
 // nextAddInstanceRow advances the focused row forward, skipping any rows
@@ -415,8 +418,9 @@ func (fp *fleetPage) prevAddInstanceRow(current int) int {
 	return current
 }
 
-// saveInstanceEdits commits color edits to the selected instance and
-// closes the dialog.
+// saveInstanceEdits commits display-name and color edits to the selected
+// instance and closes the dialog. The underlying Name is immutable; the
+// name input writes to DisplayName instead.
 func (fp *fleetPage) saveInstanceEdits(m *model) tea.Cmd {
 	f, ok := m.st.Fleets[fp.dialogFleet]
 	if !ok {
@@ -433,10 +437,17 @@ func (fp *fleetPage) saveInstanceEdits(m *model) tea.Cmd {
 		return nil
 	}
 
+	displayName := strings.TrimSpace(fp.textInput.Value())
+	if displayName == "" {
+		m.message = "Name cannot be empty"
+		return nil
+	}
+
 	color := fp.dialogColor
 	if color == instanceColorWhite {
 		color = ""
 	}
+	inst.DisplayName = displayName
 	inst.Color = color
 	_ = state.Save(m.st)
 

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -497,7 +497,7 @@ func (fp *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			if err != nil {
 				m.message = fmt.Sprintf("Could not open terminal: %v", err)
 			} else {
-				m.message = fmt.Sprintf("Opened terminal for %s", inst.Name)
+				m.message = fmt.Sprintf("Opened terminal for %s", inst.GetDisplayName())
 			}
 
 		case "c":
@@ -525,7 +525,7 @@ func (fp *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 				if err := codeCmd.Run(); err != nil {
 					m.message = fmt.Sprintf("VS Code error: %v", err)
 				} else {
-					m.message = fmt.Sprintf("Opened VS Code for %s", inst.Name)
+					m.message = fmt.Sprintf("Opened VS Code for %s", inst.GetDisplayName())
 				}
 			}
 
@@ -541,7 +541,7 @@ func (fp *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			}
 			b := m.instanceBackend(inst)
 			instanceKey := fp.currentFleetName() + "/" + inst.Name
-			m.message = fmt.Sprintf("Starting browser proxy for %s...", inst.Name)
+			m.message = fmt.Sprintf("Starting browser proxy for %s...", inst.GetDisplayName())
 			return openBrowserProxyCmd(m.portForwards, b, inst, instanceKey)
 
 		case "t":
@@ -682,7 +682,7 @@ func (fp *fleetPage) handleEnter(m *model) tea.Cmd {
 			inst.WorkspaceDir,
 			ShellCommandForSession(m.cfg, sessionName, m.width, m.height, false),
 		)
-		banner := renderGradient(nameToBanner(inst.Name))
+		banner := renderGradient(nameToBanner(inst.GetDisplayName()))
 		banner += "\n  " + dimStyle.Render("ctrl+q/ctrl+o to detach (session persists)")
 		return tea.ExecProcess(
 			execWithBannerCmd(banner, cmd),
@@ -726,7 +726,7 @@ func (fp *fleetPage) handleEnter(m *model) tea.Cmd {
 		m.lastActive[instKey] = lastSession{sessionName: sessionName}
 
 		cmd := m.instanceBackend(inst).ExecCommand(inst.WorkspaceDir, ShellCommandForSession(m.cfg, sessionName, m.width, m.height, false))
-		banner := renderGradient(nameToBanner(inst.Name))
+		banner := renderGradient(nameToBanner(inst.GetDisplayName()))
 		banner += "\n  " + dimStyle.Render("ctrl+q/ctrl+o to detach (session persists)")
 		return tea.ExecProcess(
 			execWithBannerCmd(banner, cmd),
@@ -934,7 +934,7 @@ func (fp *fleetPage) viewFleetList(m *model) string {
 				}
 			}
 
-			paddedName := fmt.Sprintf("%s%-22s", arrow, inst.Name)
+			paddedName := fmt.Sprintf("%s%-22s", arrow, inst.GetDisplayName())
 			switch {
 			case isSelected && instanceColorHasCustom(inst.Color):
 				paddedName = instanceColorStyle(inst.Color).Bold(true).Render(paddedName)
@@ -1091,8 +1091,8 @@ func (fp *fleetPage) viewFleetList(m *model) string {
 		var title, hint, nameField, branchField, deployField string
 		if fp.dialogEditing {
 			title = "Edit instance"
-			hint = "[←→/space] Cycle color  [shift+tab] Color  [enter] Save  [esc] Cancel"
-			nameField = dimStyle.Render(fp.dialogInst)
+			hint = "[↑↓] Select  [←→/space] Cycle color  [shift+tab] Color  [enter] Save  [esc] Cancel"
+			nameField = fp.textInput.View()
 			branchDisplay := fp.branchInput.Value()
 			if branchDisplay == "" {
 				branchDisplay = "default"
@@ -1111,7 +1111,7 @@ func (fp *fleetPage) viewFleetList(m *model) string {
 		}
 
 		rowMarker := func(r int) string {
-			if fp.dialogEditing && r != addInstanceRowColor {
+			if !fp.addInstanceRowEnabled(r) {
 				return "  "
 			}
 			if fp.dialogRow == r {

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -391,3 +391,87 @@ func stubToggleInstance(fn func(fleetName, instanceName string) (*instanceops.Re
 		toggleInstanceStatus = prev
 	}
 }
+
+func TestEditInstanceRenamesViaDisplayName(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	inst := &fleet.Instance{Name: "agent-1", DisplayName: "agent-1", Status: fleet.StatusRunning}
+	fp := newFleetPage()
+	fp.rows = []row{{kind: rowInstance, fleetName: "alpha", instance: inst}}
+	m := &model{
+		st: &state.State{
+			Fleets: map[string]*fleet.Fleet{
+				"alpha": {Name: "alpha", Instances: []*fleet.Instance{inst}},
+			},
+		},
+		expandedInstances: make(map[string]bool),
+		stats:             map[string]*backend.ContainerStats{},
+		fleetPage:         fp,
+	}
+
+	// Press 'e' on the instance row to open the edit dialog.
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+
+	if fp.mode != viewAddInstance || !fp.dialogEditing {
+		t.Fatalf("mode = %v, editing = %v; want viewAddInstance in edit mode", fp.mode, fp.dialogEditing)
+	}
+	if fp.dialogRow != addInstanceRowName {
+		t.Fatalf("dialogRow = %d, want addInstanceRowName (%d)", fp.dialogRow, addInstanceRowName)
+	}
+	if got := fp.textInput.Value(); got != "agent-1" {
+		t.Fatalf("prefilled input = %q, want %q", got, "agent-1")
+	}
+
+	// Type a new name and submit.
+	fp.textInput.SetValue("auth-fix")
+	fp.updateAddInstance(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if fp.mode != viewNormal {
+		t.Fatalf("mode after enter = %v, want viewNormal", fp.mode)
+	}
+	if inst.Name != "agent-1" {
+		t.Fatalf("Name = %q, want %q (should be immutable)", inst.Name, "agent-1")
+	}
+	if inst.DisplayName != "auth-fix" {
+		t.Fatalf("DisplayName = %q, want %q", inst.DisplayName, "auth-fix")
+	}
+
+	prevResolveBranch := resolveWorkspaceBranch
+	resolveWorkspaceBranch = func(string) string { return "" }
+	defer func() { resolveWorkspaceBranch = prevResolveBranch }()
+
+	view := fp.viewFleetList(m)
+	if !strings.Contains(view, "auth-fix") {
+		t.Fatalf("rendered list missing new display name:\n%s", view)
+	}
+}
+
+func TestEditInstanceRejectsEmptyName(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	inst := &fleet.Instance{Name: "agent-1", DisplayName: "agent-1", Status: fleet.StatusRunning, Color: "red"}
+	fp := newFleetPage()
+	fp.rows = []row{{kind: rowInstance, fleetName: "alpha", instance: inst}}
+	m := &model{
+		st: &state.State{
+			Fleets: map[string]*fleet.Fleet{
+				"alpha": {Name: "alpha", Instances: []*fleet.Instance{inst}},
+			},
+		},
+		fleetPage: fp,
+	}
+
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	fp.textInput.SetValue("   ")
+	fp.updateAddInstance(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if inst.DisplayName != "agent-1" {
+		t.Fatalf("DisplayName = %q, want unchanged %q", inst.DisplayName, "agent-1")
+	}
+	if m.message != "Name cannot be empty" {
+		t.Fatalf("message = %q, want rejection message", m.message)
+	}
+	if fp.mode != viewAddInstance {
+		t.Fatalf("dialog closed prematurely; mode = %v", fp.mode)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a mutable `DisplayName` to `fleet.Instance` — the user-facing label shown in the TUI — while keeping the underlying `Name` immutable as the stable identifier for container names, workspace paths, tmux session prefixes, and CLI lookups.
- Renames happen through the existing `e` edit dialog: the Name row is now editable and writes to `DisplayName`. The Branch and Deploy rows stay locked (they describe how the workspace was provisioned).
- Legacy state records without a `DisplayName` fall back to `Name` via `GetDisplayName()`, so this is backward-compatible with existing `~/.fleet/state.json` files.

Closes #18

## Design

```
fleet.Instance
  Name         ← stable ID: containers, paths, tmux, lookups (immutable)
  DisplayName  ← user-facing label, editable, falls back to Name

  GetDisplayName()  →  DisplayName or Name

  TUI row label         → GetDisplayName()
  Open-session banner   → GetDisplayName()
  Status toasts         → GetDisplayName()
  instKey, paths, sess  → Name (unchanged)
```

## Test plan
- [x] `go test ./...` passes
- [x] Unit test: `GetDisplayName()` falls back to `Name` when DisplayName is empty (legacy state)
- [x] TUI test: pressing `e`, editing the Name field, and hitting Enter writes to `DisplayName` while leaving `Name` untouched
- [x] TUI test: empty name is rejected without closing the dialog
- [x] Integration test `215_tui_rename_instance.sh` — renames via `e`, verifies `display_name` in state.json and that `name` is unchanged
- [x] Manually renamed an instance via `e` in the TUI and confirmed the new label appears everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)