### PR TITLE
test: expand integration suite with CLI gap-fill tests

### DIFF
--- a/integration/tests/070_cli_help.sh
+++ b/integration/tests/070_cli_help.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Description: `fleet --help` and every subcommand --help exit 0 and surface their usage.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+# This test is pure CLI surface — no devcontainer, no docker — so we
+# skip setup_test (it would just wipe ~/.fleet for nothing).
+
+# ===========================================
+# Root help
+# ===========================================
+info "fleet --help"
+root_help=$("${FLEET_BIN}" --help)
+assert_contains "${root_help}" "fleet-man is a CLI/TUI tool" "root help missing long description"
+assert_contains "${root_help}" "Available Commands:"        "root help missing commands header"
+
+# Each visible subcommand we ship must appear in the Available Commands block.
+# This protects against accidentally dropping one from NewRootCmd. The
+# `_create-instance` command is intentionally Hidden, so it's not asserted.
+for sub in up stop start down destroy list exec code logs status port-forward shell; do
+  assert_contains "${root_help}" "${sub}" "root help missing subcommand: ${sub}"
+done
+
+# The hidden internal command must NOT show in the public help — surfacing
+# it would invite users to call it directly, breaking the TUI contract.
+assert_not_contains "${root_help}" "_create-instance" "internal command should remain hidden"
+
+# ===========================================
+# Per-subcommand help. Each must succeed and contain its own short text.
+# Tuple format: <command>|<expected substring>
+# ===========================================
+declare -a checks=(
+  "up|Spawn a new instance"
+  "stop|Stop a devcontainer instance"
+  "start|Start an existing stopped"
+  "down|Stop and remove an instance"
+  "destroy|Remove a fleet"
+  "list|List devcontainer instances"
+  "exec|Execute a command inside an instance"
+  "logs|Show logs for an instance"
+  "status|Show fleet-wide status summary"
+)
+
+for entry in "${checks[@]}"; do
+  cmd="${entry%%|*}"
+  expected="${entry#*|}"
+  info "fleet ${cmd} --help"
+  out=$("${FLEET_BIN}" "${cmd}" --help)
+  assert_contains "${out}" "${expected}" "${cmd} --help missing expected text"
+  assert_contains "${out}" "Usage:"        "${cmd} --help missing Usage block"
+done
+
+# `ls` is the alias for `list` — verify it resolves to the same command.
+info "fleet ls --help (alias)"
+ls_help=$("${FLEET_BIN}" ls --help)
+assert_contains "${ls_help}" "List devcontainer instances" "ls alias should resolve to list"
+
+# Up advertises its flags so users discover --repo / --branch.
+info "fleet up --help advertises flags"
+up_help=$("${FLEET_BIN}" up --help)
+assert_contains "${up_help}" "--repo"   "up --help missing --repo flag"
+assert_contains "${up_help}" "--branch" "up --help missing --branch flag"
+
+pass "CLI --help works for root and all subcommands"

