### PR TITLE
Support Fleet on Docker Desktop WSL

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
   "privileged": true,
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
-  "postStartCommand": "/workspaces/fleet-man/.devcontainer/setup.sh"
+  "postStartCommand": "bash ${containerWorkspaceFolder}/.devcontainer/setup.sh"
   // Configure tool-specific properties.
   // "customizations": {},
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,55 @@ fleet up my-project/agent-3
 
 ## Requirements
 
-- Linux
+- Linux, including Ubuntu on WSL2
 - Docker
 - [devcontainer CLI](https://github.com/devcontainers/cli) (`npm install -g @devcontainers/cli`)
+
+## Windows WSL Setup
+
+Fleet is a Linux CLI, but it can run on Windows through WSL2. The confirmed
+setup is:
+
+- Ubuntu on WSL2
+- Docker Desktop with WSL integration enabled for the Ubuntu distro
+- Node installed with `nvm`
+- `@devcontainers/cli` installed under the nvm-managed Node
+- Fleet installed somewhere on the WSL `PATH`, such as `~/.local/bin/fleet`
+
+Inside WSL:
+
+```bash
+nvm install 22
+nvm alias default 22
+nvm use default
+npm install -g @devcontainers/cli
+```
+
+On Docker Desktop plus WSL, if devcontainer startup fails while building the
+UID-adjustment or feature image, disable BuildKit for Fleet-managed
+devcontainers:
+
+```bash
+export FLEET_DEVCONTAINER_BUILDKIT=never
+```
+
+To persist that setting:
+
+```bash
+echo 'export FLEET_DEVCONTAINER_BUILDKIT=never' >> ~/.bashrc
+```
+
+See [Windows WSL notes](docs/windows-wsl-notes.md) for a full health check and
+disposable smoke-test workflow.
+
+## Devcontainer BuildKit
+
+Fleet uses the devcontainer CLI's default BuildKit behavior unless explicitly
+configured. If Docker Desktop on WSL fails while building the devcontainer
+UID-adjustment image, disable BuildKit for Fleet-managed devcontainers:
+
+```bash
+export FLEET_DEVCONTAINER_BUILDKIT=never
+```
+
+Accepted values are `auto` and `never`.

--- a/docs/windows-wsl-notes.md
+++ b/docs/windows-wsl-notes.md
@@ -1,0 +1,152 @@
+# Windows WSL Notes
+
+These notes capture the Windows/WSL setup used to build and smoke test Fleet.
+
+## Quickstart
+
+Prerequisites:
+
+- WSL2 with Ubuntu installed
+- Docker Desktop with WSL integration enabled for the Ubuntu distro
+- Git available inside WSL
+- Git access to the target repository; SSH is only needed for private repos or
+  SSH remotes
+
+Inside WSL:
+
+```bash
+# Install/use Node through nvm, not Ubuntu's old distro Node.
+nvm install 22
+nvm alias default 22
+nvm use default
+npm install -g @devcontainers/cli
+
+# Fleet/Docker Desktop WSL workaround.
+export FLEET_DEVCONTAINER_BUILDKIT=never
+
+# Confirm tooling.
+node --version
+npm --version
+devcontainer --version
+docker info
+fleet --help
+```
+
+## Health Check
+
+Run Fleet from a WSL filesystem path, such as `~/code/fleet-man`, not from
+`/mnt/c`, when possible.
+
+```bash
+uname -a
+pwd
+which node && node --version
+which npm && npm --version
+which devcontainer && devcontainer --version
+which docker && docker info
+which fleet && fleet --help
+```
+
+Condensed check:
+
+```bash
+printf 'FLEET_DEVCONTAINER_BUILDKIT=%s\n' "$FLEET_DEVCONTAINER_BUILDKIT"
+node --version
+npm --version
+devcontainer --version
+docker info --format 'Docker {{.ServerVersion}} {{.OSType}} running={{.ContainersRunning}} total={{.Containers}}'
+fleet --help >/dev/null && echo fleet-ok
+fleet ls
+```
+
+If the Fleet logo or borders render without the expected colors, confirm the
+terminal and tmux session expose 256-color or truecolor support:
+
+```bash
+echo "$TERM"
+tmux show -g terminal-features 2>/dev/null || true
+```
+
+Windows Terminal plus modern tmux should preserve Fleet's truecolor gradient.
+
+## Node and devcontainer CLI
+
+Do not install modern devcontainer CLI packages against Ubuntu's old distro
+Node. Use nvm in WSL:
+
+```bash
+nvm install 22
+nvm alias default 22
+nvm use default
+npm install -g @devcontainers/cli
+```
+
+If an older user-local devcontainer CLI exists under `~/.local`, remove it so
+shells do not accidentally run it with an old Node:
+
+```bash
+npm uninstall -g --prefix ~/.local @devcontainers/cli
+hash -r
+```
+
+## BuildKit Workaround
+
+Fleet supports an opt-in BuildKit mode for devcontainer startup:
+
+```bash
+export FLEET_DEVCONTAINER_BUILDKIT=never
+```
+
+This is useful on Docker Desktop plus WSL when devcontainer startup fails while
+building the UID-adjustment image or feature image. Accepted values are:
+
+- `auto`
+- `never`
+
+Unset behavior delegates to the devcontainer CLI default.
+
+## Disposable Local Fixture
+
+For a low-risk local smoke test, create a tiny disposable repo:
+
+```bash
+mkdir -p ~/code/fleet-disposable/.devcontainer
+cd ~/code/fleet-disposable
+git init
+git config user.name "Fleet Disposable"
+git config user.email "fleet-disposable@example.com"
+
+cat > README.md <<'EOF'
+# fleet-disposable
+
+Disposable devcontainer fixture for Fleet smoke testing.
+EOF
+
+cat > .devcontainer/devcontainer.json <<'EOF'
+{
+  "name": "fleet-disposable",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
+  "remoteUser": "vscode"
+}
+EOF
+
+git add README.md .devcontainer/devcontainer.json
+git commit -m "Add disposable devcontainer fixture"
+```
+
+Run and clean it:
+
+```bash
+fleet up disposable-1 --repo ~/code/fleet-disposable
+fleet ls
+fleet exec fleet-disposable/disposable-1 -- sh -lc 'echo disposable-ok && pwd && id -un'
+fleet down fleet-disposable/disposable-1
+```
+
+Expected exec output:
+
+```text
+disposable-ok
+/workspaces/fleet-disposable
+vscode
+```

--- a/internal/backend/devcontainer/devcontainer.go
+++ b/internal/backend/devcontainer/devcontainer.go
@@ -69,6 +69,11 @@ func (b *DevcontainerBackend) Up(workspaceDir string) (*backend.UpResult, error)
 	args := []string{"up", "--workspace-folder", workspaceDir}
 	args = append(args, sshUpArgs()...)
 	cmd := exec.Command("devcontainer", args...)
+	env, err := devcontainerEnv(os.Environ())
+	if err != nil {
+		return nil, err
+	}
+	cmd.Env = env
 
 	// Capture stdout for JSON parsing, tee to os.Stdout so it appears
 	// in log files when run from the TUI background process.
@@ -98,6 +103,18 @@ func (b *DevcontainerBackend) Up(workspaceDir string) (*backend.UpResult, error)
 	}
 
 	return &result, nil
