### PR TITLE
feat: add local_dir backend for container-less instances

### DIFF
--- a/integration/tests/070_local_dir_up_and_ls.sh
+++ b/integration/tests/070_local_dir_up_and_ls.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Description: `fleet up --backend local_dir` clones the repo, marks the instance running, and creates no docker container.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test
+
+info "fleet up alpha --backend local_dir"
+"${FLEET_BIN}" up alpha --repo "${FIXTURE_REPO_URL}" --backend local_dir
+
+info "fleet ls"
+ls_out=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+printf '%s\n' "${ls_out}"
+
+assert_contains "${ls_out}" "${FIXTURE_REPO_NAME}" "fleet name missing from ls output"
+assert_contains "${ls_out}" "alpha"               "instance name missing from ls output"
+assert_contains "${ls_out}" "running"             "instance status should be 'running'"
+
+# state.json must exist and record the local_dir backend.
+assert_file_exists "${HOME}/.fleet/state.json"
+state=$(cat "${HOME}/.fleet/state.json")
+assert_contains "${state}" "\"name\": \"alpha\""             "state.json missing instance entry"
+assert_contains "${state}" "\"status\": \"running\""         "state.json instance not running"
+assert_contains "${state}" "\"backend\": \"local_dir\""      "state.json missing local_dir backend marker"
+
+# The repo should have been cloned to the workspace dir.
+workspace_dir="${HOME}/.fleet/workspaces/${FIXTURE_REPO_NAME}/alpha/${FIXTURE_REPO_NAME}"
+assert_file_exists "${workspace_dir}"
+assert_file_exists "${workspace_dir}/.devcontainer/devcontainer.json"
+
+# No docker container should exist for this workspace dir — local_dir is
+# container-less. Skip silently if docker isn't on the runner.
+if command -v docker >/dev/null 2>&1; then
+  containers=$(docker ps -aq --filter "label=devcontainer.local_folder=${workspace_dir}" 2>/dev/null || true)
+  if [ -n "${containers}" ]; then
+    fail "local_dir instance unexpectedly created docker container(s): ${containers}"
+  fi
+fi
+
+pass "up + ls (local_dir)"

--- a/integration/tests/071_local_dir_exec.sh
+++ b/integration/tests/071_local_dir_exec.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Description: `fleet exec` runs commands directly on the host with cwd set to the workspace dir for local_dir.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test
+"${FLEET_BIN}" up alpha --repo "${FIXTURE_REPO_URL}" --backend local_dir
+
+workspace_dir="${HOME}/.fleet/workspaces/${FIXTURE_REPO_NAME}/alpha/${FIXTURE_REPO_NAME}"
+
+# Listing a workspace-relative file proves cwd was set correctly.
+info "fleet exec alpha -- ls .devcontainer/devcontainer.json"
+ls_out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- ls .devcontainer/devcontainer.json)
+assert_equals ".devcontainer/devcontainer.json" "${ls_out}" "exec cwd should be the workspace dir"
+
+# A simple echo must succeed.
+info "fleet exec alpha -- sh -c 'echo hello-from-local'"
+hello_out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- sh -c "echo hello-from-local")
+assert_equals "hello-from-local" "${hello_out}" "echo output"
+
+# Non-zero exits inside the command must propagate.
+info "fleet exec alpha -- sh -c 'exit 7' should fail"
+set +e
+"${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- sh -c "exit 7" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "${rc}" -eq 0 ]; then
+  fail "expected non-zero exit from 'exit 7', got 0"
+fi
+
+# The command runs on the host (not inside any container): a unique file
+# we create on the host in the workspace must be visible to a follow-up
+# exec, and a file created via exec must be visible on the host. This
+# would be impossible inside an isolated container.
+info "host <-> exec roundtrip via shared workspace dir"
+echo "host-side" > "${workspace_dir}/.host-marker"
+exec_seen=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- cat .host-marker)
+assert_equals "host-side" "${exec_seen}" "exec should see file written by host"
+
+"${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- sh -c "echo exec-side > .exec-marker"
+host_seen=$(cat "${workspace_dir}/.exec-marker")
+assert_equals "exec-side" "${host_seen}" "host should see file written by exec"
+
+pass "exec (local_dir)"

--- a/integration/tests/072_local_dir_stop_start_refused.sh
+++ b/integration/tests/072_local_dir_stop_start_refused.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Description: stateless local_dir backend rejects `fleet stop`; `fleet start` no-ops because the instance is always running.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test
+"${FLEET_BIN}" up alpha --repo "${FIXTURE_REPO_URL}" --backend local_dir
+
+# `fleet stop` must fail with a clear "does not support" error because
+# Stateful() returns false for local_dir.
+info "fleet stop alpha (should be refused)"
+set +e
+stop_out=$("${FLEET_BIN}" stop "${FIXTURE_REPO_NAME}/alpha" 2>&1)
+rc=$?
+set -e
+printf '%s\n' "${stop_out}"
+if [ "${rc}" -eq 0 ]; then
+  fail "fleet stop should fail for local_dir, got rc=0"
+fi
+assert_contains "${stop_out}" "does not support" "stop error should mention unsupported"
+
+# Status must remain running after a refused stop.
+ls_after_stop=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+assert_contains "${ls_after_stop}" "running" "status should still be running after refused stop"
+
+# `fleet start` is a no-op because the instance is already at the target
+# state ("running"). The lifecycle short-circuits before reaching the
+# Stateful check, so this returns success and prints the friendly message.
+info "fleet start alpha (already running, should no-op)"
+start_out=$("${FLEET_BIN}" start "${FIXTURE_REPO_NAME}/alpha")
+printf '%s\n' "${start_out}"
+assert_contains "${start_out}" "already running" "start should report already running"
+
+ls_after_start=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+assert_contains "${ls_after_start}" "running" "status should still be running after start no-op"
+
+pass "stop refused + start no-op (local_dir)"

--- a/integration/tests/073_local_dir_down.sh
+++ b/integration/tests/073_local_dir_down.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Description: `fleet down` on a local_dir instance removes the workspace dir and state entry without touching docker.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test
+"${FLEET_BIN}" up alpha --repo "${FIXTURE_REPO_URL}" --backend local_dir
+
+workspace_dir="${HOME}/.fleet/workspaces/${FIXTURE_REPO_NAME}/alpha/${FIXTURE_REPO_NAME}"
+assert_file_exists "${workspace_dir}"
+
+info "fleet down alpha"
+down_out=$("${FLEET_BIN}" down "${FIXTURE_REPO_NAME}/alpha")
+printf '%s\n' "${down_out}"
+assert_contains "${down_out}" "removed" "down should mention removed"
+
+# Workspace clone gone.
+assert_file_absent "${workspace_dir}"
+
+# State no longer has the instance.
+state=$(cat "${HOME}/.fleet/state.json")
+assert_not_contains "${state}" "\"name\": \"alpha\"" "instance should be removed from state"
+
+# `ls` no longer lists it.
+ls_out=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+assert_not_contains "${ls_out}" "alpha" "ls should not list removed instance"
+
+pass "down (local_dir)"

--- a/integration/tests/074_local_dir_skips_dotfiles.sh
+++ b/integration/tests/074_local_dir_skips_dotfiles.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Description: local_dir backend skips auto-install of dotfiles to avoid trampling the host environment.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test
+
+# Configure dotfiles auto-install with a URL that, if reached, would
+# fail loudly. local_dir must NOT attempt the clone — if it did, the
+# warn file would record a "dotfiles install failed" entry.
+mkdir -p "${HOME}/.fleet"
+cat > "${HOME}/.fleet/config.json" <<'JSON'
+{
+  "general_settings": {},
+  "agent_settings": {"tool_selection": "claude"},
+  "dotfiles_settings": {
+    "repo_url": "https://example.invalid/should-never-clone.git",
+    "install_script": "install.sh",
+    "auto_install": true
+  },
+  "coder_settings": {"template": ""},
+  "codespaces_settings": {}
+}
+JSON
+
+# A pre-existing host ~/dotfiles dir would normally cause the dotfiles
+# script to skip. Make sure there is nothing there so any attempted
+# clone is observable. Save and restore if one happens to exist.
+preserved_dotfiles=""
+if [ -e "${HOME}/dotfiles" ]; then
+  preserved_dotfiles="${HOME}/dotfiles.itest-bak.$$"
+  mv "${HOME}/dotfiles" "${preserved_dotfiles}"
+fi
+itest_cleanup() {
+  if [ -n "${preserved_dotfiles}" ] && [ -e "${preserved_dotfiles}" ]; then
+    rm -rf "${HOME}/dotfiles"
+    mv "${preserved_dotfiles}" "${HOME}/dotfiles"
+  fi
+}
+
+info "fleet up alpha --backend local_dir (with auto_install dotfiles configured)"
+"${FLEET_BIN}" up alpha --repo "${FIXTURE_REPO_URL}" --backend local_dir
+
+# No dotfiles clone should have been attempted on the host.
+assert_file_absent "${HOME}/dotfiles"
+
+# No warning file from a failed dotfiles install should exist.
+warn_path="${HOME}/.fleet/logs/${FIXTURE_REPO_NAME}-alpha.warn"
+if [ -e "${warn_path}" ]; then
+  printf -- '--- warn file ---\n%s\n--- end ---\n' "$(cat "${warn_path}")" >&2
+  fail "local_dir created a dotfiles warning file: ${warn_path}"
+fi
+
+# Sanity: instance is still running.
+ls_out=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+assert_contains "${ls_out}" "running" "instance should be running after dotfiles skip"
+
+pass "skips dotfiles (local_dir)"

