### PR TITLE
feat: mouse support in fleet TUI

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -490,6 +490,56 @@ func (m model) Init() tea.Cmd {
 // handled here and returned early. Mixed messages handle their shared
 // part then fall through. Everything else is forwarded to the active page.
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// 0. Mouse — left-button press moves the cursor to the clicked row
+	// (on the fleet list and settings pages) and is then translated to
+	// a key event so existing keyboard handlers do the rest: clicks on
+	// instance rows fire Space (expand/collapse sessions), every other
+	// click fires Enter. Other mouse events (motion, wheel, release,
+	// other buttons) are dropped: page handlers only know about KeyMsgs.
+	if mm, ok := msg.(tea.MouseMsg); ok {
+		if mm.Action == tea.MouseActionPress && mm.Button == tea.MouseButtonLeft {
+			synthesizedKey := tea.KeyMsg{Type: tea.KeyEnter}
+			hit := false
+			switch page := m.currentPage.(type) {
+			case *fleetPage:
+				if page.mode == viewNormal && page.listRowY >= 0 {
+					if idx := mm.Y - page.listRowY; idx >= 0 && idx < len(page.rows) {
+						page.cursor = idx
+						hit = true
+						if page.rows[idx].kind == rowInstance {
+							synthesizedKey = tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}}
+						}
+					}
+				}
+			case *settingsPage:
+				if !page.editing && !page.showKeybindings {
+					items := page.visibleItems(&m)
+					for i, id := range items {
+						y, ok := page.itemRowYs[id]
+						if !ok {
+							continue
+						}
+						h := page.itemHeights[id]
+						if h <= 0 {
+							h = 1
+						}
+						if mm.Y >= y && mm.Y < y+h {
+							page.cursor = i
+							hit = true
+							break
+						}
+					}
+				}
+			}
+			if !hit {
+				return m, nil
+			}
+			msg = synthesizedKey
+		} else {
+			return m, nil
+		}
+	}
+
 	// 1. Window size (shared)
 	if ws, ok := msg.(tea.WindowSizeMsg); ok {
 		m.width = ws.Width
@@ -942,7 +992,7 @@ func Run() error {
 		}
 	}
 
-	p := tea.NewProgram(m, tea.WithAltScreen())
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	finalModel, err := p.Run()
 
 	if clipCancel != nil {

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -77,6 +77,11 @@ type fleetPage struct {
 	savedGroups    map[string]savedGroup
 	pendingGroupID string
 	debounceSeq    int
+
+	// listRowY is the terminal Y (0-indexed) where rows[0] is rendered,
+	// recorded during View() so mouse clicks can be mapped back to a
+	// row index. -1 means "not yet rendered" or "no clickable rows".
+	listRowY int
 }
 
 // newFleetPage creates a new fleet page with default state.
@@ -94,6 +99,7 @@ func newFleetPage() *fleetPage {
 		savedGroups: make(map[string]savedGroup),
 		textInput:   ti,
 		branchInput: bi,
+		listRowY:    -1,
 	}
 }
 