+}
+
+func devcontainerEnv(base []string) ([]string, error) {
+	mode := strings.TrimSpace(os.Getenv("FLEET_DEVCONTAINER_BUILDKIT"))
+	switch mode {
+	case "", "auto":
+		return base, nil
+	case "never":
+		return append(base, "DOCKER_BUILDKIT=0"), nil
+	default:
+		return nil, fmt.Errorf("invalid FLEET_DEVCONTAINER_BUILDKIT value %q (valid: auto, never)", mode)
+	}
 }
 
 // Exec runs `devcontainer exec` in the given workspace folder.

--- a/internal/backend/devcontainer/devcontainer_test.go
+++ b/internal/backend/devcontainer/devcontainer_test.go
@@ -1,6 +1,7 @@
 package devcontainer
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
@@ -40,6 +41,42 @@ func TestParseToolProbeOutput(t *testing.T) {
 			}
 			if tool != tt.wantTool {
 				t.Fatalf("ParseToolProbeOutput(%q) tool = %q, want %q", tt.output, tool, tt.wantTool)
+			}
+		})
+	}
+}
+
+func TestDevcontainerEnvBuildKitMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    string
+		wantEnv string
+		wantErr bool
+	}{
+		{name: "unset delegates to default"},
+		{name: "auto delegates to default", mode: "auto"},
+		{name: "never disables buildkit", mode: "never", wantEnv: "DOCKER_BUILDKIT=0"},
+		{name: "invalid errors", mode: "sometimes", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("FLEET_DEVCONTAINER_BUILDKIT", tt.mode)
+			env, err := devcontainerEnv([]string{"PATH=/bin"})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("devcontainerEnv() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("devcontainerEnv() error = %v", err)
+			}
+			if tt.wantEnv != "" && !slices.Contains(env, tt.wantEnv) {
+				t.Fatalf("devcontainerEnv() missing %q in %#v", tt.wantEnv, env)
+			}
+			if tt.wantEnv == "" && slices.Contains(env, "DOCKER_BUILDKIT=0") {
+				t.Fatalf("devcontainerEnv() unexpectedly disabled BuildKit: %#v", env)
 			}
 		})
 	}

