### PR TITLE
feat(tui): per-instance agent throbber next to instance name

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -35,8 +35,9 @@ type model struct {
 	currentPage Page
 	fleetPage   *fleetPage // persistent — has running state accessed by background message handlers
 
-	spinner  spinner.Model
-	creating map[string]bool // "fleet/instance" keys currently being created
+	spinner      spinner.Model
+	agentSpinner spinner.Model // pulse throbber rendered next to running agents' instance names
+	creating     map[string]bool // "fleet/instance" keys currently being created
 
 	backends map[fleet.BackendType]backend.Backend // one per backend type, lazily created
 	stats    map[string]*backend.ContainerStats    // containerID → stats
@@ -90,6 +91,13 @@ func newModel() model {
 	spinnerModel.Spinner = spinner.Dot
 	spinnerModel.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("170"))
 
+	agentSpinnerModel := spinner.New()
+	agentSpinnerModel.Spinner = spinner.Spinner{
+		Frames: []string{"·", "✦", "✻", "✶", "✻", "✦"},
+		FPS:    time.Second / 4,
+	}
+	agentSpinnerModel.Style = agentWorkingStyle
+
 	m := model{
 		creating:          make(map[string]bool),
 		backends:          make(map[fleet.BackendType]backend.Backend),
@@ -100,6 +108,7 @@ func newModel() model {
 		sessions:          make(map[string]*sessionDiscovery),
 		lastActive:        make(map[string]lastSession),
 		spinner:           spinnerModel,
+		agentSpinner:      agentSpinnerModel,
 		inHostTmux:        os.Getenv("TMUX") != "",
 	}
 
@@ -319,13 +328,6 @@ func (m *model) instanceBackend(instance *fleet.Instance) backend.Backend {
 	return backendImpl
 }
 
-// backendGroup holds container IDs grouped by backend type. Sessions
-// no longer need to be tracked here — CaptureAllSessions discovers
-// every tmux session inside each container at capture time.
-type backendGroup struct {
-	ids []string
-}
-
 // containersByBackend groups running instances by their backend type.
 func (m *model) containersByBackend() map[fleet.BackendType]*backendGroup {
 	groups := make(map[fleet.BackendType]*backendGroup)
@@ -463,6 +465,7 @@ func (m model) fetchAllStatsCmd(delay bool) tea.Cmd {
 func (m model) Init() tea.Cmd {
 	cmds := []tea.Cmd{
 		m.spinner.Tick,
+		m.agentSpinner.Tick,
 		m.fetchAllStatsCmd(false),
 		m.sessionDiscoveryLoop(),
 		layoutTickCmd(),
@@ -546,9 +549,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = windowSize.Height
 	}
 
-	// 2. Always update spinner
-	var spinCmd tea.Cmd
-	m.spinner, spinCmd = m.spinner.Update(msg)
+	// 2. Always update spinners
+	var statusSpinCmd tea.Cmd
+	m.spinner, statusSpinCmd = m.spinner.Update(msg)
+	var agentSpinCmd tea.Cmd
+	m.agentSpinner, agentSpinCmd = m.agentSpinner.Update(msg)
+	spinCmd := tea.Batch(statusSpinCmd, agentSpinCmd)
 
 	// 3. Shared-only messages — return early
 	switch msg := msg.(type) {

--- a/internal/tui/backend_group.go
+++ b/internal/tui/backend_group.go
@@ -1,0 +1,12 @@
+package tui
+
+// ===========================================
+// Backend Group
+// ===========================================
+
+// backendGroup holds container IDs grouped by backend type. Sessions
+// no longer need to be tracked here — CaptureAllSessions discovers
+// every tmux session inside each container at capture time.
+type backendGroup struct {
+	ids []string
+}

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -19,28 +19,6 @@ import (
 )
 
 // ===========================================
-// View Mode
-// ===========================================
-
-type viewMode int
-
-const (
-	viewNormal viewMode = iota
-	viewConfirmDelete
-	viewConfirmDeleteFleetWarn
-	viewAddInstance
-	viewAddFleet
-	viewTagInstance
-	viewPortForward
-	viewCodespacesAuth
-	viewCodespacesLimit
-	viewCodespacesMachine
-	viewCreateSession
-	viewRenameSession
-	viewConfirmDeleteSession
-)
-
-// ===========================================
 // Fleet Page
 // ===========================================
 
@@ -977,15 +955,51 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 				}
 			}
 
-			paddedName := fmt.Sprintf("%s%-22s", arrow, instance.GetDisplayName())
+			// Single switch derives BOTH the left-of-name throbber
+			// and the right-of-status agentStr. Throbber animates
+			// only in the working ("play") state; every other case
+			// (waiting, not running, instance not running) leaves
+			// the throbber at the default grey ○. agentStr is
+			// consumed below in the non-transitional render branch.
+			throbber := agentOffStyle.Render("○")
+			agentStr := ""
+			if instance.Status == fleet.StatusRunning && m.activity != nil {
+				tool := m.activity.Tool(instance.ContainerID)
+				label := agentToolLabel(tool)
+				switch m.activity.State(instance.ContainerID) {
+				case agentWorking:
+					agentStr = agentWorkingStyle.Render(fmt.Sprintf("  ▶ %s", label))
+					if len(m.agentSpinner.Spinner.Frames) > 0 {
+						throbber = strings.TrimRight(m.agentSpinner.View(), "\n")
+					} else {
+						throbber = agentWorkingStyle.Render("✻")
+					}
+				case agentWaiting:
+					agentStr = agentWaitingStyle.Render(fmt.Sprintf("  ⏸ %s", label))
+				default:
+					agentStr = agentOffStyle.Render("  ○ idle")
+				}
+			}
+
+			nameRaw := fmt.Sprintf("%-22s", instance.GetDisplayName())
+			var arrowStyled, nameStyled string
 			switch {
 			case isSelected && instanceColorHasCustom(instance.Color):
-				paddedName = instanceColorStyle(instance.Color).Bold(true).Render(paddedName)
+				colorStyle := instanceColorStyle(instance.Color).Bold(true)
+				arrowStyled = colorStyle.Render(arrow)
+				nameStyled = colorStyle.Render(nameRaw)
 			case isSelected:
-				paddedName = selectedStyle.Render(paddedName)
+				arrowStyled = selectedStyle.Render(arrow)
+				nameStyled = selectedStyle.Render(nameRaw)
 			case instanceColorHasCustom(instance.Color):
-				paddedName = instanceColorStyle(instance.Color).Render(paddedName)
+				colorStyle := instanceColorStyle(instance.Color)
+				arrowStyled = colorStyle.Render(arrow)
+				nameStyled = colorStyle.Render(nameRaw)
+			default:
+				arrowStyled = arrow
+				nameStyled = nameRaw
 			}
+			paddedName := arrowStyled + throbber + " " + nameStyled
 
 			backendIcon := "⬡"
 			switch instance.Backend {
@@ -1007,20 +1021,6 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 					cursor, paddedName, status, branchItem,
 				)
 			} else {
-				agentStr := ""
-				if instance.Status == fleet.StatusRunning && m.activity != nil {
-					tool := m.activity.Tool(instance.ContainerID)
-					label := agentToolLabel(tool)
-					switch m.activity.State(instance.ContainerID) {
-					case agentWorking:
-						agentStr = agentWorkingStyle.Render(fmt.Sprintf("  \u25b6 %s", label))
-					case agentWaiting:
-						agentStr = agentWaitingStyle.Render(fmt.Sprintf("  \u23f8 %s", label))
-					default:
-						agentStr = agentOffStyle.Render("  \u25cb idle")
-					}
-				}
-
 				statsStr := ""
 				if s, ok := m.stats[instance.ContainerID]; ok {
 					statsStr = dimStyle.Render(fmt.Sprintf("  %4.0f mcpu  %6.1f MB", s.CPUMillicores, s.MemoryMB))

--- a/internal/tui/view_mode.go
+++ b/internal/tui/view_mode.go
@@ -1,0 +1,26 @@
+package tui
+
+// ===========================================
+// View Mode
+// ===========================================
+
+// viewMode identifies which dialog or interaction mode the fleet page
+// is currently in. The default (zero) value, viewNormal, means the
+// normal fleet-list keyboard navigation is active.
+type viewMode int
+
+const (
+	viewNormal viewMode = iota
+	viewConfirmDelete
+	viewConfirmDeleteFleetWarn
+	viewAddInstance
+	viewAddFleet
+	viewTagInstance
+	viewPortForward
+	viewCodespacesAuth
+	viewCodespacesLimit
+	viewCodespacesMachine
+	viewCreateSession
+	viewRenameSession
+	viewConfirmDeleteSession
+)


### PR DESCRIPTION
## Summary
- Adds a small pulsing spinner to the immediate left of each instance name in the fleet TUI list.
- The throbber animates only when the agent is actively working (matching the right-side ▶ play indicator). Every other state — waiting (⏸), idle (○), and instance not running — falls through to a static grey ○.
- The decision is folded into the existing agent-state switch in `viewFleetList`, so the left throbber and the right-of-status indicator share one source of truth and cannot drift apart.
- Drive-by: extracts `viewMode` and `backendGroup` into their own files (one-class-per-file).

## Implementation notes
- New `agentSpinner spinner.Model` on the model with custom pulse frames `· ✦ ✻ ✶ ✻ ✦` at 4 FPS. Ticked alongside the existing status spinner; both Cmds are batched together.
- Reuses `agentWorkingStyle` (green, bold) and `agentOffStyle` (grey) — no new style vars added.
- Arrow (▶/▼) and instance name are now styled separately so the throbber keeps its own color regardless of row selection / custom instance color.

## Test plan
- [ ] `go build ./...` clean
- [ ] `go test ./internal/tui/...` passes
- [ ] Manual: launch fleet, verify a working agent shows an animated green pulse
- [ ] Manual: verify the throbber goes grey ○ when the agent transitions to waiting
- [ ] Manual: verify the throbber is grey ○ for stopped / transitional instances
- [ ] Manual: verify selection / custom instance color do not bleed into the throbber color

🤖 Generated with [Claude Code](https://claude.com/claude-code)