### PR TITLE
fix: persist tmux pane layout across fleet restarts (#16)

### DIFF
--- a/integration/tests/280_tui_pane_layout_persist.sh
+++ b/integration/tests/280_tui_pane_layout_persist.sh
@@ -35,15 +35,29 @@ tui_wait_for "+ new session" 15
 info "Open alpha shell in a split pane (first group session)"
 tui_send Enter
 tui_wait_for_pane 2 20
-sleep 3
 
-# Discover the group ID via the outer pane title that `fleet shell` sets
-# with select-pane -T. Title format: "<sanitized-instance>~<groupID>".
-pane_title=$(tmux display-message -t "${TUI_SESSION}:.1" -p "#{pane_title}" 2>/dev/null || true)
-info "pane 1 title: ${pane_title}"
-group_id="${pane_title#*~}"
-if [ -z "${group_id}" ] || [ "${group_id}" = "${pane_title}" ]; then
-  fail "could not parse group id from pane title: ${pane_title}"
+# Discover the group ID from the TUI pane itself. The first pane is
+# created by the TUI via devcontainer exec (not via `fleet shell`), so
+# #{pane_title} isn't set — it defaults to the runner hostname. Instead,
+# wait for the session-discovery loop to surface the group in the
+# expanded instance and read its ID off the screen. Group IDs are
+# randomHex(3) = exactly 6 hex chars, rendered as their own token; no
+# other on-screen text produces a standalone 6-hex-char word.
+info "Wait for the group session row to render in the TUI"
+deadline=$(( $(date +%s) + 20 ))
+group_id=""
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  screen=$(tui_capture_pane 0)
+  candidate=$(printf '%s' "${screen}" | grep -oE '\<[a-f0-9]{6}\>' | head -1 || true)
+  if [ -n "${candidate}" ]; then
+    group_id="${candidate}"
+    break
+  fi
+  sleep 0.5
+done
+if [ -z "${group_id}" ]; then
+  printf -- '--- pane 0 ---\n%s\n--- end ---\n' "$(tui_capture_pane 0)" >&2
+  fail "could not discover group id from TUI"
 fi
 info "group id: ${group_id}"
 

--- a/integration/tests/280_tui_pane_layout_persist.sh
+++ b/integration/tests/280_tui_pane_layout_persist.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Description: Tmux pane layout persists across fleet restarts (issue #16)
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+# ---------------------------------------------------------------------------
+# Phase 1 — build a multi-pane group with a non-default orientation.
+#
+# The bug in #16 is that the user's split orientation and pane sizes get
+# lost on restart — a group built with side-by-side panes comes back
+# stacked. We deliberately pick a layout that does NOT match the default
+# placeholder geometry restoreGroupCmd() would synthesise without the
+# saved layout, so the assertion at the bottom distinguishes "any layout
+# restored" from "saved layout restored".
+#
+#   default placeholder : TUI | {shell1 / shell2}   (stacked)
+#   this test's layout  : TUI | {shell1 | shell2}   (side-by-side)
+# ---------------------------------------------------------------------------
+info "Launch TUI and expand alpha"
+tui_spawn
+tui_wait_for "alpha" 15
+tui_wait_for "○ idle" 60
+
+tui_send j
+sleep 0.5
+tui_send Space
+tui_wait_for "+ new session" 15
+
+info "Open alpha shell in a split pane (first group session)"
+tui_send Enter
+tui_wait_for_pane 2 20
+sleep 3
+
+# Discover the group ID via the outer pane title that `fleet shell` sets
+# with select-pane -T. Title format: "<sanitized-instance>~<groupID>".
+pane_title=$(tmux display-message -t "${TUI_SESSION}:.1" -p "#{pane_title}" 2>/dev/null || true)
+info "pane 1 title: ${pane_title}"
+group_id="${pane_title#*~}"
+if [ -z "${group_id}" ] || [ "${group_id}" = "${pane_title}" ]; then
+  fail "could not parse group id from pane title: ${pane_title}"
+fi
+info "group id: ${group_id}"
+
+info "Add a second pane side-by-side with the first via fleet shell --group"
+# The %/" bindings are what a user would press, but tmux send-keys
+# bypasses bindings — invoke tmux split-window directly with the same
+# command the binding installs. -h gives the side-by-side layout that
+# the default restore would otherwise get wrong.
+tmux split-window -h -t "${TUI_SESSION}:.1" \
+  "env TERM=xterm-256color ${FLEET_BIN} shell ${FIXTURE_REPO_NAME}/alpha --group ${group_id}"
+tui_wait_for_pane 3 20
+sleep 5  # let the second fleet shell attach + set its outer pane title
+
+layout_before=$(tmux display-message -t "${TUI_SESSION}" -p "#{window_layout}")
+info "layout before quit: ${layout_before}"
+
+# ---------------------------------------------------------------------------
+# Phase 2 — clean quit so View() runs saveCurrentGroupLayout().
+# ---------------------------------------------------------------------------
+info "Focus TUI pane and press 'q' for a clean quit"
+tmux select-pane -t "${TUI_SESSION}:.0"
+tui_send_pane 0 q
+
+info "Wait for tmux session to exit (fleet quit tears down pane 0)"
+deadline=$(( $(date +%s) + 15 ))
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  if ! tmux has-session -t "${TUI_SESSION}" 2>/dev/null; then
+    break
+  fi
+  sleep 0.25
+done
+if tmux has-session -t "${TUI_SESSION}" 2>/dev/null; then
+  fail "tmux session did not exit after q — fleet did not quit cleanly"
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 3 — verify state.json persisted the layout.
+# ---------------------------------------------------------------------------
+info "Verify state.json contains the saved group layout"
+assert_file_exists "${HOME}/.fleet/state.json"
+state=$(cat "${HOME}/.fleet/state.json")
+assert_contains "${state}" '"groupLayouts"' "state.json missing groupLayouts field"
+assert_contains "${state}" "\"${group_id}\"" "state.json missing entry for group ${group_id}"
+assert_contains "${state}" '"paneCount": 2' "state.json should record 2 shell panes"
+
+saved_layout=$(grep -oE '"layout"[[:space:]]*:[[:space:]]*"[^"]*"' "${HOME}/.fleet/state.json" \
+  | head -1 \
+  | sed -E 's/.*:[[:space:]]*"([^"]*)".*/\1/')
+info "saved layout: ${saved_layout}"
+[ -n "${saved_layout}" ] || fail "could not extract saved layout from state.json"
+
+# ---------------------------------------------------------------------------
+# Phase 4 — respawn fleet and restore the group.
+# ---------------------------------------------------------------------------
+info "Respawn fleet"
+tui_spawn
+tui_wait_for "alpha" 15
+tui_wait_for "○ idle" 60
+
+info "Expand alpha; the saved group should appear with (2 panes) label"
+tui_send j
+sleep 0.5
+tui_send Space
+tui_wait_for "(2 panes)" 20
+
+info "Move to the group row and open it"
+tui_send j
+sleep 0.3
+tui_send Enter
+tui_wait_for_pane 3 30
+sleep 3
+
+# ---------------------------------------------------------------------------
+# Phase 5 — assert restored layout structure matches the saved one.
+#
+# window_layout strings include per-pane tmux IDs that change across
+# runs, so string equality is too strict. We compare the bracket
+# structure instead: tmux uses '{' for side-by-side and '[' for stacked
+# splits, so the sequence of braces encodes orientation and nesting
+# unambiguously. For this test:
+#   with fix    : {{}}  (outer TUI|group, inner shell|shell)
+#   without fix : {[]}  (outer TUI|group, inner shell/shell stacked)
+# ---------------------------------------------------------------------------
+layout_after=$(tmux display-message -t "${TUI_SESSION}" -p "#{window_layout}")
+info "layout after restore: ${layout_after}"
+
+brace_before=$(printf '%s' "${layout_before}" | tr -cd '{}[]')
+brace_after=$(printf '%s' "${layout_after}"  | tr -cd '{}[]')
+info "brace structure before=[${brace_before}] after=[${brace_after}]"
+assert_equals "${brace_before}" "${brace_after}" \
+  "restored layout must preserve split orientation from saved layout"
+
+pass "Tmux pane layout persists across fleet restarts"

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -14,7 +14,20 @@ var mu sync.Mutex
 
 // State holds all fleet data.
 type State struct {
-	Fleets map[string]*fleet.Fleet `json:"fleets"`
+	Fleets       map[string]*fleet.Fleet `json:"fleets"`
+	GroupLayouts map[string]GroupLayout  `json:"groupLayouts,omitempty"`
+}
+
+// GroupLayout records the outer tmux pane layout for a session group so
+// it can be restored after a fleet restart. The Layout field is a tmux
+// window_layout string (geometry + pane sizes); Sessions preserves the
+// pane-to-session mapping by screen position.
+type GroupLayout struct {
+	GroupID      string   `json:"groupID"`
+	InstanceName string   `json:"instanceName"`
+	Sessions     []string `json:"sessions"`
+	Layout       string   `json:"layout"`
+	PaneCount    int      `json:"paneCount"`
 }
 
 // FleetDir returns the base directory for fleet state.
@@ -53,6 +66,9 @@ func Load() (*State, error) {
 
 	if s.Fleets == nil {
 		s.Fleets = make(map[string]*fleet.Fleet)
+	}
+	if s.GroupLayouts == nil {
+		s.GroupLayouts = make(map[string]GroupLayout)
 	}
 
 	return s, nil

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -827,10 +827,18 @@ func (m model) View() string {
 		// tmux layout BEFORE killing panes so pane-size changes made
 		// since the last group switch are persisted and replayed on the
 		// next fleet startup.
+		//
+		// Bubbletea can call View() more than once while tearing down
+		// after tea.Quit. Clear splitPaneID after the first pass so a
+		// subsequent call doesn't re-enter this block — without that,
+		// the second saveCurrentGroupLayout reads the post-kill tmux
+		// layout (1 pane, TUI only) and overwrites the correct save
+		// with a truncated single-pane record.
 		fp := m.fleetPage
 		if fp.splitPaneID != "" {
 			fp.saveCurrentGroupLayout(m.st)
 			killAllSplitPanes()
+			fp.splitPaneID = ""
 		}
 		m.portForwards.Shutdown()
 		if m.inHostTmux {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -130,6 +130,12 @@ func newModel() model {
 
 	m.reload()
 
+	// Rehydrate saved pane layouts from disk so group restores after
+	// a fleet restart use the exact geometry the user left behind,
+	// then drop any layouts whose instance no longer exists.
+	m.hydrateSavedGroups()
+	m.pruneOrphanedSavedGroups()
+
 	// Resume tracking any instances still in "creating" state from a previous session
 	if m.st != nil {
 		for fleetName, f := range m.st.Fleets {
@@ -180,6 +186,91 @@ func (m *model) reload() {
 		}
 		delete(m.expandedInstances, key)
 		delete(m.sessions, key)
+	}
+}
+
+// hydrateSavedGroups copies persisted pane layouts from state.json into
+// the fleet page's in-memory map. Called once at startup so subsequent
+// group restores use the layout geometry the user left behind rather
+// than falling back to the default placeholder split.
+func (m *model) hydrateSavedGroups() {
+	if m.st == nil || m.fleetPage == nil {
+		return
+	}
+	for gid, gl := range m.st.GroupLayouts {
+		m.fleetPage.savedGroups[gid] = savedGroup{
+			GroupID:      gl.GroupID,
+			InstanceName: gl.InstanceName,
+			Sessions:     gl.Sessions,
+			Layout:       gl.Layout,
+			PaneCount:    gl.PaneCount,
+		}
+	}
+}
+
+// pruneSavedGroupsForInstance drops saved layout entries for the given
+// instance whose group IDs no longer appear in the latest session
+// discovery. Called after each successful discovery so the next restart
+// doesn't resurrect layouts for groups the user has already deleted.
+func (m *model) pruneSavedGroupsForInstance(instKey string) {
+	if m.st == nil || m.fleetPage == nil {
+		return
+	}
+	parts := strings.SplitN(instKey, "/", 2)
+	if len(parts) != 2 {
+		return
+	}
+	instanceName := parts[1]
+	sanitized := SanitizeSessionName(instanceName)
+	disc, ok := m.sessions[instKey]
+	if !ok || disc == nil || disc.err != nil {
+		return
+	}
+	live := make(map[string]bool)
+	for _, s := range disc.sessions {
+		if gid, ok := parseGroupID(sanitized, s.Name); ok {
+			live[gid] = true
+		}
+	}
+	changed := false
+	for gid, sg := range m.fleetPage.savedGroups {
+		if sg.InstanceName != instanceName {
+			continue
+		}
+		if !live[gid] {
+			delete(m.fleetPage.savedGroups, gid)
+			delete(m.st.GroupLayouts, gid)
+			changed = true
+		}
+	}
+	if changed {
+		_ = state.Save(m.st)
+	}
+}
+
+// pruneOrphanedSavedGroups drops saved layout entries whose instance no
+// longer exists in state (e.g. the instance was deleted while fleet
+// wasn't running). Called once at startup.
+func (m *model) pruneOrphanedSavedGroups() {
+	if m.st == nil || m.fleetPage == nil {
+		return
+	}
+	live := make(map[string]bool)
+	for _, f := range m.st.Fleets {
+		for _, inst := range f.Instances {
+			live[inst.Name] = true
+		}
+	}
+	changed := false
+	for gid, sg := range m.fleetPage.savedGroups {
+		if !live[sg.InstanceName] {
+			delete(m.fleetPage.savedGroups, gid)
+			delete(m.st.GroupLayouts, gid)
+			changed = true
+		}
+	}
+	if changed {
+		_ = state.Save(m.st)
 	}
 }
 
@@ -530,6 +621,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					delete(m.lastActive, key)
 				}
 			}
+			for key := range msg.discovered {
+				m.pruneSavedGroupsForInstance(key)
+			}
 		}
 		extraCmds = append(extraCmds, m.sessionDiscoveryLoop())
 
@@ -578,6 +672,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.sessions[msg.instanceKey] = &sessionDiscovery{err: msg.err, fetchedAt: time.Now()}
 		} else {
 			m.sessions[msg.instanceKey] = &sessionDiscovery{sessions: msg.sessions, fetchedAt: time.Now()}
+			m.pruneSavedGroupsForInstance(msg.instanceKey)
 		}
 
 	case sessionCreatedMsg:
@@ -728,9 +823,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // and port forwards.
 func (m model) View() string {
 	if m.quitting {
-		// Clean up split panes via the fleet page
+		// Clean up split panes via the fleet page. Snapshot the current
+		// tmux layout BEFORE killing panes so pane-size changes made
+		// since the last group switch are persisted and replayed on the
+		// next fleet startup.
 		fp := m.fleetPage
 		if fp.splitPaneID != "" {
+			fp.saveCurrentGroupLayout(m.st)
 			killAllSplitPanes()
 		}
 		m.portForwards.Shutdown()

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -652,7 +652,7 @@ func (fp *fleetPage) handleEnter(m *model) tea.Cmd {
 				fp.activeGroupID = ""
 			}
 			if fp.splitPaneID != "" && fp.splitInstance == inst.Name && groupID != "" && groupID == fp.activeGroupID {
-				fp.saveCurrentGroupLayout()
+				fp.saveCurrentGroupLayout(m.st)
 				killAllSplitPanes()
 				unbindHostSplitKeys()
 				fp.splitPaneID = ""
@@ -663,7 +663,7 @@ func (fp *fleetPage) handleEnter(m *model) tea.Cmd {
 				return nil
 			}
 			if fp.splitPaneID != "" && fp.activeGroupID != "" {
-				fp.saveCurrentGroupLayout()
+				fp.saveCurrentGroupLayout(m.st)
 				killAllSplitPanes()
 			}
 			fp.activeGroupID = groupID
@@ -706,7 +706,7 @@ func (fp *fleetPage) handleEnter(m *model) tea.Cmd {
 				fp.activeGroupID = ""
 			}
 			if fp.splitPaneID != "" && fp.splitInstance == inst.Name {
-				fp.saveCurrentGroupLayout()
+				fp.saveCurrentGroupLayout(m.st)
 				killAllSplitPanes()
 				unbindHostSplitKeys()
 				fp.splitPaneID = ""
@@ -1446,7 +1446,7 @@ func (fp *fleetPage) commitGroupCycle(m *model) tea.Cmd {
 	targetGroupID := fp.pendingGroupID
 	fp.pendingGroupID = ""
 
-	fp.saveCurrentGroupLayout()
+	fp.saveCurrentGroupLayout(m.st)
 	killAllSplitPanes()
 
 	fp.activeGroupID = targetGroupID

--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -272,8 +273,10 @@ func paneSessionOrder() []string {
 
 // saveCurrentGroupLayout saves the active group's outer tmux layout so
 // it can be restored later. Pane titles (set by fleet shell) are read
-// in pane index order to preserve the session-to-position mapping.
-func (fp *fleetPage) saveCurrentGroupLayout() {
+// in pane index order to preserve the session-to-position mapping. When
+// st is non-nil the layout is also mirrored into state.json so it
+// survives a fleet restart.
+func (fp *fleetPage) saveCurrentGroupLayout(st *state.State) {
 	if fp.activeGroupID == "" || fp.splitInstance == "" {
 		return
 	}
@@ -286,13 +289,29 @@ func (fp *fleetPage) saveCurrentGroupLayout() {
 		sessionNames = []string{fp.splitSession}
 	}
 
-	fp.savedGroups[fp.activeGroupID] = savedGroup{
+	sg := savedGroup{
 		GroupID:      fp.activeGroupID,
 		InstanceName: fp.splitInstance,
 		Sessions:     sessionNames,
 		Layout:       tmuxLayoutString(),
 		PaneCount:    len(sessionNames),
 	}
+	fp.savedGroups[fp.activeGroupID] = sg
+
+	if st == nil {
+		return
+	}
+	if st.GroupLayouts == nil {
+		st.GroupLayouts = make(map[string]state.GroupLayout)
+	}
+	st.GroupLayouts[fp.activeGroupID] = state.GroupLayout{
+		GroupID:      sg.GroupID,
+		InstanceName: sg.InstanceName,
+		Sessions:     sg.Sessions,
+		Layout:       sg.Layout,
+		PaneCount:    sg.PaneCount,
+	}
+	_ = state.Save(st)
 }
 
 // restoreGroupCmd recreates outer tmux panes for a saved session group.


### PR DESCRIPTION
## Summary
- Saved pane layouts lived only in `fleetPage.savedGroups` (in-memory), so restarting `fleet` lost the split orientation and pane sizes — on the next group open, `restoreGroupCmd` fell back to its default placeholder layout (TUI + one `-h` pane, subsequent panes stacked `-v`), which is what issue #16 describes.
- Mirror `savedGroups` into `state.json` via a new `GroupLayouts map[string]GroupLayout` field on `state.State`. The field holds the tmux `window_layout` string plus the pane→session ordering.
- `saveCurrentGroupLayout` now takes `*state.State`, writes through to the map, and calls `state.Save`. Triggered as before on group switch / split close, plus a new call from `View()`'s quit path so pane-resize changes made since the last lifecycle event are captured on exit.
- On startup, `newModel` hydrates `savedGroups` from disk and then drops entries whose instance no longer exists (`pruneOrphanedSavedGroups`).
- Per-instance pruning runs in the `sessionDiscoveryMsg` and `sessionsMsg` handlers: whenever a successful discovery arrives, any saved group for that instance whose ID is no longer in the live session list is dropped and `state.json` is rewritten. This keeps stale layouts from piling up after session deletes.

Fixes #16

## Test plan
- [ ] Unit: `go test ./internal/state/... ./internal/tui/...` passes.
- [ ] Manual: open a session group, split vertically with `"` and/or horizontally with `%`, resize the panes, quit fleet, relaunch, re-open the group — panes come back with the same orientation and sizes.
- [ ] Manual: delete all sessions in a group while expanded; confirm the matching entry disappears from `~/.fleet/state.json` after the next discovery tick.
- [ ] Manual: delete an instance that had a saved layout, restart fleet, confirm the orphaned entry is pruned from `state.json`.
- [ ] CI: build + vet + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)