--- a/integration/tests/075_cli_resolve_errors.sh
+++ b/integration/tests/075_cli_resolve_errors.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Description: CLI error paths — missing fleets, missing instances, and malformed targets fail with non-zero status.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test  # leaves ~/.fleet empty — no fleets registered in state
+
+# Helper: run a command outside `set -e` and capture {stdout+stderr, rc}.
+# Usage: run_capture <var_prefix> -- <fleet args...>
+# Sets ${var_prefix}_OUT and ${var_prefix}_RC.
+run_capture() {
+  local prefix="$1"; shift
+  [ "${1:-}" = "--" ] && shift
+  local _out _rc
+  set +e
+  _out=$("${FLEET_BIN}" "$@" 2>&1)
+  _rc=$?
+  set -e
+  printf -v "${prefix}_OUT" '%s' "${_out}"
+  printf -v "${prefix}_RC" '%s' "${_rc}"
+}
+
+# ===========================================
+# 1. Operations on a missing fleet must fail (non-zero) AND surface the
+#    fleet name in the error so the user can debug.
+# ===========================================
+for verb in down destroy stop start logs; do
+  case "${verb}" in
+    destroy) target="ghost-fleet" ;;
+    *)       target="ghost-fleet/missing-instance" ;;
+  esac
+  info "fleet ${verb} ${target} (fleet does not exist)"
+  run_capture R -- "${verb}" "${target}"
+  if [ "${R_RC}" -eq 0 ]; then
+    fail "expected ${verb} on missing fleet to fail, got rc=0; out=[${R_OUT}]"
+  fi
+  assert_contains "${R_OUT}" "ghost-fleet" "${verb} error should mention fleet name"
+done
+
+# ===========================================
+# 2. exec on a missing fleet — uses MinimumNArgs(2), so we must include a cmd.
+# ===========================================
+info "fleet exec ghost-fleet/missing -- echo hi (fleet does not exist)"
+run_capture R -- exec ghost-fleet/missing -- echo hi
+if [ "${R_RC}" -eq 0 ]; then
+  fail "exec on missing fleet should fail, got rc=0; out=[${R_OUT}]"
+fi
+assert_contains "${R_OUT}" "ghost-fleet" "exec error should mention fleet name"
+
+# ===========================================
+# 3. Malformed target ("/foo" or "fleet/") — Resolve returns
+#    "invalid target ... both fleet and instance names are required".
+# ===========================================
+info "fleet exec /foo -- echo hi (empty fleet)"
+run_capture R -- exec "/foo" -- echo hi
+if [ "${R_RC}" -eq 0 ]; then
+  fail "exec with empty fleet name should fail, got rc=0; out=[${R_OUT}]"
+fi
+assert_contains "${R_OUT}" "invalid target" "empty-fleet target should be rejected as invalid"
+
+info "fleet exec foo/ -- echo hi (empty instance)"
+run_capture R -- exec "foo/" -- echo hi
+if [ "${R_RC}" -eq 0 ]; then
+  fail "exec with empty instance name should fail, got rc=0; out=[${R_OUT}]"
+fi
+assert_contains "${R_OUT}" "invalid target" "empty-instance target should be rejected as invalid"
+
+# ===========================================
+# 4. Operations on an existing fleet but a missing instance should
+#    surface the instance name (not just the fleet).
+# ===========================================
+info "Bringing up itest-fleet/alpha to populate state"
+fleet_up alpha
+
+info "fleet down itest-fleet/no-such-instance (instance missing in real fleet)"
+run_capture R -- down "${FIXTURE_REPO_NAME}/no-such-instance"
+if [ "${R_RC}" -eq 0 ]; then
+  fail "down on missing instance should fail, got rc=0; out=[${R_OUT}]"
+fi
+assert_contains "${R_OUT}" "no-such-instance" "down error should mention missing instance name"
+
+info "fleet exec itest-fleet/no-such-instance -- echo hi"
+run_capture R -- exec "${FIXTURE_REPO_NAME}/no-such-instance" -- echo hi
+if [ "${R_RC}" -eq 0 ]; then
+  fail "exec on missing instance should fail, got rc=0; out=[${R_OUT}]"
+fi
+assert_contains "${R_OUT}" "no-such-instance" "exec error should mention missing instance name"
+
+# Sanity: the real instance still works after all the failed lookups —
+# none of the error paths should have corrupted state.
+real_out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- sh -c "echo still-here")
+assert_equals "still-here" "${real_out}" "valid instance should still be reachable after error-path probing"
+
+pass "CLI resolve errors fail cleanly with descriptive messages"

