### PR TITLE
feat: nav — shift+j/k jumps between instance rows + Ctrl+Shift+H refocuses TUI pane

### DIFF
--- a/integration/tests/300_tui_nav_shift_jump.sh
+++ b/integration/tests/300_tui_nav_shift_jump.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Description: TUI shift+j/k jumps between instance rows skipping session rows and wrapping
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+
+# ===========================================
+# Bring up two instances so there are two instance rows to jump between.
+# ===========================================
+info "bringing up first instance (alpha)"
+fleet_up alpha
+
+info "bringing up second instance (beta)"
+fleet_up beta
+
+tui_spawn
+tui_wait_for "${FIXTURE_REPO_NAME} (2)" 30
+tui_wait_for "alpha" 15
+tui_wait_for "beta" 15
+tui_wait_for "○ idle" 60
+
+# ===========================================
+# Helpers
+# ===========================================
+# The selected row is rendered with a literal "> " prefix inside the list
+# box border. Find the one line on screen containing "> " and assert it
+# also contains `needle`.
+assert_cursor_on() {
+  local needle="$1"; local msg="${2:-cursor not on expected row}"
+  local screen cursor_line
+  screen=$(tui_capture)
+  cursor_line=$(printf '%s\n' "${screen}" | grep -F '> ' | head -1 || true)
+  if ! printf '%s' "${cursor_line}" | grep -qF -- "${needle}"; then
+    printf -- '--- screen ---\n%s\n--- end ---\n' "${screen}" >&2
+    fail "${msg}: needle=[${needle}] cursor_line=[${cursor_line}]"
+  fi
+}
+
+# ===========================================
+# Seed cursor on alpha, then expand alpha so the row list contains a
+# non-instance "+ new session" row between alpha and beta. This lets us
+# prove that shift+j actually skips it, not just mimics plain j.
+# ===========================================
+info "moving cursor down from header to alpha"
+tui_send j
+sleep 0.3
+assert_cursor_on "alpha" "cursor should be on alpha after 1× j"
+
+info "expanding alpha so + new session row appears between alpha and beta"
+tui_send Space
+tui_wait_for "+ new session" 15
+assert_cursor_on "alpha" "cursor should remain on alpha after expand"
+
+# ===========================================
+# shift+j / shift+k — capital-letter form
+# ===========================================
+info "shift+J from alpha should jump over + new session to beta"
+tui_send J
+sleep 0.3
+assert_cursor_on "beta" "J should skip + new session and land on beta"
+
+info "shift+J from beta should wrap past settings/header to alpha"
+tui_send J
+sleep 0.3
+assert_cursor_on "alpha" "J should wrap from last instance to first"
+
+info "shift+K from alpha should wrap backward past header/settings to beta"
+tui_send K
+sleep 0.3
+assert_cursor_on "beta" "K should wrap from first instance to last"
+
+info "shift+K from beta should skip + new session and land on alpha"
+tui_send K
+sleep 0.3
+assert_cursor_on "alpha" "K should skip + new session and land on alpha"
+
+# ===========================================
+# shift+arrow form — proves the shift+Up / shift+Down keybinding path too
+# ===========================================
+info "shift+Down from alpha should jump over + new session to beta"
+tui_send S-Down
+sleep 0.3
+assert_cursor_on "beta" "shift+Down should skip + new session and land on beta"
+
+info "shift+Up from beta should jump back over + new session to alpha"
+tui_send S-Up
+sleep 0.3
+assert_cursor_on "alpha" "shift+Up should skip + new session and land on alpha"
+
+pass "TUI shift+j/k jumps between instance rows with wrapping"

