### PR TITLE
refactor(tui): extract SessionStore service for per-instance session state

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -54,14 +54,11 @@ type model struct {
 	// Port forwarding
 	portForwards *portforward.Manager // manages active port forward processes
 
-	// Instance expansion: which instances are expanded to show sessions
-	expandedInstances map[string]bool              // key: "fleet/instance"
-	sessions          map[string]*sessionDiscovery // key: "fleet/instance"
-
-	// Last active session per instance (in-memory only). Used to
-	// reconnect to the previous session when pressing enter on an
-	// instance row instead of always creating a new one.
-	lastActive map[string]lastSession // key: "fleet/instance"
+	// Per-instance session state: discovery, expansion, last-active
+	// session. All three are owned by the SessionStore so every read
+	// or write is forced through an InstanceRef and cannot collide
+	// across instances that share a session or group name.
+	sessionStore *SessionStore
 
 	// Split pane mode: when fleet runs inside a host tmux session,
 	// pressing enter opens the instance shell in a right-side pane
@@ -99,17 +96,15 @@ func newModel() model {
 	agentSpinnerModel.Style = agentWorkingStyle
 
 	m := model{
-		creating:          make(map[string]bool),
-		backends:          make(map[fleet.BackendType]backend.Backend),
-		stats:             make(map[string]*backend.ContainerStats),
-		activity:          NewActivityTracker(),
-		portForwards:      portforward.NewManager(),
-		expandedInstances: make(map[string]bool),
-		sessions:          make(map[string]*sessionDiscovery),
-		lastActive:        make(map[string]lastSession),
-		spinner:           spinnerModel,
-		agentSpinner:      agentSpinnerModel,
-		inHostTmux:        os.Getenv("TMUX") != "",
+		creating:     make(map[string]bool),
+		backends:     make(map[fleet.BackendType]backend.Backend),
+		stats:        make(map[string]*backend.ContainerStats),
+		activity:     NewActivityTracker(),
+		portForwards: portforward.NewManager(),
+		sessionStore: NewSessionStore(),
+		spinner:      spinnerModel,
+		agentSpinner: agentSpinnerModel,
+		inHostTmux:   os.Getenv("TMUX") != "",
 	}
 
 	// Create the fleet page (persistent — background handlers reference it)
@@ -185,17 +180,13 @@ func (m *model) reload() {
 	m.err = nil
 
 	// Auto-collapse expanded instances that are no longer running
-	for key := range m.expandedInstances {
-		parts := strings.SplitN(key, "/", 2)
-		if len(parts) == 2 {
-			if f, ok := st.Fleets[parts[0]]; ok {
-				if instance, err := f.GetInstance(parts[1]); err == nil && instance.Status == fleet.StatusRunning {
-					continue
-				}
+	for _, ref := range m.sessionStore.ExpandedRefs() {
+		if f, ok := st.Fleets[ref.Fleet]; ok {
+			if instance, err := f.GetInstance(ref.Instance); err == nil && instance.Status == fleet.StatusRunning {
+				continue
 			}
 		}
-		delete(m.expandedInstances, key)
-		delete(m.sessions, key)
+		m.sessionStore.CollapseAndForgetSessions(ref)
 	}
 }
 
@@ -222,22 +213,17 @@ func (m *model) hydrateSavedGroups() {
 // instance whose group IDs no longer appear in the latest session
 // discovery. Called after each successful discovery so the next restart
 // doesn't resurrect layouts for groups the user has already deleted.
-func (m *model) pruneSavedGroupsForInstance(instKey string) {
-	if m.st == nil || m.fleetPage == nil {
+func (m *model) pruneSavedGroupsForInstance(ref InstanceRef) {
+	if m.st == nil || m.fleetPage == nil || !ref.Valid() {
 		return
 	}
-	parts := strings.SplitN(instKey, "/", 2)
-	if len(parts) != 2 {
-		return
-	}
-	instanceName := parts[1]
-	sanitized := SanitizeSessionName(instanceName)
-	disc, ok := m.sessions[instKey]
-	if !ok || disc == nil || disc.err != nil {
+	sanitized := SanitizeSessionName(ref.Instance)
+	sessions := m.sessionStore.Sessions(ref)
+	if len(sessions) == 0 {
 		return
 	}
 	live := make(map[string]bool)
-	for _, s := range disc.sessions {
+	for _, s := range sessions {
 		if gid, ok := parseGroupID(sanitized, s.Name); ok {
 			live[gid] = true
 		}
@@ -247,7 +233,7 @@ func (m *model) pruneSavedGroupsForInstance(instKey string) {
 	}
 	changed := false
 	for gid, savedLayout := range m.fleetPage.savedGroups {
-		if savedLayout.InstanceName != instanceName {
+		if savedLayout.InstanceName != ref.Instance {
 			continue
 		}
 		if !live[gid] {
@@ -361,29 +347,25 @@ func (m *model) containersByBackend() map[fleet.BackendType]*backendGroup {
 // sessionDiscoveryLoop returns a tea.Cmd that lists tmux sessions for
 // expanded instances on a 1-second cycle.
 func (m model) sessionDiscoveryLoop() tea.Cmd {
-	return sessionDiscoveryCmd(m.backends, m.expandedInstances, m.st.Fleets)
+	return sessionDiscoveryCmd(m.backends, m.sessionStore.ExpandedRefs(), m.st.Fleets)
 }
 
 // refreshInstanceSessions returns a tea.Cmd that re-lists tmux sessions
-// for the given instance (if expanded). Used after split pane creation,
+// for the given ref (if expanded). Used after split pane creation,
 // group switching, and session creation to keep the UI in sync.
-func (m *model) refreshInstanceSessions(instanceName string) tea.Cmd {
-	for instKey, expanded := range m.expandedInstances {
-		if !expanded {
-			continue
-		}
-		parts := strings.SplitN(instKey, "/", 2)
-		if len(parts) != 2 || parts[1] != instanceName {
-			continue
-		}
-		if f, ok := m.st.Fleets[parts[0]]; ok {
-			if instance, err := f.GetInstance(parts[1]); err == nil {
-				instanceBackend := m.instanceBackend(instance)
-				return listSessionsCmd(instanceBackend, instance.WorkspaceDir, instKey)
-			}
-		}
+func (m *model) refreshInstanceSessions(ref InstanceRef) tea.Cmd {
+	if !ref.Valid() || !m.sessionStore.IsExpanded(ref) {
+		return nil
 	}
-	return nil
+	f, ok := m.st.Fleets[ref.Fleet]
+	if !ok {
+		return nil
+	}
+	instance, err := f.GetInstance(ref.Instance)
+	if err != nil {
+		return nil
+	}
+	return listSessionsCmd(m.instanceBackend(instance), instance.WorkspaceDir, ref)
 }
 
 // ===========================================
@@ -698,30 +680,19 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// can't race ahead of the save. The diff gate makes idle ticks
 		// free. Always reschedule so the tick keeps firing.
 		fp := m.fleetPage
-		if fp != nil && fp.splitPaneID != "" && fp.activeGroupID != "" && splitOpen() {
+		if fp != nil && fp.splitPaneID != "" && !fp.activeGroup.Empty() && splitOpen() {
 			fp.saveCurrentGroupLayout(m.st)
 		}
 		extraCmds = append(extraCmds, layoutTickCmd())
 
 	case sessionDiscoveryMsg:
 		if msg.discovered != nil {
-			for key, sessions := range msg.discovered {
-				m.sessions[key] = &sessionDiscovery{sessions: sessions, fetchedAt: time.Now()}
+			for ref, sessions := range msg.discovered {
+				m.sessionStore.SetDiscovery(ref, sessions)
 			}
-			// Clear lastActive entries that point to sessions/groups
-			// that no longer exist.
-			for key, last := range m.lastActive {
-				disc, ok := m.sessions[key]
-				if !ok || disc.err != nil {
-					delete(m.lastActive, key)
-					continue
-				}
-				if !sessionStillExists(last, disc.sessions) {
-					delete(m.lastActive, key)
-				}
-			}
-			for key := range msg.discovered {
-				m.pruneSavedGroupsForInstance(key)
+			m.sessionStore.PruneStaleLastActive()
+			for ref := range msg.discovered {
+				m.pruneSavedGroupsForInstance(ref)
 			}
 		}
 		extraCmds = append(extraCmds, m.sessionDiscoveryLoop())
@@ -764,22 +735,20 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if msg.paneID != "" {
 			fp.splitPaneID = msg.paneID
-			fp.splitFleet = msg.fleet
-			fp.splitInstance = msg.instance
+			fp.splitRef = msg.ref
 			fp.splitSession = msg.session
-			fp.activeGroupID = msg.groupID
-			instKey := msg.fleet + "/" + msg.instance
-			m.lastActive[instKey] = lastSession{sessionName: msg.session, groupID: msg.groupID}
-			bindHostSplitKeys(instKey, msg.groupID)
-			extraCmds = append(extraCmds, m.refreshInstanceSessions(msg.instance))
+			fp.activeGroup = ActiveGroup{Ref: msg.ref, GroupID: msg.groupID}
+			m.sessionStore.SetLastActive(msg.ref, lastSession{sessionName: msg.session, groupID: msg.groupID})
+			bindHostSplitKeys(msg.ref.Key(), msg.groupID)
+			extraCmds = append(extraCmds, m.refreshInstanceSessions(msg.ref))
 		}
 
 	case sessionsMsg:
 		if msg.err != nil {
-			m.sessions[msg.instanceKey] = &sessionDiscovery{err: msg.err, fetchedAt: time.Now()}
+			m.sessionStore.SetDiscoveryError(msg.ref, msg.err)
 		} else {
-			m.sessions[msg.instanceKey] = &sessionDiscovery{sessions: msg.sessions, fetchedAt: time.Now()}
-			m.pruneSavedGroupsForInstance(msg.instanceKey)
+			m.sessionStore.SetDiscovery(msg.ref, msg.sessions)
+			m.pruneSavedGroupsForInstance(msg.ref)
 		}
 
 	case sessionCreatedMsg:
@@ -788,14 +757,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.message = "Session created"
 		}
-		if m.expandedInstances[msg.instanceKey] {
-			parts := strings.SplitN(msg.instanceKey, "/", 2)
-			if len(parts) == 2 {
-				if f, ok := m.st.Fleets[parts[0]]; ok {
-					if instance, err := f.GetInstance(parts[1]); err == nil {
-						instanceBackend := m.instanceBackend(instance)
-						extraCmds = append(extraCmds, listSessionsCmd(instanceBackend, instance.WorkspaceDir, msg.instanceKey))
-					}
+		if m.sessionStore.IsExpanded(msg.ref) {
+			if f, ok := m.st.Fleets[msg.ref.Fleet]; ok {
+				if instance, err := f.GetInstance(msg.ref.Instance); err == nil {
+					extraCmds = append(extraCmds, listSessionsCmd(m.instanceBackend(instance), instance.WorkspaceDir, msg.ref))
 				}
 			}
 		}
@@ -806,14 +771,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.message = fmt.Sprintf("Renamed session %s → %s", msg.oldName, msg.newName)
 		}
-		if m.expandedInstances[msg.instanceKey] {
-			parts := strings.SplitN(msg.instanceKey, "/", 2)
-			if len(parts) == 2 {
-				if f, ok := m.st.Fleets[parts[0]]; ok {
-					if instance, err := f.GetInstance(parts[1]); err == nil {
-						instanceBackend := m.instanceBackend(instance)
-						extraCmds = append(extraCmds, listSessionsCmd(instanceBackend, instance.WorkspaceDir, msg.instanceKey))
-					}
+		if m.sessionStore.IsExpanded(msg.ref) {
+			if f, ok := m.st.Fleets[msg.ref.Fleet]; ok {
+				if instance, err := f.GetInstance(msg.ref.Instance); err == nil {
+					extraCmds = append(extraCmds, listSessionsCmd(m.instanceBackend(instance), instance.WorkspaceDir, msg.ref))
 				}
 			}
 		}
@@ -824,9 +785,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.message = fmt.Sprintf("Deleted session %s", msg.sessionName)
 		}
-		if last, ok := m.lastActive[msg.instanceKey]; ok {
-			if last.sessionName == msg.sessionName || last.groupID == msg.groupID {
-				delete(m.lastActive, msg.instanceKey)
+		if last, ok := m.sessionStore.LastActive(msg.ref); ok {
+			if last.sessionName == msg.sessionName || (msg.groupID != "" && last.groupID == msg.groupID) {
+				m.sessionStore.ClearLastActive(msg.ref)
 			}
 		}
 		fp := m.fleetPage
@@ -837,26 +798,23 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				_ = state.Save(m.st)
 			}
 		}
-		if fp.splitSession == msg.sessionName || (msg.groupID != "" && fp.activeGroupID == msg.groupID) {
+		// Tear down the split only when the deletion targets the very
+		// group/session we're attached to — must match instance too,
+		// since group IDs are not unique across instances.
+		deletedActive := fp.splitRef == msg.ref &&
+			(fp.splitSession == msg.sessionName ||
+				(msg.groupID != "" && fp.activeGroup.GroupID == msg.groupID))
+		if deletedActive {
 			if fp.splitPaneID != "" {
 				killAllSplitPanes()
 				unbindHostSplitKeys()
 			}
-			fp.splitPaneID = ""
-			fp.splitFleet = ""
-			fp.splitInstance = ""
-			fp.splitSession = ""
-			fp.activeGroupID = ""
-			fp.restoringGroupID = ""
+			fp.clearSplit()
 		}
-		if m.expandedInstances[msg.instanceKey] {
-			parts := strings.SplitN(msg.instanceKey, "/", 2)
-			if len(parts) == 2 {
-				if f, ok := m.st.Fleets[parts[0]]; ok {
-					if instance, err := f.GetInstance(parts[1]); err == nil {
-						instanceBackend := m.instanceBackend(instance)
-						extraCmds = append(extraCmds, listSessionsCmd(instanceBackend, instance.WorkspaceDir, msg.instanceKey))
-					}
+		if m.sessionStore.IsExpanded(msg.ref) {
+			if f, ok := m.st.Fleets[msg.ref.Fleet]; ok {
+				if instance, err := f.GetInstance(msg.ref.Instance); err == nil {
+					extraCmds = append(extraCmds, listSessionsCmd(m.instanceBackend(instance), instance.WorkspaceDir, msg.ref))
 				}
 			}
 		}
@@ -919,7 +877,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case groupCycleMsg:
 		fp := m.fleetPage
-		if msg.seq == fp.debounceSeq && fp.pendingGroupID != "" {
+		if msg.seq == fp.debounceSeq && !fp.pendingGroup.Empty() {
 			cmd := fp.commitGroupCycle(&m)
 			extraCmds = append(extraCmds, cmd)
 		}

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -100,7 +100,7 @@ func (fleetPage *fleetPage) updateConfirmDeleteSession(m *model, msg tea.Msg) te
 		switch msg.String() {
 		case "y", "Y", "enter":
 			fleetPage.mode = viewNormal
-			instKey := fleetPage.dialogFleet + "/" + fleetPage.dialogInst
+			ref := InstanceRef{Fleet: fleetPage.dialogFleet, Instance: fleetPage.dialogInst}
 			f, ok := m.st.Fleets[fleetPage.dialogFleet]
 			if !ok {
 				break
@@ -112,9 +112,9 @@ func (fleetPage *fleetPage) updateConfirmDeleteSession(m *model, msg tea.Msg) te
 			instanceBackend := m.instanceBackend(instance)
 			sanitized := SanitizeSessionName(instance.Name)
 			if fleetPage.dialogGroupID != "" && isGroupedSession(sanitized, fleetPage.dialogSession) {
-				return deleteGroupSessionsCmd(instanceBackend, instance.WorkspaceDir, instKey, sanitized, fleetPage.dialogGroupID)
+				return deleteGroupSessionsCmd(instanceBackend, instance.WorkspaceDir, ref, sanitized, fleetPage.dialogGroupID)
 			}
-			return deleteSessionCmd(instanceBackend, instance.WorkspaceDir, instKey, fleetPage.dialogSession)
+			return deleteSessionCmd(instanceBackend, instance.WorkspaceDir, ref, fleetPage.dialogSession)
 
 		case "n", "N", "esc", "ctrl+c":
 			fleetPage.mode = viewNormal
@@ -724,13 +724,9 @@ func (fleetPage *fleetPage) updateCreateSession(m *model, msg tea.Msg) tea.Cmd {
 		switch msg.String() {
 		case "enter":
 			name := strings.TrimSpace(fleetPage.textInput.Value())
-			instKey := fleetPage.dialogFleet + "/" + fleetPage.dialogInst
+			ref := InstanceRef{Fleet: fleetPage.dialogFleet, Instance: fleetPage.dialogInst}
 			if name == "" {
-				var existing []tmuxSession
-				if disc, ok := m.sessions[instKey]; ok && disc.err == nil {
-					existing = disc.sessions
-				}
-				name = nextSessionName(existing)
+				name = nextSessionName(m.sessionStore.Sessions(ref))
 			}
 			name = SanitizeSessionName(name)
 
@@ -754,7 +750,7 @@ func (fleetPage *fleetPage) updateCreateSession(m *model, msg tea.Msg) tea.Cmd {
 			fleetPage.textInput.Blur()
 			m.message = fmt.Sprintf("Creating session %s...", name)
 			instanceBackend := m.instanceBackend(instance)
-			return createSessionCmd(instanceBackend, instance.WorkspaceDir, instKey, fullName)
+			return createSessionCmd(instanceBackend, instance.WorkspaceDir, ref, fullName)
 
 		case "esc", "ctrl+c":
 			fleetPage.mode = viewNormal
@@ -784,7 +780,7 @@ func (fleetPage *fleetPage) updateRenameSession(m *model, msg tea.Msg) tea.Cmd {
 			}
 			newName = SanitizeSessionName(newName)
 
-			instKey := fleetPage.dialogFleet + "/" + fleetPage.dialogInst
+			ref := InstanceRef{Fleet: fleetPage.dialogFleet, Instance: fleetPage.dialogInst}
 
 			f, ok := m.st.Fleets[fleetPage.dialogFleet]
 			if !ok {
@@ -808,9 +804,9 @@ func (fleetPage *fleetPage) updateRenameSession(m *model, msg tea.Msg) tea.Cmd {
 			instanceBackend := m.instanceBackend(instance)
 
 			if isGrouped {
-				return renameGroupCmd(instanceBackend, instance.WorkspaceDir, instKey, sanitized, oldGID, newName)
+				return renameGroupCmd(instanceBackend, instance.WorkspaceDir, ref, sanitized, oldGID, newName)
 			}
-			return renameSessionCmd(instanceBackend, instance.WorkspaceDir, instKey, oldName, newName)
+			return renameSessionCmd(instanceBackend, instance.WorkspaceDir, ref, oldName, newName)
 
 		case "esc", "ctrl+c":
 			fleetPage.mode = viewNormal

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -47,14 +47,13 @@ type fleetPage struct {
 	pfCursor      int
 	pfContainerID string
 
-	splitPaneID   string
-	splitFleet    string
-	splitInstance string
-	splitSession  string
+	splitPaneID  string
+	splitRef     InstanceRef // (fleet, instance) of the open split pane; zero when none
+	splitSession string
 
-	activeGroupID    string
+	activeGroup      ActiveGroup // qualified by splitRef so two groups with the same ID across instances cannot alias
 	savedGroups      map[string]savedGroup
-	pendingGroupID   string
+	pendingGroup     ActiveGroup
 	debounceSeq      int
 	restoringGroupID string
 	restoreSeq       int
@@ -105,6 +104,17 @@ func (fleetPage *fleetPage) finishGroupRestore(seq int) bool {
 	return true
 }
 
+// clearSplit resets every field that tracks the open split pane. Used
+// whenever the split is closed (user toggle, external kill, restore
+// teardown) so a future open starts from a known-empty state.
+func (fleetPage *fleetPage) clearSplit() {
+	fleetPage.splitPaneID = ""
+	fleetPage.splitRef = InstanceRef{}
+	fleetPage.splitSession = ""
+	fleetPage.activeGroup = ActiveGroup{}
+	fleetPage.restoringGroupID = ""
+}
+
 // Init is called when the fleet page becomes active.
 func (fleetPage *fleetPage) Init(m *model) tea.Cmd {
 	fleetPage.buildRows(m)
@@ -124,7 +134,7 @@ func (fleetPage *fleetPage) Update(m *model, msg tea.Msg) tea.Cmd {
 		// %/" adds new panes via a tmux binding, mouse drag resizes,
 		// Ctrl+Q/O closes without notifying fleet. The save is
 		// diff-gated so idle ticks don't hit disk.
-		if fleetPage.splitPaneID != "" && fleetPage.activeGroupID != "" && splitOpen() {
+		if fleetPage.splitPaneID != "" && !fleetPage.activeGroup.Empty() && splitOpen() {
 			fleetPage.saveCurrentGroupLayout(m.st)
 		}
 		// Detect when panes were killed externally. savedGroups already
@@ -132,12 +142,7 @@ func (fleetPage *fleetPage) Update(m *model, msg tea.Msg) tea.Cmd {
 		// transient fields here loses nothing.
 		if fleetPage.splitPaneID != "" && !splitOpen() {
 			unbindHostSplitKeys()
-			fleetPage.splitPaneID = ""
-			fleetPage.splitFleet = ""
-			fleetPage.splitInstance = ""
-			fleetPage.splitSession = ""
-			fleetPage.activeGroupID = ""
-			fleetPage.restoringGroupID = ""
+			fleetPage.clearSplit()
 		}
 		return nil
 
@@ -220,24 +225,20 @@ func (fleetPage *fleetPage) buildRows(m *model) {
 		if !fleetPage.collapsed[name] {
 			for _, instance := range f.Instances {
 				fleetPage.rows = append(fleetPage.rows, row{kind: rowInstance, fleetName: name, instance: instance})
-				instKey := name + "/" + instance.Name
-				if m.expandedInstances[instKey] {
+				ref := InstanceRef{Fleet: name, Instance: instance.Name}
+				if m.sessionStore.IsExpanded(ref) {
 					liveGroups := make(map[string]bool)
-					if disc, ok := m.sessions[instKey]; ok && disc.err == nil {
-						sanitized := SanitizeSessionName(instance.Name)
-						groups := groupSessions(sanitized, disc.sessions)
-						for _, g := range groups {
-							liveGroups[g.GroupID] = true
-							rootName := g.Sessions[0].Name
-							fleetPage.rows = append(fleetPage.rows, row{
-								kind:        rowSession,
-								fleetName:   name,
-								instance:    instance,
-								sessionName: rootName,
-								groupID:     g.GroupID,
-								groupSize:   len(g.Sessions),
-							})
-						}
+					for _, g := range m.sessionStore.Groups(ref) {
+						liveGroups[g.GroupID] = true
+						rootName := g.Sessions[0].Name
+						fleetPage.rows = append(fleetPage.rows, row{
+							kind:        rowSession,
+							fleetName:   name,
+							instance:    instance,
+							sessionName: rootName,
+							groupID:     g.GroupID,
+							groupSize:   len(g.Sessions),
+						})
 					}
 					fleetPage.appendSavedGroupRows(name, instance, liveGroups)
 					fleetPage.rows = append(fleetPage.rows, row{
@@ -398,15 +399,15 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 						m.message = "Instance must be running to view sessions"
 						break
 					}
-					instKey := r.fleetName + "/" + r.instance.Name
-					if m.expandedInstances[instKey] {
-						delete(m.expandedInstances, instKey)
+					ref := InstanceRef{Fleet: r.fleetName, Instance: r.instance.Name}
+					if m.sessionStore.IsExpanded(ref) {
+						m.sessionStore.SetExpanded(ref, false)
 						fleetPage.buildRows(m)
 					} else {
-						m.expandedInstances[instKey] = true
+						m.sessionStore.SetExpanded(ref, true)
 						fleetPage.buildRows(m)
 						b := m.instanceBackend(r.instance)
-						return listSessionsCmd(b, r.instance.WorkspaceDir, instKey)
+						return listSessionsCmd(b, r.instance.WorkspaceDir, ref)
 					}
 				case rowSession, rowNewSession, rowSettings:
 					return fleetPage.handleEnter(m)
@@ -556,7 +557,7 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			return fleetPage.textInput.Cursor.BlinkCmd()
 
 		case "pgup", "pgdown":
-			if m.inHostTmux && fleetPage.splitInstance != "" && fleetPage.activeGroupID != "" {
+			if m.inHostTmux && fleetPage.splitRef.Valid() && !fleetPage.activeGroup.Empty() {
 				return fleetPage.cycleSessionGroup(m, msg.String() == "pgup")
 			}
 
@@ -720,8 +721,8 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 		instance := r.instance
 		sessionName := r.sessionName
 		groupID := r.groupID
-		sessInstKey := r.fleetName + "/" + instance.Name
-		m.lastActive[sessInstKey] = lastSession{sessionName: sessionName, groupID: groupID}
+		sessRef := InstanceRef{Fleet: r.fleetName, Instance: instance.Name}
+		m.sessionStore.SetLastActive(sessRef, lastSession{sessionName: sessionName, groupID: groupID})
 		if m.inHostTmux {
 			if fleetPage.restoreInProgress() {
 				m.message = "Pane group restore already in progress"
@@ -729,30 +730,22 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 			}
 			if fleetPage.splitPaneID != "" && !splitOpen() {
 				unbindHostSplitKeys()
-				fleetPage.splitPaneID = ""
-				fleetPage.splitFleet = ""
-				fleetPage.splitInstance = ""
-				fleetPage.splitSession = ""
-				fleetPage.activeGroupID = ""
-				fleetPage.restoringGroupID = ""
+				fleetPage.clearSplit()
 			}
-			if fleetPage.splitPaneID != "" && fleetPage.splitInstance == instance.Name && groupID != "" && groupID == fleetPage.activeGroupID {
+			rowGroup := ActiveGroup{Ref: sessRef, GroupID: groupID}
+			// Same instance + same group → toggle split closed.
+			if fleetPage.splitPaneID != "" && fleetPage.splitRef == sessRef && groupID != "" && fleetPage.activeGroup == rowGroup {
 				fleetPage.saveCurrentGroupLayout(m.st)
 				killAllSplitPanes()
 				unbindHostSplitKeys()
-				fleetPage.splitPaneID = ""
-				fleetPage.splitFleet = ""
-				fleetPage.splitInstance = ""
-				fleetPage.splitSession = ""
-				fleetPage.activeGroupID = ""
-				fleetPage.restoringGroupID = ""
+				fleetPage.clearSplit()
 				return nil
 			}
-			if fleetPage.splitPaneID != "" && fleetPage.activeGroupID != "" {
+			if fleetPage.splitPaneID != "" && !fleetPage.activeGroup.Empty() {
 				fleetPage.saveCurrentGroupLayout(m.st)
 				killAllSplitPanes()
 			}
-			fleetPage.activeGroupID = groupID
+			fleetPage.activeGroup = rowGroup
 			if groupID != "" && isGroupedSession(SanitizeSessionName(instance.Name), sessionName) {
 				return fleetPage.restoreGroupCmd(m, r.fleetName, instance, groupID)
 			}
@@ -762,7 +755,7 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 				instance.WorkspaceDir,
 				ShellCommandForSession(m.config, sessionName, cols, rows, true),
 			)
-			return splitPaneCmd(fleetPage.splitPaneID, r.fleetName, instance.Name, sessionName, groupID, cmd)
+			return splitPaneCmd(fleetPage.splitPaneID, sessRef, sessionName, groupID, cmd)
 		}
 		cmd := m.instanceBackend(instance).ExecCommand(
 			instance.WorkspaceDir,
@@ -781,7 +774,7 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 			break
 		}
 		instFleetName := r.fleetName
-		instKey := instFleetName + "/" + instance.Name
+		instRef := InstanceRef{Fleet: instFleetName, Instance: instance.Name}
 		if m.inHostTmux {
 			if fleetPage.restoreInProgress() {
 				m.message = "Pane group restore already in progress"
@@ -789,33 +782,23 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 			}
 			if fleetPage.splitPaneID != "" && !splitOpen() {
 				unbindHostSplitKeys()
-				fleetPage.splitPaneID = ""
-				fleetPage.splitFleet = ""
-				fleetPage.splitInstance = ""
-				fleetPage.splitSession = ""
-				fleetPage.activeGroupID = ""
-				fleetPage.restoringGroupID = ""
+				fleetPage.clearSplit()
 			}
-			if fleetPage.splitPaneID != "" && fleetPage.splitInstance == instance.Name {
+			if fleetPage.splitPaneID != "" && fleetPage.splitRef == instRef {
 				fleetPage.saveCurrentGroupLayout(m.st)
 				killAllSplitPanes()
 				unbindHostSplitKeys()
-				fleetPage.splitPaneID = ""
-				fleetPage.splitFleet = ""
-				fleetPage.splitInstance = ""
-				fleetPage.splitSession = ""
-				fleetPage.activeGroupID = ""
-				fleetPage.restoringGroupID = ""
+				fleetPage.clearSplit()
 				return nil
 			}
 			return fleetPage.openInstanceSession(m, instFleetName, instance)
 		}
 
 		sessionName := SanitizeSessionName(instance.Name)
-		if last, ok := m.lastActive[instKey]; ok {
+		if last, ok := m.sessionStore.LastActive(instRef); ok {
 			sessionName = last.sessionName
 		}
-		m.lastActive[instKey] = lastSession{sessionName: sessionName}
+		m.sessionStore.SetLastActive(instRef, lastSession{sessionName: sessionName})
 
 		cmd := m.instanceBackend(instance).ExecCommand(instance.WorkspaceDir, ShellCommandForSession(m.config, sessionName, m.width, m.height, false))
 		banner := renderGradient(nameToBanner(instance.GetDisplayName()))
@@ -879,7 +862,7 @@ func (fleetPage *fleetPage) contextualHelpKeys(m *model) []string {
 			"j/k: navigate", "space/enter/e: connect",
 			"a: new session", "d: delete session", "r: rename", "q: quit",
 		}
-		if m.inHostTmux && fleetPage.splitInstance != "" && fleetPage.activeGroupID != "" {
+		if m.inHostTmux && fleetPage.splitRef.Valid() && !fleetPage.activeGroup.Empty() {
 			keys = append(keys[:len(keys)-1], "pgup/pgdn: cycle groups", "q: quit")
 		}
 		return keys
@@ -973,11 +956,15 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 		} else if r.kind == rowSession {
 			icon := "○"
 			style := sessionStyle
-			displayGroupID := fleetPage.activeGroupID
-			if fleetPage.pendingGroupID != "" {
-				displayGroupID = fleetPage.pendingGroupID
+			displayGroup := fleetPage.activeGroup
+			if !fleetPage.pendingGroup.Empty() {
+				displayGroup = fleetPage.pendingGroup
 			}
-			if r.groupID != "" && r.groupID == displayGroupID {
+			rowGroup := ActiveGroup{
+				Ref:     InstanceRef{Fleet: r.fleetName, Instance: r.instance.Name},
+				GroupID: r.groupID,
+			}
+			if r.groupID != "" && rowGroup == displayGroup {
 				icon = "●"
 				style = sessionActiveStyle
 			}
@@ -1016,10 +1003,10 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 				status = renderStatus(instance.Status)
 			}
 
-			instKey := r.fleetName + "/" + instance.Name
+			ref := InstanceRef{Fleet: r.fleetName, Instance: instance.Name}
 			arrow := "  "
 			if instance.Status == fleet.StatusRunning {
-				if m.expandedInstances[instKey] {
+				if m.sessionStore.IsExpanded(ref) {
 					arrow = "▼ "
 				} else {
 					arrow = "▶ "
@@ -1444,16 +1431,16 @@ func (fleetPage *fleetPage) openInstanceSession(m *model, fleetName string, inst
 		return nil
 	}
 
-	instKey := fleetName + "/" + instance.Name
+	ref := InstanceRef{Fleet: fleetName, Instance: instance.Name}
 	sanitized := SanitizeSessionName(instance.Name)
 
 	// The session discovery loop only runs for expanded instances, so
 	// hitting enter on a collapsed row with no lastActive entry would
 	// otherwise always spawn a new group. Load sessions on demand here
 	// so we can attach to an existing one when available.
-	ensureSessionsLoaded(m, m.instanceBackend(instance), instance.WorkspaceDir, instKey)
+	ensureSessionsLoaded(m, m.instanceBackend(instance), instance.WorkspaceDir, ref)
 
-	if last, ok := m.lastActive[instKey]; ok {
+	if last, ok := m.sessionStore.LastActive(ref); ok {
 		if last.groupID != "" {
 			return fleetPage.restoreGroupCmd(m, fleetName, instance, last.groupID)
 		}
@@ -1463,25 +1450,22 @@ func (fleetPage *fleetPage) openInstanceSession(m *model, fleetName string, inst
 			instance.WorkspaceDir,
 			ShellCommandForSession(m.config, last.sessionName, cols, rows, true),
 		)
-		return splitPaneCmd(fleetPage.splitPaneID, fleetName, instance.Name, last.sessionName, last.groupID, cmd)
+		return splitPaneCmd(fleetPage.splitPaneID, ref, last.sessionName, last.groupID, cmd)
 	}
 
-	if disc, ok := m.sessions[instKey]; ok && disc.err == nil && len(disc.sessions) > 0 {
-		groups := groupSessions(sanitized, disc.sessions)
-		if len(groups) > 0 {
-			g := groups[0]
-			rootName := g.Sessions[0].Name
-			if g.GroupID != "" && isGroupedSession(sanitized, rootName) {
-				return fleetPage.restoreGroupCmd(m, fleetName, instance, g.GroupID)
-			}
-			cols, rows := tmuxWindowSize()
-			cols = cols * 70 / 100
-			cmd := m.instanceBackend(instance).ExecCommand(
-				instance.WorkspaceDir,
-				ShellCommandForSession(m.config, rootName, cols, rows, true),
-			)
-			return splitPaneCmd(fleetPage.splitPaneID, fleetName, instance.Name, rootName, g.GroupID, cmd)
+	if groups := m.sessionStore.Groups(ref); len(groups) > 0 {
+		g := groups[0]
+		rootName := g.Sessions[0].Name
+		if g.GroupID != "" && isGroupedSession(sanitized, rootName) {
+			return fleetPage.restoreGroupCmd(m, fleetName, instance, g.GroupID)
 		}
+		cols, rows := tmuxWindowSize()
+		cols = cols * 70 / 100
+		cmd := m.instanceBackend(instance).ExecCommand(
+			instance.WorkspaceDir,
+			ShellCommandForSession(m.config, rootName, cols, rows, true),
+		)
+		return splitPaneCmd(fleetPage.splitPaneID, ref, rootName, g.GroupID, cmd)
 	}
 
 	newGroupID := randomHex(3)
@@ -1492,45 +1476,32 @@ func (fleetPage *fleetPage) openInstanceSession(m *model, fleetName string, inst
 		instance.WorkspaceDir,
 		ShellCommandForSession(m.config, sessName, cols, rows, true),
 	)
-	return splitPaneCmd(fleetPage.splitPaneID, fleetName, instance.Name, sessName, newGroupID, cmd)
-}
-
-// instanceGroups returns the session groups for the given instance name.
-func (fleetPage *fleetPage) instanceGroups(m *model, instanceName string) []sessionGroup {
-	sanitized := SanitizeSessionName(instanceName)
-	for _, disc := range m.sessions {
-		if disc == nil || disc.err != nil {
-			continue
-		}
-		g := groupSessions(sanitized, disc.sessions)
-		if len(g) > 0 {
-			return g
-		}
-	}
-	return nil
+	return splitPaneCmd(fleetPage.splitPaneID, ref, sessName, newGroupID, cmd)
 }
 
 // cycleSessionGroup moves the visual selection to the next or previous
-// session group and starts a debounce timer.
+// session group within the currently-split instance and starts a
+// debounce timer. Group lookup is scoped to fleetPage.splitRef so two
+// instances that share group IDs cannot leak into each other.
 func (fleetPage *fleetPage) cycleSessionGroup(m *model, prev bool) tea.Cmd {
 	if fleetPage.restoreInProgress() {
 		m.message = "Pane group restore already in progress"
 		return nil
 	}
 
-	groups := fleetPage.instanceGroups(m, fleetPage.splitInstance)
+	groups := m.sessionStore.Groups(fleetPage.splitRef)
 	if len(groups) < 2 {
 		return nil
 	}
 
-	fromID := fleetPage.activeGroupID
-	if fleetPage.pendingGroupID != "" {
-		fromID = fleetPage.pendingGroupID
+	from := fleetPage.activeGroup
+	if !fleetPage.pendingGroup.Empty() {
+		from = fleetPage.pendingGroup
 	}
 
 	currentIdx := -1
 	for i, g := range groups {
-		if g.GroupID == fromID {
+		if g.GroupID == from.GroupID && from.Ref == fleetPage.splitRef {
 			currentIdx = i
 			break
 		}
@@ -1549,7 +1520,7 @@ func (fleetPage *fleetPage) cycleSessionGroup(m *model, prev bool) tea.Cmd {
 		targetIdx = 0
 	}
 
-	fleetPage.pendingGroupID = groups[targetIdx].GroupID
+	fleetPage.pendingGroup = ActiveGroup{Ref: fleetPage.splitRef, GroupID: groups[targetIdx].GroupID}
 	fleetPage.debounceSeq++
 	return groupCycleDebounce(fleetPage.debounceSeq)
 }
@@ -1562,37 +1533,29 @@ func (fleetPage *fleetPage) commitGroupCycle(m *model) tea.Cmd {
 		return nil
 	}
 
-	if fleetPage.pendingGroupID == "" || fleetPage.pendingGroupID == fleetPage.activeGroupID {
-		fleetPage.pendingGroupID = ""
+	if fleetPage.pendingGroup.Empty() || fleetPage.pendingGroup == fleetPage.activeGroup {
+		fleetPage.pendingGroup = ActiveGroup{}
 		return nil
 	}
 
-	var instance *fleet.Instance
-	for _, f := range m.st.Fleets {
-		for _, i := range f.Instances {
-			if i.Name == fleetPage.splitInstance {
-				instance = i
-				break
-			}
-		}
-		if instance != nil {
-			break
-		}
-	}
-	if instance == nil {
-		fleetPage.pendingGroupID = ""
+	target := fleetPage.pendingGroup
+	fleetPage.pendingGroup = ActiveGroup{}
+
+	f, ok := m.st.Fleets[target.Ref.Fleet]
+	if !ok {
 		return nil
 	}
-
-	targetGroupID := fleetPage.pendingGroupID
-	fleetPage.pendingGroupID = ""
+	instance, err := f.GetInstance(target.Ref.Instance)
+	if err != nil {
+		return nil
+	}
 
 	fleetPage.saveCurrentGroupLayout(m.st)
 	killAllSplitPanes()
 
-	fleetPage.activeGroupID = targetGroupID
+	fleetPage.activeGroup = target
 
-	return fleetPage.restoreGroupCmd(m, fleetPage.splitFleet, instance, targetGroupID)
+	return fleetPage.restoreGroupCmd(m, target.Ref.Fleet, instance, target.GroupID)
 }
 
 // ===========================================

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -167,7 +167,7 @@ func TestViewFleetListShowsBranchItemForInstance(t *testing.T) {
 				"alpha": {Name: "alpha", Instances: []*fleet.Instance{inst}},
 			},
 		},
-		expandedInstances: make(map[string]bool),
+		sessionStore: NewSessionStore(),
 		stats:             map[string]*backend.ContainerStats{},
 		fleetPage:         fp,
 	}
@@ -202,10 +202,13 @@ func TestBuildRowsShowsSavedGroupWithoutLiveSessions(t *testing.T) {
 				"repo": {Name: "repo", Instances: []*fleet.Instance{inst}},
 			},
 		},
-		expandedInstances: map[string]bool{"repo/alpha": true},
-		sessions: map[string]*sessionDiscovery{
-			"repo/alpha": {sessions: nil},
-		},
+		sessionStore: func() *SessionStore {
+			s := NewSessionStore()
+			ref := InstanceRef{Fleet: "repo", Instance: "alpha"}
+			s.SetExpanded(ref, true)
+			s.SetDiscovery(ref, nil)
+			return s
+		}(),
 		fleetPage: fp,
 	}
 
@@ -244,12 +247,14 @@ func TestPruneSavedGroupsKeepsSavedGroupWhenDiscoveryIsEmpty(t *testing.T) {
 			GroupLayouts: map[string]state.GroupLayout{"abc123": {GroupID: "abc123", InstanceName: "alpha"}},
 		},
 		fleetPage: fp,
-		sessions: map[string]*sessionDiscovery{
-			"repo/alpha": {sessions: nil},
-		},
+		sessionStore: func() *SessionStore {
+			s := NewSessionStore()
+			s.SetDiscovery(InstanceRef{Fleet: "repo", Instance: "alpha"}, nil)
+			return s
+		}(),
 	}
 
-	m.pruneSavedGroupsForInstance("repo/alpha")
+	m.pruneSavedGroupsForInstance(InstanceRef{Fleet: "repo", Instance: "alpha"})
 
 	if _, ok := m.fleetPage.savedGroups["abc123"]; !ok {
 		t.Fatal("saved group was pruned even though WSL discovery returned no live sessions")
@@ -277,7 +282,7 @@ func TestViewFleetListOmitsBranchItemWhenBranchIsUnavailable(t *testing.T) {
 				"alpha": {Name: "alpha", Instances: []*fleet.Instance{inst}},
 			},
 		},
-		expandedInstances: make(map[string]bool),
+		sessionStore: NewSessionStore(),
 		stats:             map[string]*backend.ContainerStats{},
 		fleetPage:         fp,
 	}
@@ -318,7 +323,7 @@ func TestViewFleetListShowsAgentWorkingIndicator(t *testing.T) {
 			map[string]agentState{"abc123": agentWorking},
 			map[string]state.AgentTool{"abc123": state.AgentToolClaude},
 		),
-		expandedInstances: make(map[string]bool),
+		sessionStore: NewSessionStore(),
 		stats:             map[string]*backend.ContainerStats{},
 		fleetPage:         fp,
 	}
@@ -359,7 +364,7 @@ func TestViewFleetListShowsAgentWaitingIndicator(t *testing.T) {
 			map[string]agentState{"abc123": agentWaiting},
 			map[string]state.AgentTool{"abc123": state.AgentToolClaude},
 		),
-		expandedInstances: make(map[string]bool),
+		sessionStore: NewSessionStore(),
 		stats:             map[string]*backend.ContainerStats{},
 		fleetPage:         fp,
 	}
@@ -400,7 +405,7 @@ func TestViewFleetListShowsAgentOffIndicator(t *testing.T) {
 			map[string]agentState{"abc123": agentNotRunning},
 			nil,
 		),
-		expandedInstances: make(map[string]bool),
+		sessionStore: NewSessionStore(),
 		stats:             map[string]*backend.ContainerStats{},
 		fleetPage:         fp,
 	}
@@ -441,7 +446,7 @@ func TestViewFleetListNoAgentIndicatorForStoppedInstance(t *testing.T) {
 			AgentSettings: state.AgentSettings{ToolSelection: state.AgentToolClaude},
 		},
 		activity:          NewActivityTracker(),
-		expandedInstances: make(map[string]bool),
+		sessionStore: NewSessionStore(),
 		stats:             map[string]*backend.ContainerStats{},
 		fleetPage:         fp,
 	}
@@ -476,7 +481,7 @@ func TestEditInstanceRenamesViaDisplayName(t *testing.T) {
 				"alpha": {Name: "alpha", Instances: []*fleet.Instance{inst}},
 			},
 		},
-		expandedInstances: make(map[string]bool),
+		sessionStore: NewSessionStore(),
 		stats:             map[string]*backend.ContainerStats{},
 		fleetPage:         fp,
 	}

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -36,28 +36,28 @@ type sessionDiscovery struct {
 
 // sessionsMsg is sent after listing tmux sessions inside a container.
 type sessionsMsg struct {
-	instanceKey string // "fleet/instance"
-	sessions    []tmuxSession
-	err         error
+	ref      InstanceRef
+	sessions []tmuxSession
+	err      error
 }
 
 // sessionCreatedMsg is sent after creating a new tmux session.
 type sessionCreatedMsg struct {
-	instanceKey string
-	err         error
+	ref InstanceRef
+	err error
 }
 
 // sessionRenamedMsg is sent after renaming a tmux session.
 type sessionRenamedMsg struct {
-	instanceKey string
-	oldName     string
-	newName     string
-	err         error
+	ref     InstanceRef
+	oldName string
+	newName string
+	err     error
 }
 
 // sessionDeletedMsg is sent after killing a tmux session (or group of sessions).
 type sessionDeletedMsg struct {
-	instanceKey string
+	ref         InstanceRef
 	sessionName string // root session name that was deleted
 	groupID     string // non-empty when a full group was deleted
 	err         error
@@ -65,7 +65,7 @@ type sessionDeletedMsg struct {
 
 // sessionDiscoveryMsg carries discovered sessions for expanded instances.
 type sessionDiscoveryMsg struct {
-	discovered map[string][]tmuxSession // instanceKey → sessions
+	discovered map[InstanceRef][]tmuxSession
 }
 
 // sessionDiscoveryCmd lists tmux sessions for all expanded, running
@@ -73,13 +73,17 @@ type sessionDiscoveryMsg struct {
 // creation/destruction.
 func sessionDiscoveryCmd(
 	backends map[fleet.BackendType]backend.Backend,
-	expanded map[string]bool,
+	expanded []InstanceRef,
 	fleets map[string]*fleet.Fleet,
 ) tea.Cmd {
 	type target struct {
-		instanceKey  string
+		ref          InstanceRef
 		workspaceDir string
 		backendType  fleet.BackendType
+	}
+	expandedSet := make(map[InstanceRef]bool, len(expanded))
+	for _, ref := range expanded {
+		expandedSet[ref] = true
 	}
 	var targets []target
 	for _, f := range fleets {
@@ -91,12 +95,12 @@ func sessionDiscoveryCmd(
 			if backendType == "" {
 				backendType = fleet.BackendDevcontainer
 			}
-			instKey := f.Name + "/" + instance.Name
-			if !expanded[instKey] {
+			ref := InstanceRef{Fleet: f.Name, Instance: instance.Name}
+			if !expandedSet[ref] {
 				continue
 			}
 			targets = append(targets, target{
-				instanceKey:  instKey,
+				ref:          ref,
 				workspaceDir: instance.WorkspaceDir,
 				backendType:  backendType,
 			})
@@ -110,7 +114,7 @@ func sessionDiscoveryCmd(
 			return sessionDiscoveryMsg{}
 		}
 
-		discovered := make(map[string][]tmuxSession)
+		discovered := make(map[InstanceRef][]tmuxSession)
 		var mu sync.Mutex
 		var wg sync.WaitGroup
 
@@ -120,7 +124,7 @@ func sessionDiscoveryCmd(
 				continue
 			}
 			wg.Add(1)
-			go func(instanceBackend backend.Backend, wsDir, instKey string) {
+			go func(instanceBackend backend.Backend, wsDir string, ref InstanceRef) {
 				defer wg.Done()
 				cmd := instanceBackend.ExecCommand(wsDir, []string{
 					"sh", "-c",
@@ -132,15 +136,15 @@ func sessionDiscoveryCmd(
 					// (server not running). Record an empty list so
 					// stale sessions are cleared from the UI.
 					mu.Lock()
-					discovered[instKey] = nil
+					discovered[ref] = nil
 					mu.Unlock()
 					return
 				}
 				sessions := parseTmuxSessions(string(out))
 				mu.Lock()
-				discovered[instKey] = sessions
+				discovered[ref] = sessions
 				mu.Unlock()
-			}(instanceBackend, t.workspaceDir, t.instanceKey)
+			}(instanceBackend, t.workspaceDir, t.ref)
 		}
 
 		wg.Wait()
@@ -148,13 +152,13 @@ func sessionDiscoveryCmd(
 	}
 }
 
-// ensureSessionsLoaded synchronously populates m.sessions[instKey] when
-// it has not been loaded yet. This is needed before opening an instance
-// session from a row that was never expanded, so the attach-vs-new
-// decision can see existing tmux sessions instead of always spawning a
-// new group.
-func ensureSessionsLoaded(m *model, instanceBackend backend.Backend, workspaceDir, instanceKey string) {
-	if _, ok := m.sessions[instanceKey]; ok {
+// ensureSessionsLoaded synchronously populates the session store for
+// ref when it has not been loaded yet. Needed before opening an
+// instance session from a row that was never expanded, so the
+// attach-vs-new decision can see existing tmux sessions instead of
+// always spawning a new group.
+func ensureSessionsLoaded(m *model, instanceBackend backend.Backend, workspaceDir string, ref InstanceRef) {
+	if m.sessionStore.HasDiscovery(ref) {
 		return
 	}
 	cmd := instanceBackend.ExecCommand(workspaceDir, []string{
@@ -163,18 +167,15 @@ func ensureSessionsLoaded(m *model, instanceBackend backend.Backend, workspaceDi
 	})
 	out, err := cmd.Output()
 	if err != nil {
-		m.sessions[instanceKey] = &sessionDiscovery{err: err, fetchedAt: time.Now()}
+		m.sessionStore.SetDiscoveryError(ref, err)
 		return
 	}
-	m.sessions[instanceKey] = &sessionDiscovery{
-		sessions:  parseTmuxSessions(string(out)),
-		fetchedAt: time.Now(),
-	}
+	m.sessionStore.SetDiscovery(ref, parseTmuxSessions(string(out)))
 }
 
 // listSessionsCmd returns a tea.Cmd that execs `tmux list-sessions`
 // inside the container and parses the output into tmuxSession structs.
-func listSessionsCmd(instanceBackend backend.Backend, workspaceDir, instanceKey string) tea.Cmd {
+func listSessionsCmd(instanceBackend backend.Backend, workspaceDir string, ref InstanceRef) tea.Cmd {
 	return func() tea.Msg {
 		cmd := instanceBackend.ExecCommand(workspaceDir, []string{
 			"sh", "-c",
@@ -182,47 +183,47 @@ func listSessionsCmd(instanceBackend backend.Backend, workspaceDir, instanceKey 
 		})
 		out, err := cmd.Output()
 		if err != nil {
-			return sessionsMsg{instanceKey: instanceKey, err: err}
+			return sessionsMsg{ref: ref, err: err}
 		}
 		sessions := parseTmuxSessions(string(out))
-		return sessionsMsg{instanceKey: instanceKey, sessions: sessions}
+		return sessionsMsg{ref: ref, sessions: sessions}
 	}
 }
 
 // createSessionCmd ensures tmux is installed (matching the interactive
 // shell path) and then creates a detached session inside the container.
-func createSessionCmd(instanceBackend backend.Backend, workspaceDir, instanceKey, sessionName string) tea.Cmd {
+func createSessionCmd(instanceBackend backend.Backend, workspaceDir string, ref InstanceRef, sessionName string) tea.Cmd {
 	return func() tea.Msg {
 		cmd := instanceBackend.ExecCommand(workspaceDir, []string{
 			"sh", "-c",
 			tmuxEnsureInstalled + fmt.Sprintf(`tmux new-session -d -s %s 2>/dev/null`, shQuote(sessionName)),
 		})
 		if err := cmd.Run(); err != nil {
-			return sessionCreatedMsg{instanceKey: instanceKey, err: err}
+			return sessionCreatedMsg{ref: ref, err: err}
 		}
-		return sessionCreatedMsg{instanceKey: instanceKey}
+		return sessionCreatedMsg{ref: ref}
 	}
 }
 
 // renameSessionCmd execs `tmux rename-session -t <old> <new>` inside
 // the container.
-func renameSessionCmd(instanceBackend backend.Backend, workspaceDir, instanceKey, oldName, newName string) tea.Cmd {
+func renameSessionCmd(instanceBackend backend.Backend, workspaceDir string, ref InstanceRef, oldName, newName string) tea.Cmd {
 	return func() tea.Msg {
 		cmd := instanceBackend.ExecCommand(workspaceDir, []string{
 			"sh", "-c",
 			fmt.Sprintf(`tmux rename-session -t %s %s 2>/dev/null`, shQuote(oldName), shQuote(newName)),
 		})
 		if err := cmd.Run(); err != nil {
-			return sessionRenamedMsg{instanceKey: instanceKey, oldName: oldName, newName: newName, err: err}
+			return sessionRenamedMsg{ref: ref, oldName: oldName, newName: newName, err: err}
 		}
-		return sessionRenamedMsg{instanceKey: instanceKey, oldName: oldName, newName: newName}
+		return sessionRenamedMsg{ref: ref, oldName: oldName, newName: newName}
 	}
 }
 
 // renameGroupCmd renames all sessions in a group. It lists sessions
 // matching the old group prefix, then renames each one by swapping the
 // old group ID for the new one.
-func renameGroupCmd(instanceBackend backend.Backend, workspaceDir, instanceKey, sanitizedInstance, oldGroupID, newGroupID string) tea.Cmd {
+func renameGroupCmd(instanceBackend backend.Backend, workspaceDir string, ref InstanceRef, sanitizedInstance, oldGroupID, newGroupID string) tea.Cmd {
 	oldPrefix := sanitizedInstance + groupSep + oldGroupID
 	newPrefix := sanitizedInstance + groupSep + newGroupID
 
@@ -234,7 +235,7 @@ func renameGroupCmd(instanceBackend backend.Backend, workspaceDir, instanceKey, 
 		})
 		out, err := listCmd.Output()
 		if err != nil {
-			return sessionRenamedMsg{instanceKey: instanceKey, oldName: oldPrefix, newName: newPrefix, err: err}
+			return sessionRenamedMsg{ref: ref, oldName: oldPrefix, newName: newPrefix, err: err}
 		}
 
 		// Rename each session that matches the old group prefix.
@@ -255,29 +256,29 @@ func renameGroupCmd(instanceBackend backend.Backend, workspaceDir, instanceKey, 
 			}
 		}
 		if lastErr != nil {
-			return sessionRenamedMsg{instanceKey: instanceKey, oldName: oldPrefix, newName: newPrefix, err: lastErr}
+			return sessionRenamedMsg{ref: ref, oldName: oldPrefix, newName: newPrefix, err: lastErr}
 		}
-		return sessionRenamedMsg{instanceKey: instanceKey, oldName: oldPrefix, newName: newPrefix}
+		return sessionRenamedMsg{ref: ref, oldName: oldPrefix, newName: newPrefix}
 	}
 }
 
 // deleteSessionCmd kills a single tmux session inside the container.
-func deleteSessionCmd(instanceBackend backend.Backend, workspaceDir, instanceKey, sessionName string) tea.Cmd {
+func deleteSessionCmd(instanceBackend backend.Backend, workspaceDir string, ref InstanceRef, sessionName string) tea.Cmd {
 	return func() tea.Msg {
 		cmd := instanceBackend.ExecCommand(workspaceDir, []string{
 			"sh", "-c",
 			fmt.Sprintf(`tmux kill-session -t %s 2>/dev/null`, shQuote(sessionName)),
 		})
 		if err := cmd.Run(); err != nil {
-			return sessionDeletedMsg{instanceKey: instanceKey, sessionName: sessionName, err: err}
+			return sessionDeletedMsg{ref: ref, sessionName: sessionName, err: err}
 		}
-		return sessionDeletedMsg{instanceKey: instanceKey, sessionName: sessionName}
+		return sessionDeletedMsg{ref: ref, sessionName: sessionName}
 	}
 }
 
 // deleteGroupSessionsCmd kills all tmux sessions belonging to a group.
 // It lists sessions matching the group prefix and kills each one.
-func deleteGroupSessionsCmd(instanceBackend backend.Backend, workspaceDir, instanceKey, sanitizedInstance, groupID string) tea.Cmd {
+func deleteGroupSessionsCmd(instanceBackend backend.Backend, workspaceDir string, ref InstanceRef, sanitizedInstance, groupID string) tea.Cmd {
 	prefix := sanitizedInstance + groupSep + groupID
 
 	return func() tea.Msg {
@@ -288,7 +289,7 @@ func deleteGroupSessionsCmd(instanceBackend backend.Backend, workspaceDir, insta
 		})
 		out, err := listCmd.Output()
 		if err != nil {
-			return sessionDeletedMsg{instanceKey: instanceKey, sessionName: prefix, groupID: groupID, err: err}
+			return sessionDeletedMsg{ref: ref, sessionName: prefix, groupID: groupID, err: err}
 		}
 
 		// Kill each session that matches the group prefix.
@@ -307,9 +308,9 @@ func deleteGroupSessionsCmd(instanceBackend backend.Backend, workspaceDir, insta
 			}
 		}
 		if lastErr != nil {
-			return sessionDeletedMsg{instanceKey: instanceKey, sessionName: prefix, groupID: groupID, err: lastErr}
+			return sessionDeletedMsg{ref: ref, sessionName: prefix, groupID: groupID, err: lastErr}
 		}
-		return sessionDeletedMsg{instanceKey: instanceKey, sessionName: prefix, groupID: groupID}
+		return sessionDeletedMsg{ref: ref, sessionName: prefix, groupID: groupID}
 	}
 }
 

--- a/internal/tui/sessionstore.go
+++ b/internal/tui/sessionstore.go
@@ -1,0 +1,257 @@
+package tui
+
+import (
+	"strings"
+	"time"
+)
+
+// ===========================================
+// Identifiers
+// ===========================================
+
+// InstanceRef uniquely identifies an instance across all fleets. Every
+// session-state operation requires one so two instances that share a
+// name (or a session/group name) can never alias each other.
+type InstanceRef struct {
+	Fleet    string
+	Instance string
+}
+
+// Valid reports whether both halves of the reference are populated.
+// SessionStore methods silently no-op on invalid refs.
+func (r InstanceRef) Valid() bool {
+	return r.Fleet != "" && r.Instance != ""
+}
+
+// Key returns the legacy "fleet/instance" string form. Reserve for
+// presentation (status messages, log lines) and external persistence
+// keys; inside fleet, pass the typed ref instead.
+func (r InstanceRef) Key() string {
+	return r.Fleet + "/" + r.Instance
+}
+
+// ParseInstanceRef parses a "fleet/instance" string back into a typed
+// ref. Returns ok=false when the input is malformed.
+func ParseInstanceRef(key string) (InstanceRef, bool) {
+	parts := strings.SplitN(key, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return InstanceRef{}, false
+	}
+	return InstanceRef{Fleet: parts[0], Instance: parts[1]}, true
+}
+
+// ActiveGroup names a specific tmux session group on a specific
+// instance. Two groups on different instances may share an ID; the
+// surrounding ref disambiguates them.
+type ActiveGroup struct {
+	Ref     InstanceRef
+	GroupID string
+}
+
+// Empty reports whether the active group is unset.
+func (a ActiveGroup) Empty() bool {
+	return a.GroupID == "" || !a.Ref.Valid()
+}
+
+// ===========================================
+// SessionStore
+// ===========================================
+
+// SessionStore owns per-instance session state. Every method requires
+// an InstanceRef so callers cannot accidentally read or write state
+// belonging to a different instance with the same session or group
+// name. Not goroutine-safe — all access happens on the bubbletea
+// message loop.
+type SessionStore struct {
+	discoveries map[InstanceRef]*sessionDiscovery
+	expanded    map[InstanceRef]bool
+	lastActive  map[InstanceRef]lastSession
+}
+
+// NewSessionStore returns an initialised, empty store.
+func NewSessionStore() *SessionStore {
+	return &SessionStore{
+		discoveries: make(map[InstanceRef]*sessionDiscovery),
+		expanded:    make(map[InstanceRef]bool),
+		lastActive:  make(map[InstanceRef]lastSession),
+	}
+}
+
+// --- Discovery ---
+
+// Discovery returns the most recent discovery for ref, if any.
+func (s *SessionStore) Discovery(ref InstanceRef) (*sessionDiscovery, bool) {
+	if s == nil || !ref.Valid() {
+		return nil, false
+	}
+	d, ok := s.discoveries[ref]
+	return d, ok
+}
+
+// HasDiscovery reports whether any discovery (success or error) has
+// been recorded for ref.
+func (s *SessionStore) HasDiscovery(ref InstanceRef) bool {
+	if s == nil || !ref.Valid() {
+		return false
+	}
+	_, ok := s.discoveries[ref]
+	return ok
+}
+
+// SetDiscovery records a successful discovery for ref.
+func (s *SessionStore) SetDiscovery(ref InstanceRef, sessions []tmuxSession) {
+	if s == nil || !ref.Valid() {
+		return
+	}
+	s.discoveries[ref] = &sessionDiscovery{
+		sessions:  sessions,
+		fetchedAt: time.Now(),
+	}
+}
+
+// SetDiscoveryError records that the most recent discovery failed.
+func (s *SessionStore) SetDiscoveryError(ref InstanceRef, err error) {
+	if s == nil || !ref.Valid() {
+		return
+	}
+	s.discoveries[ref] = &sessionDiscovery{
+		err:       err,
+		fetchedAt: time.Now(),
+	}
+}
+
+// ForgetDiscovery drops the discovery record for ref.
+func (s *SessionStore) ForgetDiscovery(ref InstanceRef) {
+	if s == nil {
+		return
+	}
+	delete(s.discoveries, ref)
+}
+
+// Sessions returns the session list from the most recent successful
+// discovery for ref, or nil if absent or errored.
+func (s *SessionStore) Sessions(ref InstanceRef) []tmuxSession {
+	d, ok := s.Discovery(ref)
+	if !ok || d == nil || d.err != nil {
+		return nil
+	}
+	return d.sessions
+}
+
+// Groups returns the session groups for ref, derived from its current
+// discovery and instance-name prefix. Sessions explicitly tagged for a
+// different instance (sanitized name + groupSep + ...) are filtered out
+// before grouping so two instances sharing a tmux server (e.g. via a
+// shared workspace mount) cannot leak each other's sessions into the
+// UI. Untagged sessions — those without a groupSep — are kept since
+// they may be ad-hoc sessions a user created outside fleet.
+func (s *SessionStore) Groups(ref InstanceRef) []sessionGroup {
+	sessions := s.Sessions(ref)
+	if len(sessions) == 0 {
+		return nil
+	}
+	sanitized := SanitizeSessionName(ref.Instance)
+	prefix := sanitized + groupSep
+	own := make([]tmuxSession, 0, len(sessions))
+	for _, sess := range sessions {
+		if strings.Contains(sess.Name, groupSep) && !strings.HasPrefix(sess.Name, prefix) {
+			continue
+		}
+		own = append(own, sess)
+	}
+	return groupSessions(sanitized, own)
+}
+
+// --- Expansion ---
+
+// IsExpanded reports whether ref's row is currently expanded.
+func (s *SessionStore) IsExpanded(ref InstanceRef) bool {
+	if s == nil || !ref.Valid() {
+		return false
+	}
+	return s.expanded[ref]
+}
+
+// SetExpanded toggles ref's expansion state.
+func (s *SessionStore) SetExpanded(ref InstanceRef, on bool) {
+	if s == nil || !ref.Valid() {
+		return
+	}
+	if on {
+		s.expanded[ref] = true
+		return
+	}
+	delete(s.expanded, ref)
+}
+
+// ExpandedRefs returns a snapshot of all currently-expanded refs.
+func (s *SessionStore) ExpandedRefs() []InstanceRef {
+	if s == nil {
+		return nil
+	}
+	out := make([]InstanceRef, 0, len(s.expanded))
+	for ref, on := range s.expanded {
+		if on {
+			out = append(out, ref)
+		}
+	}
+	return out
+}
+
+// CollapseAndForgetSessions drops the expansion and discovery records
+// for ref but preserves any last-active entry — that survives across
+// stop/start cycles so the instance can re-attach on next run.
+func (s *SessionStore) CollapseAndForgetSessions(ref InstanceRef) {
+	if s == nil {
+		return
+	}
+	delete(s.expanded, ref)
+	delete(s.discoveries, ref)
+}
+
+// --- Last active ---
+
+// LastActive returns the most recently used session for ref.
+func (s *SessionStore) LastActive(ref InstanceRef) (lastSession, bool) {
+	if s == nil || !ref.Valid() {
+		return lastSession{}, false
+	}
+	last, ok := s.lastActive[ref]
+	return last, ok
+}
+
+// SetLastActive records the most recently used session for ref.
+func (s *SessionStore) SetLastActive(ref InstanceRef, last lastSession) {
+	if s == nil || !ref.Valid() {
+		return
+	}
+	s.lastActive[ref] = last
+}
+
+// ClearLastActive removes the last-active entry for ref.
+func (s *SessionStore) ClearLastActive(ref InstanceRef) {
+	if s == nil {
+		return
+	}
+	delete(s.lastActive, ref)
+}
+
+// PruneStaleLastActive iterates every last-active entry and clears any
+// whose recorded session no longer appears in the current discovery.
+// Called after each discovery refresh so deletions don't leave stale
+// pointers behind.
+func (s *SessionStore) PruneStaleLastActive() {
+	if s == nil {
+		return
+	}
+	for ref, last := range s.lastActive {
+		d, ok := s.discoveries[ref]
+		if !ok || d == nil || d.err != nil {
+			delete(s.lastActive, ref)
+			continue
+		}
+		if !sessionStillExists(last, d.sessions) {
+			delete(s.lastActive, ref)
+		}
+	}
+}

--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -16,12 +16,11 @@ import (
 
 // splitPaneMsg is sent after a tmux split-window command completes.
 type splitPaneMsg struct {
-	paneID     string // tmux pane ID (e.g. "%3")
-	fleet      string // fleet name for the instance
-	instance   string // instance name occupying the pane
-	session    string // tmux session name in the pane
-	groupID    string // session group ID (for group management)
-	restoreSeq int    // async restore token; zero means not a group restore
+	paneID     string      // tmux pane ID (e.g. "%3")
+	ref        InstanceRef // instance occupying the pane
+	session    string      // tmux session name in the pane
+	groupID    string      // session group ID (for group management)
+	restoreSeq int         // async restore token; zero means not a group restore
 	err        error
 }
 
@@ -57,7 +56,7 @@ func quoteArgs(args []string) string {
 // command. When an existing pane ID is provided, it is respawned in-place
 // (via respawn-pane) to avoid layout changes that cause visual corruption.
 // If the pane no longer exists, it falls back to creating a fresh split.
-func splitPaneCmd(existingPaneID string, fleetName string, instanceName string, sessionName string, groupID string, cmd *exec.Cmd) tea.Cmd {
+func splitPaneCmd(existingPaneID string, ref InstanceRef, sessionName string, groupID string, cmd *exec.Cmd) tea.Cmd {
 	// Snapshot the args — we must not capture the *exec.Cmd across goroutines.
 	args := cmd.Args
 
@@ -76,7 +75,7 @@ func splitPaneCmd(existingPaneID string, fleetName string, instanceName string, 
 			}
 			if exec.Command("tmux", respawnArgs...).Run() == nil {
 				_ = exec.Command("tmux", "select-pane", "-t", existingPaneID).Run()
-				return splitPaneMsg{paneID: existingPaneID, fleet: fleetName, instance: instanceName, session: sessionName, groupID: groupID}
+				return splitPaneMsg{paneID: existingPaneID, ref: ref, session: sessionName, groupID: groupID}
 			}
 			// Pane is gone — fall through to create a fresh split.
 		}
@@ -102,7 +101,7 @@ func splitPaneCmd(existingPaneID string, fleetName string, instanceName string, 
 
 		paneID := strings.TrimSpace(string(out))
 		_ = exec.Command("tmux", "select-pane", "-t", paneID).Run()
-		return splitPaneMsg{paneID: paneID, fleet: fleetName, instance: instanceName, session: sessionName, groupID: groupID}
+		return splitPaneMsg{paneID: paneID, ref: ref, session: sessionName, groupID: groupID}
 	}
 }
 
@@ -330,7 +329,7 @@ func paneSessionOrder() []string {
 // st is non-nil the layout is also mirrored into state.json so it
 // survives a fleet restart.
 func (fleetPage *fleetPage) saveCurrentGroupLayout(st *state.State) {
-	if fleetPage.activeGroupID == "" || fleetPage.splitInstance == "" {
+	if fleetPage.activeGroup.Empty() {
 		return
 	}
 	if fleetPage.restoreInProgress() {
@@ -341,8 +340,8 @@ func (fleetPage *fleetPage) saveCurrentGroupLayout(st *state.State) {
 	// panes briefly report the host title before fleet shell sets a title;
 	// normalize those placeholders into deterministic group session names
 	// before persisting the layout.
-	sanitized := SanitizeSessionName(fleetPage.splitInstance)
-	sessionNames := normalizeSavedGroupSessions(paneSessionOrder(), sanitized, fleetPage.activeGroupID)
+	sanitized := SanitizeSessionName(fleetPage.activeGroup.Ref.Instance)
+	sessionNames := normalizeSavedGroupSessions(paneSessionOrder(), sanitized, fleetPage.activeGroup.GroupID)
 
 	// No shell panes visible in the outer tmux means either the group
 	// hasn't opened yet or its panes have already been killed (Ctrl+Q,
@@ -354,8 +353,8 @@ func (fleetPage *fleetPage) saveCurrentGroupLayout(st *state.State) {
 	}
 
 	groupSnapshot := savedGroup{
-		GroupID:      fleetPage.activeGroupID,
-		InstanceName: fleetPage.splitInstance,
+		GroupID:      fleetPage.activeGroup.GroupID,
+		InstanceName: fleetPage.activeGroup.Ref.Instance,
 		Sessions:     sessionNames,
 		Layout:       tmuxLayoutString(),
 		PaneCount:    len(sessionNames),
@@ -364,10 +363,10 @@ func (fleetPage *fleetPage) saveCurrentGroupLayout(st *state.State) {
 	// No-op when nothing changed. The 250ms layout tick fires this
 	// constantly; without this gate an idle split would rewrite
 	// state.json every tick with identical bytes.
-	if existing, ok := fleetPage.savedGroups[fleetPage.activeGroupID]; ok && sameSavedGroup(existing, groupSnapshot) {
+	if existing, ok := fleetPage.savedGroups[groupSnapshot.GroupID]; ok && sameSavedGroup(existing, groupSnapshot) {
 		return
 	}
-	fleetPage.savedGroups[fleetPage.activeGroupID] = groupSnapshot
+	fleetPage.savedGroups[groupSnapshot.GroupID] = groupSnapshot
 
 	if st == nil {
 		return
@@ -375,7 +374,7 @@ func (fleetPage *fleetPage) saveCurrentGroupLayout(st *state.State) {
 	if st.GroupLayouts == nil {
 		st.GroupLayouts = make(map[string]state.GroupLayout)
 	}
-	st.GroupLayouts[fleetPage.activeGroupID] = state.GroupLayout{
+	st.GroupLayouts[groupSnapshot.GroupID] = state.GroupLayout{
 		GroupID:      groupSnapshot.GroupID,
 		InstanceName: groupSnapshot.InstanceName,
 		Sessions:     groupSnapshot.Sessions,
@@ -518,8 +517,7 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 		}
 		msg := splitPaneMsg{
 			paneID:     firstPaneID,
-			fleet:      fleetName,
-			instance:   instanceName,
+			ref:        InstanceRef{Fleet: fleetName, Instance: instanceName},
 			session:    firstSession,
 			groupID:    groupID,
 			restoreSeq: restoreSeq,


### PR DESCRIPTION
## Summary

- Introduces `InstanceRef{Fleet, Instance}` and `ActiveGroup{Ref, GroupID}` as typed identifiers, plus a `SessionStore` service that owns the per-instance session state (discoveries, expansion, last-active). Every operation requires an `InstanceRef` so cross-instance aliasing is structurally inexpressible.
- Fixes two related bugs that fell out of the old bare-string design:
  1. Two instances with same-named session groups both lit up as "active" because the render comparison only looked at the group ID.
  2. Ghost sessions like `edit~claude` appeared under the wrong instance because `instanceGroups` scanned every discovery bucket and returned the first match — and, more generally, when two instances share a tmux server (shared workspace, mount, etc.) `tmux list-sessions` returns every session to every container. `SessionStore.Groups` now filters sessions tagged for another instance before grouping.
- Consolidates `splitFleet`+`splitInstance` into `splitRef InstanceRef`; `activeGroupID`/`pendingGroupID` (bare strings) into `activeGroup`/`pendingGroup ActiveGroup`. Adds `clearSplit()` to replace the 6-line "reset every split field" pattern that was duplicated in four places.
- All session messages (`sessionsMsg`, `sessionCreatedMsg`, `sessionRenamedMsg`, `sessionDeletedMsg`, `sessionDiscoveryMsg`, `splitPaneMsg`) and command builders (`listSessionsCmd`, `createSessionCmd`, etc.) now carry/take `InstanceRef` instead of bare `instanceKey` strings.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] Manual: create two instances in different fleets, give each a session with the same name — confirm only the active row's icon lights up.
- [ ] Manual: with sessions of the same name across instances, click around between them — confirm no ghost `<otherInstance>~<sessionName>` rows appear under the wrong instance.
- [ ] Manual: open a split pane, cycle groups with PgUp/PgDn, close the split — confirm group cycling stays scoped to the open instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)