### PR TITLE
fix: protect TUI pane during rapid session switches

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -86,9 +86,9 @@ type model struct {
 // newModel creates and initialises the top-level model, including all
 // page instances and their initial state.
 func newModel() model {
-	sp := spinner.New()
-	sp.Spinner = spinner.Dot
-	sp.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("170"))
+	spinnerModel := spinner.New()
+	spinnerModel.Spinner = spinner.Dot
+	spinnerModel.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("170"))
 
 	m := model{
 		creating:          make(map[string]bool),
@@ -99,7 +99,7 @@ func newModel() model {
 		expandedInstances: make(map[string]bool),
 		sessions:          make(map[string]*sessionDiscovery),
 		lastActive:        make(map[string]lastSession),
-		spinner:           sp,
+		spinner:           spinnerModel,
 		inHostTmux:        os.Getenv("TMUX") != "",
 	}
 
@@ -198,13 +198,13 @@ func (m *model) hydrateSavedGroups() {
 	if m.st == nil || m.fleetPage == nil {
 		return
 	}
-	for gid, gl := range m.st.GroupLayouts {
+	for gid, layout := range m.st.GroupLayouts {
 		m.fleetPage.savedGroups[gid] = savedGroup{
-			GroupID:      gl.GroupID,
-			InstanceName: gl.InstanceName,
-			Sessions:     gl.Sessions,
-			Layout:       gl.Layout,
-			PaneCount:    gl.PaneCount,
+			GroupID:      layout.GroupID,
+			InstanceName: layout.InstanceName,
+			Sessions:     layout.Sessions,
+			Layout:       layout.Layout,
+			PaneCount:    layout.PaneCount,
 		}
 	}
 }
@@ -234,8 +234,8 @@ func (m *model) pruneSavedGroupsForInstance(instKey string) {
 		}
 	}
 	changed := false
-	for gid, sg := range m.fleetPage.savedGroups {
-		if sg.InstanceName != instanceName {
+	for gid, savedLayout := range m.fleetPage.savedGroups {
+		if savedLayout.InstanceName != instanceName {
 			continue
 		}
 		if !live[gid] {
@@ -263,8 +263,8 @@ func (m *model) pruneOrphanedSavedGroups() {
 		}
 	}
 	changed := false
-	for gid, sg := range m.fleetPage.savedGroups {
-		if !live[sg.InstanceName] {
+	for gid, savedLayout := range m.fleetPage.savedGroups {
+		if !live[savedLayout.InstanceName] {
 			delete(m.fleetPage.savedGroups, gid)
 			delete(m.st.GroupLayouts, gid)
 			changed = true
@@ -428,13 +428,13 @@ func (m model) fetchAllStatsCmd(delay bool) tea.Cmd {
 		}
 
 		ch := make(chan result, len(inputs))
-		for _, inp := range inputs {
+		for _, input := range inputs {
 			go func(instanceBackend backend.Backend, ids []string) {
 				stats, _ := instanceBackend.Stats(ids)
 				screens := backend.CaptureAllSessionsForAll(instanceBackend, ids)
 				probes := backend.AgentToolProbes(instanceBackend, ids)
 				ch <- result{stats, screens, probes, ids}
-			}(inp.instanceBackend, inp.ids)
+			}(input.instanceBackend, input.ids)
 		}
 
 		for range inputs {
@@ -496,14 +496,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// instance rows fire Space (expand/collapse sessions), every other
 	// click fires Enter. Other mouse events (motion, wheel, release,
 	// other buttons) are dropped: page handlers only know about KeyMsgs.
-	if mm, ok := msg.(tea.MouseMsg); ok {
-		if mm.Action == tea.MouseActionPress && mm.Button == tea.MouseButtonLeft {
+	if mouseMsg, ok := msg.(tea.MouseMsg); ok {
+		if mouseMsg.Action == tea.MouseActionPress && mouseMsg.Button == tea.MouseButtonLeft {
 			synthesizedKey := tea.KeyMsg{Type: tea.KeyEnter}
 			hit := false
 			switch page := m.currentPage.(type) {
 			case *fleetPage:
 				if page.mode == viewNormal && page.listRowY >= 0 {
-					if idx := mm.Y - page.listRowY; idx >= 0 && idx < len(page.rows) {
+					if idx := mouseMsg.Y - page.listRowY; idx >= 0 && idx < len(page.rows) {
 						page.cursor = idx
 						hit = true
 						if page.rows[idx].kind == rowInstance {
@@ -523,7 +523,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						if h <= 0 {
 							h = 1
 						}
-						if mm.Y >= y && mm.Y < y+h {
+						if mouseMsg.Y >= y && mouseMsg.Y < y+h {
 							page.cursor = i
 							hit = true
 							break
@@ -541,9 +541,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	// 1. Window size (shared)
-	if ws, ok := msg.(tea.WindowSizeMsg); ok {
-		m.width = ws.Width
-		m.height = ws.Height
+	if windowSize, ok := msg.(tea.WindowSizeMsg); ok {
+		m.width = windowSize.Width
+		m.height = windowSize.Height
 	}
 
 	// 2. Always update spinner
@@ -716,9 +716,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.message = fmt.Sprintf("Failed to create %s: %v", key, msg.err)
 
 	case splitPaneMsg:
+		// err and paneID are independent: a restoreGroupCmd run can
+		// partially succeed (some splits OK, some failed after retries),
+		// in which case both are set — show the error AND wire up the
+		// panes that did make it.
 		if msg.err != nil {
-			m.message = fmt.Sprintf("Split pane error: %v", msg.err)
-		} else {
+			m.message = fmt.Sprintf("failed to do tmux split pane: %v", msg.err)
+		}
+		if msg.paneID != "" {
 			fp := m.fleetPage
 			fp.splitPaneID = msg.paneID
 			fp.splitFleet = msg.fleet
@@ -925,38 +930,6 @@ func (m model) View() string {
 }
 
 // ===========================================
-// Row Types (shared, used by fleet page)
-// ===========================================
-
-type rowKind int
-
-const (
-	rowFleetHeader rowKind = iota
-	rowInstance
-	rowSession
-	rowNewSession
-	rowSettings
-)
-
-// row represents a single navigable row in the TUI.
-type row struct {
-	kind        rowKind
-	fleetName   string
-	instance    *fleet.Instance
-	sessionName string // set when kind == rowSession or rowNewSession
-	groupID     string // set for grouped session rows
-	groupSize   int    // number of sessions in the group (for display)
-}
-
-// lastSession tracks the most recently used session for an instance,
-// allowing reconnection on subsequent enter presses instead of always
-// creating a new session.
-type lastSession struct {
-	sessionName string
-	groupID     string
-}
-
-// ===========================================
 // Sorting Helper
 // ===========================================
 
@@ -1007,9 +980,9 @@ func Run() error {
 	// in the new fleet exits cleanly instead of dropping back into
 	// the old fleet.
 	if err == nil {
-		if fm, ok := finalModel.(model); ok && fm.pendingExecPath != "" {
-			if execErr := syscall.Exec(fm.pendingExecPath, fm.pendingExecArgs, os.Environ()); execErr != nil {
-				return fmt.Errorf("failed to launch updated fleet %q: %w", fm.pendingExecPath, execErr)
+		if finalAppModel, ok := finalModel.(model); ok && finalAppModel.pendingExecPath != "" {
+			if execErr := syscall.Exec(finalAppModel.pendingExecPath, finalAppModel.pendingExecArgs, os.Environ()); execErr != nil {
+				return fmt.Errorf("failed to launch updated fleet %q: %w", finalAppModel.pendingExecPath, execErr)
 			}
 			// syscall.Exec does not return on success.
 		}

--- a/internal/tui/rows.go
+++ b/internal/tui/rows.go
@@ -1,0 +1,38 @@
+package tui
+
+import (
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+)
+
+// ===========================================
+// Row Types (shared, used by fleet page)
+// ===========================================
+
+// rowKind identifies the variant of a navigable row in the TUI list.
+type rowKind int
+
+const (
+	rowFleetHeader rowKind = iota
+	rowInstance
+	rowSession
+	rowNewSession
+	rowSettings
+)
+
+// row represents a single navigable row in the TUI.
+type row struct {
+	kind        rowKind
+	fleetName   string
+	instance    *fleet.Instance
+	sessionName string // set when kind == rowSession or rowNewSession
+	groupID     string // set for grouped session rows
+	groupSize   int    // number of sessions in the group (for display)
+}
+
+// lastSession tracks the most recently used session for an instance,
+// allowing reconnection on subsequent enter presses instead of always
+// creating a new session.
+type lastSession struct {
+	sessionName string
+	groupID     string
+}

--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -46,8 +46,8 @@ func tmuxWindowSize() (int, int) {
 // quoteArgs builds a shell-safe command string from exec args.
 func quoteArgs(args []string) string {
 	quoted := make([]string, len(args))
-	for i, a := range args {
-		quoted[i] = "'" + strings.ReplaceAll(a, "'", "'\\''") + "'"
+	for i, arg := range args {
+		quoted[i] = "'" + strings.ReplaceAll(arg, "'", "'\\''") + "'"
 	}
 	return strings.Join(quoted, " ")
 }
@@ -81,7 +81,10 @@ func splitPaneCmd(existingPaneID string, fleetName string, instanceName string, 
 		}
 
 		// Kill any stale sibling panes before creating a fresh split.
-		_ = exec.Command("tmux", "kill-pane", "-a").Run()
+		// Must select the TUI pane first — `kill-pane -a` kills every
+		// pane except the focused one, and rapid switches can leave a
+		// child shell pane focused, which would kill the TUI itself.
+		killAllSplitPanes()
 
 		// Create a horizontal split (side by side). -P -F prints the new
 		// pane ID so we can track it. -l 70% gives the shell pane 70% width.
@@ -164,6 +167,27 @@ func unbindDefaultSplitKeys() {
 	msg := "Select an instance in fleet first"
 	_ = exec.Command("tmux", "bind-key", "%", "display-message", msg).Run()
 	_ = exec.Command("tmux", "bind-key", `"`, "display-message", msg).Run()
+}
+
+// splitWindowWithRetry runs `tmux split-window` with the given args,
+// retrying up to 3 times with a 250ms pause between attempts. tmux
+// occasionally fails a split mid-layout under rapid pane churn — a
+// short backoff lets the server settle. Returns the trimmed stdout
+// (the new pane's ID, captured via -P -F) on success, or the last
+// error after all attempts fail.
+func splitWindowWithRetry(args []string) (string, error) {
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			time.Sleep(250 * time.Millisecond)
+		}
+		out, err := exec.Command("tmux", args...).Output()
+		if err == nil {
+			return strings.TrimSpace(string(out)), nil
+		}
+		lastErr = err
+	}
+	return "", lastErr
 }
 
 // killAllSplitPanes kills all panes except the TUI pane (index 0).
@@ -321,7 +345,7 @@ func (fleetPage *fleetPage) saveCurrentGroupLayout(st *state.State) {
 		return
 	}
 
-	sg := savedGroup{
+	groupSnapshot := savedGroup{
 		GroupID:      fleetPage.activeGroupID,
 		InstanceName: fleetPage.splitInstance,
 		Sessions:     sessionNames,
@@ -332,10 +356,10 @@ func (fleetPage *fleetPage) saveCurrentGroupLayout(st *state.State) {
 	// No-op when nothing changed. The 250ms layout tick fires this
 	// constantly; without this gate an idle split would rewrite
 	// state.json every tick with identical bytes.
-	if existing, ok := fleetPage.savedGroups[fleetPage.activeGroupID]; ok && sameSavedGroup(existing, sg) {
+	if existing, ok := fleetPage.savedGroups[fleetPage.activeGroupID]; ok && sameSavedGroup(existing, groupSnapshot) {
 		return
 	}
-	fleetPage.savedGroups[fleetPage.activeGroupID] = sg
+	fleetPage.savedGroups[fleetPage.activeGroupID] = groupSnapshot
 
 	if st == nil {
 		return
@@ -344,11 +368,11 @@ func (fleetPage *fleetPage) saveCurrentGroupLayout(st *state.State) {
 		st.GroupLayouts = make(map[string]state.GroupLayout)
 	}
 	st.GroupLayouts[fleetPage.activeGroupID] = state.GroupLayout{
-		GroupID:      sg.GroupID,
-		InstanceName: sg.InstanceName,
-		Sessions:     sg.Sessions,
-		Layout:       sg.Layout,
-		PaneCount:    sg.PaneCount,
+		GroupID:      groupSnapshot.GroupID,
+		InstanceName: groupSnapshot.InstanceName,
+		Sessions:     groupSnapshot.Sessions,
+		Layout:       groupSnapshot.Layout,
+		PaneCount:    groupSnapshot.PaneCount,
 	}
 	_ = state.Save(st)
 }
@@ -367,15 +391,15 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 
 	// Grab saved layout if available.
 	savedLayout := ""
-	if sg, ok := fleetPage.savedGroups[groupID]; ok {
-		savedLayout = sg.Layout
+	if groupSnapshot, ok := fleetPage.savedGroups[groupID]; ok {
+		savedLayout = groupSnapshot.Layout
 	}
 
 	// Prefer saved session order (from pane titles) to preserve
 	// the exact pane-to-session mapping.
 	var savedOrder []string
-	if sg, ok := fleetPage.savedGroups[groupID]; ok && len(sg.Sessions) > 0 {
-		savedOrder = sg.Sessions
+	if groupSnapshot, ok := fleetPage.savedGroups[groupID]; ok && len(groupSnapshot.Sessions) > 0 {
+		savedOrder = groupSnapshot.Sessions
 	}
 
 	return func() tea.Msg {
@@ -422,14 +446,23 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 			return splitPaneMsg{err: fmt.Errorf("no sessions found for group %s", groupID)}
 		}
 
-		// Kill any existing split panes.
-		_ = exec.Command("tmux", "kill-pane", "-a").Run()
+		// Kill any existing split panes. Must select the TUI pane first —
+		// `kill-pane -a` kills every pane except the focused one, and a
+		// previous switch may have left a child shell pane focused.
+		killAllSplitPanes()
 
 		// Phase 1: Create placeholder panes with `sleep` so we can
 		// establish the layout geometry without worrying about which
-		// session goes where.
+		// session goes where. Each split is retried (see
+		// splitWindowWithRetry) because tmux can transiently refuse
+		// splits during rapid pane churn. If a pane still can't be
+		// created after retries, we record the error, skip that slot,
+		// and surface the failure via splitPaneMsg.err so the user
+		// sees it in the status line — Phases 2 and 3 still run on
+		// whatever panes did succeed.
 		var firstPaneID string
 		var lastPaneID string
+		var splitErr error
 		for i := range sessions {
 			var tmuxArgs []string
 			if i == 0 {
@@ -447,11 +480,11 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 					"--", "sleep", "infinity",
 				}
 			}
-			paneOut, err := exec.Command("tmux", tmuxArgs...).Output()
+			paneID, err := splitWindowWithRetry(tmuxArgs)
 			if err != nil {
+				splitErr = err
 				continue
 			}
-			paneID := strings.TrimSpace(string(paneOut))
 			lastPaneID = paneID
 			if i == 0 {
 				firstPaneID = paneID
@@ -494,13 +527,17 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 		if len(sessions) > 0 {
 			firstSession = sessions[0]
 		}
-		return splitPaneMsg{
+		msg := splitPaneMsg{
 			paneID:   firstPaneID,
 			fleet:    fleetName,
 			instance: instanceName,
 			session:  firstSession,
 			groupID:  groupID,
 		}
+		if splitErr != nil {
+			msg.err = fmt.Errorf("failed to do tmux split pane: %w", splitErr)
+		}
+		return msg
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Bug fix**: rapid session switching (especially via mouse) could kill the fleet TUI itself. Two `kill-pane -a` call sites in `splitpane.go` didn't first focus the TUI pane, so when a previous switch left a child shell pane focused, the next switch killed the fleet pane instead of the children — leaving a lone shell and an unrecoverable fleet process. Both sites now route through the existing `killAllSplitPanes()` helper, which selects `:.0` first.
- **Resilience**: `restoreGroupCmd` Phase 1 splits now retry up to 3 times with a 250ms backoff (`splitWindowWithRetry`) to address occasional layout glitches where panes spawned in the wrong slot. After retries, failures are surfaced to the status line as `failed to do tmux split pane: …` while Phases 2 and 3 still run on whatever panes succeeded. The `splitPaneMsg` handler in `app.go` now treats `err` and `paneID` independently so partial successes still wire up the panes that made it.
- **Drive-by autofix**: row types extracted from `app.go` into `internal/tui/rows.go`; a handful of short local names renamed (`sp`→`spinnerModel`, `gl`→`layout`, `sg`→`savedLayout`/`groupSnapshot`, `inp`→`input`, `mm`→`mouseMsg`, `ws`→`windowSize`, `fm`→`finalAppModel`, `a`→`arg`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/tui/`
- [ ] Manual: rapidly click between session group rows in a host tmux — fleet should no longer die; instead panes should refresh cleanly or, on the rare layout failure, surface the new status-line error.
- [ ] Manual: confirm normal (non-rapid) session switching is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)