### PR TITLE
Restore saved pane groups on WSL

### DIFF
--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -128,14 +128,6 @@ jobs:
           # budget by 3 so legitimately-passing tests aren't killed by the
           # default polling deadlines. Linux job is unaffected.
           export FLEET_TUI_WAIT_SCALE=3
-          # 280_tui_pane_layout_persist exposes a real fleet-on-WSL
-          # behavior gap, not a CI flake — tracked in #41. When fleet
-          # quits under dockerd-in-WSL, the inner tmux sessions inside
-          # the devcontainer do not survive the signal cascade the way
-          # they do on bare Linux; restoreGroupCmd then sees zero live
-          # sessions and the saved layout gets pruned from state. Skip
-          # here until #41 is fixed so the CI gate stays useful.
-          export FLEET_ITEST_SKIP=280_tui_pane_layout_persist
           ./integration/run.sh
 
       - name: Dump dockerd log on failure

--- a/README.md
+++ b/README.md
@@ -102,16 +102,19 @@ npm install -g @devcontainers/cli
 
 On Docker Desktop plus WSL, if devcontainer startup fails while building the
 UID-adjustment or feature image, disable BuildKit for Fleet-managed
-devcontainers:
+devcontainers. If the failure is specifically in `updateUID.Dockerfile`,
+disable the devcontainer CLI's remote user UID rewrite as well:
 
 ```bash
 export FLEET_DEVCONTAINER_BUILDKIT=never
+export FLEET_DEVCONTAINER_UPDATE_REMOTE_USER_UID=never
 ```
 
 To persist that setting:
 
 ```bash
 echo 'export FLEET_DEVCONTAINER_BUILDKIT=never' >> ~/.bashrc
+echo 'export FLEET_DEVCONTAINER_UPDATE_REMOTE_USER_UID=never' >> ~/.bashrc
 ```
 
 See [Windows WSL notes](docs/windows-wsl-notes.md) for a full health check and
