### PR TITLE
Support Windows clipboard in WSL

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/doctor"
+	"github.com/BenjaminBenetti/fleet-man/internal/platform"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	"github.com/BenjaminBenetti/fleet-man/internal/tui"
 	"github.com/spf13/cobra"
@@ -111,11 +112,12 @@ func relaunchInTmux() error {
 	// Middle-click paste: `mouse on` makes terminals forward MMB
 	// to tmux as an escape sequence instead of doing local X11
 	// PRIMARY paste. The outer (host) tmux has access to
-	// xclip/wl-paste, so we intercept MouseDown2Pane here, read
-	// the host PRIMARY selection, and feed it into the clicked
+	// clipboard tools, so we intercept MouseDown2Pane here, read
+	// the host selection or clipboard, and feed it into the clicked
 	// pane as bracketed paste. The text flows transparently
 	// through any inner container tmux and into the app. Missing
-	// clipboard tool or empty clipboard is a silent no-op. xsel
+	// clipboard tool or empty clipboard is a silent no-op. On WSL,
+	// Windows PowerShell reads the host clipboard. Elsewhere, xsel
 	// is tried before xclip because xclip has a stdout-close bug
 	// that can stall run-shell; xclip is wrapped in timeout as a
 	// belt-and-braces guard.
@@ -132,9 +134,7 @@ func relaunchInTmux() error {
 	setupArgs = append(setupArgs,
 		";", "bind-key", "-n", "MouseDown2Pane",
 		"run-shell",
-		`tmux select-pane -t "$TMUX_PANE"; `+
-			`CLIP=$(wl-paste -p 2>/dev/null || xsel -op 2>/dev/null || timeout 0.5 xclip -o -selection primary 2>/dev/null || pbpaste 2>/dev/null); `+
-			`[ -n "$CLIP" ] && { tmux set-buffer -b __fleet_primary -- "$CLIP"; tmux paste-buffer -p -d -b __fleet_primary -t "$TMUX_PANE"; }`,
+		mousePasteCommand(),
 	)
 	// terminal-features tells tmux the terminal supports OSC 52
 	// clipboard and RGB/truecolor (tmux 3.2+). Appended last so
@@ -151,4 +151,21 @@ func relaunchInTmux() error {
 	return syscall.Exec(tmuxBin, []string{
 		"tmux", "attach", "-t", session,
 	}, os.Environ())
+}
+
+func mousePasteCommand() string {
+	return `tmux select-pane -t "$TMUX_PANE"; ` +
+		`CLIP=$(` + pasteClipboardCommand() + `); ` +
+		`[ -n "$CLIP" ] && { tmux set-buffer -b __fleet_primary -- "$CLIP"; tmux paste-buffer -p -d -b __fleet_primary -t "$TMUX_PANE"; }`
+}
+
+func pasteClipboardCommand() string {
+	return pasteClipboardCommandFor(platform.IsWSL())
+}
+
+func pasteClipboardCommandFor(isWSL bool) string {
+	if isWSL {
+		return `powershell.exe -NoProfile -Command Get-Clipboard 2>/dev/null`
+	}
+	return `wl-paste -p 2>/dev/null || xsel -op 2>/dev/null || timeout 0.5 xclip -o -selection primary 2>/dev/null || pbpaste 2>/dev/null`
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPasteClipboardCommandWSL(t *testing.T) {
+	got := pasteClipboardCommandFor(true)
+	if !strings.Contains(got, "powershell.exe") || !strings.Contains(got, "Get-Clipboard") {
+		t.Fatalf("WSL paste command = %q, want PowerShell Get-Clipboard", got)
+	}
+}
+
+func TestPasteClipboardCommandLinux(t *testing.T) {
+	got := pasteClipboardCommandFor(false)
+	for _, want := range []string{"wl-paste", "xsel", "xclip", "pbpaste"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Linux paste command = %q, want %q fallback", got, want)
+		}
+	}
+}

--- a/internal/deps/dependency.go
+++ b/internal/deps/dependency.go
@@ -1,6 +1,10 @@
 package deps
 
-import "os/exec"
+import (
+	"os/exec"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/platform"
+)
 
 // Dependency describes a binary dependency and how to install it.
 type Dependency struct {
@@ -35,20 +39,31 @@ func Check() []Dependency {
 			Required:   false,
 			InstallURL: "https://coder.com/docs/install",
 		},
-		{
-			Name:        "wl-clipboard",
-			Binary:      "wl-copy",
+	}
+	if platform.IsWSL() {
+		deps = append(deps, Dependency{
+			Name:        "Windows clipboard",
+			Binary:      "powershell.exe",
 			Required:    false,
-			InstallURL:  wlClipboardInstallURL(),
-			Description: "Copy/paste support on Wayland (only one of wl-clipboard or xclip needed).",
-		},
-		{
-			Name:        "xclip",
-			Binary:      "xclip",
-			Required:    false,
-			InstallURL:  "https://github.com/astrand/xclip",
-			Description: "Copy/paste support on X11 (only one of wl-copy or xclip needed).",
-		},
+			Description: "Copy/paste support through the Windows clipboard when running inside WSL.",
+		})
+	} else {
+		deps = append(deps,
+			Dependency{
+				Name:        "wl-clipboard",
+				Binary:      "wl-copy",
+				Required:    false,
+				InstallURL:  wlClipboardInstallURL(),
+				Description: "Copy/paste support on Wayland (only one of wl-clipboard or xclip needed).",
+			},
+			Dependency{
+				Name:        "xclip",
+				Binary:      "xclip",
+				Required:    false,
+				InstallURL:  "https://github.com/astrand/xclip",
+				Description: "Copy/paste support on X11 (only one of wl-copy or xclip needed).",
+			},
+		)
 	}
 
 	for i := range deps {

--- a/internal/deps/tool_status.go
+++ b/internal/deps/tool_status.go
@@ -1,6 +1,10 @@
 package deps
 
-import "os/exec"
+import (
+	"os/exec"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/platform"
+)
 
 // ToolStatus describes an optional tool, its install state, and purpose.
 type ToolStatus struct {
@@ -33,18 +37,28 @@ func CheckTools() []ToolStatus {
 			Description: "Adds remote coder workspace development.",
 			InstallURL:  "https://coder.com/docs/install",
 		},
-		{
-			Name:        "wl-clipboard",
-			Binary:      "wl-copy",
-			Description: "Optional — copy/paste support on Wayland (only one of wl-clipboard or xclip needed).",
-			InstallURL:  wlClipboardInstallURL(),
-		},
-		{
-			Name:        "xclip",
-			Binary:      "xclip",
-			Description: "Optional — copy/paste support on X11 (only one of wl-copy or xclip needed).",
-			InstallURL:  "https://github.com/astrand/xclip",
-		},
+	}
+	if platform.IsWSL() {
+		tools = append(tools, ToolStatus{
+			Name:        "Windows clipboard",
+			Binary:      "powershell.exe",
+			Description: "Optional — copy/paste support through the Windows clipboard when running inside WSL.",
+		})
+	} else {
+		tools = append(tools,
+			ToolStatus{
+				Name:        "wl-clipboard",
+				Binary:      "wl-copy",
+				Description: "Optional — copy/paste support on Wayland (only one of wl-clipboard or xclip needed).",
+				InstallURL:  wlClipboardInstallURL(),
+			},
+			ToolStatus{
+				Name:        "xclip",
+				Binary:      "xclip",
+				Description: "Optional — copy/paste support on X11 (only one of wl-copy or xclip needed).",
+				InstallURL:  "https://github.com/astrand/xclip",
+			},
+		)
 	}
 
 	for i := range tools {

--- a/internal/platform/wsl.go
+++ b/internal/platform/wsl.go
@@ -1,0 +1,23 @@
+package platform
+
+import (
+	"os"
+	"runtime"
+	"strings"
+)
+
+// IsWSL reports whether Fleet is running inside Windows Subsystem for Linux.
+func IsWSL() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	if os.Getenv("WSL_DISTRO_NAME") != "" || os.Getenv("WSL_INTEROP") != "" {
+		return true
+	}
+	data, err := os.ReadFile("/proc/version")
+	if err != nil {
+		return false
+	}
+	version := strings.ToLower(string(data))
+	return strings.Contains(version, "microsoft") || strings.Contains(version, "wsl")
+}

--- a/internal/tui/clipboard.go
+++ b/internal/tui/clipboard.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/platform"
 )
 
 // ===========================================
@@ -31,10 +33,17 @@ type clipboardSync struct {
 // the primary selection (middle-click). On macOS, only pbcopy is
 // returned because there is no primary selection concept.
 func clipboardCmds() []string {
-	if runtime.GOOS == "darwin" {
+	return clipboardCmdsFor(runtime.GOOS, os.Getenv("WAYLAND_DISPLAY") != "", platform.IsWSL())
+}
+
+func clipboardCmdsFor(goos string, hasWayland, isWSL bool) []string {
+	if goos == "darwin" {
 		return []string{"pbcopy"}
 	}
-	if os.Getenv("WAYLAND_DISPLAY") != "" {
+	if goos == "linux" && isWSL {
+		return []string{`powershell.exe -NoProfile -Command "Set-Clipboard -Value ([Console]::In.ReadToEnd())"`}
+	}
+	if hasWayland {
 		return []string{"wl-copy", "wl-copy --primary"}
 	}
 	return []string{"xclip -sel clip -i", "xclip -sel primary -i"}

--- a/internal/tui/clipboard_test.go
+++ b/internal/tui/clipboard_test.go
@@ -1,7 +1,6 @@
 package tui
 
 import (
-	"os"
 	"reflect"
 	"runtime"
 	"testing"
@@ -11,8 +10,7 @@ func TestClipboardCmdsWayland(t *testing.T) {
 	if runtime.GOOS == "darwin" {
 		t.Skip("darwin always returns pbcopy")
 	}
-	t.Setenv("WAYLAND_DISPLAY", "wayland-0")
-	got := clipboardCmds()
+	got := clipboardCmdsFor("linux", true, false)
 	want := []string{"wl-copy", "wl-copy --primary"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("clipboardCmds() with WAYLAND_DISPLAY = %q, want %q", got, want)
@@ -23,11 +21,18 @@ func TestClipboardCmdsX11Fallback(t *testing.T) {
 	if runtime.GOOS == "darwin" {
 		t.Skip("darwin always returns pbcopy")
 	}
-	os.Unsetenv("WAYLAND_DISPLAY")
-	got := clipboardCmds()
+	got := clipboardCmdsFor("linux", false, false)
 	want := []string{"xclip -sel clip -i", "xclip -sel primary -i"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("clipboardCmds() without WAYLAND_DISPLAY = %q, want %q", got, want)
+	}
+}
+
+func TestClipboardCmdsWSL(t *testing.T) {
+	got := clipboardCmdsFor("linux", false, true)
+	want := []string{`powershell.exe -NoProfile -Command "Set-Clipboard -Value ([Console]::In.ReadToEnd())"`}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("clipboardCmds() on WSL = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
Summary:
- detect WSL and use Windows PowerShell clipboard commands instead of Linux GUI clipboard providers
- copy tmux buffer changes to the Windows clipboard with Set-Clipboard
- paste from the Windows clipboard for the outer tmux MouseDown2Pane binding
- show Windows clipboard status in dependency/tool checks on WSL instead of wl-clipboard/xclip

Validation:
- go test ./...
- go vet ./...
- git diff --check
- live WSL clipboard check: piped text through powershell.exe Set-Clipboard and read it back with Get-Clipboard