--- a/integration/tests/310_tui_focus_tui_pane.sh
+++ b/integration/tests/310_tui_focus_tui_pane.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Description: TUI installs a C-S-h binding that refocuses the fleet TUI pane
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+tui_spawn
+tui_wait_for "alpha" 15
+tui_wait_for "○ idle" 60
+
+# ===========================================
+# 1. Binding is installed at the root key table.
+# ===========================================
+info "asserting Ctrl+Shift+H is bound at the root table"
+# tmux normalises the modifier order, so "C-S-h" is listed as "S-C-h".
+# Match either spelling defensively in case newer tmux versions change
+# the canonical form.
+keys=$(tmux list-keys -T root 2>/dev/null || true)
+csh_line=$(printf '%s\n' "${keys}" | grep -E '(^| )(S-C-h|C-S-h)( |$)' | head -1 || true)
+if [ -z "${csh_line}" ]; then
+  printf -- '--- list-keys root ---\n%s\n--- end ---\n' "${keys}" >&2
+  fail "Ctrl+Shift+H binding missing from root table"
+fi
+info "binding: ${csh_line}"
+assert_contains "${csh_line}" "select-pane" "Ctrl+Shift+H should run select-pane"
+assert_contains "${csh_line}" ":.0" "Ctrl+Shift+H should target pane 0 of the current window"
+
+# ===========================================
+# 2. Open a shell split so the active pane moves away from the TUI.
+# ===========================================
+info "moving cursor to alpha and opening a shell split"
+tui_send j
+sleep 0.3
+tui_send Enter
+tui_wait_for_pane 2 20
+sleep 0.5
+
+active_idx=$(tmux display-message -t "${TUI_SESSION}" -p '#{pane_index}')
+info "active pane after opening split: index=${active_idx}"
+if [ "${active_idx}" = "0" ]; then
+  fail "expected the split to take focus, still on pane 0 (TUI)"
+fi
+
+# ===========================================
+# 3. Invoking the same command the binding would run must refocus the
+#    TUI pane. send-keys cannot trigger tmux bindings (it delivers keys
+#    straight to the pane, bypassing the key table), so this is the
+#    closest check we can make without a real terminal emulator driving
+#    the tmux client.
+# ===========================================
+info "running the binding's command directly: select-pane -t :.0"
+tmux select-pane -t "${TUI_SESSION}:.0"
+sleep 0.3
+active_idx=$(tmux display-message -t "${TUI_SESSION}" -p '#{pane_index}')
+info "active pane after select-pane: index=${active_idx}"
+assert_equals "0" "${active_idx}" "select-pane -t :.0 must focus the TUI pane"
+
+# ===========================================
+# 4. The split still exists — refocusing didn't destroy it.
+# ===========================================
+assert_equals "2" "$(tui_pane_count)" "refocus must not close the split pane"
+
+pass "C-S-h binding installed and refocuses the TUI pane"

--- a/integration/tests/310_tui_focus_tui_pane.sh
+++ b/integration/tests/310_tui_focus_tui_pane.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Description: TUI installs a C-S-h binding that refocuses the fleet TUI pane
+# Description: TUI installs a prefix + H binding that refocuses the fleet TUI pane
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
@@ -14,21 +14,18 @@ tui_wait_for "alpha" 15
 tui_wait_for "○ idle" 60
 
 # ===========================================
-# 1. Binding is installed at the root key table.
+# 1. Binding is installed in the prefix key table.
 # ===========================================
-info "asserting Ctrl+Shift+H is bound at the root table"
-# tmux normalises the modifier order, so "C-S-h" is listed as "S-C-h".
-# Match either spelling defensively in case newer tmux versions change
-# the canonical form.
-keys=$(tmux list-keys -T root 2>/dev/null || true)
-csh_line=$(printf '%s\n' "${keys}" | grep -E '(^| )(S-C-h|C-S-h)( |$)' | head -1 || true)
-if [ -z "${csh_line}" ]; then
-  printf -- '--- list-keys root ---\n%s\n--- end ---\n' "${keys}" >&2
-  fail "Ctrl+Shift+H binding missing from root table"
+info "asserting prefix + H is bound in the prefix table"
+keys=$(tmux list-keys -T prefix 2>/dev/null || true)
+h_line=$(printf '%s\n' "${keys}" | grep -E '(^| )H( |$)' | head -1 || true)
+if [ -z "${h_line}" ]; then
+  printf -- '--- list-keys prefix ---\n%s\n--- end ---\n' "${keys}" >&2
+  fail "prefix + H binding missing from prefix table"
 fi
-info "binding: ${csh_line}"
-assert_contains "${csh_line}" "select-pane" "Ctrl+Shift+H should run select-pane"
-assert_contains "${csh_line}" ":.0" "Ctrl+Shift+H should target pane 0 of the current window"
+info "binding: ${h_line}"
+assert_contains "${h_line}" "select-pane" "prefix + H should run select-pane"
+assert_contains "${h_line}" ":.0" "prefix + H should target pane 0 of the current window"
 
 # ===========================================
 # 2. Open a shell split so the active pane moves away from the TUI.
@@ -65,4 +62,4 @@ assert_equals "0" "${active_idx}" "select-pane -t :.0 must focus the TUI pane"
 # ===========================================
 assert_equals "2" "$(tui_pane_count)" "refocus must not close the split pane"
 