--- a/integration/tests/075_local_dir_strips_tmux_env.sh
+++ b/integration/tests/075_local_dir_strips_tmux_env.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Description: local_dir exec scrubs $TMUX/$TMUX_PANE so a nested tmux can start cleanly.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test
+"${FLEET_BIN}" up alpha --repo "${FIXTURE_REPO_URL}" --backend local_dir
+
+# Simulate being launched from inside an outer tmux by setting TMUX/
+# TMUX_PANE in the env we pass to fleet. local_dir's exec must strip
+# them so a nested tmux invocation does not error with "sessions
+# should be nested with care".
+info "fleet exec sees \$TMUX scrubbed"
+seen_tmux=$(TMUX="/tmp/fake-tmux,1234,0" TMUX_PANE="%99" \
+  "${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- sh -c 'printf "%s" "${TMUX:-EMPTY}"')
+assert_equals "EMPTY" "${seen_tmux}" "TMUX should be unset inside local_dir exec"
+
+seen_pane=$(TMUX="/tmp/fake-tmux,1234,0" TMUX_PANE="%99" \
+  "${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- sh -c 'printf "%s" "${TMUX_PANE:-EMPTY}"')
+assert_equals "EMPTY" "${seen_pane}" "TMUX_PANE should be unset inside local_dir exec"
+
+# Sanity: other env vars still pass through (PATH must be present or
+# almost no command would work).
+seen_path=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- sh -c 'printf "%s" "${PATH:-MISSING}"')
+if [ "${seen_path}" = "MISSING" ] || [ -z "${seen_path}" ]; then
+  fail "PATH should pass through to local_dir exec, got: [${seen_path}]"
+fi
+
+# End-to-end: a real nested tmux command (the failure mode the user
+# hit) must succeed when invoked through local_dir exec from inside
+# a fake outer-tmux env. We start a detached session, list it, then
+# kill it. Skip if tmux isn't installed on the runner.
+if command -v tmux >/dev/null 2>&1; then
+  info "nested tmux start under fake outer TMUX"
+  socket_dir="$(mktemp -d)"
+  TMUX="/tmp/fake-tmux,1234,0" TMUX_PANE="%99" \
+    "${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- \
+    tmux -S "${socket_dir}/sock" new-session -d -s nested-itest 'sleep 5'
+  list_out=$(tmux -S "${socket_dir}/sock" list-sessions -F "#{session_name}" 2>&1 || true)
+  tmux -S "${socket_dir}/sock" kill-server >/dev/null 2>&1 || true
+  rm -rf "${socket_dir}"
+  assert_contains "${list_out}" "nested-itest" "nested tmux session should be listed"
+fi
+
+pass "strips TMUX env (local_dir)"

--- a/integration/tests/076_local_dir_no_host_session_leak.sh
+++ b/integration/tests/076_local_dir_no_host_session_leak.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Description: TUI session list for a local_dir instance does not leak unrelated host tmux sessions.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+
+HOST_SESSION="itest-host-leak-$$"
+
+itest_cleanup() {
+  tmux kill-session -t "${HOST_SESSION}" >/dev/null 2>&1 || true
+  tui_kill
+}
+itest_begin
+
+setup_test
+"${FLEET_BIN}" up alpha --repo "${FIXTURE_REPO_URL}" --backend local_dir
+
+# Spawn a host-side tmux session that does NOT match the instance's
+# session-name prefix. local_dir shares the host tmux server, so this
+# session would be visible to the instance unless the discovery code
+# filters by prefix.
+tmux new-session -d -s "${HOST_SESSION}" 'sleep 60'
+
+# Sanity: the host session exists.
+list=$(tmux list-sessions -F "#{session_name}" 2>/dev/null || true)
+assert_contains "${list}" "${HOST_SESSION}" "host tmux session should have been created"
+
+info "spawning fleet TUI"
+tui_spawn
+
+info "waiting for TUI to hydrate"
+tui_wait_for "alpha" 15
+
+info "moving cursor to alpha row and expanding"
+tui_send j
+sleep 0.5
+tui_send Space
+tui_wait_for "+ new session" 15
+
+# Wait for the session-discovery loop to tick at least once (1s cadence).
+sleep 2
+
+screen=$(tui_capture)
+printf -- '--- screen ---\n%s\n--- end ---\n' "${screen}"
+
+# The unrelated host session must NOT appear anywhere in the rendered
+# session list.
+if printf '%s' "${screen}" | grep -qF -- "${HOST_SESSION}"; then
+  fail "host tmux session ${HOST_SESSION} leaked into local_dir instance's session list"
+fi
+
+# The fleet TUI itself runs inside the outer tmux session named
+# "fleetman-itest" (set by tui_spawn). It must also be filtered out.
+if printf '%s' "${screen}" | grep -qF -- "fleetman-itest"; then
+  fail "outer fleet TUI tmux session 'fleetman-itest' leaked into instance's session list"
+fi
+
+pass "host tmux sessions filtered (local_dir)"

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -68,4 +68,10 @@ type Backend interface {
 	// describe instances that are always "running" — callers must not
 	// invoke Stop/Start and must not transition instance status.
 	Stateful() bool
+
+	// SupportsDotfiles reports whether dotfiles installation should be
+	// attempted for this backend's instances. False when the workspace is
+	// the host filesystem (where the user's real dotfiles already live and
+	// cloning into ~/dotfiles would interfere with the host environment).
+	SupportsDotfiles() bool
 }

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -62,4 +62,10 @@ type Backend interface {
 	// connections to hostname:port without spawning external processes.
 	// Returns ("", false) when the container is not directly reachable.
 	ResolveHostname(containerID string) (string, bool)
+
+	// Stateful reports whether the backend has lifecycle state, i.e.
+	// whether Stop and Start are meaningful. Backends that return false
+	// describe instances that are always "running" — callers must not
+	// invoke Stop/Start and must not transition instance status.
+	Stateful() bool
 }

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -74,4 +74,13 @@ type Backend interface {
 	// the host filesystem (where the user's real dotfiles already live and
 	// cloning into ~/dotfiles would interfere with the host environment).
 	SupportsDotfiles() bool
+
+	// SupportsAgentForwarding reports whether the SSH-agent socket needs
+	// to be re-pinned inside the workspace for stability across reattach.
+	// True for backends that cross an SSH/exec boundary (devcontainer,
+	// coder, codespaces) where each connection mints a fresh socket path.
+	// False for host-side backends (local_dir) where the user's real SSH
+	// agent is already directly accessible — attempting the relink would
+	// fail on system paths like /run/ssh-agent.sock.
+	SupportsAgentForwarding() bool
 }

--- a/internal/backend/coder/coder.go
+++ b/internal/backend/coder/coder.go
@@ -314,6 +314,10 @@ func (b *CoderBackend) Stateful() bool { return true }
 // dotfiles — each remote workspace is a distinct environment.
 func (b *CoderBackend) SupportsDotfiles() bool { return true }
 
+// SupportsAgentForwarding reports that the SSH agent socket should be
+// re-pinned inside Coder workspaces — each ssh connection creates a new socket.
+func (b *CoderBackend) SupportsAgentForwarding() bool { return true }
+
 // EditorURI returns a VS Code URI for connecting to a Coder workspace.
 func (b *CoderBackend) EditorURI(workspaceDir string, projectName string) (string, bool) {
 	name := coderWorkspaceName(workspaceDir)

--- a/internal/backend/coder/coder.go
+++ b/internal/backend/coder/coder.go
@@ -310,6 +310,10 @@ func (b *CoderBackend) ResolveHostname(containerID string) (string, bool) {
 // Stateful reports that Coder workspaces have lifecycle state (running/stopped).
 func (b *CoderBackend) Stateful() bool { return true }
 
+// SupportsDotfiles reports that Coder workspace instances should receive
+// dotfiles — each remote workspace is a distinct environment.
+func (b *CoderBackend) SupportsDotfiles() bool { return true }
+
 // EditorURI returns a VS Code URI for connecting to a Coder workspace.
 func (b *CoderBackend) EditorURI(workspaceDir string, projectName string) (string, bool) {
 	name := coderWorkspaceName(workspaceDir)

--- a/internal/backend/coder/coder.go
+++ b/internal/backend/coder/coder.go
@@ -307,6 +307,9 @@ func (b *CoderBackend) ResolveHostname(containerID string) (string, bool) {
 	return "", false
 }
 
+// Stateful reports that Coder workspaces have lifecycle state (running/stopped).
+func (b *CoderBackend) Stateful() bool { return true }
+
 // EditorURI returns a VS Code URI for connecting to a Coder workspace.
 func (b *CoderBackend) EditorURI(workspaceDir string, projectName string) (string, bool) {
 	name := coderWorkspaceName(workspaceDir)

--- a/internal/backend/codespaces/codespaces.go
+++ b/internal/backend/codespaces/codespaces.go
@@ -339,6 +339,10 @@ func (b *CodespacesBackend) Stateful() bool { return true }
 // each codespace is a distinct remote environment.
 func (b *CodespacesBackend) SupportsDotfiles() bool { return true }
 
+// SupportsAgentForwarding reports that the SSH agent socket should be
+// re-pinned inside codespaces — each ssh connection creates a new socket.
+func (b *CodespacesBackend) SupportsAgentForwarding() bool { return true }
+
 // ===========================================
 // Internal helpers
 // ===========================================

--- a/internal/backend/codespaces/codespaces.go
+++ b/internal/backend/codespaces/codespaces.go
@@ -332,6 +332,9 @@ func (b *CodespacesBackend) ResolveHostname(containerID string) (string, bool) {
 	return "", false
 }
 
+// Stateful reports that codespaces have lifecycle state (running/stopped).
+func (b *CodespacesBackend) Stateful() bool { return true }
+
 // ===========================================
 // Internal helpers
 // ===========================================

--- a/internal/backend/codespaces/codespaces.go
+++ b/internal/backend/codespaces/codespaces.go
@@ -335,6 +335,10 @@ func (b *CodespacesBackend) ResolveHostname(containerID string) (string, bool) {
 // Stateful reports that codespaces have lifecycle state (running/stopped).
 func (b *CodespacesBackend) Stateful() bool { return true }
 
+// SupportsDotfiles reports that codespaces should receive dotfiles —
+// each codespace is a distinct remote environment.
+func (b *CodespacesBackend) SupportsDotfiles() bool { return true }
+
 // ===========================================
 // Internal helpers
 // ===========================================

--- a/internal/backend/devcontainer/devcontainer.go
+++ b/internal/backend/devcontainer/devcontainer.go
@@ -256,6 +256,9 @@ func (b *DevcontainerBackend) PortForwardCommand(containerID string, localPort, 
 	return exec.Command("sh", "-c", script)
 }
 
+// Stateful reports that devcontainers have lifecycle state (running/stopped).
+func (b *DevcontainerBackend) Stateful() bool { return true }
+
 // ResolveHostname returns the container's IP address obtained via
 // `docker inspect`. For local Docker containers this is directly reachable.
 func (b *DevcontainerBackend) ResolveHostname(containerID string) (string, bool) {

--- a/internal/backend/devcontainer/devcontainer.go
+++ b/internal/backend/devcontainer/devcontainer.go
@@ -263,6 +263,10 @@ func (b *DevcontainerBackend) Stateful() bool { return true }
 // dotfiles, since each container is an isolated environment.
 func (b *DevcontainerBackend) SupportsDotfiles() bool { return true }
 
+// SupportsAgentForwarding reports that the SSH agent socket should be
+// re-pinned inside the container — each docker exec creates a new socket.
+func (b *DevcontainerBackend) SupportsAgentForwarding() bool { return true }
+
 // ResolveHostname returns the container's IP address obtained via
 // `docker inspect`. For local Docker containers this is directly reachable.
 func (b *DevcontainerBackend) ResolveHostname(containerID string) (string, bool) {

--- a/internal/backend/devcontainer/devcontainer.go
+++ b/internal/backend/devcontainer/devcontainer.go
@@ -259,6 +259,10 @@ func (b *DevcontainerBackend) PortForwardCommand(containerID string, localPort, 
 // Stateful reports that devcontainers have lifecycle state (running/stopped).
 func (b *DevcontainerBackend) Stateful() bool { return true }
 
+// SupportsDotfiles reports that devcontainer instances should receive
+// dotfiles, since each container is an isolated environment.
+func (b *DevcontainerBackend) SupportsDotfiles() bool { return true }
+
 // ResolveHostname returns the container's IP address obtained via
 // `docker inspect`. For local Docker containers this is directly reachable.
 func (b *DevcontainerBackend) ResolveHostname(containerID string) (string, bool) {

--- a/internal/backend/localdir/localdir.go
+++ b/internal/backend/localdir/localdir.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 )
@@ -105,6 +106,7 @@ func (b *LocalDirBackend) Exec(workspaceDir string, command []string) error {
 	}
 	cmd := exec.Command(command[0], command[1:]...)
 	cmd.Dir = workspaceDir
+	cmd.Env = sanitizedEnv()
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -123,7 +125,27 @@ func (b *LocalDirBackend) ExecCommand(workspaceDir string, command []string) *ex
 		cmd = exec.Command(command[0], command[1:]...)
 	}
 	cmd.Dir = workspaceDir
+	cmd.Env = sanitizedEnv()
 	return cmd
+}
+
+// sanitizedEnv returns os.Environ() minus variables that would leak
+// the parent process's tmux context into the child. The other backends
+// avoid this naturally because docker exec / ssh spawn a fresh process
+// tree; local_dir inherits parent env directly, which makes tmux refuse
+// to start a new session ("sessions should be nested with care") when
+// the parent is itself running inside tmux (e.g. the fleet TUI's split
+// pane mode).
+func sanitizedEnv() []string {
+	env := os.Environ()
+	out := make([]string, 0, len(env))
+	for _, e := range env {
+		if strings.HasPrefix(e, "TMUX=") || strings.HasPrefix(e, "TMUX_PANE=") {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
 }
 
 // ===========================================

--- a/internal/backend/localdir/localdir.go
+++ b/internal/backend/localdir/localdir.go
@@ -88,6 +88,12 @@ func (b *LocalDirBackend) Stateful() bool { return false }
 // would interfere with the host environment.
 func (b *LocalDirBackend) SupportsDotfiles() bool { return false }
 
+// SupportsAgentForwarding reports false: the host's SSH_AUTH_SOCK is
+// already directly accessible. Re-pinning the socket would try to
+// touch system paths like /run/ssh-agent.sock, which fails without
+// privileges and serves no purpose locally.
+func (b *LocalDirBackend) SupportsAgentForwarding() bool { return false }
+
 // ===========================================
 // Execution
 // ===========================================

--- a/internal/backend/localdir/localdir.go
+++ b/internal/backend/localdir/localdir.go
@@ -83,6 +83,11 @@ func (b *LocalDirBackend) Start(containerID string) error { return nil }
 // Stateful reports false: local directories have no lifecycle state.
 func (b *LocalDirBackend) Stateful() bool { return false }
 
+// SupportsDotfiles reports false: the workspace is the host filesystem,
+// where the user's real dotfiles already live. Cloning into ~/dotfiles
+// would interfere with the host environment.
+func (b *LocalDirBackend) SupportsDotfiles() bool { return false }
+
 // ===========================================
 // Execution
 // ===========================================

--- a/internal/backend/localdir/localdir.go
+++ b/internal/backend/localdir/localdir.go
@@ -1,0 +1,189 @@
+// Package localdir implements a Backend that operates directly on a host
+// filesystem directory without any container, VM, or remote workspace.
+// Lifecycle calls (Stop/Start/Down) are no-ops; Exec runs commands with
+// the workspace dir as the working directory; port forwards short-circuit
+// to localhost via the in-process TCP proxy.
+package localdir
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// ===========================================
+// Options
+// ===========================================
+
+// Option configures a LocalDirBackend.
+type Option func(*LocalDirBackend)
+
+// WithVerbose enables verbose output. Currently a no-op for parity with
+// other backends; reserved for future diagnostics.
+func WithVerbose(v bool) Option {
+	return func(b *LocalDirBackend) { b.verbose = v }
+}
+
+// ===========================================
+// Backend
+// ===========================================
+
+// LocalDirBackend implements backend.Backend for instances that live as
+// plain directories on the host filesystem. The "containerID" is set to
+// the workspace directory path itself; methods that would normally
+// address a container ignore it.
+type LocalDirBackend struct {
+	verbose bool
+}
+
+// New creates a new LocalDirBackend.
+func New(opts ...Option) *LocalDirBackend {
+	b := &LocalDirBackend{}
+	for _, o := range opts {
+		o(b)
+	}
+	return b
+}
+
+// ===========================================
+// Lifecycle
+// ===========================================
+
+// Up validates that the workspace directory exists (the caller is
+// expected to have cloned the repo) and returns a synthetic UpResult.
+// The ContainerID is set to the workspace dir so downstream code that
+// gates on a non-empty ContainerID still treats the instance as valid.
+func (b *LocalDirBackend) Up(workspaceDir string) (*backend.UpResult, error) {
+	if _, err := os.Stat(workspaceDir); err != nil {
+		return nil, fmt.Errorf("local workspace dir not accessible: %w", err)
+	}
+	user := os.Getenv("USER")
+	return &backend.UpResult{
+		Outcome:               "success",
+		ContainerID:           workspaceDir,
+		RemoteUser:            user,
+		RemoteWorkspaceFolder: workspaceDir,
+	}, nil
+}
+
+// Down is a no-op. Workspace directory cleanup is performed by the
+// caller after Down returns (the same is true for the other backends).
+func (b *LocalDirBackend) Down(containerID string) error { return nil }
+
+// Stop is a no-op. The interface contract requires Stateful()==false
+// callers to skip Stop entirely; this implementation is defensive.
+func (b *LocalDirBackend) Stop(containerID string) error { return nil }
+
+// Start is a no-op. See Stop.
+func (b *LocalDirBackend) Start(containerID string) error { return nil }
+
+// Stateful reports false: local directories have no lifecycle state.
+func (b *LocalDirBackend) Stateful() bool { return false }
+
+// ===========================================
+// Execution
+// ===========================================
+
+// Exec runs an interactive command with the workspace dir as cwd.
+func (b *LocalDirBackend) Exec(workspaceDir string, command []string) error {
+	if len(command) == 0 {
+		return fmt.Errorf("exec requires a command")
+	}
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.Dir = workspaceDir
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// ExecCommand returns an unstarted *exec.Cmd that will run command with
+// the workspace dir as cwd. Returning a benign /bin/true command for an
+// empty argv keeps cmd.String() and cmd.Start() safe for callers that
+// don't pre-validate.
+func (b *LocalDirBackend) ExecCommand(workspaceDir string, command []string) *exec.Cmd {
+	var cmd *exec.Cmd
+	if len(command) == 0 {
+		cmd = exec.Command("true")
+	} else {
+		cmd = exec.Command(command[0], command[1:]...)
+	}
+	cmd.Dir = workspaceDir
+	return cmd
+}
+
+// ===========================================
+// Monitoring
+// ===========================================
+
+// Stats always reports no data. Surfacing per-instance host process stats
+// is left for a future iteration (would require scoping by cwd or pgid).
+func (b *LocalDirBackend) Stats(containerIDs []string) (map[string]*backend.ContainerStats, error) {
+	return nil, nil
+}
+
+// Logs prints a short notice — local instances have no separate runtime
+// log stream. The creation log captured by `fleet up` is still available
+// through the TUI logs viewer.
+func (b *LocalDirBackend) Logs(containerID string, follow bool) error {
+	fmt.Println("Local backend has no runtime logs.")
+	return nil
+}
+
+// LogsCommand returns an `echo` cmd so the TUI's logs script can splice
+// it in without nil checks. Using echo (not printf) keeps cmd.String()
+// shell-safe when interpolated into a wrapper script.
+func (b *LocalDirBackend) LogsCommand(containerID string, follow bool) *exec.Cmd {
+	return exec.Command("echo", "Local backend has no runtime logs.")
+}
+
+// CaptureAllSessions runs the shared tmux capture script directly on the
+// host. The host's tmux server is shared across all local instances, but
+// session-name prefixing (sanitized instance name) keeps them disjoint.
+// Sessions belonging to unrelated host work may also appear; they will
+// simply be ignored by the per-instance session filtering upstream.
+func (b *LocalDirBackend) CaptureAllSessions(containerID string) backend.AllSessions {
+	cmd := exec.Command("sh", "-c", backend.CaptureAllScript)
+	out, err := cmd.Output()
+	if err != nil {
+		return backend.AllSessions{OK: false}
+	}
+	return backend.AllSessions{
+		Sessions: backend.ParseAllSessionsOutput(string(out)),
+		OK:       true,
+	}
+}
+
+// AgentToolProbe always reports "no agent" for local instances. A host
+// `ps` scan would match agents from any unrelated process, so we opt out
+// of detection until a scoped probe (cwd or pgid based) is implemented.
+func (b *LocalDirBackend) AgentToolProbe(containerID string) (string, bool) {
+	return "", true
+}
+
+// ===========================================
+// Integration
+// ===========================================
+
+// EditorURI returns a `file://` URI pointing at the workspace dir, which
+// `code --folder-uri` accepts to open the directory in VS Code.
+func (b *LocalDirBackend) EditorURI(workspaceDir string, projectName string) (string, bool) {
+	u := &url.URL{Scheme: "file", Path: workspaceDir}
+	return u.String(), true
+}
+
+// PortForwardCommand should not be reached: ResolveHostname returns
+// ("localhost", true), which directs the port-forward manager to use
+// its in-process TCP proxy. The returned cmd fails loudly if invoked.
+func (b *LocalDirBackend) PortForwardCommand(containerID string, localPort, remotePort int) *exec.Cmd {
+	return exec.Command("sh", "-c", "echo 'local backend uses in-process port forwarding' >&2; exit 1")
+}
+
+// ResolveHostname always returns localhost so the port-forward manager
+// can spin up an in-process TCP proxy instead of shelling out.
+func (b *LocalDirBackend) ResolveHostname(containerID string) (string, bool) {
+	return "localhost", true
+}

--- a/internal/backendutil/backendutil.go
+++ b/internal/backendutil/backendutil.go
@@ -5,6 +5,7 @@ import (
 	coderbackend "github.com/BenjaminBenetti/fleet-man/internal/backend/coder"
 	codespacesbackend "github.com/BenjaminBenetti/fleet-man/internal/backend/codespaces"
 	devcontainerbackend "github.com/BenjaminBenetti/fleet-man/internal/backend/devcontainer"
+	localdirbackend "github.com/BenjaminBenetti/fleet-man/internal/backend/localdir"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 )
 
@@ -23,6 +24,12 @@ func New(bt fleet.BackendType, verbose bool) backend.Backend {
 			opts = append(opts, codespacesbackend.WithVerbose(verbose))
 		}
 		return codespacesbackend.New(opts...)
+	case fleet.BackendLocalDir:
+		opts := []localdirbackend.Option{}
+		if verbose {
+			opts = append(opts, localdirbackend.WithVerbose(verbose))
+		}
+		return localdirbackend.New(opts...)
 	default:
 		opts := []devcontainerbackend.Option{}
 		if verbose {

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -86,7 +86,7 @@ existing group, or --session to reconnect to a specific named session.`,
 			cols, rows := termSize()
 
 			dc := backendutil.NewForInstance(inst, false)
-			shellCmd := tui.ShellCommandForSession(cfg, sessionName, cols, rows, nested, dc.SupportsDotfiles())
+			shellCmd := tui.ShellCommandForSession(cfg, sessionName, cols, rows, nested, dc.SupportsDotfiles(), dc.SupportsAgentForwarding())
 			execCmd := dc.ExecCommand(inst.WorkspaceDir, shellCmd)
 			execCmd.Stdin = os.Stdin
 			execCmd.Stdout = os.Stdout

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -85,8 +85,8 @@ existing group, or --session to reconnect to a specific named session.`,
 
 			cols, rows := termSize()
 
-			shellCmd := tui.ShellCommandForSession(cfg, sessionName, cols, rows, nested)
 			dc := backendutil.NewForInstance(inst, false)
+			shellCmd := tui.ShellCommandForSession(cfg, sessionName, cols, rows, nested, dc.SupportsDotfiles())
 			execCmd := dc.ExecCommand(inst.WorkspaceDir, shellCmd)
 			execCmd.Stdin = os.Stdin
 			execCmd.Stdout = os.Stdout

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -29,6 +29,8 @@ func newUpCmd() *cobra.Command {
 				bt = fleet.BackendCoder
 			case "codespaces":
 				bt = fleet.BackendCodespaces
+			case "local_dir", "local":
+				bt = fleet.BackendLocalDir
 			}
 
 			target, err := fleet.Resolve(name, repoFlag)
@@ -100,7 +102,7 @@ func newUpCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&repoFlag, "repo", "", "Git remote URL to clone from")
-	cmd.Flags().StringVar(&backendFlag, "backend", "devcontainer", "Backend type: devcontainer, coder, or codespaces")
+	cmd.Flags().StringVar(&backendFlag, "backend", "devcontainer", "Backend type: devcontainer, coder, codespaces, or local_dir")
 	cmd.Flags().StringVar(&branchFlag, "branch", "", "Git branch to check out (defaults to the repository's default branch)")
 	return cmd
 }

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -76,9 +76,11 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, bt fle
 
 	// Auto-install dotfiles. A failure here is non-fatal — the instance
 	// is still usable, so we mark it running and surface the error as a
-	// warning rather than blocking the whole creation.
+	// warning rather than blocking the whole creation. Backends whose
+	// workspace is the host filesystem (e.g. local_dir) opt out via
+	// SupportsDotfiles() so we don't trample the user's real dotfiles.
 	cfg, _ := state.LoadConfig()
-	if cfg != nil && cfg.DotfilesSettings.AutoInstall {
+	if cfg != nil && cfg.DotfilesSettings.AutoInstall && dc.SupportsDotfiles() {
 		if script := dotfiles.SetupScript(cfg); script != "" {
 			cmd := dc.ExecCommand(wsDir, []string{"sh", "-c", script})
 			out, err := cmd.CombinedOutput()

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -40,8 +40,11 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, bt fle
 		dc = backendutil.New(bt, verbose)
 	}
 
-	if bt != fleet.BackendCoder && bt != fleet.BackendCodespaces {
-		// Devcontainer: clone repo first, then provision
+	// Backends that operate on a host-side workspace dir need the repo
+	// cloned locally before Up() runs. Coder and Codespaces clone inside
+	// their remote workspace via their own template/devcontainer flow.
+	if bt == fleet.BackendDevcontainer || bt == fleet.BackendLocalDir || bt == "" {
+		// Devcontainer / local dir: clone repo first, then provision
 		if err := os.MkdirAll(filepath.Dir(wsDir), 0755); err != nil {
 			setFailed(fleetName, instanceName, err)
 			return fmt.Errorf("mkdir: %w", err)

--- a/internal/fleet/instance.go
+++ b/internal/fleet/instance.go
@@ -21,6 +21,7 @@ const (
 	BackendDevcontainer BackendType = "devcontainer"
 	BackendCoder        BackendType = "coder"
 	BackendCodespaces   BackendType = "codespaces"
+	BackendLocalDir     BackendType = "local_dir"
 )
 
 // Instance represents a single devcontainer workspace in a fleet.

--- a/internal/instanceops/lifecycle.go
+++ b/internal/instanceops/lifecycle.go
@@ -11,6 +11,7 @@ import (
 type containerController interface {
 	Start(containerID string) error
 	Stop(containerID string) error
+	Stateful() bool
 }
 
 var newClient = func(bt fleet.BackendType) containerController {
@@ -75,6 +76,10 @@ func transitionLoadedInstance(st *state.State, inst *fleet.Instance, fleetName, 
 	}
 
 	dc := newClient(inst.Backend)
+
+	if !dc.Stateful() {
+		return nil, fmt.Errorf("backend %q does not support start/stop for instance %s/%s", inst.Backend, fleetName, instanceName)
+	}
 
 	switch targetStatus {
 	case fleet.StatusStopped:

--- a/internal/instanceops/lifecycle_test.go
+++ b/internal/instanceops/lifecycle_test.go
@@ -25,6 +25,8 @@ func (f *fakeClient) Stop(containerID string) error {
 	return f.stopErr
 }
 
+func (f *fakeClient) Stateful() bool { return true }
+
 func TestStopInstanceTransitionsRunningToStopped(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -284,6 +284,9 @@ func (m *model) backendFor(bt fleet.BackendType) backend.Backend {
 	if bt == "" {
 		bt = fleet.BackendDevcontainer
 	}
+	if m.backends == nil {
+		m.backends = make(map[fleet.BackendType]backend.Backend)
+	}
 	if b, ok := m.backends[bt]; ok {
 		return b
 	}

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -132,8 +132,9 @@ func (fp *fleetPage) updateConfirmDeleteSession(m *model, msg tea.Msg) tea.Cmd {
 // requires. An empty string means no external tool is needed.
 var backendToolRequirements = map[fleet.BackendType]string{
 	fleet.BackendDevcontainer: "devcontainer",
-	fleet.BackendCoder:       "coder",
-	fleet.BackendCodespaces:  "gh",
+	fleet.BackendCoder:        "coder",
+	fleet.BackendCodespaces:   "gh",
+	fleet.BackendLocalDir:     "",
 }
 
 // allBackendTypes is the ordered master list of every backend type.
@@ -141,6 +142,7 @@ var allBackendTypes = []fleet.BackendType{
 	fleet.BackendDevcontainer,
 	fleet.BackendCoder,
 	fleet.BackendCodespaces,
+	fleet.BackendLocalDir,
 }
 
 // nextBackendType cycles through the given options list from current.
@@ -166,6 +168,8 @@ func backendTypeLabel(bt fleet.BackendType) string {
 		return "Coder"
 	case fleet.BackendCodespaces:
 		return "Codespaces"
+	case fleet.BackendLocalDir:
+		return "Local Dir"
 	default:
 		return "Devcontainer"
 	}

--- a/internal/tui/dotfiles.go
+++ b/internal/tui/dotfiles.go
@@ -33,9 +33,13 @@ func dotfilesSetupScript(cfg *state.Config) string {
 }
 
 // dotfilesSetup returns a shell snippet that clones and installs dotfiles,
-// or an empty string if dotfiles are not configured or auto-install is enabled
-// (in which case dotfiles are installed in the background on instance creation).
-func dotfilesSetup(cfg *state.Config) string {
+// or an empty string if dotfiles are not configured, auto-install is enabled
+// (in which case dotfiles are installed in the background on instance creation),
+// or the backend reports SupportsDotfiles()==false (e.g. local_dir).
+func dotfilesSetup(cfg *state.Config, supportsDotfiles bool) string {
+	if !supportsDotfiles {
+		return ""
+	}
 	if cfg != nil && cfg.DotfilesSettings.AutoInstall {
 		return ""
 	}
@@ -63,16 +67,16 @@ var tmuxEnsureInstalled = `command -v tmux >/dev/null 2>&1 || { echo '==> Instal
 // is used to correct the remote PTY size before tmux starts. This is
 // needed for backends like coder ssh that may report incorrect sizes
 // (e.g. 128x128).
-func shellCommand(cfg *state.Config, instanceName string, cols, rows int, nested bool) []string {
-	return ShellCommandForSession(cfg, SanitizeSessionName(instanceName), cols, rows, nested)
+func shellCommand(cfg *state.Config, instanceName string, cols, rows int, nested, supportsDotfiles bool) []string {
+	return ShellCommandForSession(cfg, SanitizeSessionName(instanceName), cols, rows, nested, supportsDotfiles)
 }
 
 // ShellCommandForSession returns the command to run inside a devcontainer
 // with a persistent tmux session using the given session name. This allows
 // connecting to a specific named session rather than the default one derived
 // from the instance name.
-func ShellCommandForSession(cfg *state.Config, session string, cols, rows int, nested bool) []string {
-	setup := dotfilesSetup(cfg)
+func ShellCommandForSession(cfg *state.Config, session string, cols, rows int, nested, supportsDotfiles bool) []string {
+	setup := dotfilesSetup(cfg, supportsDotfiles)
 	// coder ssh may report incorrect terminal dimensions (e.g. 128x128).
 	// We fix the PTY size with stty before tmux starts and pass -x/-y for
 	// new session creation. "window-size latest" tells tmux to always
@@ -163,8 +167,8 @@ func ShellCommandForSession(cfg *state.Config, session string, cols, rows int, n
 // freshShellCommand returns the command to run inside a devcontainer
 // without tmux. Used by the "open in new terminal" action where a fresh,
 // non-persistent session is desired.
-func freshShellCommand(cfg *state.Config) []string {
-	setup := dotfilesSetup(cfg)
+func freshShellCommand(cfg *state.Config, supportsDotfiles bool) []string {
+	setup := dotfilesSetup(cfg, supportsDotfiles)
 	if setup == "" {
 		return []string{"bash"}
 	}

--- a/internal/tui/dotfiles.go
+++ b/internal/tui/dotfiles.go
@@ -67,15 +67,15 @@ var tmuxEnsureInstalled = `command -v tmux >/dev/null 2>&1 || { echo '==> Instal
 // is used to correct the remote PTY size before tmux starts. This is
 // needed for backends like coder ssh that may report incorrect sizes
 // (e.g. 128x128).
-func shellCommand(cfg *state.Config, instanceName string, cols, rows int, nested, supportsDotfiles bool) []string {
-	return ShellCommandForSession(cfg, SanitizeSessionName(instanceName), cols, rows, nested, supportsDotfiles)
+func shellCommand(cfg *state.Config, instanceName string, cols, rows int, nested, supportsDotfiles, supportsAgentForwarding bool) []string {
+	return ShellCommandForSession(cfg, SanitizeSessionName(instanceName), cols, rows, nested, supportsDotfiles, supportsAgentForwarding)
 }
 
 // ShellCommandForSession returns the command to run inside a devcontainer
 // with a persistent tmux session using the given session name. This allows
 // connecting to a specific named session rather than the default one derived
 // from the instance name.
-func ShellCommandForSession(cfg *state.Config, session string, cols, rows int, nested, supportsDotfiles bool) []string {
+func ShellCommandForSession(cfg *state.Config, session string, cols, rows int, nested, supportsDotfiles, supportsAgentForwarding bool) []string {
 	setup := dotfilesSetup(cfg, supportsDotfiles)
 	// coder ssh may report incorrect terminal dimensions (e.g. 128x128).
 	// We fix the PTY size with stty before tmux starts and pass -x/-y for
@@ -118,8 +118,13 @@ func ShellCommandForSession(cfg *state.Config, session string, cols, rows int, n
 	// Each SSH connection creates a new agent socket, but tmux keeps the
 	// old SSH_AUTH_SOCK from the original session. We symlink the current
 	// socket to a fixed path and point SSH_AUTH_SOCK there so it survives
-	// reconnects.
-	sshAgentFix := `if [ -n "$SSH_AUTH_SOCK" ] && [ "$SSH_AUTH_SOCK" != "$HOME/.ssh/ssh_auth_sock" ]; then mkdir -p ~/.ssh && ln -sf "$SSH_AUTH_SOCK" ~/.ssh/ssh_auth_sock; if [ ! -S /run/ssh-agent.sock ]; then ln -sf "$SSH_AUTH_SOCK" /run/ssh-agent.sock; fi; export SSH_AUTH_SOCK="$HOME/.ssh/ssh_auth_sock"; fi; `
+	// reconnects. Skipped for backends that report SupportsAgentForwarding
+	// ()==false (e.g. local_dir) where the host's real agent is already
+	// directly accessible and writing /run/ssh-agent.sock would fail.
+	sshAgentFix := ""
+	if supportsAgentForwarding {
+		sshAgentFix = `if [ -n "$SSH_AUTH_SOCK" ] && [ "$SSH_AUTH_SOCK" != "$HOME/.ssh/ssh_auth_sock" ]; then mkdir -p ~/.ssh && ln -sf "$SSH_AUTH_SOCK" ~/.ssh/ssh_auth_sock; if [ ! -S /run/ssh-agent.sock ]; then ln -sf "$SSH_AUTH_SOCK" /run/ssh-agent.sock; fi; export SSH_AUTH_SOCK="$HOME/.ssh/ssh_auth_sock"; fi; `
+	}
 	hookClear := fmt.Sprintf(
 		`tmux has-session -t %s 2>/dev/null && tmux set-hook -gu client-attached 2>/dev/null; `,
 		shQuote(session),

--- a/internal/tui/dotfiles_test.go
+++ b/internal/tui/dotfiles_test.go
@@ -54,7 +54,7 @@ func TestSanitizeSessionName(t *testing.T) {
 
 func TestShellCommandProducesTmux(t *testing.T) {
 	cfg := state.DefaultConfig()
-	got := shellCommand(cfg, "agent-1", 0, 0, false)
+	got := shellCommand(cfg, "agent-1", 0, 0, false, true)
 	if len(got) != 3 || got[0] != "sh" || got[1] != "-c" {
 		t.Fatalf("shellCommand() = %v, want [sh -c ...]", got)
 	}
@@ -75,7 +75,7 @@ func TestShellCommandProducesTmux(t *testing.T) {
 
 func TestShellCommandClipboard(t *testing.T) {
 	cfg := state.DefaultConfig()
-	got := shellCommand(cfg, "agent-1", 0, 0, false)
+	got := shellCommand(cfg, "agent-1", 0, 0, false, true)
 	script := got[2]
 	if !strings.Contains(script, "set -g set-clipboard on") {
 		t.Errorf("script missing set-clipboard on: %s", script)
@@ -87,7 +87,7 @@ func TestShellCommandClipboard(t *testing.T) {
 
 func TestShellCommandClipboardNested(t *testing.T) {
 	cfg := state.DefaultConfig()
-	got := shellCommand(cfg, "agent-1", 80, 24, true)
+	got := shellCommand(cfg, "agent-1", 80, 24, true, true)
 	script := got[2]
 	if !strings.Contains(script, "set -g set-clipboard on") {
 		t.Errorf("nested script missing set-clipboard on: %s", script)
@@ -99,7 +99,7 @@ func TestShellCommandClipboardNested(t *testing.T) {
 
 func TestShellCommandClipboardFeaturesIsLast(t *testing.T) {
 	cfg := state.DefaultConfig()
-	got := shellCommand(cfg, "agent-1", 80, 24, false)
+	got := shellCommand(cfg, "agent-1", 80, 24, false, true)
 	script := got[2]
 	featIdx := strings.LastIndex(script, "terminal-features")
 	mouseIdx := strings.Index(script, "set -g mouse on")
@@ -120,7 +120,7 @@ func TestShellCommandWithDotfilesAndTmux(t *testing.T) {
 	cfg.DotfilesSettings.RepoURL = "https://github.com/user/dots"
 	cfg.DotfilesSettings.InstallScript = "install.sh"
 
-	got := shellCommand(cfg, "worker-2", 0, 0, false)
+	got := shellCommand(cfg, "worker-2", 0, 0, false, true)
 	script := got[2]
 
 	// Dotfiles setup should come before tmux
@@ -145,7 +145,7 @@ func TestShellCommandWithDotfilesAndTmux(t *testing.T) {
 
 func TestShellCommandSanitizesSessionName(t *testing.T) {
 	cfg := state.DefaultConfig()
-	got := shellCommand(cfg, "my.instance:1", 0, 0, false)
+	got := shellCommand(cfg, "my.instance:1", 0, 0, false, true)
 	script := got[2]
 	if !strings.Contains(script, "tmux -u new-session -A -s 'my-instance-1'") {
 		t.Errorf("script should sanitize session name: %s", script)
@@ -155,15 +155,15 @@ func TestShellCommandSanitizesSessionName(t *testing.T) {
 // --- freshShellCommand tests ---
 
 func TestFreshShellCommandNilConfig(t *testing.T) {
-	got := freshShellCommand(nil)
+	got := freshShellCommand(nil, true)
 	if len(got) != 1 || got[0] != "bash" {
-		t.Fatalf("freshShellCommand(nil) = %v, want [bash]", got)
+		t.Fatalf("freshShellCommand(nil, true) = %v, want [bash]", got)
 	}
 }
 
 func TestFreshShellCommandEmptyDotfiles(t *testing.T) {
 	cfg := state.DefaultConfig()
-	got := freshShellCommand(cfg)
+	got := freshShellCommand(cfg, true)
 	if len(got) != 1 || got[0] != "bash" {
 		t.Fatalf("freshShellCommand(empty) = %v, want [bash]", got)
 	}
@@ -172,7 +172,7 @@ func TestFreshShellCommandEmptyDotfiles(t *testing.T) {
 func TestFreshShellCommandRepoOnlyNoScript(t *testing.T) {
 	cfg := state.DefaultConfig()
 	cfg.DotfilesSettings.RepoURL = "https://github.com/user/dots"
-	got := freshShellCommand(cfg)
+	got := freshShellCommand(cfg, true)
 	if len(got) != 1 || got[0] != "bash" {
 		t.Fatalf("freshShellCommand(repo only) = %v, want [bash]", got)
 	}
@@ -181,7 +181,7 @@ func TestFreshShellCommandRepoOnlyNoScript(t *testing.T) {
 func TestFreshShellCommandScriptOnlyNoRepo(t *testing.T) {
 	cfg := state.DefaultConfig()
 	cfg.DotfilesSettings.InstallScript = "install.sh"
-	got := freshShellCommand(cfg)
+	got := freshShellCommand(cfg, true)
 	if len(got) != 1 || got[0] != "bash" {
 		t.Fatalf("freshShellCommand(script only) = %v, want [bash]", got)
 	}
@@ -192,7 +192,7 @@ func TestFreshShellCommandBothSet(t *testing.T) {
 	cfg.DotfilesSettings.RepoURL = "https://github.com/user/dots"
 	cfg.DotfilesSettings.InstallScript = "install.sh"
 
-	got := freshShellCommand(cfg)
+	got := freshShellCommand(cfg, true)
 	if len(got) != 3 {
 		t.Fatalf("freshShellCommand() returned %d args, want 3", len(got))
 	}
@@ -217,7 +217,7 @@ func TestFreshShellCommandBothSet(t *testing.T) {
 
 func TestShellCommandNestedNoInnerPaneKeys(t *testing.T) {
 	cfg := state.DefaultConfig()
-	got := shellCommand(cfg, "agent-1", 80, 24, true)
+	got := shellCommand(cfg, "agent-1", 80, 24, true, true)
 	script := got[2]
 	// Pane navigation is handled by the outer tmux, so the inner
 	// tmux should not bind j/k even when vim keys are enabled.
@@ -242,7 +242,7 @@ func TestShellCommandNestedVimKeysDisabled(t *testing.T) {
 	off := false
 	cfg.GeneralSettings.TmuxVimKeys = &off
 
-	got := shellCommand(cfg, "agent-1", 80, 24, true)
+	got := shellCommand(cfg, "agent-1", 80, 24, true, true)
 	script := got[2]
 	if strings.Contains(script, "bind-key j select-pane") {
 		t.Errorf("nested script should not have j keybinding when vim keys disabled: %s", script)
@@ -265,7 +265,7 @@ func TestShellCommandAutoInstallSkipsDotfiles(t *testing.T) {
 	cfg.DotfilesSettings.InstallScript = "install.sh"
 	cfg.DotfilesSettings.AutoInstall = true
 
-	got := shellCommand(cfg, "agent-1", 80, 24, false)
+	got := shellCommand(cfg, "agent-1", 80, 24, false, true)
 	script := got[2]
 	if strings.Contains(script, "dotfiles") {
 		t.Errorf("script should not contain dotfiles setup when auto-install is on: %s", script)
@@ -281,7 +281,7 @@ func TestFreshShellCommandAutoInstallSkipsDotfiles(t *testing.T) {
 	cfg.DotfilesSettings.InstallScript = "install.sh"
 	cfg.DotfilesSettings.AutoInstall = true
 
-	got := freshShellCommand(cfg)
+	got := freshShellCommand(cfg, true)
 	if len(got) != 1 || got[0] != "bash" {
 		t.Fatalf("freshShellCommand(auto-install) = %v, want [bash]", got)
 	}
@@ -302,12 +302,39 @@ func TestDotfilesSetupScriptIgnoresAutoInstall(t *testing.T) {
 	}
 }
 
+func TestShellCommandSkipsDotfilesWhenBackendUnsupported(t *testing.T) {
+	cfg := state.DefaultConfig()
+	cfg.DotfilesSettings.RepoURL = "https://github.com/user/dots"
+	cfg.DotfilesSettings.InstallScript = "install.sh"
+	// AutoInstall=false so dotfiles WOULD normally be injected at attach time.
+
+	got := shellCommand(cfg, "agent-1", 0, 0, false, false)
+	script := got[2]
+	if strings.Contains(script, "dotfiles") {
+		t.Errorf("script should not reference dotfiles when supportsDotfiles=false: %s", script)
+	}
+	if !strings.Contains(script, "exec tmux") {
+		t.Errorf("script should still contain tmux: %s", script)
+	}
+}
+
+func TestFreshShellCommandSkipsDotfilesWhenBackendUnsupported(t *testing.T) {
+	cfg := state.DefaultConfig()
+	cfg.DotfilesSettings.RepoURL = "https://github.com/user/dots"
+	cfg.DotfilesSettings.InstallScript = "install.sh"
+
+	got := freshShellCommand(cfg, false)
+	if len(got) != 1 || got[0] != "bash" {
+		t.Fatalf("freshShellCommand(supportsDotfiles=false) = %v, want [bash]", got)
+	}
+}
+
 func TestFreshShellCommandQuotesSpecialCharacters(t *testing.T) {
 	cfg := state.DefaultConfig()
 	cfg.DotfilesSettings.RepoURL = "https://github.com/user/it's-dots"
 	cfg.DotfilesSettings.InstallScript = "my script.sh"
 
-	got := freshShellCommand(cfg)
+	got := freshShellCommand(cfg, true)
 	if len(got) != 3 {
 		t.Fatalf("freshShellCommand() returned %d args, want 3", len(got))
 	}

--- a/internal/tui/dotfiles_test.go
+++ b/internal/tui/dotfiles_test.go
@@ -54,7 +54,7 @@ func TestSanitizeSessionName(t *testing.T) {
 
 func TestShellCommandProducesTmux(t *testing.T) {
 	cfg := state.DefaultConfig()
-	got := shellCommand(cfg, "agent-1", 0, 0, false, true)
+	got := shellCommand(cfg, "agent-1", 0, 0, false, true, true)
 	if len(got) != 3 || got[0] != "sh" || got[1] != "-c" {
 		t.Fatalf("shellCommand() = %v, want [sh -c ...]", got)
 	}
@@ -75,7 +75,7 @@ func TestShellCommandProducesTmux(t *testing.T) {
 
 func TestShellCommandClipboard(t *testing.T) {
 	cfg := state.DefaultConfig()
-	got := shellCommand(cfg, "agent-1", 0, 0, false, true)
+	got := shellCommand(cfg, "agent-1", 0, 0, false, true, true)
 	script := got[2]
 	if !strings.Contains(script, "set -g set-clipboard on") {
 		t.Errorf("script missing set-clipboard on: %s", script)
@@ -87,7 +87,7 @@ func TestShellCommandClipboard(t *testing.T) {
 
 func TestShellCommandClipboardNested(t *testing.T) {
 	cfg := state.DefaultConfig()
-	got := shellCommand(cfg, "agent-1", 80, 24, true, true)
+	got := shellCommand(cfg, "agent-1", 80, 24, true, true, true)
 	script := got[2]
 	if !strings.Contains(script, "set -g set-clipboard on") {
 		t.Errorf("nested script missing set-clipboard on: %s", script)
@@ -99,7 +99,7 @@ func TestShellCommandClipboardNested(t *testing.T) {
 
 func TestShellCommandClipboardFeaturesIsLast(t *testing.T) {
 	cfg := state.DefaultConfig()
-	got := shellCommand(cfg, "agent-1", 80, 24, false, true)
+	got := shellCommand(cfg, "agent-1", 80, 24, false, true, true)
 	script := got[2]
 	featIdx := strings.LastIndex(script, "terminal-features")
 	mouseIdx := strings.Index(script, "set -g mouse on")
@@ -120,7 +120,7 @@ func TestShellCommandWithDotfilesAndTmux(t *testing.T) {
 	cfg.DotfilesSettings.RepoURL = "https://github.com/user/dots"
 	cfg.DotfilesSettings.InstallScript = "install.sh"
 
-	got := shellCommand(cfg, "worker-2", 0, 0, false, true)
+	got := shellCommand(cfg, "worker-2", 0, 0, false, true, true)
 	script := got[2]
 
 	// Dotfiles setup should come before tmux
@@ -145,7 +145,7 @@ func TestShellCommandWithDotfilesAndTmux(t *testing.T) {
 
 func TestShellCommandSanitizesSessionName(t *testing.T) {
 	cfg := state.DefaultConfig()
-	got := shellCommand(cfg, "my.instance:1", 0, 0, false, true)
+	got := shellCommand(cfg, "my.instance:1", 0, 0, false, true, true)
 	script := got[2]
 	if !strings.Contains(script, "tmux -u new-session -A -s 'my-instance-1'") {
 		t.Errorf("script should sanitize session name: %s", script)
@@ -217,7 +217,7 @@ func TestFreshShellCommandBothSet(t *testing.T) {
 
 func TestShellCommandNestedNoInnerPaneKeys(t *testing.T) {
 	cfg := state.DefaultConfig()
-	got := shellCommand(cfg, "agent-1", 80, 24, true, true)
+	got := shellCommand(cfg, "agent-1", 80, 24, true, true, true)
 	script := got[2]
 	// Pane navigation is handled by the outer tmux, so the inner
 	// tmux should not bind j/k even when vim keys are enabled.
@@ -242,7 +242,7 @@ func TestShellCommandNestedVimKeysDisabled(t *testing.T) {
 	off := false
 	cfg.GeneralSettings.TmuxVimKeys = &off
 
-	got := shellCommand(cfg, "agent-1", 80, 24, true, true)
+	got := shellCommand(cfg, "agent-1", 80, 24, true, true, true)
 	script := got[2]
 	if strings.Contains(script, "bind-key j select-pane") {
 		t.Errorf("nested script should not have j keybinding when vim keys disabled: %s", script)
@@ -265,7 +265,7 @@ func TestShellCommandAutoInstallSkipsDotfiles(t *testing.T) {
 	cfg.DotfilesSettings.InstallScript = "install.sh"
 	cfg.DotfilesSettings.AutoInstall = true
 
-	got := shellCommand(cfg, "agent-1", 80, 24, false, true)
+	got := shellCommand(cfg, "agent-1", 80, 24, false, true, true)
 	script := got[2]
 	if strings.Contains(script, "dotfiles") {
 		t.Errorf("script should not contain dotfiles setup when auto-install is on: %s", script)
@@ -308,13 +308,37 @@ func TestShellCommandSkipsDotfilesWhenBackendUnsupported(t *testing.T) {
 	cfg.DotfilesSettings.InstallScript = "install.sh"
 	// AutoInstall=false so dotfiles WOULD normally be injected at attach time.
 
-	got := shellCommand(cfg, "agent-1", 0, 0, false, false)
+	got := shellCommand(cfg, "agent-1", 0, 0, false, false, true)
 	script := got[2]
 	if strings.Contains(script, "dotfiles") {
 		t.Errorf("script should not reference dotfiles when supportsDotfiles=false: %s", script)
 	}
 	if !strings.Contains(script, "exec tmux") {
 		t.Errorf("script should still contain tmux: %s", script)
+	}
+}
+
+func TestShellCommandIncludesAgentForwardingFixWhenSupported(t *testing.T) {
+	cfg := state.DefaultConfig()
+	got := shellCommand(cfg, "agent-1", 0, 0, false, true, true)
+	script := got[2]
+	if !strings.Contains(script, "/run/ssh-agent.sock") {
+		t.Errorf("script should contain SSH agent socket relink when supportsAgentForwarding=true: %s", script)
+	}
+}
+
+func TestShellCommandSkipsAgentForwardingFixWhenUnsupported(t *testing.T) {
+	cfg := state.DefaultConfig()
+	got := shellCommand(cfg, "agent-1", 0, 0, false, true, false)
+	script := got[2]
+	if strings.Contains(script, "/run/ssh-agent.sock") {
+		t.Errorf("script should NOT touch /run/ssh-agent.sock when supportsAgentForwarding=false: %s", script)
+	}
+	if strings.Contains(script, "ssh_auth_sock") {
+		t.Errorf("script should NOT relink SSH_AUTH_SOCK when supportsAgentForwarding=false: %s", script)
+	}
+	if !strings.Contains(script, "exec tmux") {
+		t.Errorf("script should still launch tmux: %s", script)
 	}
 }
 

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -409,6 +409,10 @@ func (fp *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 				m.message = fmt.Sprintf("Instance %s is failed and cannot be toggled", key)
 				break
 			}
+			if !m.instanceBackend(r.instance).Stateful() {
+				m.message = fmt.Sprintf("%s instances cannot be stopped or started", backendTypeLabel(r.instance.Backend))
+				break
+			}
 
 			if r.instance.Status == fleet.StatusRunning {
 				r.instance.Status = fleet.StatusStopping

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -533,7 +533,8 @@ func (fp *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 				m.message = "Select an instance"
 				break
 			}
-			cmd := m.instanceBackend(inst).ExecCommand(inst.WorkspaceDir, freshShellCommand(m.cfg))
+			b := m.instanceBackend(inst)
+			cmd := b.ExecCommand(inst.WorkspaceDir, freshShellCommand(m.cfg, b.SupportsDotfiles()))
 			err := openInTerminal(cmd.Args)
 			if err != nil {
 				m.message = fmt.Sprintf("Could not open terminal: %v", err)
@@ -713,15 +714,17 @@ func (fp *fleetPage) handleEnter(m *model) tea.Cmd {
 			}
 			cols, rows := tmuxWindowSize()
 			cols = cols * 70 / 100
-			cmd := m.instanceBackend(inst).ExecCommand(
+			b := m.instanceBackend(inst)
+			cmd := b.ExecCommand(
 				inst.WorkspaceDir,
-				ShellCommandForSession(m.cfg, sessionName, cols, rows, true),
+				ShellCommandForSession(m.cfg, sessionName, cols, rows, true, b.SupportsDotfiles()),
 			)
 			return splitPaneCmd(fp.splitPaneID, r.fleetName, inst.Name, sessionName, groupID, cmd)
 		}
-		cmd := m.instanceBackend(inst).ExecCommand(
+		b := m.instanceBackend(inst)
+		cmd := b.ExecCommand(
 			inst.WorkspaceDir,
-			ShellCommandForSession(m.cfg, sessionName, m.width, m.height, false),
+			ShellCommandForSession(m.cfg, sessionName, m.width, m.height, false, b.SupportsDotfiles()),
 		)
 		banner := renderGradient(nameToBanner(inst.GetDisplayName()))
 		banner += "\n  " + dimStyle.Render("ctrl+q/ctrl+o to detach (session persists)")
@@ -766,7 +769,8 @@ func (fp *fleetPage) handleEnter(m *model) tea.Cmd {
 		}
 		m.lastActive[instKey] = lastSession{sessionName: sessionName}
 
-		cmd := m.instanceBackend(inst).ExecCommand(inst.WorkspaceDir, ShellCommandForSession(m.cfg, sessionName, m.width, m.height, false))
+		b := m.instanceBackend(inst)
+		cmd := b.ExecCommand(inst.WorkspaceDir, ShellCommandForSession(m.cfg, sessionName, m.width, m.height, false, b.SupportsDotfiles()))
 		banner := renderGradient(nameToBanner(inst.GetDisplayName()))
 		banner += "\n  " + dimStyle.Render("ctrl+q/ctrl+o to detach (session persists)")
 		return tea.ExecProcess(
@@ -1369,9 +1373,10 @@ func (fp *fleetPage) openInstanceSession(m *model, fleetName string, inst *fleet
 		}
 		cols, rows := tmuxWindowSize()
 		cols = cols * 70 / 100
-		cmd := m.instanceBackend(inst).ExecCommand(
+		b := m.instanceBackend(inst)
+		cmd := b.ExecCommand(
 			inst.WorkspaceDir,
-			ShellCommandForSession(m.cfg, last.sessionName, cols, rows, true),
+			ShellCommandForSession(m.cfg, last.sessionName, cols, rows, true, b.SupportsDotfiles()),
 		)
 		return splitPaneCmd(fp.splitPaneID, fleetName, inst.Name, last.sessionName, last.groupID, cmd)
 	}
@@ -1386,9 +1391,10 @@ func (fp *fleetPage) openInstanceSession(m *model, fleetName string, inst *fleet
 			}
 			cols, rows := tmuxWindowSize()
 			cols = cols * 70 / 100
-			cmd := m.instanceBackend(inst).ExecCommand(
+			b := m.instanceBackend(inst)
+			cmd := b.ExecCommand(
 				inst.WorkspaceDir,
-				ShellCommandForSession(m.cfg, rootName, cols, rows, true),
+				ShellCommandForSession(m.cfg, rootName, cols, rows, true, b.SupportsDotfiles()),
 			)
 			return splitPaneCmd(fp.splitPaneID, fleetName, inst.Name, rootName, g.GroupID, cmd)
 		}
@@ -1398,9 +1404,10 @@ func (fp *fleetPage) openInstanceSession(m *model, fleetName string, inst *fleet
 	sessName := groupSessionName(sanitized, newGroupID)
 	cols, rows := tmuxWindowSize()
 	cols = cols * 70 / 100
-	cmd := m.instanceBackend(inst).ExecCommand(
+	b := m.instanceBackend(inst)
+	cmd := b.ExecCommand(
 		inst.WorkspaceDir,
-		ShellCommandForSession(m.cfg, sessName, cols, rows, true),
+		ShellCommandForSession(m.cfg, sessName, cols, rows, true, b.SupportsDotfiles()),
 	)
 	return splitPaneCmd(fp.splitPaneID, fleetName, inst.Name, sessName, newGroupID, cmd)
 }

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -717,14 +717,14 @@ func (fp *fleetPage) handleEnter(m *model) tea.Cmd {
 			b := m.instanceBackend(inst)
 			cmd := b.ExecCommand(
 				inst.WorkspaceDir,
-				ShellCommandForSession(m.cfg, sessionName, cols, rows, true, b.SupportsDotfiles()),
+				ShellCommandForSession(m.cfg, sessionName, cols, rows, true, b.SupportsDotfiles(), b.SupportsAgentForwarding()),
 			)
 			return splitPaneCmd(fp.splitPaneID, r.fleetName, inst.Name, sessionName, groupID, cmd)
 		}
 		b := m.instanceBackend(inst)
 		cmd := b.ExecCommand(
 			inst.WorkspaceDir,
-			ShellCommandForSession(m.cfg, sessionName, m.width, m.height, false, b.SupportsDotfiles()),
+			ShellCommandForSession(m.cfg, sessionName, m.width, m.height, false, b.SupportsDotfiles(), b.SupportsAgentForwarding()),
 		)
 		banner := renderGradient(nameToBanner(inst.GetDisplayName()))
 		banner += "\n  " + dimStyle.Render("ctrl+q/ctrl+o to detach (session persists)")
@@ -770,7 +770,7 @@ func (fp *fleetPage) handleEnter(m *model) tea.Cmd {
 		m.lastActive[instKey] = lastSession{sessionName: sessionName}
 
 		b := m.instanceBackend(inst)
-		cmd := b.ExecCommand(inst.WorkspaceDir, ShellCommandForSession(m.cfg, sessionName, m.width, m.height, false, b.SupportsDotfiles()))
+		cmd := b.ExecCommand(inst.WorkspaceDir, ShellCommandForSession(m.cfg, sessionName, m.width, m.height, false, b.SupportsDotfiles(), b.SupportsAgentForwarding()))
 		banner := renderGradient(nameToBanner(inst.GetDisplayName()))
 		banner += "\n  " + dimStyle.Render("ctrl+q/ctrl+o to detach (session persists)")
 		return tea.ExecProcess(
@@ -1376,7 +1376,7 @@ func (fp *fleetPage) openInstanceSession(m *model, fleetName string, inst *fleet
 		b := m.instanceBackend(inst)
 		cmd := b.ExecCommand(
 			inst.WorkspaceDir,
-			ShellCommandForSession(m.cfg, last.sessionName, cols, rows, true, b.SupportsDotfiles()),
+			ShellCommandForSession(m.cfg, last.sessionName, cols, rows, true, b.SupportsDotfiles(), b.SupportsAgentForwarding()),
 		)
 		return splitPaneCmd(fp.splitPaneID, fleetName, inst.Name, last.sessionName, last.groupID, cmd)
 	}
@@ -1394,7 +1394,7 @@ func (fp *fleetPage) openInstanceSession(m *model, fleetName string, inst *fleet
 			b := m.instanceBackend(inst)
 			cmd := b.ExecCommand(
 				inst.WorkspaceDir,
-				ShellCommandForSession(m.cfg, rootName, cols, rows, true, b.SupportsDotfiles()),
+				ShellCommandForSession(m.cfg, rootName, cols, rows, true, b.SupportsDotfiles(), b.SupportsAgentForwarding()),
 			)
 			return splitPaneCmd(fp.splitPaneID, fleetName, inst.Name, rootName, g.GroupID, cmd)
 		}
@@ -1407,7 +1407,7 @@ func (fp *fleetPage) openInstanceSession(m *model, fleetName string, inst *fleet
 	b := m.instanceBackend(inst)
 	cmd := b.ExecCommand(
 		inst.WorkspaceDir,
-		ShellCommandForSession(m.cfg, sessName, cols, rows, true, b.SupportsDotfiles()),
+		ShellCommandForSession(m.cfg, sessName, cols, rows, true, b.SupportsDotfiles(), b.SupportsAgentForwarding()),
 	)
 	return splitPaneCmd(fp.splitPaneID, fleetName, inst.Name, sessName, newGroupID, cmd)
 }

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -136,7 +136,7 @@ func sessionDiscoveryCmd(
 					mu.Unlock()
 					return
 				}
-				sessions := parseTmuxSessions(string(out))
+				sessions := parseTmuxSessions(string(out), sanitizedFromInstanceKey(instKey))
 				mu.Lock()
 				discovered[instKey] = sessions
 				mu.Unlock()
@@ -167,7 +167,7 @@ func ensureSessionsLoaded(m *model, b backend.Backend, workspaceDir, instanceKey
 		return
 	}
 	m.sessions[instanceKey] = &sessionDiscovery{
-		sessions:  parseTmuxSessions(string(out)),
+		sessions:  parseTmuxSessions(string(out), sanitizedFromInstanceKey(instanceKey)),
 		fetchedAt: time.Now(),
 	}
 }
@@ -184,7 +184,7 @@ func listSessionsCmd(b backend.Backend, workspaceDir, instanceKey string) tea.Cm
 		if err != nil {
 			return sessionsMsg{instanceKey: instanceKey, err: err}
 		}
-		sessions := parseTmuxSessions(string(out))
+		sessions := parseTmuxSessions(string(out), sanitizedFromInstanceKey(instanceKey))
 		return sessionsMsg{instanceKey: instanceKey, sessions: sessions}
 	}
 }
@@ -341,9 +341,18 @@ func sessionStillExists(last lastSession, sessions []tmuxSession) bool {
 
 // parseTmuxSessions parses the output of `tmux list-sessions -F
 // "#{session_name}:#{session_windows}:#{session_attached}"` into
-// a slice of tmuxSession.
-func parseTmuxSessions(output string) []tmuxSession {
+// a slice of tmuxSession scoped to a single instance.
+//
+// Only sessions whose name equals sanitizedInstance (legacy non-grouped
+// shell session) or starts with sanitizedInstance + groupSep are
+// returned. Containerized backends naturally only have fleet-managed
+// sessions on their per-container tmux server, so this filter is a
+// no-op for them. For local_dir the host tmux server is shared, and
+// the prefix filter is what keeps unrelated host sessions (the fleet
+// TUI's own outer tmux, the user's other work) out of the instance view.
+func parseTmuxSessions(output string, sanitizedInstance string) []tmuxSession {
 	var sessions []tmuxSession
+	prefix := sanitizedInstance + groupSep
 	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -353,7 +362,11 @@ func parseTmuxSessions(output string) []tmuxSession {
 		if len(parts) < 1 || parts[0] == "" {
 			continue
 		}
-		s := tmuxSession{Name: parts[0]}
+		name := parts[0]
+		if name != sanitizedInstance && !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		s := tmuxSession{Name: name}
 		if len(parts) >= 2 {
 			s.Windows, _ = strconv.Atoi(parts[1])
 		}
@@ -363,6 +376,15 @@ func parseTmuxSessions(output string) []tmuxSession {
 		sessions = append(sessions, s)
 	}
 	return sessions
+}
+
+// sanitizedFromInstanceKey returns the sanitized instance name from an
+// "<fleet>/<instance>" key, suitable for matching tmux session prefixes.
+func sanitizedFromInstanceKey(instanceKey string) string {
+	if i := strings.LastIndex(instanceKey, "/"); i >= 0 {
+		return SanitizeSessionName(instanceKey[i+1:])
+	}
+	return SanitizeSessionName(instanceKey)
 }
 
 // nextSessionName generates an auto-incrementing session name like

--- a/internal/tui/sessions_test.go
+++ b/internal/tui/sessions_test.go
@@ -1,0 +1,72 @@
+package tui
+
+import "testing"
+
+func TestParseTmuxSessionsFiltersToInstancePrefix(t *testing.T) {
+	// Mixed list: fleet-managed sessions for "alpha", a fleet-managed
+	// session for "beta", a manually-named host session, and the outer
+	// fleet TUI's own tmux session. Only alpha sessions should survive.
+	out := `alpha:1:0
+alpha~deadbeef:2:1
+alpha~feedface~01:1:0
+beta~aaaa:1:0
+host-foo:1:0
+fleetman-itest:1:1
+`
+	got := parseTmuxSessions(out, "alpha")
+	wantNames := []string{"alpha", "alpha~deadbeef", "alpha~feedface~01"}
+	if len(got) != len(wantNames) {
+		t.Fatalf("parseTmuxSessions returned %d sessions, want %d: %+v", len(got), len(wantNames), got)
+	}
+	for i, name := range wantNames {
+		if got[i].Name != name {
+			t.Errorf("session[%d].Name = %q, want %q", i, got[i].Name, name)
+		}
+	}
+}
+
+func TestParseTmuxSessionsExactMatchKeepsLegacyName(t *testing.T) {
+	// A session named exactly the sanitized instance (legacy non-grouped
+	// shell session) must be kept.
+	got := parseTmuxSessions("agent-1:1:0\n", "agent-1")
+	if len(got) != 1 || got[0].Name != "agent-1" {
+		t.Fatalf("parseTmuxSessions = %+v, want [{Name: agent-1}]", got)
+	}
+}
+
+func TestParseTmuxSessionsRejectsUnrelatedSessions(t *testing.T) {
+	// Sessions that don't start with the prefix or equal the sanitized
+	// name must be dropped — even if they share a substring.
+	out := `alpha-other:1:0
+not-alpha~xx:1:0
+`
+	got := parseTmuxSessions(out, "alpha")
+	if len(got) != 0 {
+		t.Fatalf("parseTmuxSessions = %+v, want empty", got)
+	}
+}
+
+func TestParseTmuxSessionsHandlesEmptyOutput(t *testing.T) {
+	got := parseTmuxSessions("", "alpha")
+	if len(got) != 0 {
+		t.Fatalf("parseTmuxSessions(\"\") = %+v, want empty", got)
+	}
+}
+
+func TestSanitizedFromInstanceKey(t *testing.T) {
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{"itest-fleet/alpha", "alpha"},
+		{"itest-fleet/my.instance", "my-instance"},
+		{"alpha", "alpha"},
+		{"foo/bar/baz", "baz"},
+	}
+	for _, tt := range tests {
+		got := sanitizedFromInstanceKey(tt.key)
+		if got != tt.want {
+			t.Errorf("sanitizedFromInstanceKey(%q) = %q, want %q", tt.key, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Introduces a `Backend` strategy implementation that operates directly on a host filesystem directory — no container, VM, or remote workspace.
- Adds `Stateful() bool` to the `Backend` interface so callers can skip `Stop`/`Start` for backends with no lifecycle state. Devcontainer, Coder, and Codespaces return `true`; LocalDir returns `false`.
- Wires the new backend through the factory, TUI dialog metadata, CLI `--backend local_dir` flag, and the `create.Run` git-clone allowlist.

## Behavior

| Method | LocalDir behavior |
|---|---|
| `Up` | Validates wsDir exists; returns `ContainerID = workspaceDir` |
| `Down` / `Stop` / `Start` | No-op (Stateful=false; instanceops refuses Stop/Start) |
| `Exec` / `ExecCommand` | Runs with `cmd.Dir = workspaceDir` |
| `Stats` | `nil, nil` |
| `Logs` / `LogsCommand` | Emits "Local backend has no runtime logs." |
| `CaptureAllSessions` | Runs the shared tmux capture script on the host |
| `AgentToolProbe` | `("", true)` — no agent reported (scoped probe deferred) |
| `EditorURI` | `file:///<workspaceDir>` |
| `ResolveHostname` | `("localhost", true)` — port forwards use the in-process TCP proxy |

## TUI
- `s` (toggle) on a Local Dir instance shows "Local Dir instances cannot be stopped or started" instead of mutating status.
- `backendFor` now lazy-inits `m.backends` defensively (fixed an existing test fragility surfaced by the new code path).

## Test plan
- [ ] CI passes (`go build ./...`, `go test ./...`)
- [ ] Manual: create a Local Dir instance from the TUI, exec a shell, open VS Code via `c`, attempt `s` toggle (expect refusal)
- [ ] Manual: port-forward a local service through the in-process proxy
- [ ] Manual: confirm the existing devcontainer/coder/codespaces flows still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)