### PR TITLE
fix: keep savedGroups in sync with tmux via discovery poll

### DIFF
--- a/integration/tests/290_tui_pane_layout_poll.sh
+++ b/integration/tests/290_tui_pane_layout_poll.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Description: Pane layout stays in sync with tmux via the discovery poll (%/Ctrl+Q coverage).
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+# ---------------------------------------------------------------------------
+# Regression test for the spotty-save behaviour in v0.16.0: saves only
+# happened on close-toggle / switch / clean-quit, so panes added via %
+# (which go through the outer tmux binding, not fleet) or panes killed
+# via Ctrl+Q (same) left savedGroups and state.json stale. The fix
+# piggybacks a re-snapshot onto the 1 s sessionDiscoveryMsg tick.
+#
+# This test exercises three assertions against state.json:
+#
+#   1. Opening a group with no close/quit eventually produces a saved
+#      entry — i.e. the poll is actually running.
+#   2. Adding a pane via `fleet shell --group` (what the % binding
+#      does) bumps paneCount on the next tick.
+#   3. An external kill-pane -a (what the Ctrl+Q binding does) does
+#      NOT clobber the pre-kill snapshot — the last tick before the
+#      kill captured it.
+# ---------------------------------------------------------------------------
+
+tui_spawn
+tui_wait_for "alpha" 15
+tui_wait_for "○ idle" 60
+
+tui_send j
+sleep 0.5
+tui_send Space
+tui_wait_for "+ new session" 15
+
+info "Open the first group pane"
+tui_send Enter
+tui_wait_for_pane 2 20
+
+# Discover the group ID from the TUI — the random 6-hex token rendered
+# on the session row. Same trick as 280_tui_pane_layout_persist.sh.
+info "Wait for the group session row to render"
+deadline=$(( $(date +%s) + 20 ))
+group_id=""
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  screen=$(tui_capture_pane 0)
+  candidate=$(printf '%s' "${screen}" | grep -oE '\<[a-f0-9]{6}\>' | head -1 || true)
+  if [ -n "${candidate}" ]; then
+    group_id="${candidate}"
+    break
+  fi
+  sleep 0.5
+done
+if [ -z "${group_id}" ]; then
+  printf -- '--- pane 0 ---\n%s\n--- end ---\n' "$(tui_capture_pane 0)" >&2
+  fail "could not discover group id"
+fi
+info "group id: ${group_id}"
+
+# ---------------------------------------------------------------------------
+# Assertion 1: poll persists the group without any explicit close/quit.
+#
+# Before the fix, state.json would only gain groupLayouts[<gid>] after
+# the user toggled the split off or quit fleet cleanly. With the poll,
+# opening is enough: the next tick snapshots and saves.
+# ---------------------------------------------------------------------------
+info "Wait for discovery poll to persist the group (no close/quit)"
+deadline=$(( $(date +%s) + 10 ))
+found=""
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  if [ -f "${HOME}/.fleet/state.json" ] \
+     && grep -q "\"${group_id}\"" "${HOME}/.fleet/state.json"; then
+    found=1
+    break
+  fi
+  sleep 0.5
+done
+[ -n "${found}" ] || fail "poll tick did not persist group before any close"
+info "group recorded in state.json"
+
+# ---------------------------------------------------------------------------
+# Assertion 2: a pane added via `fleet shell --group` (what the %
+# binding does) gets picked up on the next poll.
+# ---------------------------------------------------------------------------
+info "Add a second pane to the group (mimics %/\" binding)"
+tmux split-window -h -t "${TUI_SESSION}:.1" \
+  "env TERM=xterm-256color ${FLEET_BIN} shell ${FIXTURE_REPO_NAME}/alpha --group ${group_id}"
+tui_wait_for_pane 3 20
+
+info "Wait for discovery poll to capture new pane count"
+deadline=$(( $(date +%s) + 15 ))
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  if grep -q '"paneCount": 2' "${HOME}/.fleet/state.json"; then
+    break
+  fi
+  sleep 0.5
+done
+if ! grep -q '"paneCount": 2' "${HOME}/.fleet/state.json"; then
+  printf -- '--- state.json ---\n%s\n--- end ---\n' "$(cat "${HOME}/.fleet/state.json")" >&2
+  fail "discovery poll did not capture new pane count (expected paneCount: 2)"
+fi
+info "new pane count captured"
+
+# ---------------------------------------------------------------------------
+# Assertion 3: an external kill-pane -a (what Ctrl+Q does) does NOT
+# erase the pre-kill snapshot. The tick AFTER the kill detects
+# !splitOpen() and clears the transient tracking fields, but
+# savedGroups[<gid>] was already saved by the tick BEFORE the kill.
+# ---------------------------------------------------------------------------
+info "Kill split panes via tmux (what the Ctrl+Q binding does)"
+tmux select-pane -t "${TUI_SESSION}:.0"
+tmux kill-pane -a -t "${TUI_SESSION}"
+tui_wait_for_pane 1 10
+
+# Let at least one more discovery tick run so the TUI processes the
+# external kill. The clear-transient-fields path should NOT touch
+# groupLayouts — if a regression puts a save there, this check catches it.
+sleep 2
+
+state=$(cat "${HOME}/.fleet/state.json")
+assert_contains "${state}" "\"${group_id}\"" \
+  "group entry should survive external kill"
+assert_contains "${state}" '"paneCount": 2' \
+  "pre-kill pane count should survive external kill"
+
+pass "Pane layout syncs with tmux via discovery poll (%/Ctrl+Q coverage)"