--- a/integration/tests/080_cli_up_duplicate.sh
+++ b/integration/tests/080_cli_up_duplicate.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Description: `fleet up` rejects creating an instance with a name that already exists in the fleet.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test
+fleet_up alpha
+
+# Snapshot the container ID so we can assert the second `up` did not
+# silently replace it with a fresh container.
+container_id_before=$(grep -oE '"container_id":\s*"[^"]+"' "${HOME}/.fleet/state.json" \
+  | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
+[ -n "${container_id_before}" ] || fail "could not read container_id from state.json"
+info "container id before second up: ${container_id_before}"
+
+# ===========================================
+# Second `fleet up` for the same name must error and not create a new
+# container, not duplicate the state entry, and not nuke the existing
+# instance.
+# ===========================================
+info "fleet up alpha (already exists, should fail)"
+set +e
+dup_out=$("${FLEET_BIN}" up alpha --repo "${FIXTURE_REPO_URL}" 2>&1)
+dup_rc=$?
+set -e
+printf '%s\n' "${dup_out}"
+
+if [ "${dup_rc}" -eq 0 ]; then
+  fail "duplicate up should fail, got rc=0; out=[${dup_out}]"
+fi
+assert_contains "${dup_out}" "already exists" "duplicate up should mention 'already exists'"
+assert_contains "${dup_out}" "alpha"           "duplicate up should mention instance name"
+
+# ===========================================
+# State must still reflect the original instance. The container ID must
+# not have changed and there must be exactly one alpha entry.
+# ===========================================
+container_id_after=$(grep -oE '"container_id":\s*"[^"]+"' "${HOME}/.fleet/state.json" \
+  | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
+assert_equals "${container_id_before}" "${container_id_after}" \
+  "container ID changed after rejected duplicate up"
+
+alpha_count=$(grep -cE '"name":\s*"alpha"' "${HOME}/.fleet/state.json" || true)
+assert_equals "1" "${alpha_count}" "expected exactly one alpha entry in state.json"
+
+# Original container is still usable — nothing was torn down by the
+# rejected duplicate.
+info "fleet exec alpha -- echo still-alive"
+echo_out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- sh -c "echo still-alive")
+assert_equals "still-alive" "${echo_out}" "exec on alpha after rejected duplicate"
+
+# ===========================================
+# A different instance name in the same fleet must succeed — the rejection
+# is per-instance, not per-fleet.
+# ===========================================
+info "fleet up beta (new name, same fleet, should succeed)"
+fleet_up beta
+ls_out=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+assert_contains "${ls_out}" "alpha" "alpha should still be present"
+assert_contains "${ls_out}" "beta"  "beta should now be present"
+
+pass "fleet up rejects duplicate instance names"

--- a/integration/tests/085_cli_start_already_running.sh
+++ b/integration/tests/085_cli_start_already_running.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Description: `fleet start` on an already-running instance is a no-op (mirror of stop's already-stopped path).
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test
+fleet_up alpha
+
+# Container should already be running after `fleet up`.
+container_id=$(grep -oE '"container_id":\s*"[^"]+"' "${HOME}/.fleet/state.json" \
+  | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
+[ -n "${container_id}" ] || fail "could not read container_id from state.json"
+
+state_before=$(docker inspect -f '{{.State.Status}}' "${container_id}")
+assert_equals "running" "${state_before}" "container should be running after fleet up"
+
+# ===========================================
+# `fleet start` while running — should succeed (rc=0) and surface the
+# already-running message rather than error.
+# ===========================================
+info "fleet start alpha (already running)"
+start_out=$("${FLEET_BIN}" start "${FIXTURE_REPO_NAME}/alpha")
+printf '%s\n' "${start_out}"
+assert_contains "${start_out}" "already running" "start on running instance should report already-running"
+
+# Container is still the SAME container — the no-op must not have replaced it.
+state_after=$(docker inspect -f '{{.State.Status}}' "${container_id}")
+assert_equals "running" "${state_after}" "container should remain running after no-op start"
+
+new_container_id=$(grep -oE '"container_id":\s*"[^"]+"' "${HOME}/.fleet/state.json" \
+  | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
+assert_equals "${container_id}" "${new_container_id}" \
+  "container ID should not change after no-op start"
+
+# ===========================================
+# Real round-trip: stop → start → stop on already-stopped → start on running
+# exercises both no-op branches in instanceops without re-pulling the image.
+# ===========================================
+info "fleet stop alpha"
+"${FLEET_BIN}" stop "${FIXTURE_REPO_NAME}/alpha" >/dev/null
+docker_state=$(docker inspect -f '{{.State.Status}}' "${container_id}")
+if [ "${docker_state}" = "running" ]; then
+  fail "container should not be running after stop, got: ${docker_state}"
+fi
+
+info "fleet start alpha (was stopped)"
+start_out=$("${FLEET_BIN}" start "${FIXTURE_REPO_NAME}/alpha")
+assert_contains "${start_out}" "started" "start after stop should report started"
+docker_state=$(docker inspect -f '{{.State.Status}}' "${container_id}")
+assert_equals "running" "${docker_state}" "container should be running after start"
+
+info "fleet start alpha (still running — second no-op)"
+start_again=$("${FLEET_BIN}" start "${FIXTURE_REPO_NAME}/alpha")
+assert_contains "${start_again}" "already running" "second start should still be a no-op"
+
+pass "fleet start no-op on already-running instance"

--- a/integration/tests/090_cli_multi_instance_isolation.sh
+++ b/integration/tests/090_cli_multi_instance_isolation.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Description: stop/start/down only affect the named instance; other instances in the same fleet are untouched.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test
+fleet_up alpha
+fleet_up beta
+
+# Pull both container IDs out of state so we can verify docker-level state
+# independently of what fleet says. The state file is small JSON pretty-
+# printed by Go's encoder — `name` always appears in the same object as
+# its sibling `container_id`, so awk can walk to the next container_id
+# after each `name` line.
+state_file="${HOME}/.fleet/state.json"
+extract_container_id() {
+  local instance_name="$1"
+  awk -v want="\"name\": \"${instance_name}\"" '
+    index($0, want)        { found=1; next }
+    found && /"container_id"/ { print; exit }
+  ' "${state_file}" | grep -oE '"[a-f0-9]{12,}"' | tr -d '"' | head -1
+}
+alpha_id=$(extract_container_id alpha)
+beta_id=$(extract_container_id beta)
+[ -n "${alpha_id}" ] || fail "could not resolve alpha container id"
+[ -n "${beta_id}"  ] || fail "could not resolve beta container id"
+[ "${alpha_id}" != "${beta_id}" ] || fail "alpha and beta share a container id?"
+info "alpha=${alpha_id} beta=${beta_id}"
+
+# ===========================================
+# Stop alpha — beta must remain running.
+# ===========================================
+info "fleet stop alpha"
+"${FLEET_BIN}" stop "${FIXTURE_REPO_NAME}/alpha" >/dev/null
+
+state_alpha=$(docker inspect -f '{{.State.Status}}' "${alpha_id}")
+state_beta=$(docker inspect -f '{{.State.Status}}' "${beta_id}")
+info "after stop alpha: alpha=${state_alpha} beta=${state_beta}"
+if [ "${state_alpha}" = "running" ]; then
+  fail "alpha should not be running after stop"
+fi
+assert_equals "running" "${state_beta}" "stopping alpha must not affect beta"
+
+# ls confirms both rows present, with the right per-row status.
+ls_out=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+printf '%s\n' "${ls_out}"
+# Find the per-row line for each instance and check its status column.
+alpha_row=$(printf '%s\n' "${ls_out}" | grep -E '^\S+\s+alpha\s' || true)
+beta_row=$(printf '%s\n' "${ls_out}" | grep -E '^\S+\s+beta\s'  || true)
+[ -n "${alpha_row}" ] || fail "ls missing alpha row: [${ls_out}]"
+[ -n "${beta_row}"  ] || fail "ls missing beta row: [${ls_out}]"
+assert_contains "${alpha_row}" "stopped" "alpha row should show stopped"
+assert_contains "${beta_row}"  "running" "beta row should still show running"
+
+# Beta still works.
+echo_out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/beta" -- sh -c "echo beta-alive")
+assert_equals "beta-alive" "${echo_out}" "beta should still be reachable while alpha is stopped"
+
+# ===========================================
+# Start alpha back up — beta untouched.
+# ===========================================
+info "fleet start alpha"
+"${FLEET_BIN}" start "${FIXTURE_REPO_NAME}/alpha" >/dev/null
+state_alpha=$(docker inspect -f '{{.State.Status}}' "${alpha_id}")
+state_beta=$(docker inspect -f '{{.State.Status}}' "${beta_id}")
+assert_equals "running" "${state_alpha}" "alpha should be running again"
+assert_equals "running" "${state_beta}"  "starting alpha must not affect beta"
+
+# ===========================================
+# Down beta — alpha must survive in state and on docker.
+# ===========================================
+info "fleet down beta"
+"${FLEET_BIN}" down "${FIXTURE_REPO_NAME}/beta" >/dev/null
+
+if docker inspect "${beta_id}" >/dev/null 2>&1; then
+  fail "beta container ${beta_id} still exists after down"
+fi
+state_alpha=$(docker inspect -f '{{.State.Status}}' "${alpha_id}")
+assert_equals "running" "${state_alpha}" "alpha should remain running after beta is removed"
+
+ls_after=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+assert_contains     "${ls_after}" "alpha" "alpha should remain in ls"
+assert_not_contains "${ls_after}" "beta"  "beta should be gone from ls"
+
+# Alpha still functional after sibling teardown.
+echo_out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- sh -c "echo alpha-alive")
+assert_equals "alpha-alive" "${echo_out}" "alpha should still be reachable after beta down"
+
+pass "stop / start / down target only the named instance"

--- a/integration/tests/095_cli_logs.sh
+++ b/integration/tests/095_cli_logs.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Description: `fleet logs` streams the container's docker logs output, including the entrypoint banner.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test
+fleet_up alpha
+
+container_id=$(grep -oE '"container_id":\s*"[^"]+"' "${HOME}/.fleet/state.json" \
+  | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
+[ -n "${container_id}" ] || fail "could not read container_id from state.json"
+
+# ===========================================
+# 1. `fleet logs` (non-follow) returns the container's stdout. The
+#    fixture's entrypoint runs `echo Container started`, so that
+#    sentinel should appear. We compare against `docker logs` directly
+#    to make sure the two outputs agree — that's the contract.
+# ===========================================
+info "fleet logs alpha (non-follow)"
+fleet_logs=$("${FLEET_BIN}" logs "${FIXTURE_REPO_NAME}/alpha")
+docker_logs=$(docker logs "${container_id}" 2>&1)
+
+# Sanity: the entrypoint banner is in there.
+assert_contains "${fleet_logs}" "Container started" "fleet logs missing entrypoint banner"
+
+# Equality with docker logs is the real assertion. Strip trailing newlines
+# both sides for a clean compare.
+fl_norm=$(printf '%s' "${fleet_logs}" | sed -e 's/[[:space:]]*$//')
+dl_norm=$(printf '%s' "${docker_logs}" | sed -e 's/[[:space:]]*$//')
+if [ "${fl_norm}" != "${dl_norm}" ]; then
+  printf -- '--- fleet logs ---\n%s\n--- docker logs ---\n%s\n--- end ---\n' \
+    "${fleet_logs}" "${docker_logs}" >&2
+  fail "fleet logs output should match docker logs output"
+fi
+
+# ===========================================
+# 2. logs against an unknown instance must fail without leaking docker
+#    output (the resolver has to error out before invoking docker).
+# ===========================================
+info "fleet logs ${FIXTURE_REPO_NAME}/no-such (must fail)"
+set +e
+miss_out=$("${FLEET_BIN}" logs "${FIXTURE_REPO_NAME}/no-such" 2>&1)
+miss_rc=$?
+set -e
+if [ "${miss_rc}" -eq 0 ]; then
+  fail "logs on missing instance should fail, got rc=0; out=[${miss_out}]"
+fi
+assert_contains     "${miss_out}" "no-such"           "missing-instance error should name the instance"
+assert_not_contains "${miss_out}" "Container started" "missing-instance error must not leak real container logs"
+
+pass "fleet logs streams container output"

--- a/integration/tests/100_cli_branch.sh
+++ b/integration/tests/100_cli_branch.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Description: `fleet up --branch <branch>` clones that branch and `fleet ls` reports it in the BRANCH column.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test
+
+# ===========================================
+# The shared fixture only commits to `main`. Add a second branch
+# `feature/x` with a sentinel file so we can prove (a) --branch is
+# forwarded to git clone, (b) ls reports the actual checked-out branch
+# from the workspace, and (c) the workspace contains the branch's content.
+# ===========================================
+sentinel_file="branch-marker.txt"
+sentinel_text="from-feature-branch"
+(
+  cd "${FIXTURE_REPO_DIR}"
+  git checkout -q -b feature/x
+  printf '%s\n' "${sentinel_text}" > "${sentinel_file}"
+  git add "${sentinel_file}"
+  git commit -q -m "feature: add branch marker"
+  git checkout -q main
+)
+
+# ===========================================
+# Spawn the instance against the feature branch.
+# ===========================================
+info "fleet up alpha --branch feature/x"
+"${FLEET_BIN}" up alpha --repo "${FIXTURE_REPO_URL}" --branch feature/x
+
+# Workspace clone must be on feature/x — git rev-parse is the source of truth.
+ws_dir="${HOME}/.fleet/workspaces/${FIXTURE_REPO_NAME}/alpha/${FIXTURE_REPO_NAME}"
+assert_file_exists "${ws_dir}"
+checked_branch=$(git -C "${ws_dir}" rev-parse --abbrev-ref HEAD)
+assert_equals "feature/x" "${checked_branch}" "workspace should be on the requested branch"
+
+# Branch content arrived too — sentinel file present with expected body.
+assert_file_exists "${ws_dir}/${sentinel_file}"
+contents=$(cat "${ws_dir}/${sentinel_file}")
+assert_equals "${sentinel_text}" "${contents}" "branch sentinel content should match"
+
+# ===========================================
+# `fleet ls` must surface the branch in its BRANCH column. The header
+# itself is "BRANCH" — assert both the column and the per-row value.
+# ===========================================
+info "fleet ls (branch column)"
+ls_out=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+printf '%s\n' "${ls_out}"
+assert_contains "${ls_out}" "BRANCH"    "ls header should include BRANCH column"
+alpha_row=$(printf '%s\n' "${ls_out}" | grep -E '^\S+\s+alpha\s' || true)
+[ -n "${alpha_row}" ] || fail "ls missing alpha row: [${ls_out}]"
+assert_contains "${alpha_row}" "feature/x" "alpha row should report feature/x in BRANCH column"
+
+# Sanity: state.json records the branch the user requested. (Fleet stores
+# the requested ref under the instance entry's `branch` field; whether or
+# not that key is set, the workspace HEAD above is the real check.)
+state=$(cat "${HOME}/.fleet/state.json")
+assert_contains "${state}" "alpha" "state.json should still list alpha"
+
+pass "fleet up --branch clones requested ref and ls reports it"

--- a/integration/tests/320_tui_tag_visible.sh
+++ b/integration/tests/320_tui_tag_visible.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Description: After tagging an instance, the tag is rendered in the instance row and survives a TUI restart.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+# ===========================================
+# Spawn TUI, wait for the instance row to fully hydrate before sending
+# any keys (matches the pattern used by other tag/rename tests so we
+# don't race the build-rows pass).
+# ===========================================
+tui_spawn
+tui_wait_for "alpha" 15
+tui_wait_for "○ idle" 60
+
+# Before tagging, the row must NOT contain a `# ` segment — otherwise the
+# post-tag assertion would be meaningless.
+tui_assert_not_contains "# release-blocker" "tag should not be present yet"
+
+# ===========================================
+# Tag the instance via 't'.
+# ===========================================
+info "moving cursor to alpha"
+tui_send j
+sleep 0.3
+
+info "opening tag dialog"
+tui_send t
+tui_wait_for "Tag instance" 5
+
+info "submitting tag 'release-blocker'"
+tui_send_text "release-blocker"
+sleep 0.3
+tui_send Enter
+tui_wait_for "Tagged itest-fleet/alpha: release-blocker" 5
+tui_wait_for_absent "Tag instance" 5
+
+# ===========================================
+# 1. The tag must be rendered in the row. page_fleet renders it as
+#    `  # <tag>` appended to the instance line. Capture once and assert
+#    on the literal token — the dim style does not change the substring.
+# ===========================================
+info "asserting tag visible in row"
+tui_assert_contains "# release-blocker" "tag should be rendered in instance row after save"
+
+# Persistence in state.json — same contract as test 210, kept here so
+# this test is self-contained.
+tag_value=$(grep -oE '"tag"[[:space:]]*:[[:space:]]*"[^"]*"' "${HOME}/.fleet/state.json" | head -1 || true)
+assert_contains "${tag_value}" "release-blocker" "tag missing from state.json after save"
+
+# ===========================================
+# 2. Quit + relaunch the TUI; the tag must still render.
+# ===========================================
+info "quitting TUI"
+tui_send q
+deadline=$(( $(date +%s) + 10 ))
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  if ! tmux has-session -t "${TUI_SESSION}" 2>/dev/null; then
+    break
+  fi
+  sleep 0.25
+done
+if tmux has-session -t "${TUI_SESSION}" 2>/dev/null; then
+  fail "TUI did not exit after q"
+fi
+
+info "respawning TUI"
+tui_spawn
+tui_wait_for "alpha" 15
+tui_wait_for "○ idle" 60
+
+info "asserting tag visible after relaunch"
+tui_assert_contains "# release-blocker" "tag should still render after TUI relaunch"
+
+pass "TUI tag is rendered in the row and persists across restart"

--- a/integration/tests/325_tui_rename_persist.sh
+++ b/integration/tests/325_tui_rename_persist.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Description: Renamed instance display_name renders in the row and survives a TUI restart.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+# ===========================================
+# Rename alpha → triage via the edit dialog. This mirrors test 215 but
+# focuses on the rendered display name rather than just state.json,
+# and additionally asserts the new name survives a TUI relaunch.
+# ===========================================
+tui_spawn
+tui_wait_for "alpha"  15
+tui_wait_for "○ idle" 60
+
+info "moving cursor to alpha"
+tui_send j
+sleep 0.3
+
+info "opening edit dialog"
+tui_send e
+tui_wait_for "Edit instance" 5
+
+info "clearing prefilled name and submitting 'triage'"
+for _ in 1 2 3 4 5; do tui_send BSpace; done
+tui_send_text "triage"
+sleep 0.3
+tui_send Enter
+
+info "asserting new label appears immediately"
+tui_wait_for_absent "Edit instance" 5
+tui_wait_for "triage" 5
+
+# state.json is the source of truth — verify display_name persisted.
+display_value=$(grep -oE '"display_name"[[:space:]]*:[[:space:]]*"[^"]*"' "${HOME}/.fleet/state.json" \
+  | head -1 || true)
+assert_contains "${display_value}" "triage" "display_name should persist in state.json"
+
+# Underlying instance name must NOT change (rename is display-only).
+name_value=$(grep -oE '"name"[[:space:]]*:[[:space:]]*"alpha"' "${HOME}/.fleet/state.json" \
+  | head -1 || true)
+assert_contains "${name_value}" "alpha" "underlying instance name must remain 'alpha'"
+
+# ===========================================
+# Quit + relaunch. The rendered row must continue to use the renamed
+# label rather than reverting to the underlying instance name.
+# ===========================================
+info "quitting TUI"
+tui_send q
+deadline=$(( $(date +%s) + 10 ))
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  tmux has-session -t "${TUI_SESSION}" 2>/dev/null || break
+  sleep 0.25
+done
+if tmux has-session -t "${TUI_SESSION}" 2>/dev/null; then
+  fail "TUI did not exit after q"
+fi
+
+info "respawning TUI"
+tui_spawn
+tui_wait_for "triage" 15
+tui_wait_for "○ idle" 60
+
+info "asserting renamed row visible after restart"
+tui_assert_contains "triage" "display name should still render after TUI relaunch"
+
+# CLI ls reads from state.json — it shows the underlying name, not the
+# display label. This is an intentional split (CLI uses stable identifiers,
+# TUI shows user-facing labels). Lock that contract in.
+ls_out=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+assert_contains "${ls_out}" "alpha" "CLI ls should list the underlying instance name"
+
+pass "TUI rename persists across restart and stays distinct from underlying name"

--- a/integration/tests/330_tui_logs_view.sh
+++ b/integration/tests/330_tui_logs_view.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Description: Pressing `l` on a running instance shows its logs and Enter returns to the TUI.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+tui_spawn
+tui_wait_for "alpha"  15
+tui_wait_for "○ idle" 60
+
+# ===========================================
+# Move to alpha and press `l`. tea.ExecProcess suspends the TUI and runs
+# a wrapper shell script that cats the creation log + container runtime
+# logs, then waits on `read _` for an Enter keypress before returning.
+# ===========================================
+info "moving cursor to alpha"
+tui_send j
+sleep 0.3
+
+info "pressing 'l' to view logs"
+tui_send l
+
+# The wrapper script always ends with this prompt — match on it as the
+# canonical "logs view is up" signal.
+info "waiting for press-Enter prompt"
+tui_wait_for "--- Press Enter to return ---" 20
+
+# Container runtime logs always include the entrypoint banner.
+tui_assert_contains "Container started" "logs view should include container runtime output"
+# The wrapper labels the runtime section explicitly.
+tui_assert_contains "Container runtime logs" "logs view should label the runtime section"
+
+# ===========================================
+# Press Enter to dismiss; the TUI redraws and execDoneMsg triggers a
+# reload + buildRows. The fleet row should be visible again.
+# ===========================================
+info "pressing Enter to dismiss logs view"
+tui_send Enter
+tui_wait_for_absent "--- Press Enter to return ---" 10
+tui_wait_for "alpha" 15
+tui_wait_for "○ idle" 60
+
+pass "TUI 'l' shows instance logs and dismisses on Enter"

--- a/integration/tests/340_tui_port_forward_dialog.sh
+++ b/integration/tests/340_tui_port_forward_dialog.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Description: TUI 'f' opens the port-forward dialog on running instances, validates input, and closes on esc; refuses on stopped instances.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+tui_spawn
+tui_wait_for "alpha"  15
+tui_wait_for "○ idle" 60
+
+# ===========================================
+# 'f' on the fleet header has no instance selected — defensive UX
+# prints "Select an instance" instead of opening the dialog.
+# ===========================================
+info "pressing 'f' on fleet header (no instance selected)"
+tui_send f
+tui_wait_for "Select an instance" 5
+# Make sure the dialog did NOT open.
+tui_assert_not_contains "local:remote" "port-forward dialog should not open without an instance"
+
+# ===========================================
+# Move cursor to alpha and press 'f' to open the dialog.
+# ===========================================
+info "moving cursor to alpha"
+tui_send j
+sleep 0.3
+
+info "pressing 'f' to open port-forward dialog"
+tui_send f
+tui_wait_for "local:remote" 5
+
+# ===========================================
+# Bad input — the dialog handler routes through parsePortMapping and
+# surfaces the error in m.message. Type "abc" (no colon) and submit.
+# ===========================================
+info "submitting invalid mapping 'abc'"
+tui_send_text "abc"
+sleep 0.3
+tui_send Enter
+tui_wait_for "expected local:remote" 5
+
+# Bad port number — type "0:80" (local out of range).
+# Clear the input first via repeated backspace.
+for _ in 1 2 3 4 5; do tui_send BSpace; done
+info "submitting invalid local port '0:80'"
+tui_send_text "0:80"
+sleep 0.3
+tui_send Enter
+tui_wait_for "invalid local port" 5
+
+# ===========================================
+# Esc closes the dialog without adding any forward.
+# ===========================================
+info "pressing Esc to close dialog"
+tui_send Escape
+tui_wait_for_absent "local:remote" 5
+# Row should not have a "⇄" port-forward indicator (none was added).
+tui_assert_not_contains "⇄" "no port forwards should be active after esc"
+
+# ===========================================
+# Stop the instance via 's' and verify 'f' refuses to open the dialog
+# with a state-gate message.
+# ===========================================
+info "stopping alpha via 's'"
+tui_send s
+tui_wait_for "Stopped itest-fleet/alpha" 20
+tui_wait_for "stopped" 5
+
+info "pressing 'f' on a stopped instance"
+tui_send f
+tui_wait_for "Instance must be running to port-forward" 5
+tui_assert_not_contains "local:remote" "port-forward dialog should not open on stopped instance"
+
+pass "TUI 'f' port-forward dialog gating + validation"

--- a/integration/tests/350_tui_tag_clear.sh
+++ b/integration/tests/350_tui_tag_clear.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Description: Re-opening the tag dialog with empty input clears the tag from the row and state.json.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+tui_spawn
+tui_wait_for "alpha"  15
+tui_wait_for "○ idle" 60
+
+# ===========================================
+# Step 1 — set a tag the test will later clear. The row must visibly
+# show "# wip" once saved.
+# ===========================================
+TAG="wip"
+info "moving cursor to alpha"
+tui_send j
+sleep 0.3
+
+info "opening tag dialog and saving '${TAG}'"
+tui_send t
+tui_wait_for "Tag instance" 5
+tui_send_text "${TAG}"
+sleep 0.3
+tui_send Enter
+tui_wait_for "Tagged itest-fleet/alpha: ${TAG}" 5
+tui_wait_for_absent "Tag instance" 5
+tui_assert_contains "# ${TAG}" "tag must render in row after save"
+
+# state.json sanity — the tag field is "wip".
+tag_value=$(grep -oE '"tag"[[:space:]]*:[[:space:]]*"[^"]*"' "${HOME}/.fleet/state.json" | head -1 || true)
+assert_contains "${tag_value}" "${TAG}" "tag should be in state.json after save"
+
+# ===========================================
+# Step 2 — re-open the dialog. The text input is prefilled with the
+# current tag (page_fleet.go:599 SetValue(inst.Tag)), so we backspace
+# every character to leave it empty, then submit.
+# ===========================================
+# Defensive cursor re-seat — after dialog close, cursor stays on alpha,
+# but small wiggle protects against any buildRows reorder edge cases.
+tui_send j
+sleep 0.2
+tui_send k
+sleep 0.2
+
+info "re-opening tag dialog (prefilled with '${TAG}')"
+tui_send t
+tui_wait_for "Tag instance" 5
+
+info "backspacing the prefilled tag"
+# One backspace per character in TAG (3 chars), plus a couple extra for
+# safety against any leading whitespace.
+for _ in 1 2 3 4 5; do tui_send BSpace; done
+sleep 0.3
+tui_send Enter
+
+# The handler emits "Cleared tag for ..." when the trimmed value is empty.
+info "waiting for 'Cleared tag' confirmation"
+tui_wait_for "Cleared tag for itest-fleet/alpha" 5
+tui_wait_for_absent "Tag instance" 5
+
+# ===========================================
+# Step 3 — the row must no longer carry the "# wip" suffix. The status
+# message itself contains "wip" only via "Cleared tag for itest-fleet/
+# alpha" — which does NOT include the tag — so plain absence is safe.
+# ===========================================
+info "verifying tag no longer rendered in row"
+tui_assert_not_contains "# ${TAG}" "tag suffix must be gone from row after clear"
+
+# state.json: tag field is the empty string.
+tag_value=$(grep -oE '"tag"[[:space:]]*:[[:space:]]*"[^"]*"' "${HOME}/.fleet/state.json" | head -1 || true)
+# Either the field is absent (nothing matched) or it's `"tag": ""`.
+if [ -n "${tag_value}" ]; then
+  assert_contains "${tag_value}" '""' "tag should be empty in state.json after clear"
+fi
+
+# Persistence check — relaunch the TUI and verify the row stays clean.
+info "quitting TUI"
+tui_send q
+deadline=$(( $(date +%s) + 10 ))
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  tmux has-session -t "${TUI_SESSION}" 2>/dev/null || break
+  sleep 0.25
+done
+tmux has-session -t "${TUI_SESSION}" 2>/dev/null && fail "TUI did not exit after q"
+
+info "respawning TUI"
+tui_spawn
+tui_wait_for "alpha"  15
+tui_wait_for "○ idle" 60
+tui_assert_not_contains "# ${TAG}" "cleared tag must stay cleared after restart"
+
+pass "TUI tag-clear round-trip removes tag from row + state and persists"


### PR DESCRIPTION
## Summary

Adds four new integration tests filling gaps in the CLI half of the suite:

- **`070_cli_help.sh`** — root and every visible subcommand expose `--help`; root lists all public subcommands and the internal `_create-instance` stays hidden.
- **`075_cli_resolve_errors.sh`** — operations on missing fleets, malformed targets, and missing instances all fail non-zero with the offending name in the error message; valid instances still work after error-path probing.
- **`080_cli_up_duplicate.sh`** — second `up` for the same instance name is rejected with `already exists`, the existing container's ID is unchanged, state has exactly one entry, and a different name in the same fleet still succeeds.
- **`085_cli_start_already_running.sh`** — `start` on a running instance prints `already running` without churning the container; full `stop` → `start` → `start` cycle exercises both no-op branches.

All four pass locally against this devcontainer.

## Test plan
- [x] Tests pass locally with `FLEET_BIN=/tmp/fleet bash integration/tests/0XX_*.sh`
- [ ] CI integration job is green on this branch
- [ ] Review test descriptions render in the GitHub Actions step summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)