-pass "C-S-h binding installed and refocuses the TUI pane"
+pass "prefix + H binding installed and refocuses the TUI pane"

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -113,6 +113,7 @@ func newModel() model {
 	if m.inHostTmux {
 		bindHostSessionCycleKeys()
 		bindHostCloseKeys()
+		bindRefocusTUIKey()
 		// Neutralise default split bindings so the user doesn't
 		// accidentally open a host shell before selecting an instance.
 		// These will be rebound to connect to the active instance
@@ -858,6 +859,7 @@ func (m model) View() string {
 			unbindHostSessionCycleKeys()
 			unbindHostSplitKeys()
 			unbindHostCloseKeys()
+			unbindRefocusTUIKey()
 		}
 		return ""
 	}

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -262,6 +262,26 @@ func (fp *fleetPage) moveCursor(delta int) {
 	fp.cursor = (fp.cursor + delta + len(fp.rows)) % len(fp.rows)
 }
 
+// moveCursorToInstance moves the cursor to the next (delta > 0) or previous
+// (delta < 0) instance row, wrapping around. If the row list contains no
+// instance rows, the cursor is left unchanged.
+func (fp *fleetPage) moveCursorToInstance(delta int) {
+	n := len(fp.rows)
+	if n == 0 || delta == 0 {
+		return
+	}
+	step := 1
+	if delta < 0 {
+		step = -1
+	}
+	for range n {
+		fp.cursor = (fp.cursor + step + n) % n
+		if fp.rows[fp.cursor].kind == rowInstance {
+			return
+		}
+	}
+}
+
 // currentFleetName returns the fleet name for the row at the cursor.
 func (fp *fleetPage) currentFleetName() string {
 	r := fp.currentRow()
@@ -313,6 +333,12 @@ func (fp *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 
 		case "down", "j":
 			fp.moveCursor(1)
+
+		case "shift+up", "K":
+			fp.moveCursorToInstance(-1)
+
+		case "shift+down", "J":
+			fp.moveCursorToInstance(1)
 
 		case " ", "tab":
 			if r := fp.currentRow(); r != nil {

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -475,3 +475,160 @@ func TestEditInstanceRejectsEmptyName(t *testing.T) {
 		t.Fatalf("dialog closed prematurely; mode = %v", fp.mode)
 	}
 }
+
+// TestMoveCursorToInstanceSkipsBetweenInstances verifies that shift-jump
+// navigation lands on the next instance row, skipping sessions, headers,
+// and settings rows in between.
+func TestMoveCursorToInstanceSkipsBetweenInstances(t *testing.T) {
+	inst1 := &fleet.Instance{Name: "agent-1"}
+	inst2 := &fleet.Instance{Name: "agent-2"}
+	fp := newFleetPage()
+	fp.rows = []row{
+		{kind: rowFleetHeader, fleetName: "alpha"},      // 0
+		{kind: rowInstance, fleetName: "alpha", instance: inst1}, // 1
+		{kind: rowSession, fleetName: "alpha", instance: inst1, sessionName: "s1"}, // 2
+		{kind: rowSession, fleetName: "alpha", instance: inst1, sessionName: "s2"}, // 3
+		{kind: rowNewSession, fleetName: "alpha", instance: inst1}, // 4
+		{kind: rowInstance, fleetName: "alpha", instance: inst2}, // 5
+		{kind: rowSettings}, // 6
+	}
+
+	// Forward: from instance 1 should jump to instance 2.
+	fp.cursor = 1
+	fp.moveCursorToInstance(1)
+	if fp.cursor != 5 {
+		t.Fatalf("forward from instance: cursor = %d, want 5", fp.cursor)
+	}
+
+	// Forward: from a session row under instance 1 should also jump to instance 2.
+	fp.cursor = 3
+	fp.moveCursorToInstance(1)
+	if fp.cursor != 5 {
+		t.Fatalf("forward from session: cursor = %d, want 5", fp.cursor)
+	}
+
+	// Backward: from instance 2 should jump to instance 1.
+	fp.cursor = 5
+	fp.moveCursorToInstance(-1)
+	if fp.cursor != 1 {
+		t.Fatalf("backward from instance: cursor = %d, want 1", fp.cursor)
+	}
+
+	// Backward: from a session row under instance 1 should jump back to instance 1.
+	fp.cursor = 3
+	fp.moveCursorToInstance(-1)
+	if fp.cursor != 1 {
+		t.Fatalf("backward from session: cursor = %d, want 1", fp.cursor)
+	}
+}
+
+// TestMoveCursorToInstanceWraps verifies wrap-around in both directions when
+// the cursor would otherwise run past the ends of the row list.
+func TestMoveCursorToInstanceWraps(t *testing.T) {
+	inst1 := &fleet.Instance{Name: "agent-1"}
+	inst2 := &fleet.Instance{Name: "agent-2"}
+	fp := newFleetPage()
+	fp.rows = []row{
+		{kind: rowFleetHeader, fleetName: "alpha"},      // 0
+		{kind: rowInstance, fleetName: "alpha", instance: inst1}, // 1
+		{kind: rowInstance, fleetName: "alpha", instance: inst2}, // 2
+		{kind: rowSettings}, // 3
+	}
+
+	// Forward from last instance wraps past settings/header to first instance.
+	fp.cursor = 2
+	fp.moveCursorToInstance(1)
+	if fp.cursor != 1 {
+		t.Fatalf("forward wrap: cursor = %d, want 1", fp.cursor)
+	}
+
+	// Backward from first instance wraps past header/settings to last instance.
+	fp.cursor = 1
+	fp.moveCursorToInstance(-1)
+	if fp.cursor != 2 {
+		t.Fatalf("backward wrap: cursor = %d, want 2", fp.cursor)
+	}
+
+	// Forward from settings row (after the last instance) wraps to first instance.
+	fp.cursor = 3
+	fp.moveCursorToInstance(1)
+	if fp.cursor != 1 {
+		t.Fatalf("forward wrap from settings: cursor = %d, want 1", fp.cursor)
+	}
+
+	// Backward from header row (before the first instance) wraps to last instance.
+	fp.cursor = 0
+	fp.moveCursorToInstance(-1)
+	if fp.cursor != 2 {
+		t.Fatalf("backward wrap from header: cursor = %d, want 2", fp.cursor)
+	}
+}
+
+// TestMoveCursorToInstanceNoInstances verifies the cursor is left untouched
+// when there are no instance rows to jump to (e.g. all fleets collapsed).
+func TestMoveCursorToInstanceNoInstances(t *testing.T) {
+	fp := newFleetPage()
+	fp.rows = []row{
+		{kind: rowFleetHeader, fleetName: "alpha"},
+		{kind: rowFleetHeader, fleetName: "beta"},
+		{kind: rowSettings},
+	}
+
+	fp.cursor = 1
+	fp.moveCursorToInstance(1)
+	if fp.cursor != 1 {
+		t.Fatalf("no instances forward: cursor = %d, want 1", fp.cursor)
+	}
+	fp.moveCursorToInstance(-1)
+	if fp.cursor != 1 {
+		t.Fatalf("no instances backward: cursor = %d, want 1", fp.cursor)
+	}
+}
+
+// TestUpdateNormalShiftJumpKeys verifies that capital J/K and shift+arrow
+// keys dispatch to moveCursorToInstance via updateNormal.
+func TestUpdateNormalShiftJumpKeys(t *testing.T) {
+	inst1 := &fleet.Instance{Name: "agent-1"}
+	inst2 := &fleet.Instance{Name: "agent-2"}
+	fp := newFleetPage()
+	fp.rows = []row{
+		{kind: rowFleetHeader, fleetName: "alpha"},
+		{kind: rowInstance, fleetName: "alpha", instance: inst1},
+		{kind: rowSession, fleetName: "alpha", instance: inst1, sessionName: "s1"},
+		{kind: rowInstance, fleetName: "alpha", instance: inst2},
+		{kind: rowSettings},
+	}
+	m := &model{
+		st: &state.State{
+			Fleets: map[string]*fleet.Fleet{
+				"alpha": {Name: "alpha", Instances: []*fleet.Instance{inst1, inst2}},
+			},
+		},
+		fleetPage: fp,
+	}
+
+	// Capital J should jump forward to the next instance.
+	fp.cursor = 1
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'J'}})
+	if fp.cursor != 3 {
+		t.Fatalf("J: cursor = %d, want 3", fp.cursor)
+	}
+
+	// Capital K should jump backward to the previous instance.
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'K'}})
+	if fp.cursor != 1 {
+		t.Fatalf("K: cursor = %d, want 1", fp.cursor)
+	}
+
+	// shift+down should behave the same as J.
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyShiftDown})
+	if fp.cursor != 3 {
+		t.Fatalf("shift+down: cursor = %d, want 3", fp.cursor)
+	}
+
+	// shift+up should behave the same as K.
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyShiftUp})
+	if fp.cursor != 1 {
+		t.Fatalf("shift+up: cursor = %d, want 1", fp.cursor)
+	}
+}