@@ -128,3 +131,16 @@ export FLEET_DEVCONTAINER_BUILDKIT=never
 ```
 
 Accepted values are `auto` and `never`.
+
+## Devcontainer UID Rewrite
+
+Fleet uses the devcontainer CLI's default remote-user UID/GID rewrite behavior
+unless explicitly configured. On Docker Desktop plus WSL, that rewrite can fail
+while building `updateUID.Dockerfile`. To disable it for Fleet-managed
+devcontainers:
+
+```bash
+export FLEET_DEVCONTAINER_UPDATE_REMOTE_USER_UID=never
+```
+
+Accepted values are `default`, `never`, `on`, and `off`.

--- a/internal/backend/devcontainer/devcontainer.go
+++ b/internal/backend/devcontainer/devcontainer.go
@@ -76,6 +76,11 @@ func (devcontainerBackend *DevcontainerBackend) containerUser(containerID string
 // Up runs `devcontainer up` for the given workspace folder.
 func (devcontainerBackend *DevcontainerBackend) Up(workspaceDir string) (*backend.UpResult, error) {
 	args := []string{"up", "--workspace-folder", workspaceDir}
+	var err error
+	args, err = devcontainerUpArgs(args)
+	if err != nil {
+		return nil, err
+	}
 	args = append(args, sshUpArgs()...)
 	cmd := exec.Command("devcontainer", args...)
 	env, err := devcontainerEnv(os.Environ())
@@ -112,6 +117,18 @@ func (devcontainerBackend *DevcontainerBackend) Up(workspaceDir string) (*backen
 	}
 
 	return &result, nil
+}
+
+func devcontainerUpArgs(base []string) ([]string, error) {
+	mode := strings.TrimSpace(os.Getenv("FLEET_DEVCONTAINER_UPDATE_REMOTE_USER_UID"))
+	switch mode {
+	case "", "default":
+		return base, nil
+	case "never", "on", "off":
+		return append(base, "--update-remote-user-uid-default", mode), nil
+	default:
+		return nil, fmt.Errorf("invalid FLEET_DEVCONTAINER_UPDATE_REMOTE_USER_UID value %q (valid: default, never, on, off)", mode)
+	}
 }
 
 func devcontainerEnv(base []string) ([]string, error) {

--- a/internal/backend/devcontainer/devcontainer_test.go
+++ b/internal/backend/devcontainer/devcontainer_test.go
@@ -81,3 +81,41 @@ func TestDevcontainerEnvBuildKitMode(t *testing.T) {
 		})
 	}
 }
+
+func TestDevcontainerUpArgsUpdateRemoteUserUID(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    string
+		want    []string
+		wantErr bool
+	}{
+		{name: "unset delegates to default"},
+		{name: "default delegates to default", mode: "default"},
+		{name: "never disables uid rewrite", mode: "never", want: []string{"up", "--update-remote-user-uid-default", "never"}},
+		{name: "on is passed through", mode: "on", want: []string{"up", "--update-remote-user-uid-default", "on"}},
+		{name: "off is passed through", mode: "off", want: []string{"up", "--update-remote-user-uid-default", "off"}},
+		{name: "invalid errors", mode: "sometimes", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("FLEET_DEVCONTAINER_UPDATE_REMOTE_USER_UID", tt.mode)
+			got, err := devcontainerUpArgs([]string{"up"})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("devcontainerUpArgs() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("devcontainerUpArgs() error = %v", err)
+			}
+			if tt.want == nil {
+				tt.want = []string{"up"}
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("devcontainerUpArgs() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -729,11 +729,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// partially succeed (some splits OK, some failed after retries),
 		// in which case both are set — show the error AND wire up the
 		// panes that did make it.
+		fp := m.fleetPage
+		if !fp.finishGroupRestore(msg.restoreSeq) {
+			break
+		}
 		if msg.err != nil {
 			m.message = fmt.Sprintf("failed to do tmux split pane: %v", msg.err)
 		}
 		if msg.paneID != "" {
-			fp := m.fleetPage
 			fp.splitPaneID = msg.paneID
 			fp.splitFleet = msg.fleet
 			fp.splitInstance = msg.instance
@@ -818,6 +821,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			fp.splitInstance = ""
 			fp.splitSession = ""
 			fp.activeGroupID = ""
+			fp.restoringGroupID = ""
 		}
 		if m.expandedInstances[msg.instanceKey] {
 			parts := strings.SplitN(msg.instanceKey, "/", 2)
@@ -924,6 +928,7 @@ func (m model) View() string {
 			fp.saveCurrentGroupLayout(m.st)
 			killAllSplitPanes()
 			fp.splitPaneID = ""
+			fp.restoringGroupID = ""
 		}
 		m.portForwards.Shutdown()
 		if m.inHostTmux {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
-	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
 	codespacesbackend "github.com/BenjaminBenetti/fleet-man/internal/backend/codespaces"
+	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/deps"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/portforward"
@@ -36,7 +36,7 @@ type model struct {
 	fleetPage   *fleetPage // persistent — has running state accessed by background message handlers
 
 	spinner      spinner.Model
-	agentSpinner spinner.Model // pulse throbber rendered next to running agents' instance names
+	agentSpinner spinner.Model   // pulse throbber rendered next to running agents' instance names
 	creating     map[string]bool // "fleet/instance" keys currently being created
 
 	backends map[fleet.BackendType]backend.Backend // one per backend type, lazily created
@@ -241,6 +241,9 @@ func (m *model) pruneSavedGroupsForInstance(instKey string) {
 		if gid, ok := parseGroupID(sanitized, s.Name); ok {
 			live[gid] = true
 		}
+	}
+	if len(live) == 0 {
+		return
 	}
 	changed := false
 	for gid, savedLayout := range m.fleetPage.savedGroups {
@@ -798,6 +801,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		fp := m.fleetPage
+		if msg.groupID != "" {
+			delete(fp.savedGroups, msg.groupID)
+			if m.st != nil && m.st.GroupLayouts != nil {
+				delete(m.st.GroupLayouts, msg.groupID)
+				_ = state.Save(m.st)
+			}
+		}
 		if fp.splitSession == msg.sessionName || (msg.groupID != "" && fp.activeGroupID == msg.groupID) {
 			if fp.splitPaneID != "" {
 				killAllSplitPanes()

--- a/internal/tui/groups.go
+++ b/internal/tui/groups.go
@@ -79,6 +79,9 @@ func savedGroupSessionNames(sg savedGroup, sanitizedInstance string) []string {
 		sessions = append(sessions, name)
 		seen[name] = true
 	}
+	if len(sessions) > count {
+		return sessions[:count]
+	}
 	if len(sessions) == 0 {
 		root := groupSessionName(sanitizedInstance, sg.GroupID)
 		sessions = append(sessions, root)
@@ -91,6 +94,37 @@ func savedGroupSessionNames(sg savedGroup, sanitizedInstance string) []string {
 		}
 		sessions = append(sessions, name)
 		seen[name] = true
+	}
+	return sessions
+}
+
+func normalizeSavedGroupSessions(raw []string, sanitizedInstance, groupID string) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	sessions := make([]string, 0, len(raw))
+	seen := make(map[string]bool, len(raw))
+	root := groupSessionName(sanitizedInstance, groupID)
+	for _, name := range raw {
+		parsedGroupID, ok := parseGroupID(sanitizedInstance, name)
+		if ok && parsedGroupID == groupID {
+			if !seen[name] {
+				sessions = append(sessions, name)
+				seen[name] = true
+			}
+			continue
+		}
+		replacement := root
+		if seen[replacement] {
+			replacement = groupMemberName(sanitizedInstance, groupID, fmt.Sprintf("restored%02d", len(sessions)))
+		}
+		if !seen[replacement] {
+			sessions = append(sessions, replacement)
+			seen[replacement] = true
+		}
+	}
+	if len(sessions) > len(raw) {
+		return sessions[:len(raw)]
 	}
 	return sessions
 }

--- a/internal/tui/groups.go
+++ b/internal/tui/groups.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -55,6 +56,43 @@ func sameSavedGroup(a, b savedGroup) bool {
 		}
 	}
 	return true
+}
+
+func savedGroupPaneCount(sg savedGroup) int {
+	if sg.PaneCount > 0 {
+		return sg.PaneCount
+	}
+	if len(sg.Sessions) > 0 {
+		return len(sg.Sessions)
+	}
+	return 1
+}
+
+func savedGroupSessionNames(sg savedGroup, sanitizedInstance string) []string {
+	count := savedGroupPaneCount(sg)
+	sessions := make([]string, 0, count)
+	seen := make(map[string]bool, count)
+	for _, name := range sg.Sessions {
+		if name == "" || seen[name] {
+			continue
+		}
+		sessions = append(sessions, name)
+		seen[name] = true
+	}
+	if len(sessions) == 0 {
+		root := groupSessionName(sanitizedInstance, sg.GroupID)
+		sessions = append(sessions, root)
+		seen[root] = true
+	}
+	for len(sessions) < count {
+		name := groupMemberName(sanitizedInstance, sg.GroupID, fmt.Sprintf("restored%02d", len(sessions)))
+		if seen[name] {
+			name = groupMemberName(sanitizedInstance, sg.GroupID, randomHex(2))
+		}
+		sessions = append(sessions, name)
+		seen[name] = true
+	}
+	return sessions
 }
 
 // groupSessionName builds a session name for the root session of a new group.

--- a/internal/tui/groups_test.go
+++ b/internal/tui/groups_test.go
@@ -2,6 +2,35 @@ package tui
 
 import "testing"
 
+func TestGroupRestoreTokens(t *testing.T) {
+	fp := newFleetPage()
+
+	first := fp.beginGroupRestore("abc123")
+	if first == 0 {
+		t.Fatal("beginGroupRestore returned zero token")
+	}
+	if !fp.restoreInProgress() {
+		t.Fatal("restore should be marked in progress")
+	}
+
+	second := fp.beginGroupRestore("def456")
+	if second == first {
+		t.Fatal("restore token did not advance")
+	}
+	if fp.finishGroupRestore(first) {
+		t.Fatal("stale restore token should be rejected")
+	}
+	if !fp.restoreInProgress() {
+		t.Fatal("stale restore token cleared active restore")
+	}
+	if !fp.finishGroupRestore(second) {
+		t.Fatal("current restore token should be accepted")
+	}
+	if fp.restoreInProgress() {
+		t.Fatal("current restore token did not clear active restore")
+	}
+}
+
 // TestSameSavedGroupEqual confirms byte-identical savedGroups compare equal.
 // The diff gate in saveCurrentGroupLayout depends on this being true so
 // that idle discovery ticks don't rewrite state.json.

--- a/internal/tui/groups_test.go
+++ b/internal/tui/groups_test.go
@@ -147,6 +147,23 @@ func TestSavedGroupSessionNamesSynthesizesMissingPanes(t *testing.T) {
 	}
 }
 
+func TestNormalizeSavedGroupSessionsReplacesHostPaneTitles(t *testing.T) {
+	got := normalizeSavedGroupSessions(
+		[]string{"runner-host", "alpha~abc123~ff00"},
+		"alpha",
+		"abc123",
+	)
+	want := []string{"alpha~abc123", "alpha~abc123~ff00"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("session[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestRestoreSessionNamesTopsUpIncompleteLiveDiscovery(t *testing.T) {
 	sg := savedGroup{
 		GroupID:      "abc123",
@@ -173,7 +190,7 @@ func TestRestoreSessionNamesTopsUpIncompleteLiveDiscovery(t *testing.T) {
 	}
 }
 
-func TestRestoreSessionNamesCapsLiveDiscoveryToSavedPaneCount(t *testing.T) {
+func TestRestoreSessionNamesUsesSavedLayoutOverLiveDiscovery(t *testing.T) {
 	sg := savedGroup{
 		GroupID:      "abc123",
 		InstanceName: "alpha",
@@ -182,9 +199,9 @@ func TestRestoreSessionNamesCapsLiveDiscoveryToSavedPaneCount(t *testing.T) {
 	}
 
 	got := restoreSessionNames(
-		"alpha~abc123\nalpha~abc123~ff00\nalpha~abc123~stale\n",
+		"alpha~abc123\nalpha~abc123~stale\n",
 		"alpha~abc123",
-		sg.Sessions,
+		nil,
 		&sg,
 		"alpha",
 	)

--- a/internal/tui/groups_test.go
+++ b/internal/tui/groups_test.go
@@ -107,3 +107,42 @@ func TestSameSavedGroupNilVsEmpty(t *testing.T) {
 		t.Fatal("nil and empty Sessions slices should compare equal")
 	}
 }
+
+func TestSavedGroupSessionNamesUsesSavedOrder(t *testing.T) {
+	sg := savedGroup{
+		GroupID:      "abc123",
+		InstanceName: "alpha",
+		Sessions:     []string{"alpha~abc123", "alpha~abc123~ff00"},
+		PaneCount:    2,
+	}
+
+	got := savedGroupSessionNames(sg, "alpha")
+	want := []string{"alpha~abc123", "alpha~abc123~ff00"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("session[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestSavedGroupSessionNamesSynthesizesMissingPanes(t *testing.T) {
+	sg := savedGroup{
+		GroupID:      "abc123",
+		InstanceName: "alpha",
+		PaneCount:    2,
+	}
+
+	got := savedGroupSessionNames(sg, "alpha")
+	want := []string{"alpha~abc123", "alpha~abc123~restored01"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("session[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/tui/groups_test.go
+++ b/internal/tui/groups_test.go
@@ -146,3 +146,29 @@ func TestSavedGroupSessionNamesSynthesizesMissingPanes(t *testing.T) {
 		}
 	}
 }
+
+func TestRestoreSessionNamesTopsUpIncompleteLiveDiscovery(t *testing.T) {
+	sg := savedGroup{
+		GroupID:      "abc123",
+		InstanceName: "alpha",
+		Sessions:     []string{"alpha~abc123", "alpha~abc123~ff00"},
+		PaneCount:    2,
+	}
+
+	got := restoreSessionNames(
+		"alpha~abc123\n",
+		"alpha~abc123",
+		sg.Sessions,
+		&sg,
+		"alpha",
+	)
+	want := []string{"alpha~abc123", "alpha~abc123~ff00"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("session[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/tui/groups_test.go
+++ b/internal/tui/groups_test.go
@@ -172,3 +172,29 @@ func TestRestoreSessionNamesTopsUpIncompleteLiveDiscovery(t *testing.T) {
 		}
 	}
 }
+
+func TestRestoreSessionNamesCapsLiveDiscoveryToSavedPaneCount(t *testing.T) {
+	sg := savedGroup{
+		GroupID:      "abc123",
+		InstanceName: "alpha",
+		Sessions:     []string{"alpha~abc123", "alpha~abc123~ff00"},
+		PaneCount:    2,
+	}
+
+	got := restoreSessionNames(
+		"alpha~abc123\nalpha~abc123~ff00\nalpha~abc123~stale\n",
+		"alpha~abc123",
+		sg.Sessions,
+		&sg,
+		"alpha",
+	)
+	want := []string{"alpha~abc123", "alpha~abc123~ff00"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("session[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -52,10 +52,12 @@ type fleetPage struct {
 	splitInstance string
 	splitSession  string
 
-	activeGroupID  string
-	savedGroups    map[string]savedGroup
-	pendingGroupID string
-	debounceSeq    int
+	activeGroupID    string
+	savedGroups      map[string]savedGroup
+	pendingGroupID   string
+	debounceSeq      int
+	restoringGroupID string
+	restoreSeq       int
 
 	// listRowY is the terminal Y (0-indexed) where rows[0] is rendered,
 	// recorded during View() so mouse clicks can be mapped back to a
@@ -80,6 +82,27 @@ func newFleetPage() *fleetPage {
 		branchInput: bi,
 		listRowY:    -1,
 	}
+}
+
+func (fleetPage *fleetPage) restoreInProgress() bool {
+	return fleetPage.restoringGroupID != ""
+}
+
+func (fleetPage *fleetPage) beginGroupRestore(groupID string) int {
+	fleetPage.restoreSeq++
+	fleetPage.restoringGroupID = groupID
+	return fleetPage.restoreSeq
+}
+
+func (fleetPage *fleetPage) finishGroupRestore(seq int) bool {
+	if seq == 0 {
+		return true
+	}
+	if seq != fleetPage.restoreSeq {
+		return false
+	}
+	fleetPage.restoringGroupID = ""
+	return true
 }
 
 // Init is called when the fleet page becomes active.
@@ -114,6 +137,7 @@ func (fleetPage *fleetPage) Update(m *model, msg tea.Msg) tea.Cmd {
 			fleetPage.splitInstance = ""
 			fleetPage.splitSession = ""
 			fleetPage.activeGroupID = ""
+			fleetPage.restoringGroupID = ""
 		}
 		return nil
 
@@ -699,6 +723,10 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 		sessInstKey := r.fleetName + "/" + instance.Name
 		m.lastActive[sessInstKey] = lastSession{sessionName: sessionName, groupID: groupID}
 		if m.inHostTmux {
+			if fleetPage.restoreInProgress() {
+				m.message = "Pane group restore already in progress"
+				return nil
+			}
 			if fleetPage.splitPaneID != "" && !splitOpen() {
 				unbindHostSplitKeys()
 				fleetPage.splitPaneID = ""
@@ -706,6 +734,7 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 				fleetPage.splitInstance = ""
 				fleetPage.splitSession = ""
 				fleetPage.activeGroupID = ""
+				fleetPage.restoringGroupID = ""
 			}
 			if fleetPage.splitPaneID != "" && fleetPage.splitInstance == instance.Name && groupID != "" && groupID == fleetPage.activeGroupID {
 				fleetPage.saveCurrentGroupLayout(m.st)
@@ -716,6 +745,7 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 				fleetPage.splitInstance = ""
 				fleetPage.splitSession = ""
 				fleetPage.activeGroupID = ""
+				fleetPage.restoringGroupID = ""
 				return nil
 			}
 			if fleetPage.splitPaneID != "" && fleetPage.activeGroupID != "" {
@@ -753,6 +783,10 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 		instFleetName := r.fleetName
 		instKey := instFleetName + "/" + instance.Name
 		if m.inHostTmux {
+			if fleetPage.restoreInProgress() {
+				m.message = "Pane group restore already in progress"
+				return nil
+			}
 			if fleetPage.splitPaneID != "" && !splitOpen() {
 				unbindHostSplitKeys()
 				fleetPage.splitPaneID = ""
@@ -760,6 +794,7 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 				fleetPage.splitInstance = ""
 				fleetPage.splitSession = ""
 				fleetPage.activeGroupID = ""
+				fleetPage.restoringGroupID = ""
 			}
 			if fleetPage.splitPaneID != "" && fleetPage.splitInstance == instance.Name {
 				fleetPage.saveCurrentGroupLayout(m.st)
@@ -770,6 +805,7 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 				fleetPage.splitInstance = ""
 				fleetPage.splitSession = ""
 				fleetPage.activeGroupID = ""
+				fleetPage.restoringGroupID = ""
 				return nil
 			}
 			return fleetPage.openInstanceSession(m, instFleetName, instance)
@@ -1403,6 +1439,11 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 // openInstanceSession opens a split pane for the given instance, reusing
 // the last active session when available.
 func (fleetPage *fleetPage) openInstanceSession(m *model, fleetName string, instance *fleet.Instance) tea.Cmd {
+	if fleetPage.restoreInProgress() {
+		m.message = "Pane group restore already in progress"
+		return nil
+	}
+
 	instKey := fleetName + "/" + instance.Name
 	sanitized := SanitizeSessionName(instance.Name)
 
@@ -1472,6 +1513,11 @@ func (fleetPage *fleetPage) instanceGroups(m *model, instanceName string) []sess
 // cycleSessionGroup moves the visual selection to the next or previous
 // session group and starts a debounce timer.
 func (fleetPage *fleetPage) cycleSessionGroup(m *model, prev bool) tea.Cmd {
+	if fleetPage.restoreInProgress() {
+		m.message = "Pane group restore already in progress"
+		return nil
+	}
+
 	groups := fleetPage.instanceGroups(m, fleetPage.splitInstance)
 	if len(groups) < 2 {
 		return nil
@@ -1511,6 +1557,11 @@ func (fleetPage *fleetPage) cycleSessionGroup(m *model, prev bool) tea.Cmd {
 // commitGroupCycle performs the actual pane switch after the debounce
 // timer expires.
 func (fleetPage *fleetPage) commitGroupCycle(m *model) tea.Cmd {
+	if fleetPage.restoreInProgress() {
+		m.message = "Pane group restore already in progress"
+		return nil
+	}
+
 	if fleetPage.pendingGroupID == "" || fleetPage.pendingGroupID == fleetPage.activeGroupID {
 		fleetPage.pendingGroupID = ""
 		return nil

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
@@ -197,10 +198,12 @@ func (fleetPage *fleetPage) buildRows(m *model) {
 				fleetPage.rows = append(fleetPage.rows, row{kind: rowInstance, fleetName: name, instance: instance})
 				instKey := name + "/" + instance.Name
 				if m.expandedInstances[instKey] {
+					liveGroups := make(map[string]bool)
 					if disc, ok := m.sessions[instKey]; ok && disc.err == nil {
 						sanitized := SanitizeSessionName(instance.Name)
 						groups := groupSessions(sanitized, disc.sessions)
 						for _, g := range groups {
+							liveGroups[g.GroupID] = true
 							rootName := g.Sessions[0].Name
 							fleetPage.rows = append(fleetPage.rows, row{
 								kind:        rowSession,
@@ -212,6 +215,7 @@ func (fleetPage *fleetPage) buildRows(m *model) {
 							})
 						}
 					}
+					fleetPage.appendSavedGroupRows(name, instance, liveGroups)
 					fleetPage.rows = append(fleetPage.rows, row{
 						kind:      rowNewSession,
 						fleetName: name,
@@ -228,6 +232,37 @@ func (fleetPage *fleetPage) buildRows(m *model) {
 	if fleetPage.cursor >= len(fleetPage.rows) {
 		fleetPage.cursor = max(0, len(fleetPage.rows)-1)
 	}
+}
+
+func (fleetPage *fleetPage) appendSavedGroupRows(fleetName string, instance *fleet.Instance, liveGroups map[string]bool) {
+	sanitized := SanitizeSessionName(instance.Name)
+	for _, sg := range fleetPage.savedGroupsForInstance(instance.Name) {
+		if liveGroups[sg.GroupID] {
+			continue
+		}
+		sessions := savedGroupSessionNames(sg, sanitized)
+		fleetPage.rows = append(fleetPage.rows, row{
+			kind:        rowSession,
+			fleetName:   fleetName,
+			instance:    instance,
+			sessionName: sessions[0],
+			groupID:     sg.GroupID,
+			groupSize:   savedGroupPaneCount(sg),
+		})
+	}
+}
+
+func (fleetPage *fleetPage) savedGroupsForInstance(instanceName string) []savedGroup {
+	groups := make([]savedGroup, 0, len(fleetPage.savedGroups))
+	for _, sg := range fleetPage.savedGroups {
+		if sg.InstanceName == instanceName {
+			groups = append(groups, sg)
+		}
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		return groups[i].GroupID < groups[j].GroupID
+	})
+	return groups
 }
 
 // currentRow returns a pointer to the row at the cursor position.

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -187,6 +187,78 @@ func TestViewFleetListShowsBranchItemForInstance(t *testing.T) {
 	}
 }
 
+func TestBuildRowsShowsSavedGroupWithoutLiveSessions(t *testing.T) {
+	inst := &fleet.Instance{Name: "alpha", Status: fleet.StatusRunning, ContainerID: "abc"}
+	fp := newFleetPage()
+	fp.savedGroups["abc123"] = savedGroup{
+		GroupID:      "abc123",
+		InstanceName: "alpha",
+		Sessions:     []string{"alpha~abc123", "alpha~abc123~ff00"},
+		PaneCount:    2,
+	}
+	m := &model{
+		st: &state.State{
+			Fleets: map[string]*fleet.Fleet{
+				"repo": {Name: "repo", Instances: []*fleet.Instance{inst}},
+			},
+		},
+		expandedInstances: map[string]bool{"repo/alpha": true},
+		sessions: map[string]*sessionDiscovery{
+			"repo/alpha": {sessions: nil},
+		},
+		fleetPage: fp,
+	}
+
+	fp.buildRows(m)
+
+	found := false
+	for _, r := range fp.rows {
+		if r.kind == rowSession && r.groupID == "abc123" {
+			found = true
+			if r.sessionName != "alpha~abc123" {
+				t.Fatalf("sessionName = %q, want alpha~abc123", r.sessionName)
+			}
+			if r.groupSize != 2 {
+				t.Fatalf("groupSize = %d, want 2", r.groupSize)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("saved group row not found in %#v", fp.rows)
+	}
+}
+
+func TestPruneSavedGroupsKeepsSavedGroupWhenDiscoveryIsEmpty(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fp := newFleetPage()
+	fp.savedGroups["abc123"] = savedGroup{
+		GroupID:      "abc123",
+		InstanceName: "alpha",
+		Sessions:     []string{"alpha~abc123"},
+		PaneCount:    1,
+	}
+	m := &model{
+		st: &state.State{
+			Fleets:       map[string]*fleet.Fleet{},
+			GroupLayouts: map[string]state.GroupLayout{"abc123": {GroupID: "abc123", InstanceName: "alpha"}},
+		},
+		fleetPage: fp,
+		sessions: map[string]*sessionDiscovery{
+			"repo/alpha": {sessions: nil},
+		},
+	}
+
+	m.pruneSavedGroupsForInstance("repo/alpha")
+
+	if _, ok := m.fleetPage.savedGroups["abc123"]; !ok {
+		t.Fatal("saved group was pruned even though WSL discovery returned no live sessions")
+	}
+	if _, ok := m.st.GroupLayouts["abc123"]; !ok {
+		t.Fatal("state group layout was pruned even though WSL discovery returned no live sessions")
+	}
+}
+
 func TestViewFleetListOmitsBranchItemWhenBranchIsUnavailable(t *testing.T) {
 	inst := &fleet.Instance{
 		Name:         "agent-1",
@@ -484,12 +556,12 @@ func TestMoveCursorToInstanceSkipsBetweenInstances(t *testing.T) {
 	inst2 := &fleet.Instance{Name: "agent-2"}
 	fp := newFleetPage()
 	fp.rows = []row{
-		{kind: rowFleetHeader, fleetName: "alpha"},      // 0
-		{kind: rowInstance, fleetName: "alpha", instance: inst1}, // 1
+		{kind: rowFleetHeader, fleetName: "alpha"},                                 // 0
+		{kind: rowInstance, fleetName: "alpha", instance: inst1},                   // 1
 		{kind: rowSession, fleetName: "alpha", instance: inst1, sessionName: "s1"}, // 2
 		{kind: rowSession, fleetName: "alpha", instance: inst1, sessionName: "s2"}, // 3
-		{kind: rowNewSession, fleetName: "alpha", instance: inst1}, // 4
-		{kind: rowInstance, fleetName: "alpha", instance: inst2}, // 5
+		{kind: rowNewSession, fleetName: "alpha", instance: inst1},                 // 4
+		{kind: rowInstance, fleetName: "alpha", instance: inst2},                   // 5
 		{kind: rowSettings}, // 6
 	}
 
@@ -529,7 +601,7 @@ func TestMoveCursorToInstanceWraps(t *testing.T) {
 	inst2 := &fleet.Instance{Name: "agent-2"}
 	fp := newFleetPage()
 	fp.rows = []row{
-		{kind: rowFleetHeader, fleetName: "alpha"},      // 0
+		{kind: rowFleetHeader, fleetName: "alpha"},               // 0
 		{kind: rowInstance, fleetName: "alpha", instance: inst1}, // 1
 		{kind: rowInstance, fleetName: "alpha", instance: inst2}, // 2
 		{kind: rowSettings}, // 3

--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -333,8 +333,12 @@ func (fleetPage *fleetPage) saveCurrentGroupLayout(st *state.State) {
 		return
 	}
 
-	// Read session names from outer tmux pane titles, in pane order.
-	sessionNames := paneSessionOrder()
+	// Read session names from outer tmux pane titles, in pane order. Some
+	// panes briefly report the host title before fleet shell sets a title;
+	// normalize those placeholders into deterministic group session names
+	// before persisting the layout.
+	sanitized := SanitizeSessionName(fleetPage.splitInstance)
+	sessionNames := normalizeSavedGroupSessions(paneSessionOrder(), sanitized, fleetPage.activeGroupID)
 
 	// No shell panes visible in the outer tmux means either the group
 	// hasn't opened yet or its panes have already been killed (Ctrl+Q,
@@ -420,7 +424,6 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 			savedSnapshot = &sg
 		}
 		sessions := restoreSessionNames(string(out), prefix, savedOrder, savedSnapshot, sanitized)
-
 		if len(sessions) == 0 {
 			if _, ok := fleetPage.savedGroups[groupID]; !ok {
 				return splitPaneMsg{err: fmt.Errorf("no sessions found for group %s", groupID)}
@@ -523,6 +526,16 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 }
 
 func restoreSessionNames(discovered, prefix string, savedOrder []string, savedSnapshot *savedGroup, sanitized string) []string {
+	// A saved layout is the source of truth for restore: it records the
+	// pane count and session-to-pane order the user left behind. Each
+	// restored `fleet shell --session` uses tmux new-session -A, so the
+	// named session is attached if it survived or recreated if it did
+	// not. Avoid mixing live discovery into this path because Linux and
+	// WSL can report different stale/live inner tmux sets during restart.
+	if savedSnapshot != nil {
+		return savedGroupSessionNames(*savedSnapshot, sanitized)
+	}
+
 	// Build a set of live sessions for validation.
 	live := make(map[string]bool)
 	var liveOrder []string
@@ -549,21 +562,6 @@ func restoreSessionNames(discovered, prefix string, savedOrder []string, savedSn
 		if !seen[name] {
 			sessions = append(sessions, name)
 			seen[name] = true
-		}
-	}
-
-	// If live discovery is incomplete, top up from the saved layout. A
-	// restored `fleet shell --session` uses tmux new-session -A, so a
-	// stale or missing saved session name can be recreated safely.
-	if savedSnapshot != nil {
-		for _, name := range savedGroupSessionNames(*savedSnapshot, sanitized) {
-			if !seen[name] {
-				sessions = append(sessions, name)
-				seen[name] = true
-			}
-		}
-		if count := savedGroupPaneCount(*savedSnapshot); count > 0 && len(sessions) > count {
-			sessions = sessions[:count]
 		}
 	}
 

--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -443,7 +443,11 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 		}
 
 		if len(sessions) == 0 {
-			return splitPaneMsg{err: fmt.Errorf("no sessions found for group %s", groupID)}
+			sg, ok := fleetPage.savedGroups[groupID]
+			if !ok {
+				return splitPaneMsg{err: fmt.Errorf("no sessions found for group %s", groupID)}
+			}
+			sessions = savedGroupSessionNames(sg, sanitized)
 		}
 
 		// Kill any existing split panes. Must select the TUI pane first —

--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -16,12 +16,13 @@ import (
 
 // splitPaneMsg is sent after a tmux split-window command completes.
 type splitPaneMsg struct {
-	paneID   string // tmux pane ID (e.g. "%3")
-	fleet    string // fleet name for the instance
-	instance string // instance name occupying the pane
-	session  string // tmux session name in the pane
-	groupID  string // session group ID (for group management)
-	err      error
+	paneID     string // tmux pane ID (e.g. "%3")
+	fleet      string // fleet name for the instance
+	instance   string // instance name occupying the pane
+	session    string // tmux session name in the pane
+	groupID    string // session group ID (for group management)
+	restoreSeq int    // async restore token; zero means not a group restore
+	err        error
 }
 
 // tmuxWindowSize queries the host tmux for the current window dimensions.
@@ -332,6 +333,9 @@ func (fleetPage *fleetPage) saveCurrentGroupLayout(st *state.State) {
 	if fleetPage.activeGroupID == "" || fleetPage.splitInstance == "" {
 		return
 	}
+	if fleetPage.restoreInProgress() {
+		return
+	}
 
 	// Read session names from outer tmux pane titles, in pane order. Some
 	// panes briefly report the host title before fleet shell sets a title;
@@ -386,6 +390,7 @@ func (fleetPage *fleetPage) saveCurrentGroupLayout(st *state.State) {
 // queries the inner tmux directly for sessions matching the group prefix.
 // Each discovered session gets its own pane via `fleet shell --session`.
 func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance *fleet.Instance, groupID string) tea.Cmd {
+	restoreSeq := fleetPage.beginGroupRestore(groupID)
 	instanceBackend := m.instanceBackend(instance)
 	instanceName := instance.Name
 	qualifiedName := fleetName + "/" + instanceName
@@ -409,7 +414,7 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 	return func() tea.Msg {
 		self, err := os.Executable()
 		if err != nil {
-			return splitPaneMsg{err: fmt.Errorf("os.Executable: %w", err)}
+			return splitPaneMsg{restoreSeq: restoreSeq, err: fmt.Errorf("os.Executable: %w", err)}
 		}
 
 		// Query the inner tmux for all sessions in this group.
@@ -426,7 +431,7 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 		sessions := restoreSessionNames(string(out), prefix, savedOrder, savedSnapshot, sanitized)
 		if len(sessions) == 0 {
 			if _, ok := fleetPage.savedGroups[groupID]; !ok {
-				return splitPaneMsg{err: fmt.Errorf("no sessions found for group %s", groupID)}
+				return splitPaneMsg{restoreSeq: restoreSeq, err: fmt.Errorf("no sessions found for group %s", groupID)}
 			}
 		}
 
@@ -512,11 +517,12 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 			firstSession = sessions[0]
 		}
 		msg := splitPaneMsg{
-			paneID:   firstPaneID,
-			fleet:    fleetName,
-			instance: instanceName,
-			session:  firstSession,
-			groupID:  groupID,
+			paneID:     firstPaneID,
+			fleet:      fleetName,
+			instance:   instanceName,
+			session:    firstSession,
+			groupID:    groupID,
+			restoreSeq: restoreSeq,
 		}
 		if splitErr != nil {
 			msg.err = fmt.Errorf("failed to do tmux split pane: %w", splitErr)

--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -415,39 +415,16 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 		})
 		out, _ := listCmd.Output()
 
-		// Build a set of live sessions for validation.
-		live := make(map[string]bool)
-		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-			name := strings.TrimSpace(line)
-			if name != "" && strings.HasPrefix(name, prefix) {
-				live[name] = true
-			}
+		var savedSnapshot *savedGroup
+		if sg, ok := fleetPage.savedGroups[groupID]; ok {
+			savedSnapshot = &sg
 		}
-
-		// Use saved order if available, filtering to sessions that
-		// still exist. Then append any newly discovered sessions
-		// that weren't in the saved order.
-		var sessions []string
-		seen := make(map[string]bool)
-		for _, s := range savedOrder {
-			if live[s] {
-				sessions = append(sessions, s)
-				seen[s] = true
-			}
-		}
-		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-			name := strings.TrimSpace(line)
-			if name != "" && strings.HasPrefix(name, prefix) && !seen[name] {
-				sessions = append(sessions, name)
-			}
-		}
+		sessions := restoreSessionNames(string(out), prefix, savedOrder, savedSnapshot, sanitized)
 
 		if len(sessions) == 0 {
-			sg, ok := fleetPage.savedGroups[groupID]
-			if !ok {
+			if _, ok := fleetPage.savedGroups[groupID]; !ok {
 				return splitPaneMsg{err: fmt.Errorf("no sessions found for group %s", groupID)}
 			}
-			sessions = savedGroupSessionNames(sg, sanitized)
 		}
 
 		// Kill any existing split panes. Must select the TUI pane first —
@@ -543,6 +520,51 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 		}
 		return msg
 	}
+}
+
+func restoreSessionNames(discovered, prefix string, savedOrder []string, savedSnapshot *savedGroup, sanitized string) []string {
+	// Build a set of live sessions for validation.
+	live := make(map[string]bool)
+	var liveOrder []string
+	for _, line := range strings.Split(strings.TrimSpace(discovered), "\n") {
+		name := strings.TrimSpace(line)
+		if name != "" && strings.HasPrefix(name, prefix) {
+			live[name] = true
+			liveOrder = append(liveOrder, name)
+		}
+	}
+
+	// Use saved order if available, filtering to sessions that still
+	// exist. Then append any newly discovered sessions that weren't in
+	// the saved order.
+	var sessions []string
+	seen := make(map[string]bool)
+	for _, s := range savedOrder {
+		if live[s] {
+			sessions = append(sessions, s)
+			seen[s] = true
+		}
+	}
+	for _, name := range liveOrder {
+		if !seen[name] {
+			sessions = append(sessions, name)
+			seen[name] = true
+		}
+	}
+
+	// If live discovery is incomplete, top up from the saved layout. A
+	// restored `fleet shell --session` uses tmux new-session -A, so a
+	// stale or missing saved session name can be recreated safely.
+	if savedSnapshot != nil {
+		for _, name := range savedGroupSessionNames(*savedSnapshot, sanitized) {
+			if !seen[name] {
+				sessions = append(sessions, name)
+				seen[name] = true
+			}
+		}
+	}
+
+	return sessions
 }
 
 // bindHostSessionCycleKeys binds Ctrl+PageUp/Down on the outer tmux to

--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -562,6 +562,9 @@ func restoreSessionNames(discovered, prefix string, savedOrder []string, savedSn
 				seen[name] = true
 			}
 		}
+		if count := savedGroupPaneCount(*savedSnapshot); count > 0 && len(sessions) > count {
+			sessions = sessions[:count]
+		}
 	}
 
 	return sessions


### PR DESCRIPTION
Fixes #41.

Summary:
- keep saved pane-group rows visible when WSL reports no live inner tmux sessions
- restore missing group sessions from saved layout state instead of failing immediately
- preserve saved group state when discovery returns an empty live group set, while still deleting saved layouts on explicit group delete
- add FLEET_DEVCONTAINER_UPDATE_REMOTE_USER_UID to pass devcontainer up --update-remote-user-uid-default for WSL/Docker Desktop UID-rewrite failures

Validation:
- go test ./...
- go vet ./...
- git diff --check
- attempted integration/tests/280_tui_pane_layout_persist.sh with FLEET_DEVCONTAINER_BUILDKIT=never and FLEET_DEVCONTAINER_UPDATE_REMOTE_USER_UID=never; local run is blocked by Docker Desktop/MCR EOF while pulling mcr.microsoft.com/devcontainers/base:debian-12
