### PR TITLE
refactor: extract agent state detection into strategy interface

### DIFF
--- a/internal/agentdetect/detector.go
+++ b/internal/agentdetect/detector.go
@@ -1,0 +1,25 @@
+package agentdetect
+
+import (
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// Detector is the strategy interface for agent run-state detection.
+//
+// One Detector instance corresponds to one container. Implementations
+// own whatever per-container state they need (e.g., previous screen
+// captures, last-change timestamps) so the caller does not have to
+// thread that state through on every cycle.
+//
+// A new Detector is built via the factory whenever a container's
+// detected agent tool changes (or appears for the first time). When
+// the agent disappears the Detector should be discarded so a future
+// agent starts from a clean slate.
+type Detector interface {
+	// Detect inspects a fresh capture and returns the current state
+	// for the container. Implementations may mutate internal state
+	// to record history for the next call.
+	Detect(capture backend.AllSessions, now time.Time) State
+}

--- a/internal/agentdetect/factory.go
+++ b/internal/agentdetect/factory.go
@@ -1,0 +1,21 @@
+package agentdetect
+
+import (
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// NewDetector returns the appropriate Detector strategy for a given
+// agent tool.
+//
+// Today every tool falls back to TmuxPaneChangeDetector — the generic
+// pane-diffing strategy works for any CLI agent that draws into a
+// tmux pane. As tool-specific signals are added (e.g., parsing a
+// known agent's status line, watching its log files, hitting an
+// exposed status endpoint) new branches can be added here without
+// touching the call sites.
+func NewDetector(tool state.AgentTool) Detector {
+	switch tool {
+	default:
+		return NewTmuxPaneChangeDetector()
+	}
+}

--- a/internal/agentdetect/state.go
+++ b/internal/agentdetect/state.go
@@ -1,0 +1,22 @@
+// Package agentdetect determines whether the AI agent inside a
+// container is currently working, waiting for input, or absent.
+//
+// Detection is split behind a strategy interface so different agent
+// tools (claude, codex, gemini, copilot) can plug in tool-specific
+// signals when they are available, while the generic tmux pane-change
+// strategy remains the safe default fallback.
+package agentdetect
+
+// State represents the runtime status of an agent inside a container.
+type State int
+
+const (
+	// StateNotRunning means no agent process was detected, or the
+	// expected session/process artifact is absent.
+	StateNotRunning State = iota
+	// StateWorking means the agent is actively producing output.
+	StateWorking
+	// StateWaiting means the agent is alive but idle (e.g., waiting
+	// for user input or a tool result).
+	StateWaiting
+)

--- a/internal/agentdetect/tmux_detector.go
+++ b/internal/agentdetect/tmux_detector.go
@@ -1,0 +1,137 @@
+package agentdetect
+
+import (
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// ===========================================
+// Constants
+// ===========================================
+
+// screenChangeThreshold is the minimum number of characters that must
+// differ between consecutive screen captures to count as meaningful
+// activity (catches spinner animations while ignoring cursor blink).
+const screenChangeThreshold = 3
+
+// screenActivityWindow is how recently a meaningful screen change must
+// have occurred for the agent to be considered actively working.
+const screenActivityWindow = 12 * time.Second
+
+// ===========================================
+// TmuxPaneChangeDetector
+// ===========================================
+
+// TmuxPaneChangeDetector implements Detector by diffing consecutive
+// tmux pane captures. It is the generic fallback that works for any
+// agent tool that runs inside a tmux session: if the visible screen
+// keeps changing, the agent is working; if it has been static for
+// longer than screenActivityWindow, the agent is waiting.
+//
+// The detector is per-container and tracks each tmux session inside
+// it independently — activity in any session marks the container as
+// working.
+type TmuxPaneChangeDetector struct {
+	// ===========================================
+	// Fields
+	// ===========================================
+
+	prevScreen map[string]string    // sessionName → last captured content
+	lastChange map[string]time.Time // sessionName → timestamp of last meaningful change
+}
+
+// ===========================================
+// Constructors
+// ===========================================
+
+// NewTmuxPaneChangeDetector returns an initialised detector with no
+// prior screen history.
+func NewTmuxPaneChangeDetector() *TmuxPaneChangeDetector {
+	return &TmuxPaneChangeDetector{
+		prevScreen: make(map[string]string),
+		lastChange: make(map[string]time.Time),
+	}
+}
+
+// ===========================================
+// Public Methods
+// ===========================================
+
+// Detect compares each session's current content against the last
+// captured content for that session. Behaviour:
+//
+//   - capture.OK=true with no sessions → StateNotRunning
+//   - any session changed by ≥ screenChangeThreshold within
+//     screenActivityWindow → StateWorking
+//   - sessions exist but none changed → StateWaiting
+//   - first call (no history yet) → StateWaiting
+//
+// The OK=false (exec failure) case is intentionally NOT handled here
+// — the tracker preserves prior state across transient failures
+// before consulting the detector.
+func (d *TmuxPaneChangeDetector) Detect(capture backend.AllSessions, now time.Time) State {
+	if len(capture.Sessions) == 0 {
+		return StateNotRunning
+	}
+
+	nextPrev := make(map[string]string, len(capture.Sessions))
+	nextLastChange := make(map[string]time.Time, len(capture.Sessions))
+	anyHadHistory := false
+	workingDetected := false
+
+	for sessionName, sc := range capture.Sessions {
+		if !sc.OK {
+			continue
+		}
+		prev, hasPrev := d.prevScreen[sessionName]
+		lc := d.lastChange[sessionName]
+		if hasPrev {
+			anyHadHistory = true
+			if countDiffs(prev, sc.Content) >= screenChangeThreshold {
+				lc = now
+			}
+		}
+		nextPrev[sessionName] = sc.Content
+		nextLastChange[sessionName] = lc
+		if !lc.IsZero() && now.Sub(lc) < screenActivityWindow {
+			workingDetected = true
+		}
+	}
+
+	d.prevScreen = nextPrev
+	d.lastChange = nextLastChange
+
+	switch {
+	case workingDetected:
+		return StateWorking
+	case anyHadHistory:
+		return StateWaiting
+	default:
+		// First capture(s) — no history yet, assume waiting.
+		return StateWaiting
+	}
+}
+
+// ===========================================
+// Helpers
+// ===========================================
+
+// countDiffs returns the number of character positions that differ
+// between two strings, plus any length difference.
+func countDiffs(a, b string) int {
+	diffs := 0
+	ar, br := []rune(a), []rune(b)
+	minLen := min(len(ar), len(br))
+	for i := range minLen {
+		if ar[i] != br[i] {
+			diffs++
+		}
+	}
+	if len(ar) > minLen {
+		diffs += len(ar) - minLen
+	} else {
+		diffs += len(br) - minLen
+	}
+	return diffs
+}

--- a/internal/agentdetect/tmux_detector_test.go
+++ b/internal/agentdetect/tmux_detector_test.go
@@ -1,0 +1,132 @@
+package agentdetect
+
+import (
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// allFor wraps a sessionName→content map into a backend.AllSessions
+// with OK=true on every capture.
+func allFor(sessions map[string]string) backend.AllSessions {
+	out := backend.AllSessions{Sessions: make(map[string]backend.ScreenCapture, len(sessions)), OK: true}
+	for name, content := range sessions {
+		out.Sessions[name] = backend.ScreenCapture{Content: content, OK: true}
+	}
+	return out
+}
+
+func TestCountDiffs(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want int
+	}{
+		{"identical", "hello", "hello", 0},
+		{"one diff", "hello", "hallo", 1},
+		{"all diff", "abc", "xyz", 3},
+		{"different lengths", "ab", "abcde", 3},
+		{"empty vs content", "", "hello", 5},
+		{"both empty", "", "", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := countDiffs(tt.a, tt.b)
+			if got != tt.want {
+				t.Fatalf("countDiffs(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTmuxPaneChangeDetector(t *testing.T) {
+	now := time.Now()
+
+	t.Run("no sessions means not running", func(t *testing.T) {
+		d := NewTmuxPaneChangeDetector()
+		got := d.Detect(backend.AllSessions{Sessions: map[string]backend.ScreenCapture{}, OK: true}, now)
+		if got != StateNotRunning {
+			t.Fatalf("got %d, want StateNotRunning", got)
+		}
+	})
+
+	t.Run("first capture assumes waiting", func(t *testing.T) {
+		d := NewTmuxPaneChangeDetector()
+		got := d.Detect(allFor(map[string]string{"main": "spinner content here"}), now)
+		if got != StateWaiting {
+			t.Fatalf("got %d, want StateWaiting on first capture", got)
+		}
+	})
+
+	t.Run("screen changed above threshold marks working", func(t *testing.T) {
+		d := NewTmuxPaneChangeDetector()
+		d.Detect(allFor(map[string]string{"main": "hello world"}), now.Add(-1*time.Second))
+		got := d.Detect(allFor(map[string]string{"main": "XXXXX world"}), now)
+		if got != StateWorking {
+			t.Fatalf("got %d, want StateWorking", got)
+		}
+	})
+
+	t.Run("screen changed below threshold stays waiting", func(t *testing.T) {
+		d := NewTmuxPaneChangeDetector()
+		d.Detect(allFor(map[string]string{"main": "hello world"}), now.Add(-31*time.Second))
+		got := d.Detect(allFor(map[string]string{"main": "hellX world"}), now) // 1 char diff < threshold
+		if got != StateWaiting {
+			t.Fatalf("got %d, want StateWaiting", got)
+		}
+	})
+
+	t.Run("no change but recent activity stays working", func(t *testing.T) {
+		d := NewTmuxPaneChangeDetector()
+		// Cycle 1: seed prev content.
+		d.Detect(allFor(map[string]string{"main": "hello world"}), now.Add(-10*time.Second))
+		// Cycle 2: big change records lastChange.
+		d.Detect(allFor(map[string]string{"main": "XXXXX world"}), now.Add(-9*time.Second))
+		// Cycle 3: identical content, but well within activity window.
+		got := d.Detect(allFor(map[string]string{"main": "XXXXX world"}), now)
+		if got != StateWorking {
+			t.Fatalf("got %d, want StateWorking", got)
+		}
+	})
+
+	t.Run("no change and stale activity means waiting", func(t *testing.T) {
+		d := NewTmuxPaneChangeDetector()
+		d.Detect(allFor(map[string]string{"main": "hello world"}), now.Add(-31*time.Second))
+		got := d.Detect(allFor(map[string]string{"main": "hello world"}), now)
+		if got != StateWaiting {
+			t.Fatalf("got %d, want StateWaiting", got)
+		}
+	})
+
+	t.Run("activity in any session marks container working", func(t *testing.T) {
+		d := NewTmuxPaneChangeDetector()
+		d.Detect(allFor(map[string]string{
+			"main":      "static content",
+			"session-2": "old agent content",
+		}), now.Add(-1*time.Second))
+		// session-2 has a big change (agent active there); main is unchanged.
+		got := d.Detect(allFor(map[string]string{
+			"main":      "static content",
+			"session-2": "NEW agent content",
+		}), now)
+		if got != StateWorking {
+			t.Fatalf("got %d, want StateWorking (session-2 changed)", got)
+		}
+	})
+
+	t.Run("idle in all sessions means waiting", func(t *testing.T) {
+		d := NewTmuxPaneChangeDetector()
+		d.Detect(allFor(map[string]string{
+			"main":      "static content",
+			"session-2": "another static",
+		}), now.Add(-30*time.Second))
+		got := d.Detect(allFor(map[string]string{
+			"main":      "static content",
+			"session-2": "another static",
+		}), now)
+		if got != StateWaiting {
+			t.Fatalf("got %d, want StateWaiting", got)
+		}
+	})
+}

--- a/internal/tui/activity.go
+++ b/internal/tui/activity.go
@@ -3,54 +3,67 @@ package tui
 import (
 	"time"
 
+	"github.com/BenjaminBenetti/fleet-man/internal/agentdetect"
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 )
 
-type agentState int
+// ===========================================
+// ActivityTracker
+// ===========================================
 
-const (
-	agentNotRunning agentState = iota
-	agentWorking
-	agentWaiting
-)
-
-// screenChangeThreshold is the minimum number of characters that must
-// differ between consecutive screen captures to count as meaningful
-// activity (catches spinner animations while ignoring cursor blink).
-const screenChangeThreshold = 3
-
-// screenActivityWindow is how recently a meaningful screen change must
-// have occurred for the agent to be considered actively working.
-const screenActivityWindow = 12 * time.Second
-
-// ActivityTracker determines agent working/waiting/idle state by
-// diffing consecutive tmux screen captures. State is aggregated
-// across every session inside a container — a working agent in any
-// session marks the container as working.
+// ActivityTracker is the generic, strategy-agnostic owner of agent
+// run-state across all tracked containers.
+//
+// It is responsible for:
+//
+//   - Tool detection (from process probes).
+//   - Lifecycle of per-container Detector strategies — built via
+//     agentdetect.NewDetector when a container's tool first appears
+//     or changes, discarded when the agent disappears.
+//   - The transient-failure semantics that apply regardless of
+//     strategy: an OK=false capture preserves the previous state so
+//     the UI does not flicker through "not running" when an exec
+//     blips.
+//
+// The actual working/waiting decision is delegated to whichever
+// agentdetect.Detector the factory returned for the container.
 type ActivityTracker struct {
-	states     map[string]agentState
-	tools      map[string]state.AgentTool
-	prevScreen map[string]map[string]string    // containerID → sessionName → last content
-	lastChange map[string]map[string]time.Time // containerID → sessionName → last change
+	// ===========================================
+	// Fields
+	// ===========================================
+
+	states    map[string]agentdetect.State     // containerID → last derived state
+	tools     map[string]state.AgentTool       // containerID → last detected agent tool
+	detectors map[string]agentdetect.Detector  // containerID → per-container strategy
 }
 
-// NewActivityTracker returns an initialized tracker.
+// ===========================================
+// Constructors
+// ===========================================
+
+// NewActivityTracker returns an initialised tracker with no tracked
+// containers.
 func NewActivityTracker() *ActivityTracker {
 	return &ActivityTracker{
-		states:     make(map[string]agentState),
-		tools:      make(map[string]state.AgentTool),
-		prevScreen: make(map[string]map[string]string),
-		lastChange: make(map[string]map[string]time.Time),
+		states:    make(map[string]agentdetect.State),
+		tools:     make(map[string]state.AgentTool),
+		detectors: make(map[string]agentdetect.Detector),
 	}
 }
 
-// State returns the derived agent state for a container.
-func (t *ActivityTracker) State(containerID string) agentState {
+// ===========================================
+// Public Methods
+// ===========================================
+
+// State returns the derived agent state for a container. Unknown
+// containers return agentdetect.StateNotRunning (the zero value).
+func (t *ActivityTracker) State(containerID string) agentdetect.State {
 	return t.states[containerID]
 }
 
-// Tool returns the detected tool for a container.
+// Tool returns the detected agent tool for a container, or the empty
+// string when no tool has been observed.
 func (t *ActivityTracker) Tool(containerID string) state.AgentTool {
 	return t.tools[containerID]
 }
@@ -62,144 +75,99 @@ func (t *ActivityTracker) Tool(containerID string) state.AgentTool {
 // and is independent of screen capture success — a probe finding
 // claude is recorded even if every tmux capture failed transiently.
 //
-// State detection iterates over every session captured per container:
-//   - Container missing from captures → preserve previous state
-//   - Container OK=false → agentNotRunning (exec failed entirely)
-//   - Container OK=true with no sessions → agentNotRunning
-//   - Container OK=true with sessions → diff each session against its
-//     previous capture; container is agentWorking if ANY session had
-//     ≥ threshold change within the activity window
+// State detection per container:
+//   - Container missing from captures, or OK=false → preserve
+//     previous state, tool, and detector (transient exec failure).
+//   - Probe explicitly returned no tool → StateNotRunning, detector
+//     dropped so a future agent starts from a clean slate.
+//   - Otherwise the per-container Detector (built/refreshed via the
+//     factory based on the current tool) decides the state.
 //
 // Containers absent from expectedIDs are dropped (cleanup).
-func (t *ActivityTracker) Update(captures map[string]backend.AllSessions, probes map[string]string, expectedIDs []string, now time.Time) {
-	newStates := make(map[string]agentState, len(expectedIDs))
+func (t *ActivityTracker) Update(
+	captures map[string]backend.AllSessions,
+	probes map[string]string,
+	expectedIDs []string,
+	now time.Time,
+) {
+	newStates := make(map[string]agentdetect.State, len(expectedIDs))
 	newTools := make(map[string]state.AgentTool, len(expectedIDs))
-	newPrev := make(map[string]map[string]string, len(expectedIDs))
-	newLastChange := make(map[string]map[string]time.Time, len(expectedIDs))
+	newDetectors := make(map[string]agentdetect.Detector, len(expectedIDs))
 
 	for _, id := range expectedIDs {
-		all, captured := captures[id]
-		if !captured || !all.OK {
-			// Capture exec failed — preserve previous state to avoid flicker
+		capture, captured := captures[id]
+		if !captured || !capture.OK {
+			// Capture exec failed — preserve previous state to avoid flicker.
 			if prev, ok := t.states[id]; ok {
 				newStates[id] = prev
 			}
 			if tool, ok := t.tools[id]; ok {
 				newTools[id] = tool
 			}
-			if s, ok := t.prevScreen[id]; ok {
-				newPrev[id] = s
-			}
-			if lc, ok := t.lastChange[id]; ok {
-				newLastChange[id] = lc
+			if existing, ok := t.detectors[id]; ok {
+				newDetectors[id] = existing
 			}
 			continue
 		}
 
-		// Tool detection runs independently of session capture — a
-		// probe that found claude must be recorded even when no
-		// sessions match a tracked baseline.
-		probeConfirmedEmpty := false
-		if probes != nil {
-			if probeTool, probed := probes[id]; probed {
-				if probeTool != "" {
-					newTools[id] = state.AgentTool(probeTool)
-				} else {
-					probeConfirmedEmpty = true
-				}
-			} else if tool, ok := t.tools[id]; ok {
-				newTools[id] = tool
-			}
-		} else if tool, ok := t.tools[id]; ok {
-			newTools[id] = tool
-		}
-
-		// Snapshot every captured session as the new baseline. Doing
-		// this even when probeConfirmedEmpty / no-sessions ensures
-		// the next cycle has prev content to diff against once an
-		// agent starts.
-		nextPrev := make(map[string]string, len(all.Sessions))
-		for sName, sc := range all.Sessions {
-			if sc.OK {
-				nextPrev[sName] = sc.Content
-			}
-		}
-		newPrev[id] = nextPrev
+		probeConfirmedEmpty := t.applyProbe(id, probes, newTools)
 
 		if probeConfirmedEmpty {
-			newStates[id] = agentNotRunning
+			newStates[id] = agentdetect.StateNotRunning
+			// Detector intentionally dropped: when a new agent starts
+			// later we want a fresh strategy keyed off the new tool.
 			continue
 		}
 
-		if len(all.Sessions) == 0 {
-			newStates[id] = agentNotRunning
-			continue
-		}
-
-		prevBySession := t.prevScreen[id]
-		lcBySession := t.lastChange[id]
-
-		nextLC := make(map[string]time.Time, len(all.Sessions))
-		anyHadHistory := false
-		workingDetected := false
-
-		for sName, sc := range all.Sessions {
-			if !sc.OK {
-				continue
-			}
-			prev, hasPrev := prevBySession[sName]
-			var lc time.Time
-			if lcBySession != nil {
-				lc = lcBySession[sName]
-			}
-			if hasPrev {
-				anyHadHistory = true
-				if countDiffs(prev, sc.Content) >= screenChangeThreshold {
-					lc = now
-				}
-			}
-			nextLC[sName] = lc
-			if !lc.IsZero() && now.Sub(lc) < screenActivityWindow {
-				workingDetected = true
-			}
-		}
-		newLastChange[id] = nextLC
-
-		switch {
-		case workingDetected:
-			newStates[id] = agentWorking
-		case anyHadHistory:
-			newStates[id] = agentWaiting
-		default:
-			// First capture(s) — no history yet, assume waiting
-			newStates[id] = agentWaiting
-		}
+		detector := t.detectorFor(id, newTools[id])
+		newDetectors[id] = detector
+		newStates[id] = detector.Detect(capture, now)
 	}
 
 	t.states = newStates
 	t.tools = newTools
-	t.prevScreen = newPrev
-	t.lastChange = newLastChange
+	t.detectors = newDetectors
 }
 
-// countDiffs returns the number of character positions that differ
-// between two strings, plus any length difference.
-func countDiffs(a, b string) int {
-	diffs := 0
-	ar, br := []rune(a), []rune(b)
-	minLen := len(ar)
-	if len(br) < minLen {
-		minLen = len(br)
-	}
-	for i := 0; i < minLen; i++ {
-		if ar[i] != br[i] {
-			diffs++
+// ===========================================
+// Private Methods
+// ===========================================
+
+// applyProbe records the tool for a container based on the probe
+// result, falling back to the previously-known tool when no probe
+// ran this cycle. Returns true when the probe explicitly confirmed
+// that no agent is running.
+func (t *ActivityTracker) applyProbe(
+	containerID string,
+	probes map[string]string,
+	newTools map[string]state.AgentTool,
+) bool {
+	if probes == nil {
+		if tool, ok := t.tools[containerID]; ok {
+			newTools[containerID] = tool
 		}
+		return false
 	}
-	if len(ar) > minLen {
-		diffs += len(ar) - minLen
-	} else {
-		diffs += len(br) - minLen
+	probeTool, probed := probes[containerID]
+	if !probed {
+		if tool, ok := t.tools[containerID]; ok {
+			newTools[containerID] = tool
+		}
+		return false
 	}
-	return diffs
+	if probeTool == "" {
+		return true
+	}
+	newTools[containerID] = state.AgentTool(probeTool)
+	return false
+}
+
+// detectorFor returns the Detector for a container, building a fresh
+// one when none exists yet or when the detected tool has changed
+// since the last cycle.
+func (t *ActivityTracker) detectorFor(containerID string, tool state.AgentTool) agentdetect.Detector {
+	if existing, ok := t.detectors[containerID]; ok && t.tools[containerID] == tool {
+		return existing
+	}
+	return agentdetect.NewDetector(tool)
 }

--- a/internal/tui/activity_test.go
+++ b/internal/tui/activity_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/BenjaminBenetti/fleet-man/internal/agentdetect"
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 )
@@ -18,88 +19,57 @@ func allFor(sessions map[string]string) backend.AllSessions {
 	return out
 }
 
-func TestCountDiffs(t *testing.T) {
-	tests := []struct {
-		name string
-		a, b string
-		want int
-	}{
-		{"identical", "hello", "hello", 0},
-		{"one diff", "hello", "hallo", 1},
-		{"all diff", "abc", "xyz", 3},
-		{"different lengths", "ab", "abcde", 3},
-		{"empty vs content", "", "hello", 5},
-		{"both empty", "", "", 0},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := countDiffs(tt.a, tt.b)
-			if got != tt.want {
-				t.Fatalf("countDiffs(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestActivityTrackerUpdate(t *testing.T) {
 	now := time.Now()
 
-	t.Run("screen changed above threshold marks working", func(t *testing.T) {
+	t.Run("first capture assumes waiting", func(t *testing.T) {
 		tr := NewActivityTracker()
-		tr.prevScreen["c1"] = map[string]string{"main": "hello world"}
+		tr.Update(map[string]backend.AllSessions{
+			"c1": allFor(map[string]string{"main": "spinner content here"}),
+		}, nil, []string{"c1"}, now)
+		if tr.State("c1") != agentdetect.StateWaiting {
+			t.Fatalf("got %d, want StateWaiting on first capture", tr.State("c1"))
+		}
+	})
+
+	t.Run("screen changed above threshold marks working across cycles", func(t *testing.T) {
+		tr := NewActivityTracker()
+		// Seed the per-container detector with prior content.
+		tr.Update(map[string]backend.AllSessions{
+			"c1": allFor(map[string]string{"main": "hello world"}),
+		}, nil, []string{"c1"}, now.Add(-1*time.Second))
+		// Big change — should flip to working.
 		tr.Update(map[string]backend.AllSessions{
 			"c1": allFor(map[string]string{"main": "XXXXX world"}),
 		}, nil, []string{"c1"}, now)
-		if tr.State("c1") != agentWorking {
-			t.Fatalf("got %d, want agentWorking", tr.State("c1"))
+		if tr.State("c1") != agentdetect.StateWorking {
+			t.Fatalf("got %d, want StateWorking", tr.State("c1"))
 		}
 	})
 
-	t.Run("screen changed below threshold stays waiting", func(t *testing.T) {
+	t.Run("exec failure preserves previous state", func(t *testing.T) {
 		tr := NewActivityTracker()
-		tr.prevScreen["c1"] = map[string]string{"main": "hello world"}
-		tr.lastChange["c1"] = map[string]time.Time{"main": now.Add(-31 * time.Second)}
+		tr.states["c1"] = agentdetect.StateWorking
+		tr.tools["c1"] = state.AgentToolClaude
+		tr.detectors["c1"] = agentdetect.NewTmuxPaneChangeDetector()
 		tr.Update(map[string]backend.AllSessions{
-			"c1": allFor(map[string]string{"main": "hellX world"}), // 1 char diff < threshold
+			"c1": {OK: false},
 		}, nil, []string{"c1"}, now)
-		if tr.State("c1") != agentWaiting {
-			t.Fatalf("got %d, want agentWaiting", tr.State("c1"))
+		if tr.State("c1") != agentdetect.StateWorking {
+			t.Fatalf("got %d, want StateWorking (preserved)", tr.State("c1"))
+		}
+		if tr.Tool("c1") != state.AgentToolClaude {
+			t.Fatalf("tool not preserved: got %q", tr.Tool("c1"))
 		}
 	})
 
-	t.Run("no change but recent activity stays working", func(t *testing.T) {
-		tr := NewActivityTracker()
-		tr.prevScreen["c1"] = map[string]string{"main": "hello world"}
-		tr.lastChange["c1"] = map[string]time.Time{"main": now.Add(-10 * time.Second)}
-		tr.Update(map[string]backend.AllSessions{
-			"c1": allFor(map[string]string{"main": "hello world"}),
-		}, nil, []string{"c1"}, now)
-		if tr.State("c1") != agentWorking {
-			t.Fatalf("got %d, want agentWorking", tr.State("c1"))
-		}
-	})
-
-	t.Run("no change and stale activity means waiting", func(t *testing.T) {
-		tr := NewActivityTracker()
-		tr.prevScreen["c1"] = map[string]string{"main": "hello world"}
-		tr.lastChange["c1"] = map[string]time.Time{"main": now.Add(-31 * time.Second)}
-		tr.Update(map[string]backend.AllSessions{
-			"c1": allFor(map[string]string{"main": "hello world"}),
-		}, nil, []string{"c1"}, now)
-		if tr.State("c1") != agentWaiting {
-			t.Fatalf("got %d, want agentWaiting", tr.State("c1"))
-		}
-	})
-
-	t.Run("exec failure marks not running", func(t *testing.T) {
+	t.Run("exec failure on fresh tracker means not running", func(t *testing.T) {
 		tr := NewActivityTracker()
 		tr.Update(map[string]backend.AllSessions{
 			"c1": {OK: false},
 		}, nil, []string{"c1"}, now)
-		// OK=false is treated as transient — preserve previous state
-		// (which is zero/agentNotRunning here since tracker is fresh)
-		if tr.State("c1") != agentNotRunning {
-			t.Fatalf("got %d, want agentNotRunning", tr.State("c1"))
+		if tr.State("c1") != agentdetect.StateNotRunning {
+			t.Fatalf("got %d, want StateNotRunning", tr.State("c1"))
 		}
 	})
 
@@ -108,63 +78,13 @@ func TestActivityTrackerUpdate(t *testing.T) {
 		tr.Update(map[string]backend.AllSessions{
 			"c1": {Sessions: map[string]backend.ScreenCapture{}, OK: true},
 		}, nil, []string{"c1"}, now)
-		if tr.State("c1") != agentNotRunning {
-			t.Fatalf("got %d, want agentNotRunning", tr.State("c1"))
-		}
-	})
-
-	t.Run("first capture assumes waiting", func(t *testing.T) {
-		tr := NewActivityTracker()
-		tr.Update(map[string]backend.AllSessions{
-			"c1": allFor(map[string]string{"main": "spinner content here"}),
-		}, nil, []string{"c1"}, now)
-		if tr.State("c1") != agentWaiting {
-			t.Fatalf("got %d, want agentWaiting on first capture", tr.State("c1"))
-		}
-	})
-
-	t.Run("activity in any session marks container working", func(t *testing.T) {
-		tr := NewActivityTracker()
-		tr.prevScreen["c1"] = map[string]string{
-			"main":      "static content",
-			"session-2": "old agent content",
-		}
-		// session-2 has a big change (agent active there); main is unchanged.
-		tr.Update(map[string]backend.AllSessions{
-			"c1": allFor(map[string]string{
-				"main":      "static content",
-				"session-2": "NEW agent content",
-			}),
-		}, nil, []string{"c1"}, now)
-		if tr.State("c1") != agentWorking {
-			t.Fatalf("got %d, want agentWorking (session-2 changed)", tr.State("c1"))
-		}
-	})
-
-	t.Run("idle in all sessions means waiting", func(t *testing.T) {
-		tr := NewActivityTracker()
-		tr.prevScreen["c1"] = map[string]string{
-			"main":      "static content",
-			"session-2": "another static",
-		}
-		tr.lastChange["c1"] = map[string]time.Time{
-			"main":      now.Add(-30 * time.Second),
-			"session-2": now.Add(-30 * time.Second),
-		}
-		tr.Update(map[string]backend.AllSessions{
-			"c1": allFor(map[string]string{
-				"main":      "static content",
-				"session-2": "another static",
-			}),
-		}, nil, []string{"c1"}, now)
-		if tr.State("c1") != agentWaiting {
-			t.Fatalf("got %d, want agentWaiting", tr.State("c1"))
+		if tr.State("c1") != agentdetect.StateNotRunning {
+			t.Fatalf("got %d, want StateNotRunning", tr.State("c1"))
 		}
 	})
 
 	t.Run("detects tool from probe results", func(t *testing.T) {
 		tr := NewActivityTracker()
-		tr.prevScreen["c1"] = map[string]string{"main": "old content"}
 		tr.Update(map[string]backend.AllSessions{
 			"c1": allFor(map[string]string{"main": "some screen content"}),
 		}, map[string]string{"c1": "codex"}, []string{"c1"}, now)
@@ -174,10 +94,9 @@ func TestActivityTrackerUpdate(t *testing.T) {
 	})
 
 	t.Run("tool detected even when no sessions captured", func(t *testing.T) {
-		// Regression: in the single-session implementation the
-		// !sc.OK branch short-circuited tool detection. The probe
-		// must record claude regardless of session state so the UI
-		// shows the right label.
+		// Regression: tool detection runs independently of session
+		// capture so the UI shows the right label even when tmux has
+		// not started serving sessions yet.
 		tr := NewActivityTracker()
 		tr.Update(map[string]backend.AllSessions{
 			"c1": {Sessions: map[string]backend.ScreenCapture{}, OK: true},
@@ -190,53 +109,64 @@ func TestActivityTrackerUpdate(t *testing.T) {
 	t.Run("clears tool and marks idle when probe finds no agent", func(t *testing.T) {
 		tr := NewActivityTracker()
 		tr.tools["c1"] = state.AgentToolClaude
-		tr.states["c1"] = agentWaiting
-		tr.prevScreen["c1"] = map[string]string{"main": "old content"}
+		tr.states["c1"] = agentdetect.StateWaiting
+		tr.detectors["c1"] = agentdetect.NewTmuxPaneChangeDetector()
 		tr.Update(map[string]backend.AllSessions{
 			"c1": allFor(map[string]string{"main": "some screen content"}),
 		}, map[string]string{"c1": ""}, []string{"c1"}, now)
 		if tr.Tool("c1") != "" {
 			t.Fatalf("tool should be cleared, got %q", tr.Tool("c1"))
 		}
-		if tr.State("c1") != agentNotRunning {
-			t.Fatalf("got %d, want agentNotRunning", tr.State("c1"))
-		}
-	})
-
-	t.Run("preserves tool on capture failure", func(t *testing.T) {
-		tr := NewActivityTracker()
-		tr.states["c1"] = agentWorking
-		tr.tools["c1"] = state.AgentToolClaude
-		tr.prevScreen["c1"] = map[string]string{"main": "prev"}
-		tr.lastChange["c1"] = map[string]time.Time{"main": now}
-		tr.Update(map[string]backend.AllSessions{}, nil, []string{"c1"}, now)
-		if tr.Tool("c1") != state.AgentToolClaude {
-			t.Fatalf("tool not preserved: got %q", tr.Tool("c1"))
-		}
-	})
-
-	t.Run("preserves state on capture failure", func(t *testing.T) {
-		tr := NewActivityTracker()
-		tr.states["c1"] = agentWorking
-		tr.prevScreen["c1"] = map[string]string{"main": "prev"}
-		tr.lastChange["c1"] = map[string]time.Time{"main": now}
-		tr.Update(map[string]backend.AllSessions{}, nil, []string{"c1"}, now)
-		if tr.State("c1") != agentWorking {
-			t.Fatalf("got %d, want agentWorking (preserved)", tr.State("c1"))
+		if tr.State("c1") != agentdetect.StateNotRunning {
+			t.Fatalf("got %d, want StateNotRunning", tr.State("c1"))
 		}
 	})
 
 	t.Run("cleans up removed containers", func(t *testing.T) {
 		tr := NewActivityTracker()
-		tr.states["c1"] = agentWorking
-		tr.states["c2"] = agentWaiting
-		tr.prevScreen["c1"] = map[string]string{"main": "a"}
-		tr.prevScreen["c2"] = map[string]string{"main": "b"}
+		tr.states["c1"] = agentdetect.StateWorking
+		tr.states["c2"] = agentdetect.StateWaiting
+		tr.tools["c2"] = state.AgentToolClaude
+		tr.detectors["c2"] = agentdetect.NewTmuxPaneChangeDetector()
 		tr.Update(map[string]backend.AllSessions{
 			"c1": allFor(map[string]string{"main": "a"}),
 		}, nil, []string{"c1"}, now)
-		if tr.State("c2") != agentNotRunning {
+		if tr.State("c2") != agentdetect.StateNotRunning {
 			t.Fatal("c2 should have been cleaned up")
+		}
+		if tr.Tool("c2") != "" {
+			t.Fatalf("c2 tool should be cleared, got %q", tr.Tool("c2"))
+		}
+	})
+
+	t.Run("rebuilds detector when tool changes", func(t *testing.T) {
+		// Different tools may want different strategies; when the
+		// detected tool changes the tracker must hand out a fresh
+		// detector instead of reusing the one tied to the old tool.
+		tr := NewActivityTracker()
+		tr.Update(map[string]backend.AllSessions{
+			"c1": allFor(map[string]string{"main": "first"}),
+		}, map[string]string{"c1": "claude"}, []string{"c1"}, now)
+		first := tr.detectors["c1"]
+		tr.Update(map[string]backend.AllSessions{
+			"c1": allFor(map[string]string{"main": "second"}),
+		}, map[string]string{"c1": "codex"}, []string{"c1"}, now)
+		if tr.detectors["c1"] == first {
+			t.Fatal("detector should have been rebuilt when tool changed")
+		}
+	})
+
+	t.Run("reuses detector when tool stays the same", func(t *testing.T) {
+		tr := NewActivityTracker()
+		tr.Update(map[string]backend.AllSessions{
+			"c1": allFor(map[string]string{"main": "first"}),
+		}, map[string]string{"c1": "claude"}, []string{"c1"}, now)
+		first := tr.detectors["c1"]
+		tr.Update(map[string]backend.AllSessions{
+			"c1": allFor(map[string]string{"main": "second"}),
+		}, map[string]string{"c1": "claude"}, []string{"c1"}, now)
+		if tr.detectors["c1"] != first {
+			t.Fatal("detector should be reused when tool is unchanged")
 		}
 	})
 }

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/BenjaminBenetti/fleet-man/internal/agentdetect"
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/deps"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
@@ -1039,14 +1040,14 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 				tool := m.activity.Tool(instance.ContainerID)
 				label := agentToolLabel(tool)
 				switch m.activity.State(instance.ContainerID) {
-				case agentWorking:
+				case agentdetect.StateWorking:
 					agentStr = agentWorkingStyle.Render(fmt.Sprintf("  ▶ %s", label))
 					if len(m.agentSpinner.Spinner.Frames) > 0 {
 						throbber = strings.TrimRight(m.agentSpinner.View(), "\n")
 					} else {
 						throbber = agentWorkingStyle.Render("✻")
 					}
-				case agentWaiting:
+				case agentdetect.StateWaiting:
 					agentStr = agentWaitingStyle.Render(fmt.Sprintf("  ⏸ %s", label))
 					throbber = agentWaitingStyle.Render("○")
 				default:

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/BenjaminBenetti/fleet-man/internal/agentdetect"
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/instanceops"
@@ -12,7 +13,7 @@ import (
 )
 
 // testTracker returns an ActivityTracker pre-loaded with specific states/tools.
-func testTracker(states map[string]agentState, tools map[string]state.AgentTool) *ActivityTracker {
+func testTracker(states map[string]agentdetect.State, tools map[string]state.AgentTool) *ActivityTracker {
 	t := NewActivityTracker()
 	for k, v := range states {
 		t.states[k] = v
@@ -315,7 +316,7 @@ func TestViewFleetListShowsAgentWorkingIndicator(t *testing.T) {
 			AgentSettings: state.AgentSettings{ToolSelection: state.AgentToolClaude},
 		},
 		activity: testTracker(
-			map[string]agentState{"abc123": agentWorking},
+			map[string]agentdetect.State{"abc123": agentdetect.StateWorking},
 			map[string]state.AgentTool{"abc123": state.AgentToolClaude},
 		),
 		expandedInstances: make(map[string]bool),
@@ -356,7 +357,7 @@ func TestViewFleetListShowsAgentWaitingIndicator(t *testing.T) {
 			AgentSettings: state.AgentSettings{ToolSelection: state.AgentToolClaude},
 		},
 		activity: testTracker(
-			map[string]agentState{"abc123": agentWaiting},
+			map[string]agentdetect.State{"abc123": agentdetect.StateWaiting},
 			map[string]state.AgentTool{"abc123": state.AgentToolClaude},
 		),
 		expandedInstances: make(map[string]bool),
@@ -397,7 +398,7 @@ func TestViewFleetListShowsAgentOffIndicator(t *testing.T) {
 			AgentSettings: state.AgentSettings{ToolSelection: state.AgentToolClaude},
 		},
 		activity: testTracker(
-			map[string]agentState{"abc123": agentNotRunning},
+			map[string]agentdetect.State{"abc123": agentdetect.StateNotRunning},
 			nil,
 		),
 		expandedInstances: make(map[string]bool),


### PR DESCRIPTION
## Summary
- New `internal/agentdetect` package with a `Detector` strategy interface, a `TmuxPaneChangeDetector` implementation that owns the existing pane-diff logic, and a `NewDetector(tool)` factory whose default branch returns the tmux strategy.
- `ActivityTracker` becomes the generic, strategy-agnostic owner: it handles tool detection, detector lifecycle (build on first appearance, rebuild on tool change, drop when the agent disappears), and the OK=false preserve-on-flicker semantics — it no longer holds any pane-diff state.
- Adding a tool-specific detector later is a single `case` in `factory.go` plus a new `Detector` implementation; no changes needed at call sites.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] Manual TUI smoke: confirm working/waiting/idle throbbers still flip as expected with a real agent inside a devcontainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)