--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -191,6 +191,21 @@ func unbindHostCloseKeys() {
 	_ = exec.Command("tmux", "unbind", "-n", "C-o").Run()
 }
 
+// bindRefocusTUIKey binds Ctrl+Shift+H on the outer tmux root table to
+// refocus the TUI pane (index 0 of the current window) from any split.
+// Many terminals collapse Ctrl+Shift+H to Ctrl+H (backspace) at the byte
+// level, so this only fires in terminals that send CSI u / modifyOtherKeys
+// (Kitty, WezTerm, Alacritty with modern config, recent iTerm2, ...).
+func bindRefocusTUIKey() {
+	_ = exec.Command("tmux", "bind-key", "-n", "C-S-h", "select-pane", "-t", ":.0").Run()
+}
+
+// unbindRefocusTUIKey removes the Ctrl+Shift+H binding from the outer
+// tmux root table.
+func unbindRefocusTUIKey() {
+	_ = exec.Command("tmux", "unbind", "-n", "C-S-h").Run()
+}
+
 // layoutTickMsg fires the fast layout poll. Unlike sessionDiscoveryMsg
 // (which pays a ~2-3s round-trip to devcontainer exec), this tick only
 // queries the outer tmux server — cheap local IPC — so it can run at

--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -191,19 +191,17 @@ func unbindHostCloseKeys() {
 	_ = exec.Command("tmux", "unbind", "-n", "C-o").Run()
 }
 