--- a/internal/cli/create_instance.go
+++ b/internal/cli/create_instance.go
@@ -23,11 +23,19 @@ func newCreateInstanceCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			bt := fleet.BackendDevcontainer
 			if backendFlag != "" {
-				bt = fleet.BackendType(backendFlag)
+				parsed, err := fleet.ParseBackendType(backendFlag)
+				if err != nil {
+					return err
+				}
+				bt = parsed
 			} else if len(args) >= 4 {
 				// Preserve the legacy 4th positional form for compatibility
 				// with older callers that predate the --backend flag.
-				bt = fleet.BackendType(args[3])
+				parsed, err := fleet.ParseBackendType(args[3])
+				if err != nil {
+					return err
+				}
+				bt = parsed
 			}
 			return create.Run(args[0], args[1], args[2], branchFlag, false, bt)
 		},

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -74,7 +74,8 @@ func TestListIncludesBranchColumnAndValues(t *testing.T) {
 	if strings.Contains(agentTwoLine, "feature/status-line") {
 		t.Fatalf("agent-2 line unexpectedly contains branch value:\n%s", agentTwoLine)
 	}
-	if !strings.HasSuffix(strings.TrimRight(agentTwoLine, " "), "1970-01-01 00:00") {
+	expectedCreated := time.Unix(0, 0).Local().Format("2006-01-02 15:04")
+	if !strings.HasSuffix(strings.TrimRight(agentTwoLine, " "), expectedCreated) {
 		t.Fatalf("agent-2 line should end at CREATED column when branch is empty:\n%s", agentTwoLine)
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -137,10 +137,11 @@ func relaunchInTmux() error {
 			`[ -n "$CLIP" ] && { tmux set-buffer -b __fleet_primary -- "$CLIP"; tmux paste-buffer -p -d -b __fleet_primary -t "$TMUX_PANE"; }`,
 	)
 	// terminal-features tells tmux the terminal supports OSC 52
-	// clipboard (tmux 3.2+). Appended last so older versions just
-	// lose this feature without breaking the session.
+	// clipboard and RGB/truecolor (tmux 3.2+). Appended last so
+	// older versions just lose these features without breaking the
+	// session.
 	setupArgs = append(setupArgs,
-		";", "set", "-as", "terminal-features", ",*:clipboard",
+		";", "set", "-as", "terminal-features", ",*:clipboard:RGB",
 	)
 	//nolint:errcheck // terminal-features may fail on tmux <3.2
 	exec.Command(setupArgs[0], setupArgs[1:]...).Run()

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -23,12 +23,9 @@ func newUpCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
-			bt := fleet.BackendDevcontainer
-			switch backendFlag {
-			case "coder":
-				bt = fleet.BackendCoder
-			case "codespaces":
-				bt = fleet.BackendCodespaces
+			bt, err := fleet.ParseBackendType(backendFlag)
+			if err != nil {
+				return err
 			}
 
 			target, err := fleet.Resolve(name, repoFlag)

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
-	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
 	coderbackend "github.com/BenjaminBenetti/fleet-man/internal/backend/coder"
 	codespacesbackend "github.com/BenjaminBenetti/fleet-man/internal/backend/codespaces"
+	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/dotfiles"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
@@ -28,6 +28,11 @@ import (
 // --branch <branch>` so the instance is provisioned against that ref
 // rather than the repository's default branch.
 func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, bt fleet.BackendType) error {
+	if err := fleet.ValidateBackendType(bt); err != nil {
+		setFailed(fleetName, instanceName, err)
+		return err
+	}
+
 	wsDir := filepath.Join(state.WorkspacesDir(), fleetName, instanceName, fleetName)
 
 	var dc backend.Backend

--- a/internal/fleet/instance.go
+++ b/internal/fleet/instance.go
@@ -1,6 +1,9 @@
 package fleet
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 type InstanceStatus string
 
@@ -22,6 +25,26 @@ const (
 	BackendCoder        BackendType = "coder"
 	BackendCodespaces   BackendType = "codespaces"
 )
+
+// ParseBackendType validates a CLI/backend string and returns its BackendType.
+func ParseBackendType(value string) (BackendType, error) {
+	switch BackendType(value) {
+	case BackendDevcontainer:
+		return BackendDevcontainer, nil
+	case BackendCoder:
+		return BackendCoder, nil
+	case BackendCodespaces:
+		return BackendCodespaces, nil
+	default:
+		return "", fmt.Errorf("invalid backend %q (valid: devcontainer, coder, codespaces)", value)
+	}
+}
+
+// ValidateBackendType returns an error if bt is not a known backend.
+func ValidateBackendType(bt BackendType) error {
+	_, err := ParseBackendType(string(bt))
+	return err
+}
 
 // Instance represents a single devcontainer workspace in a fleet.
 //

--- a/internal/fleet/instance_test.go
+++ b/internal/fleet/instance_test.go
@@ -35,3 +35,35 @@ func TestInstanceUnmarshalLegacyHasNoDisplayName(t *testing.T) {
 		t.Fatalf("GetDisplayName() = %q, want %q", got, "agent-1")
 	}
 }
+
+func TestParseBackendType(t *testing.T) {
+	tests := []struct {
+		value   string
+		want    BackendType
+		wantErr bool
+	}{
+		{value: "devcontainer", want: BackendDevcontainer},
+		{value: "coder", want: BackendCoder},
+		{value: "codespaces", want: BackendCodespaces},
+		{value: "bogus", wantErr: true},
+		{value: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			got, err := ParseBackendType(tt.value)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("ParseBackendType() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseBackendType() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseBackendType() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds the small changes needed to make Fleet easier to build and smoke test from Windows through Ubuntu on WSL2 while preserving Fleet's existing upstream project identity.

## Changes

- Adds `FLEET_DEVCONTAINER_BUILDKIT=never` support so Fleet can disable BuildKit only for `devcontainer up` when Docker Desktop + WSL hits the UID-adjustment / feature-image BuildKit failure.
- Validates backend names for `fleet up --backend` and the internal `_create-instance --backend` path instead of silently falling back to devcontainer for unknown values.
- Makes the repository devcontainer `postStartCommand` repo-name independent and runs the setup script through `bash`.
- Advertises RGB truecolor support in Fleet's tmux launcher so the TUI gradient/colors survive tmux more reliably.
- Documents a Windows/WSL setup path and disposable local smoke test.
- Makes a branch-column list test timezone-stable.

## Validation

```bash
go test ./...
go vet ./...
go build -o /tmp/fleet-pr-check ./cmd/fleet
/tmp/fleet-pr-check --help
```

All checks passed.