--- a/internal/tui/groups.go
+++ b/internal/tui/groups.go
@@ -38,6 +38,25 @@ type savedGroup struct {
 	PaneCount    int      // number of shell panes (excluding TUI)
 }
 
+// sameSavedGroup reports whether two savedGroup values are byte-identical.
+// Used by saveCurrentGroupLayout to skip redundant writes on poll ticks
+// when the user hasn't changed anything.
+func sameSavedGroup(a, b savedGroup) bool {
+	if a.GroupID != b.GroupID ||
+		a.InstanceName != b.InstanceName ||
+		a.Layout != b.Layout ||
+		a.PaneCount != b.PaneCount ||
+		len(a.Sessions) != len(b.Sessions) {
+		return false
+	}
+	for i := range a.Sessions {
+		if a.Sessions[i] != b.Sessions[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // groupSessionName builds a session name for the root session of a new group.
 func groupSessionName(sanitizedInstance, groupID string) string {
 	return sanitizedInstance + groupSep + groupID

--- a/internal/tui/groups_test.go
+++ b/internal/tui/groups_test.go
@@ -1,0 +1,109 @@
+package tui
+
+import "testing"
+
+// TestSameSavedGroupEqual confirms byte-identical savedGroups compare equal.
+// The diff gate in saveCurrentGroupLayout depends on this being true so
+// that idle discovery ticks don't rewrite state.json.
+func TestSameSavedGroupEqual(t *testing.T) {
+	a := savedGroup{
+		GroupID:      "abc123",
+		InstanceName: "alpha",
+		Sessions:     []string{"alpha~abc123", "alpha~abc123~ff00"},
+		Layout:       "4fe2,140x40,0,0{...}",
+		PaneCount:    2,
+	}
+	b := savedGroup{
+		GroupID:      "abc123",
+		InstanceName: "alpha",
+		Sessions:     []string{"alpha~abc123", "alpha~abc123~ff00"},
+		Layout:       "4fe2,140x40,0,0{...}",
+		PaneCount:    2,
+	}
+	if !sameSavedGroup(a, b) {
+		t.Fatalf("identical savedGroups reported unequal")
+	}
+}
+
+// TestSameSavedGroupFieldDifferences verifies every scalar field
+// participates in the comparison. If any field is dropped from
+// sameSavedGroup, the corresponding subtest fails and the poll loop
+// silently stops persisting that kind of change.
+func TestSameSavedGroupFieldDifferences(t *testing.T) {
+	base := savedGroup{
+		GroupID:      "abc123",
+		InstanceName: "alpha",
+		Sessions:     []string{"alpha~abc123"},
+		Layout:       "L",
+		PaneCount:    1,
+	}
+	cases := []struct {
+		name string
+		mut  func(*savedGroup)
+	}{
+		{"GroupID", func(g *savedGroup) { g.GroupID = "other" }},
+		{"InstanceName", func(g *savedGroup) { g.InstanceName = "beta" }},
+		{"Layout", func(g *savedGroup) { g.Layout = "L2" }},
+		{"PaneCount", func(g *savedGroup) { g.PaneCount = 2 }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := base
+			tc.mut(&b)
+			if sameSavedGroup(base, b) {
+				t.Fatalf("sameSavedGroup returned true when %s differed", tc.name)
+			}
+		})
+	}
+}
+
+// TestSameSavedGroupSessionsDiffer covers slice-content and slice-length
+// differences, which the scalar loop above can't express without a
+// helper.
+func TestSameSavedGroupSessionsDiffer(t *testing.T) {
+	base := savedGroup{
+		GroupID:      "abc123",
+		InstanceName: "alpha",
+		Sessions:     []string{"alpha~abc123", "alpha~abc123~ff00"},
+		Layout:       "L",
+		PaneCount:    2,
+	}
+
+	t.Run("different element", func(t *testing.T) {
+		b := base
+		b.Sessions = []string{"alpha~abc123", "alpha~abc123~aaaa"}
+		if sameSavedGroup(base, b) {
+			t.Fatal("sameSavedGroup ignored a session content change")
+		}
+	})
+
+	t.Run("shorter slice", func(t *testing.T) {
+		b := base
+		b.Sessions = []string{"alpha~abc123"}
+		b.PaneCount = 1 // keep scalars aligned — otherwise the scalar check short-circuits
+		if sameSavedGroup(base, b) {
+			t.Fatal("sameSavedGroup ignored a session length change")
+		}
+	})
+
+	t.Run("longer slice", func(t *testing.T) {
+		b := base
+		b.Sessions = []string{"alpha~abc123", "alpha~abc123~ff00", "alpha~abc123~bbbb"}
+		b.PaneCount = 3
+		if sameSavedGroup(base, b) {
+			t.Fatal("sameSavedGroup ignored a session length change")
+		}
+	})
+}
+
+// TestSameSavedGroupNilVsEmpty documents that nil and empty Sessions
+// slices compare equal — both have length zero and the content loop
+// never runs. saveCurrentGroupLayout only ever assigns non-nil slices,
+// so the distinction doesn't matter in practice.
+func TestSameSavedGroupNilVsEmpty(t *testing.T) {
+	a := savedGroup{GroupID: "g", InstanceName: "i", Sessions: nil, Layout: "L"}
+	b := savedGroup{GroupID: "g", InstanceName: "i", Sessions: []string{}, Layout: "L"}
+	if !sameSavedGroup(a, b) {
+		t.Fatal("nil and empty Sessions slices should compare equal")
+	}
+}

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -110,7 +110,18 @@ func (fp *fleetPage) Update(m *model, msg tea.Msg) tea.Cmd {
 	switch msg.(type) {
 	case sessionDiscoveryMsg:
 		fp.buildRows(m)
-		// Detect when panes were killed externally
+		// While a split is open, re-snapshot the active group's tmux
+		// layout into savedGroups on every tick. This keeps the map
+		// honest against mutations that bypass fleet's handlers —
+		// %/" adds new panes via a tmux binding, mouse drag resizes,
+		// Ctrl+Q/O closes without notifying fleet. The save is
+		// diff-gated so idle ticks don't hit disk.
+		if fp.splitPaneID != "" && fp.activeGroupID != "" && splitOpen() {
+			fp.saveCurrentGroupLayout(m.st)
+		}
+		// Detect when panes were killed externally. savedGroups already
+		// holds the pre-kill snapshot from the tick before, so clearing
+		// transient fields here loses nothing.
 		if fp.splitPaneID != "" && !splitOpen() {
 			unbindHostSplitKeys()
 			fp.splitPaneID = ""

--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -296,6 +296,13 @@ func (fp *fleetPage) saveCurrentGroupLayout(st *state.State) {
 		Layout:       tmuxLayoutString(),
 		PaneCount:    len(sessionNames),
 	}
+
+	// No-op when nothing changed. The discovery tick fires this every
+	// second; without this gate an idle split would rewrite state.json
+	// on every tick with identical bytes.
+	if existing, ok := fp.savedGroups[fp.activeGroupID]; ok && sameSavedGroup(existing, sg) {
+		return
+	}
 	fp.savedGroups[fp.activeGroupID] = sg
 
 	if st == nil {


### PR DESCRIPTION
## Summary
- `saveCurrentGroupLayout` only ran on explicit TUI events (close-toggle, group switch, clean quit). Anything that mutated panes outside the TUI left `savedGroups` stale or missing:
  - `Ctrl+Q` / `Ctrl+O` kill bindings (`splitpane.go:181-184`) run `tmux kill-pane -a` directly
  - `%` / `"` add panes via `fleet shell --group` via an outer tmux binding
  - Mouse-drag pane resizes
- Re-opening the same group — even within a single fleet process — then pulled the stale layout. Follow-up to #22.
- Piggyback the save onto the 1s `sessionDiscoveryMsg` tick: while a split is open, re-snapshot `savedGroups[activeGroupID]` from tmux. The last tick before an external kill captures the true state, so the existing clear-on-external-kill path loses nothing.
- Diff-gate via `sameSavedGroup` so idle ticks don't rewrite `state.json` with identical bytes.

## Test plan
- [x] Manual: open a group, `%` to split, drag to resize, `Ctrl+Q`, reopen — layout matches what was on screen.
- [x] Manual: save state in `~/.fleet/state.json` now reflects pane adds/resizes after Ctrl+Q, not just clean-close.
- [x] CI: existing 280 integration test (save-on-quit path) continues to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)