@@ -1056,6 +1062,16 @@ func (fp *fleetPage) viewFleetList(m *model) string {
 	if m.width > 0 {
 		box = box.Width(m.width - 2)
 	}
+	// Record where rows[0] will land on screen so mouse clicks can map
+	// Y → row index. The cursor is at line `newlines` after consuming
+	// `b` so far; +1 skips the box top border, +emptyMsgLines skips the
+	// "No instances" line that precedes the (settings-only) rows when
+	// no fleets exist.
+	emptyMsgLines := 0
+	if m.st == nil || len(m.st.Fleets) == 0 {
+		emptyMsgLines = 1
+	}
+	fp.listRowY = strings.Count(b.String(), "\n") + 1 + emptyMsgLines
 	b.WriteString(box.Render(boxContent))
 	b.WriteString("\n")
 

--- a/internal/tui/page_settings.go
+++ b/internal/tui/page_settings.go
@@ -56,6 +56,13 @@ type settingsPage struct {
 	editing         bool
 	input           textinput.Model
 	showKeybindings bool
+
+	// itemRowYs maps item ID -> terminal Y where the item's first line
+	// is rendered. itemHeights maps item ID -> number of lines the item
+	// occupies. Both are populated during View() so mouse clicks can be
+	// mapped back to the item under the cursor.
+	itemRowYs   map[int]int
+	itemHeights map[int]int
 }
 
 // newSettingsPage creates a new settings page with default state.
@@ -63,7 +70,9 @@ func newSettingsPage() *settingsPage {
 	si := textinput.New()
 	si.CharLimit = 256
 	return &settingsPage{
-		input: si,
+		input:       si,
+		itemRowYs:   make(map[int]int),
+		itemHeights: make(map[int]int),
 	}
 }
 
@@ -585,6 +594,18 @@ func (sp *settingsPage) viewSettings(m *model) string {
 	var listContent strings.Builder
 	currentItem := sp.settingsCursorItem(m)
 
+	// Record where each settings row lands on screen so mouse clicks
+	// can resolve back to a cursor index. The box adds a top border
+	// before its content, hence +1.
+	clear(sp.itemRowYs)
+	clear(sp.itemHeights)
+	firstContentY := strings.Count(b.String(), "\n") + 1
+	recordRow := func(item int, content string) {
+		sp.itemRowYs[item] = firstContentY + strings.Count(listContent.String(), "\n")
+		sp.itemHeights[item] = 1 + strings.Count(content, "\n")
+		listContent.WriteString(content)
+	}
+
 	for _, s := range settingsSections {
 		if !sp.sectionVisible(m, s) {
 			continue
@@ -601,19 +622,19 @@ func (sp *settingsPage) viewSettings(m *model) string {
 			if cfg.GeneralSettings.TmuxVimKeysEnabled() {
 				vimKeysValue = "[ on ]"
 			}
-			listContent.WriteString(sp.renderSettingsRow(m, currentItem == settingsItemTmuxVimKeys, "Tmux vim keys", vimKeysValue))
+			recordRow(settingsItemTmuxVimKeys, sp.renderSettingsRow(m, currentItem == settingsItemTmuxVimKeys, "Tmux vim keys", vimKeysValue))
 			listContent.WriteString("\n")
 
 			helpTextValue := "[ off ]"
 			if cfg.GeneralSettings.ShowHelpTextEnabled() {
 				helpTextValue = "[ on ]"
 			}
-			listContent.WriteString(sp.renderSettingsRow(m, currentItem == settingsItemShowHelpText, "Show help text", helpTextValue))
+			recordRow(settingsItemShowHelpText, sp.renderSettingsRow(m, currentItem == settingsItemShowHelpText, "Show help text", helpTextValue))
 
 			if m.updateAvailable != "" {
 				listContent.WriteString("\n")
 				updateValue := updateStyle.Render(m.updateAvailable+" available ⚡") + "  " + dimStyle.Render("press enter to update")
-				listContent.WriteString(sp.renderSettingsRow(m, currentItem == settingsItemUpdate, "Update", updateValue))
+				recordRow(settingsItemUpdate, sp.renderSettingsRow(m, currentItem == settingsItemUpdate, "Update", updateValue))
 			}
 
 		case "Dotfiles":
@@ -621,21 +642,21 @@ func (sp *settingsPage) viewSettings(m *model) string {
 			if repoValue == "" && !(sp.editing && currentItem == settingsItemDotfilesRepo) {
 				repoValue = dimStyle.Render("(not set)")
 			}
-			listContent.WriteString(sp.renderSettingsRow(m, currentItem == settingsItemDotfilesRepo, "Repository URL", repoValue))
+			recordRow(settingsItemDotfilesRepo, sp.renderSettingsRow(m, currentItem == settingsItemDotfilesRepo, "Repository URL", repoValue))
 			listContent.WriteString("\n")
 
 			scriptValue := cfg.DotfilesSettings.InstallScript
 			if scriptValue == "" && !(sp.editing && currentItem == settingsItemDotfilesScript) {
 				scriptValue = dimStyle.Render("(not set)")
 			}
-			listContent.WriteString(sp.renderSettingsRow(m, currentItem == settingsItemDotfilesScript, "Install script", scriptValue))
+			recordRow(settingsItemDotfilesScript, sp.renderSettingsRow(m, currentItem == settingsItemDotfilesScript, "Install script", scriptValue))
 			listContent.WriteString("\n")
 
 			autoInstallValue := "[ off ]"
 			if cfg.DotfilesSettings.AutoInstall {
 				autoInstallValue = "[ on ]"
 			}
-			listContent.WriteString(sp.renderSettingsRow(m, currentItem == settingsItemDotfilesAutoInstall, "Auto install", autoInstallValue))
+			recordRow(settingsItemDotfilesAutoInstall, sp.renderSettingsRow(m, currentItem == settingsItemDotfilesAutoInstall, "Auto install", autoInstallValue))
 			listContent.WriteString("\n")
 
 			agentName, _, agentErr := agent.FindAgent()
@@ -645,7 +666,7 @@ func (sp *settingsPage) viewSettings(m *model) string {
 			} else {
 				setupValue = statusRunningStyle.Render(agentName) + "  " + dimStyle.Render("press enter to get help setting up dotfiles")
 			}
-			listContent.WriteString(sp.renderSettingsRow(m, currentItem == settingsItemDotfilesSetup, "Help me set this up", setupValue))
+			recordRow(settingsItemDotfilesSetup, sp.renderSettingsRow(m, currentItem == settingsItemDotfilesSetup, "Help me set this up", setupValue))
 
 		case "Coder":
 			templateValue := cfg.CoderSettings.Template
@@ -655,7 +676,7 @@ func (sp *settingsPage) viewSettings(m *model) string {
 			if m.coderFetchingParams {
 				templateValue += "  " + m.spinner.View() + " fetching..."
 			}
-			listContent.WriteString(sp.renderSettingsRow(m, currentItem == settingsItemCoderTemplate, "Template", templateValue))
+			recordRow(settingsItemCoderTemplate, sp.renderSettingsRow(m, currentItem == settingsItemCoderTemplate, "Template", templateValue))
 			listContent.WriteString("\n")
 
 			presetValue := cfg.CoderSettings.Preset
@@ -664,7 +685,7 @@ func (sp *settingsPage) viewSettings(m *model) string {
 			} else {
 				presetValue = fmt.Sprintf("[ %s ]", presetValue)
 			}
-			listContent.WriteString(sp.renderSettingsRow(m, currentItem == settingsItemCoderPreset, "Preset", presetValue))
+			recordRow(settingsItemCoderPreset, sp.renderSettingsRow(m, currentItem == settingsItemCoderPreset, "Preset", presetValue))
 
 			for i, p := range cfg.CoderSettings.Parameters {
 				listContent.WriteString("\n")
@@ -681,7 +702,7 @@ func (sp *settingsPage) viewSettings(m *model) string {
 				if p.DisplayName != "" {
 					label = p.DisplayName
 				}
-				listContent.WriteString(sp.renderSettingsRow(m, currentItem == paramItem, label, value))
+				recordRow(paramItem, sp.renderSettingsRow(m, currentItem == paramItem, label, value))
 			}
 
 		case "Codespaces":
@@ -698,7 +719,7 @@ func (sp *settingsPage) viewSettings(m *model) string {
 					machineValue += "\n" + strings.Repeat(" ", 21) + dimStyle.Render(label)
 				}
 			}
-			listContent.WriteString(sp.renderSettingsRow(m, currentItem == settingsItemCodespacesMachine, "Machine", machineValue))
+			recordRow(settingsItemCodespacesMachine, sp.renderSettingsRow(m, currentItem == settingsItemCodespacesMachine, "Machine", machineValue))
 
 		case "Tool Status":
 			for i, t := range m.toolStatus {
@@ -713,7 +734,7 @@ func (sp *settingsPage) viewSettings(m *model) string {
 				}
 				value := badge + "  " + dimStyle.Render(t.Description)
 				itemID := settingsItemToolStatusBase + i
-				listContent.WriteString(sp.renderSettingsRow(m, currentItem == itemID, t.Name, value))
+				recordRow(itemID, sp.renderSettingsRow(m, currentItem == itemID, t.Name, value))
 			}
 
 		case "Help":
@@ -724,9 +745,9 @@ func (sp *settingsPage) viewSettings(m *model) string {
 			} else {
 				value = statusRunningStyle.Render(agentName) + "  " + dimStyle.Render("press enter to diagnose your setup")
 			}
-			listContent.WriteString(sp.renderSettingsRow(m, currentItem == settingsItemDoctor, "Run Doctor", value))
+			recordRow(settingsItemDoctor, sp.renderSettingsRow(m, currentItem == settingsItemDoctor, "Run Doctor", value))
 			listContent.WriteString("\n")
-			listContent.WriteString(sp.renderSettingsRow(m, currentItem == settingsItemKeybindings, "Keybindings", dimStyle.Render("press enter to view all keybindings")))
+			recordRow(settingsItemKeybindings, sp.renderSettingsRow(m, currentItem == settingsItemKeybindings, "Keybindings", dimStyle.Render("press enter to view all keybindings")))
 		}
 
 		listContent.WriteString("\n\n")


### PR DESCRIPTION
## Summary
- Enable cell-motion mouse reporting via `tea.WithMouseCellMotion()`.
- Left-click maps to "move cursor to clicked row, then synthesize the right key" — Enter for fleet headers / sessions / settings; Space for instance rows so they expand sessions inline.
- Click-to-cursor works on the fleet list (normal mode) and the settings page. Clicks while a dialog, text edit, or the keybindings overlay is active are ignored, and clicks outside any row are dropped silently (no spurious Enter).
- Each page records its row Y positions during `View()` so the click handler can resolve coords → cursor index without re-rendering.

## Test plan
- [ ] Click instance row → expands/collapses sessions
- [ ] Click fleet header → collapses/expands the fleet
- [ ] Click session row → connects to that session
- [ ] Click `+ new session` → opens new-session dialog
- [ ] Click settings row → opens settings; clicking a settings item moves cursor and triggers its action
- [ ] Click multi-line "Machine" row in settings (when set) on either of its two lines → cursor lands on it
- [ ] Click empty space below the list → nothing happens
- [ ] Mouse wheel / right-click / motion → no effect
- [ ] In a dialog (e.g. New fleet, Add instance, Confirm delete), mouse click does not move cursor or fire enter
- [ ] Shift+drag still works for native text selection in your terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)