-// bindRefocusTUIKey binds Ctrl+Shift+H on the outer tmux root table to
-// refocus the TUI pane (index 0 of the current window) from any split.
-// Many terminals collapse Ctrl+Shift+H to Ctrl+H (backspace) at the byte
-// level, so this only fires in terminals that send CSI u / modifyOtherKeys
-// (Kitty, WezTerm, Alacritty with modern config, recent iTerm2, ...).
+// bindRefocusTUIKey binds prefix + Shift+H to refocus the TUI pane
+// (index 0 of the current window) from any split. Uses the prefix key
+// table rather than a root binding so it composes cleanly with other
+// tmux bindings and works across every terminal.
 func bindRefocusTUIKey() {
-	_ = exec.Command("tmux", "bind-key", "-n", "C-S-h", "select-pane", "-t", ":.0").Run()
+	_ = exec.Command("tmux", "bind-key", "H", "select-pane", "-t", ":.0").Run()
 }
 
-// unbindRefocusTUIKey removes the Ctrl+Shift+H binding from the outer
-// tmux root table.
+// unbindRefocusTUIKey removes the prefix + Shift+H binding.
 func unbindRefocusTUIKey() {
-	_ = exec.Command("tmux", "unbind", "-n", "C-S-h").Run()
+	_ = exec.Command("tmux", "unbind", "H").Run()
 }
 
 // layoutTickMsg fires the fast layout poll. Unlike sessionDiscoveryMsg


### PR DESCRIPTION
Closes #25

## Summary
Two small navigation quality-of-life changes bundled together.

### 1. `shift+j` / `shift+k` on the fleet list jumps between instance rows
- Holding Shift with `j`/`k` (or Down/Up) skips past session, header, and settings rows to land on the next instance row. Regular `j`/`k` still steps one row at a time.
- Wrapping is preserved: Shift+J past the last instance wraps to the first, Shift+K past the first wraps to the last.
- New helper `moveCursorToInstance` in `internal/tui/page_fleet.go` iterates with the same modulo wrap as `moveCursor`; if there are no instance rows it leaves the cursor alone.

### 2. `prefix + Shift+H` refocuses the fleet TUI pane
- Inside a shell split and want to jump back to the list? Hit `Ctrl+B` then `Shift+H` — focus returns to the TUI pane (pane 0 of the current window).
- Bound in the prefix key table, so it sidesteps the Ctrl+Shift+H terminal-encoding problem (many terminals collapse Ctrl+Shift+H to Ctrl+H at the byte level). Works across every terminal.
- Installed at TUI startup alongside the existing host bindings (`bindRefocusTUIKey` in `splitpane.go`); removed on shutdown.

## Test plan
- [x] Unit: `TestMoveCursorToInstanceSkipsBetweenInstances`
- [x] Unit: `TestMoveCursorToInstanceWraps`
- [x] Unit: `TestMoveCursorToInstanceNoInstances`
- [x] Unit: `TestUpdateNormalShiftJumpKeys`
- [x] Integration: `300_tui_nav_shift_jump.sh` — two real instances with the first expanded so `+ new session` sits between them; cursor tracked via the `> ` marker in the captured screen
- [x] Integration: `310_tui_focus_tui_pane.sh` — verifies the binding is registered in the prefix key table and that its target (`:.0`) resolves to the TUI pane after a shell split has taken focus
- [x] Manual: `prefix + Shift+H` refocuses the TUI pane from inside a shell split
- [x] `go test ./internal/tui/` green
- [x] `go build ./...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)