### PR TITLE
feat(tui): unify dialog controls with settings-page scheme

### DIFF
--- a/integration/tests/170_tui_new_fleet_cancel.sh
+++ b/integration/tests/170_tui_new_fleet_cancel.sh
@@ -17,8 +17,8 @@ tui_send n
 tui_wait_for "git@github.com" 5
 tui_assert_contains "New fleet" "new-fleet dialog title missing"
 
-info "cancelling dialog with Escape"
-tui_send Escape
+info "cancelling dialog with Ctrl+c (field auto-focuses on open; the hint advertises ctrl+c as the cancel key)"
+tui_send "C-c"
 tui_wait_for_absent "git@github.com" 5
 tui_wait_for_absent "New fleet" 5
 

--- a/integration/tests/180_tui_new_instance_cancel.sh
+++ b/integration/tests/180_tui_new_instance_cancel.sh
@@ -18,8 +18,8 @@ tui_send a
 tui_wait_for "instance-name" 5
 tui_assert_contains "New instance" "new-instance dialog title missing"
 
-info "pressing Escape to cancel the dialog"
-tui_send Escape
+info "pressing Ctrl+c to cancel the dialog (Name field auto-focuses on open; ctrl+c is the documented cancel from active mode)"
+tui_send "C-c"
 tui_wait_for_absent "instance-name" 5
 tui_wait_for_absent "New instance" 5
 

--- a/integration/tests/260_tui_session_rename.sh
+++ b/integration/tests/260_tui_session_rename.sh
@@ -43,8 +43,8 @@ tui_wait_for "Rename session" 5
 tui_assert_contains "Current:" "rename dialog missing Current label"
 tui_assert_contains "origname" "rename dialog should reference original name"
 
-info "testing esc-cancel on rename dialog"
-tui_send Escape
+info "testing ctrl+c cancel on rename dialog (name field auto-focuses on open)"
+tui_send "C-c"
 tui_wait_for "Cancelled" 5
 tui_wait_for_absent "Rename session" 5
 tui_assert_contains "origname" "session should still exist after cancel"

--- a/integration/tests/340_tui_port_forward_dialog.sh
+++ b/integration/tests/340_tui_port_forward_dialog.sh
@@ -54,10 +54,12 @@ tui_send Enter
 tui_wait_for "invalid local port" 5
 
 # ===========================================
-# Esc closes the dialog without adding any forward.
+# Close the dialog without adding any forward. The Add field is active
+# (after the failed submits), so Esc would only deactivate it. The
+# rendered hint `[ctrl+c] Close` is the direct close path.
 # ===========================================
-info "pressing Esc to close dialog"
-tui_send Escape
+info "pressing Ctrl+c to close dialog"
+tui_send "C-c"
 tui_wait_for_absent "local:remote" 5
 # Row should not have a "⇄" port-forward indicator (none was added).
 tui_assert_not_contains "⇄" "no port forwards should be active after esc"

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -54,8 +54,9 @@ func (fleetPage *fleetPage) updateConfirmDelete(m *model, msg tea.Msg) tea.Cmd {
 			}
 			fleetPage.mode = viewNormal
 
-		case "n", "N", "esc", "ctrl+c":
+		case "n", "N", "esc", "q", "Q", "ctrl+c":
 			fleetPage.mode = viewNormal
+			fleetPage.blurDialogFields()
 			m.message = "Cancelled"
 		}
 	}
@@ -87,8 +88,9 @@ func (fleetPage *fleetPage) updateConfirmDeleteFleetWarn(m *model, msg tea.Msg) 
 			}
 			fleetPage.mode = viewNormal
 
-		case "n", "N", "esc", "ctrl+c":
+		case "n", "N", "esc", "q", "Q", "ctrl+c":
 			fleetPage.mode = viewNormal
+			fleetPage.blurDialogFields()
 			m.message = "Cancelled"
 		}
 	}
@@ -118,8 +120,9 @@ func (fleetPage *fleetPage) updateConfirmDeleteSession(m *model, msg tea.Msg) te
 			}
 			return deleteSessionCmd(instanceBackend, instance.WorkspaceDir, ref, fleetPage.dialogSession)
 
-		case "n", "N", "esc", "ctrl+c":
+		case "n", "N", "esc", "q", "Q", "ctrl+c":
 			fleetPage.mode = viewNormal
+			fleetPage.blurDialogFields()
 			m.message = "Cancelled"
 		}
 	}
@@ -134,8 +137,8 @@ func (fleetPage *fleetPage) updateConfirmDeleteSession(m *model, msg tea.Msg) te
 // requires. An empty string means no external tool is needed.
 var backendToolRequirements = map[fleet.BackendType]string{
 	fleet.BackendDevcontainer: "devcontainer",
-	fleet.BackendCoder:       "coder",
-	fleet.BackendCodespaces:  "gh",
+	fleet.BackendCoder:        "coder",
+	fleet.BackendCodespaces:   "gh",
 }
 
 // allBackendTypes is the ordered master list of every backend type.
@@ -171,6 +174,59 @@ func backendTypeLabel(backendType fleet.BackendType) string {
 	default:
 		return "Devcontainer"
 	}
+}
+
+func isDialogUpKey(key string) bool {
+	return key == "up" || key == "k"
+}
+
+func isDialogDownKey(key string) bool {
+	return key == "down" || key == "j"
+}
+
+func isDialogLeftKey(key string) bool {
+	return key == "left" || key == "h"
+}
+
+func isDialogRightKey(key string) bool {
+	return key == "right" || key == "l"
+}
+
+func isDialogTextKey(msg tea.KeyMsg) bool {
+	if msg.Type != tea.KeyRunes || len(msg.Runes) == 0 || msg.Alt {
+		return false
+	}
+	switch msg.String() {
+	case "h", "j", "k", "l", "q", "Q", "d", "x":
+		return false
+	default:
+		return true
+	}
+}
+
+func (fleetPage *fleetPage) blurDialogFields() {
+	fleetPage.dialogFieldActive = false
+	fleetPage.textInput.Blur()
+	fleetPage.branchInput.Blur()
+	fleetPage.homedirInput.Blur()
+}
+
+func (fleetPage *fleetPage) activateTextInput() tea.Cmd {
+	fleetPage.dialogFieldActive = true
+	fleetPage.textInput.Focus()
+	return fleetPage.textInput.Cursor.BlinkCmd()
+}
+
+func (fleetPage *fleetPage) deactivateTextInput() {
+	fleetPage.dialogFieldActive = false
+	fleetPage.textInput.Blur()
+}
+
+func (fleetPage *fleetPage) activateTextInputWithMsg(msg tea.Msg) tea.Cmd {
+	blinkCmd := fleetPage.activateTextInput()
+	var inputCmd tea.Cmd
+	fleetPage.textInput, inputCmd = fleetPage.textInput.Update(msg)
+	return tea.Batch(blinkCmd, inputCmd)
 }
 
 // ===========================================
@@ -211,83 +267,37 @@ func (fleetPage *fleetPage) openEditInstanceDialog(m *model) tea.Cmd {
 		fleetPage.dialogColor = instanceColorWhite
 	}
 	fleetPage.dialogRow = addInstanceRowName
+	fleetPage.dialogFieldActive = false
 	fleetPage.textInput.SetValue(instance.GetDisplayName())
 	fleetPage.branchInput.SetValue(instance.Branch)
 	fleetPage.syncAddInstanceFocus()
-	return fleetPage.textInput.Cursor.BlinkCmd()
+	return nil
 }
 
 // updateAddInstance handles the add-instance dialog.
 func (fleetPage *fleetPage) updateAddInstance(m *model, msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		if fleetPage.dialogFieldActive {
+			switch msg.String() {
+			case "enter":
+				return fleetPage.submitAddInstance(m)
+			case "esc":
+				fleetPage.dialogFieldActive = false
+				fleetPage.syncAddInstanceFocus()
+				return nil
+			case "ctrl+c":
+				return fleetPage.cancelAddInstance(m)
+			}
+			return fleetPage.updateActiveAddInstanceField(msg)
+		}
+
 		switch msg.String() {
 		case "enter":
-			if fleetPage.dialogEditing {
-				return fleetPage.saveInstanceEdits(m)
+			if fleetPage.dialogRow == addInstanceRowName || (fleetPage.dialogRow == addInstanceRowBranch && !fleetPage.dialogEditing) {
+				return fleetPage.activateAddInstanceField()
 			}
-			name := strings.TrimSpace(fleetPage.textInput.Value())
-			if name == "" {
-				m.message = "Name cannot be empty"
-				fleetPage.mode = viewNormal
-				return nil
-			}
-
-			fleetName := fleetPage.dialogFleet
-			f, ok := m.st.Fleets[fleetName]
-			if !ok {
-				m.message = fmt.Sprintf("Fleet %s not found", fleetName)
-				fleetPage.mode = viewNormal
-				return nil
-			}
-
-			if _, err := f.GetInstance(name); err == nil {
-				m.message = fmt.Sprintf("Instance %s/%s already exists", fleetName, name)
-				fleetPage.mode = viewNormal
-				return nil
-			}
-
-			backendType := fleetPage.dialogBackend
-			if backendType == "" {
-				backendType = fleet.BackendDevcontainer
-			}
-
-			color := fleetPage.dialogColor
-			if color == instanceColorWhite {
-				color = ""
-			}
-
-			branch := strings.TrimSpace(fleetPage.branchInput.Value())
-
-			wsDir := filepath.Join(state.WorkspacesDir(), fleetName, name, fleetName)
-			instance := &fleet.Instance{
-				Name:         name,
-				DisplayName:  name,
-				Config:       ".devcontainer/devcontainer.json",
-				WorkspaceDir: wsDir,
-				CreatedAt:    time.Now(),
-				Status:       fleet.StatusCreating,
-				Backend:      backendType,
-				Color:        color,
-				Branch:       branch,
-			}
-			_ = f.AddInstance(instance)
-			_ = state.Save(m.st)
-
-			if m.config != nil {
-				m.config.DefaultBackend = string(backendType)
-				_ = state.SaveConfig(m.config)
-			}
-
-			key := fleetName + "/" + name
-			m.creating[key] = true
-			fleetPage.buildRows(m)
-			fleetPage.mode = viewNormal
-			fleetPage.textInput.Blur()
-			fleetPage.branchInput.Blur()
-			m.message = fmt.Sprintf("Creating %s (%s)...", key, backendTypeLabel(backendType))
-
-			return createInstanceCmd(fleetName, name, f.Remote, branch, backendType)
+			return fleetPage.submitAddInstance(m)
 
 		case "tab":
 			if fleetPage.dialogEditing {
@@ -304,11 +314,13 @@ func (fleetPage *fleetPage) updateAddInstance(m *model, msg tea.Msg) tea.Cmd {
 			return nil
 
 		case "up":
+			fleetPage.dialogFieldActive = false
 			fleetPage.dialogRow = fleetPage.prevAddInstanceRow(fleetPage.dialogRow)
 			fleetPage.syncAddInstanceFocus()
 			return nil
 
 		case "down":
+			fleetPage.dialogFieldActive = false
 			fleetPage.dialogRow = fleetPage.nextAddInstanceRow(fleetPage.dialogRow)
 			fleetPage.syncAddInstanceFocus()
 			return nil
@@ -327,6 +339,9 @@ func (fleetPage *fleetPage) updateAddInstance(m *model, msg tea.Msg) tea.Cmd {
 			}
 
 		case "right", " ":
+			if msg.String() == " " && (fleetPage.dialogRow == addInstanceRowName || (fleetPage.dialogRow == addInstanceRowBranch && !fleetPage.dialogEditing)) {
+				return fleetPage.activateAddInstanceField()
+			}
 			if fleetPage.dialogRow == addInstanceRowDeploy && !fleetPage.dialogEditing {
 				opts := fleetPage.availableBackendTypes(m)
 				if len(opts) > 1 {
@@ -339,18 +354,57 @@ func (fleetPage *fleetPage) updateAddInstance(m *model, msg tea.Msg) tea.Cmd {
 				return nil
 			}
 
-		case "esc", "ctrl+c":
-			fleetPage.mode = viewNormal
-			fleetPage.textInput.Blur()
-			fleetPage.branchInput.Blur()
-			m.message = "Cancelled"
+		case "esc", "q", "Q", "ctrl+c":
+			return fleetPage.cancelAddInstance(m)
+		}
+
+		if isDialogUpKey(msg.String()) {
+			fleetPage.dialogFieldActive = false
+			fleetPage.dialogRow = fleetPage.prevAddInstanceRow(fleetPage.dialogRow)
+			fleetPage.syncAddInstanceFocus()
 			return nil
+		}
+		if isDialogDownKey(msg.String()) {
+			fleetPage.dialogFieldActive = false
+			fleetPage.dialogRow = fleetPage.nextAddInstanceRow(fleetPage.dialogRow)
+			fleetPage.syncAddInstanceFocus()
+			return nil
+		}
+		if isDialogLeftKey(msg.String()) {
+			if fleetPage.dialogRow == addInstanceRowDeploy && !fleetPage.dialogEditing {
+				opts := fleetPage.availableBackendTypes(m)
+				if len(opts) > 1 {
+					fleetPage.dialogBackend = nextBackendType(fleetPage.dialogBackend, -1, opts)
+				}
+				return nil
+			}
+			if fleetPage.dialogRow == addInstanceRowColor {
+				fleetPage.dialogColor = nextInstanceColor(fleetPage.dialogColor, -1)
+				return nil
+			}
+		}
+		if isDialogRightKey(msg.String()) {
+			if fleetPage.dialogRow == addInstanceRowDeploy && !fleetPage.dialogEditing {
+				opts := fleetPage.availableBackendTypes(m)
+				if len(opts) > 1 {
+					fleetPage.dialogBackend = nextBackendType(fleetPage.dialogBackend, 1, opts)
+				}
+				return nil
+			}
+			if fleetPage.dialogRow == addInstanceRowColor {
+				fleetPage.dialogColor = nextInstanceColor(fleetPage.dialogColor, 1)
+				return nil
+			}
+		}
+		if isDialogTextKey(msg) && (fleetPage.dialogRow == addInstanceRowName || (fleetPage.dialogRow == addInstanceRowBranch && !fleetPage.dialogEditing)) {
+			return fleetPage.activateAddInstanceFieldWithMsg(msg)
 		}
 	}
 
-	// Forward key input to whichever text field currently has focus. The
-	// color and deploy rows are cycled with arrow keys and should swallow
-	// character input rather than mutate either field.
+	return nil
+}
+
+func (fleetPage *fleetPage) updateActiveAddInstanceField(msg tea.Msg) tea.Cmd {
 	switch fleetPage.dialogRow {
 	case addInstanceRowName:
 		var cmd tea.Cmd
@@ -364,13 +418,91 @@ func (fleetPage *fleetPage) updateAddInstance(m *model, msg tea.Msg) tea.Cmd {
 	return nil
 }
 
+func (fleetPage *fleetPage) submitAddInstance(m *model) tea.Cmd {
+	if fleetPage.dialogEditing {
+		return fleetPage.saveInstanceEdits(m)
+	}
+	name := strings.TrimSpace(fleetPage.textInput.Value())
+	if name == "" {
+		m.message = "Name cannot be empty"
+		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
+		return nil
+	}
+
+	fleetName := fleetPage.dialogFleet
+	f, ok := m.st.Fleets[fleetName]
+	if !ok {
+		m.message = fmt.Sprintf("Fleet %s not found", fleetName)
+		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
+		return nil
+	}
+
+	if _, err := f.GetInstance(name); err == nil {
+		m.message = fmt.Sprintf("Instance %s/%s already exists", fleetName, name)
+		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
+		return nil
+	}
+
+	backendType := fleetPage.dialogBackend
+	if backendType == "" {
+		backendType = fleet.BackendDevcontainer
+	}
+
+	color := fleetPage.dialogColor
+	if color == instanceColorWhite {
+		color = ""
+	}
+
+	branch := strings.TrimSpace(fleetPage.branchInput.Value())
+
+	wsDir := filepath.Join(state.WorkspacesDir(), fleetName, name, fleetName)
+	instance := &fleet.Instance{
+		Name:         name,
+		DisplayName:  name,
+		Config:       ".devcontainer/devcontainer.json",
+		WorkspaceDir: wsDir,
+		CreatedAt:    time.Now(),
+		Status:       fleet.StatusCreating,
+		Backend:      backendType,
+		Color:        color,
+		Branch:       branch,
+	}
+	_ = f.AddInstance(instance)
+	_ = state.Save(m.st)
+
+	if m.config != nil {
+		m.config.DefaultBackend = string(backendType)
+		_ = state.SaveConfig(m.config)
+	}
+
+	key := fleetName + "/" + name
+	m.creating[key] = true
+	fleetPage.buildRows(m)
+	fleetPage.mode = viewNormal
+	fleetPage.blurDialogFields()
+	m.message = fmt.Sprintf("Creating %s (%s)...", key, backendTypeLabel(backendType))
+
+	return createInstanceCmd(fleetName, name, f.Remote, branch, backendType)
+}
+
+func (fleetPage *fleetPage) cancelAddInstance(m *model) tea.Cmd {
+	fleetPage.mode = viewNormal
+	fleetPage.dialogEditing = false
+	fleetPage.blurDialogFields()
+	m.message = "Cancelled"
+	return nil
+}
+
 // syncAddInstanceFocus focuses the text input of the currently selected
 // row so the cursor visually reflects the current focus. In edit mode
 // the branch input is immutable so it never receives focus; the name
 // input edits DisplayName and stays focusable.
 func (fleetPage *fleetPage) syncAddInstanceFocus() {
-	nameFocus := fleetPage.dialogRow == addInstanceRowName
-	branchFocus := fleetPage.dialogRow == addInstanceRowBranch && !fleetPage.dialogEditing
+	nameFocus := fleetPage.dialogFieldActive && fleetPage.dialogRow == addInstanceRowName
+	branchFocus := fleetPage.dialogFieldActive && fleetPage.dialogRow == addInstanceRowBranch && !fleetPage.dialogEditing
 
 	if nameFocus {
 		fleetPage.textInput.Focus()
@@ -383,6 +515,28 @@ func (fleetPage *fleetPage) syncAddInstanceFocus() {
 	} else {
 		fleetPage.branchInput.Blur()
 	}
+}
+
+func (fleetPage *fleetPage) activateAddInstanceField() tea.Cmd {
+	fleetPage.dialogFieldActive = true
+	fleetPage.syncAddInstanceFocus()
+	switch fleetPage.dialogRow {
+	case addInstanceRowName:
+		return fleetPage.textInput.Cursor.BlinkCmd()
+	case addInstanceRowBranch:
+		if !fleetPage.dialogEditing {
+			return fleetPage.branchInput.Cursor.BlinkCmd()
+		}
+	}
+	fleetPage.dialogFieldActive = false
+	fleetPage.syncAddInstanceFocus()
+	return nil
+}
+
+func (fleetPage *fleetPage) activateAddInstanceFieldWithMsg(msg tea.Msg) tea.Cmd {
+	blinkCmd := fleetPage.activateAddInstanceField()
+	inputCmd := fleetPage.updateActiveAddInstanceField(msg)
+	return tea.Batch(blinkCmd, inputCmd)
 }
 
 // addInstanceRowEnabled reports whether a given row is selectable in the
@@ -428,6 +582,7 @@ func (fleetPage *fleetPage) saveInstanceEdits(m *model) tea.Cmd {
 	if !ok {
 		fleetPage.mode = viewNormal
 		fleetPage.dialogEditing = false
+		fleetPage.blurDialogFields()
 		m.message = fmt.Sprintf("Fleet %s not found", fleetPage.dialogFleet)
 		return nil
 	}
@@ -435,6 +590,7 @@ func (fleetPage *fleetPage) saveInstanceEdits(m *model) tea.Cmd {
 	if err != nil {
 		fleetPage.mode = viewNormal
 		fleetPage.dialogEditing = false
+		fleetPage.blurDialogFields()
 		m.message = fmt.Sprintf("Instance %s/%s not found", fleetPage.dialogFleet, fleetPage.dialogInst)
 		return nil
 	}
@@ -456,7 +612,7 @@ func (fleetPage *fleetPage) saveInstanceEdits(m *model) tea.Cmd {
 	fleetPage.buildRows(m)
 	fleetPage.mode = viewNormal
 	fleetPage.dialogEditing = false
-	fleetPage.textInput.Blur()
+	fleetPage.blurDialogFields()
 	m.message = fmt.Sprintf("Updated %s/%s", fleetPage.dialogFleet, fleetPage.dialogInst)
 	return nil
 }
@@ -469,38 +625,63 @@ func (fleetPage *fleetPage) saveInstanceEdits(m *model) tea.Cmd {
 func (fleetPage *fleetPage) updateTagInstance(m *model, msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		if fleetPage.dialogFieldActive {
+			switch msg.String() {
+			case "enter":
+				return fleetPage.saveTagInstance(m)
+			case "esc":
+				fleetPage.deactivateTextInput()
+				return nil
+			case "ctrl+c":
+				return fleetPage.cancelTextDialog(m)
+			}
+			var cmd tea.Cmd
+			fleetPage.textInput, cmd = fleetPage.textInput.Update(msg)
+			return cmd
+		}
+
 		switch msg.String() {
 		case "enter":
-			tag := strings.TrimSpace(fleetPage.textInput.Value())
-
-			f, ok := m.st.Fleets[fleetPage.dialogFleet]
-			if ok {
-				if instance, err := f.GetInstance(fleetPage.dialogInst); err == nil {
-					instance.Tag = tag
-					_ = state.Save(m.st)
-				}
-			}
-
-			fleetPage.mode = viewNormal
-			fleetPage.textInput.Blur()
-			if tag == "" {
-				m.message = fmt.Sprintf("Cleared tag for %s/%s", fleetPage.dialogFleet, fleetPage.dialogInst)
-			} else {
-				m.message = fmt.Sprintf("Tagged %s/%s: %s", fleetPage.dialogFleet, fleetPage.dialogInst, tag)
-			}
-			return nil
-
-		case "esc", "ctrl+c":
-			fleetPage.mode = viewNormal
-			fleetPage.textInput.Blur()
-			m.message = "Cancelled"
-			return nil
+			return fleetPage.activateTextInput()
+		case " ":
+			return fleetPage.activateTextInput()
+		case "esc", "q", "Q", "ctrl+c":
+			return fleetPage.cancelTextDialog(m)
+		}
+		if isDialogTextKey(msg) {
+			return fleetPage.activateTextInputWithMsg(msg)
 		}
 	}
 
-	var cmd tea.Cmd
-	fleetPage.textInput, cmd = fleetPage.textInput.Update(msg)
-	return cmd
+	return nil
+}
+
+func (fleetPage *fleetPage) saveTagInstance(m *model) tea.Cmd {
+	tag := strings.TrimSpace(fleetPage.textInput.Value())
+
+	f, ok := m.st.Fleets[fleetPage.dialogFleet]
+	if ok {
+		if instance, err := f.GetInstance(fleetPage.dialogInst); err == nil {
+			instance.Tag = tag
+			_ = state.Save(m.st)
+		}
+	}
+
+	fleetPage.mode = viewNormal
+	fleetPage.blurDialogFields()
+	if tag == "" {
+		m.message = fmt.Sprintf("Cleared tag for %s/%s", fleetPage.dialogFleet, fleetPage.dialogInst)
+	} else {
+		m.message = fmt.Sprintf("Tagged %s/%s: %s", fleetPage.dialogFleet, fleetPage.dialogInst, tag)
+	}
+	return nil
+}
+
+func (fleetPage *fleetPage) cancelTextDialog(m *model) tea.Cmd {
+	fleetPage.mode = viewNormal
+	fleetPage.blurDialogFields()
+	m.message = "Cancelled"
+	return nil
 }
 
 // ===========================================
@@ -511,39 +692,59 @@ func (fleetPage *fleetPage) updateTagInstance(m *model, msg tea.Msg) tea.Cmd {
 func (fleetPage *fleetPage) updateAddFleet(m *model, msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		if fleetPage.dialogFieldActive {
+			switch msg.String() {
+			case "enter":
+				return fleetPage.saveAddFleet(m)
+			case "esc":
+				fleetPage.deactivateTextInput()
+				return nil
+			case "ctrl+c":
+				return fleetPage.cancelTextDialog(m)
+			}
+			var cmd tea.Cmd
+			fleetPage.textInput, cmd = fleetPage.textInput.Update(msg)
+			return cmd
+		}
+
 		switch msg.String() {
 		case "enter":
-			repoURL := strings.TrimSpace(fleetPage.textInput.Value())
-			if repoURL == "" {
-				m.message = "URL cannot be empty"
-				fleetPage.mode = viewNormal
-				return nil
-			}
-			fleetName := fleet.FleetNameFromRemote(repoURL)
-			if fleetName == "" {
-				m.message = "Could not derive fleet name from URL"
-				fleetPage.mode = viewNormal
-				return nil
-			}
-			m.st.GetOrCreateFleet(fleetName, repoURL)
-			_ = state.Save(m.st)
-			fleetPage.buildRows(m)
-			fleetPage.mode = viewNormal
-			fleetPage.textInput.Blur()
-			m.message = fmt.Sprintf("Added fleet %s", fleetName)
-			return nil
-
-		case "esc", "ctrl+c":
-			fleetPage.mode = viewNormal
-			fleetPage.textInput.Blur()
-			m.message = "Cancelled"
-			return nil
+			return fleetPage.activateTextInput()
+		case " ":
+			return fleetPage.activateTextInput()
+		case "esc", "q", "Q", "ctrl+c":
+			return fleetPage.cancelTextDialog(m)
+		}
+		if isDialogTextKey(msg) {
+			return fleetPage.activateTextInputWithMsg(msg)
 		}
 	}
 
-	var cmd tea.Cmd
-	fleetPage.textInput, cmd = fleetPage.textInput.Update(msg)
-	return cmd
+	return nil
+}
+
+func (fleetPage *fleetPage) saveAddFleet(m *model) tea.Cmd {
+	repoURL := strings.TrimSpace(fleetPage.textInput.Value())
+	if repoURL == "" {
+		m.message = "URL cannot be empty"
+		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
+		return nil
+	}
+	fleetName := fleet.FleetNameFromRemote(repoURL)
+	if fleetName == "" {
+		m.message = "Could not derive fleet name from URL"
+		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
+		return nil
+	}
+	m.st.GetOrCreateFleet(fleetName, repoURL)
+	_ = state.Save(m.st)
+	fleetPage.buildRows(m)
+	fleetPage.mode = viewNormal
+	fleetPage.blurDialogFields()
+	m.message = fmt.Sprintf("Added fleet %s", fleetName)
+	return nil
 }
 
 // ===========================================
@@ -616,6 +817,7 @@ func (fleetPage *fleetPage) openEditFleetDialog(m *model) tea.Cmd {
 	fleetPage.dialogCodexMount = f.Settings.CodexMount
 	fleetPage.dialogRow = editFleetRowClaude
 	fleetPage.dialogDetecting = false
+	fleetPage.dialogFieldActive = false
 
 	fleetPage.homedirInput.SetValue(f.Settings.HomeDir)
 	fleetPage.homedirInput.Blur()
@@ -635,23 +837,51 @@ func (fleetPage *fleetPage) updateEditFleet(m *model, msg tea.Msg) tea.Cmd {
 		return nil
 	}
 
+	if fleetPage.dialogFieldActive {
+		switch keyMsg.String() {
+		case "enter":
+			return fleetPage.saveFleetEdits(m)
+		case "esc":
+			fleetPage.dialogFieldActive = false
+			fleetPage.syncEditFleetFocus()
+			return nil
+		case "ctrl+c":
+			fleetPage.mode = viewNormal
+			fleetPage.blurDialogFields()
+			m.message = "Cancelled"
+			return nil
+		}
+		if fleetPage.dialogRow == editFleetRowHomeDir {
+			var cmd tea.Cmd
+			fleetPage.homedirInput, cmd = fleetPage.homedirInput.Update(msg)
+			return cmd
+		}
+	}
+
 	switch keyMsg.String() {
 	case "enter":
+		if fleetPage.dialogRow == editFleetRowHomeDir {
+			fleetPage.dialogFieldActive = true
+			fleetPage.syncEditFleetFocus()
+			return fleetPage.homedirInput.Cursor.BlinkCmd()
+		}
 		return fleetPage.saveFleetEdits(m)
 
-	case "up":
+	case "up", "k":
+		fleetPage.dialogFieldActive = false
 		fleetPage.dialogRow = (fleetPage.dialogRow - 1 + editFleetRowCount) % editFleetRowCount
 		fleetPage.syncEditFleetFocus()
 		return nil
 
-	case "down", "tab":
+	case "down", "j", "tab":
+		fleetPage.dialogFieldActive = false
 		fleetPage.dialogRow = (fleetPage.dialogRow + 1) % editFleetRowCount
 		fleetPage.syncEditFleetFocus()
 		return nil
 
-	case "esc", "ctrl+c":
+	case "esc", "q", "Q", "ctrl+c":
 		fleetPage.mode = viewNormal
-		fleetPage.homedirInput.Blur()
+		fleetPage.blurDialogFields()
 		m.message = "Cancelled"
 		return nil
 	}
@@ -660,14 +890,25 @@ func (fleetPage *fleetPage) updateEditFleet(m *model, msg tea.Msg) tea.Cmd {
 	switch fleetPage.dialogRow {
 	case editFleetRowClaude, editFleetRowCodex:
 		switch keyMsg.String() {
-		case " ", "left", "right", "x":
+		case " ", "left", "right", "h", "l", "x":
 			return fleetPage.toggleEditFleetRow(m)
 		}
 		return nil
 	case editFleetRowHomeDir:
-		var cmd tea.Cmd
-		fleetPage.homedirInput, cmd = fleetPage.homedirInput.Update(msg)
-		return cmd
+		switch keyMsg.String() {
+		case " ":
+			fleetPage.dialogFieldActive = true
+			fleetPage.syncEditFleetFocus()
+			return fleetPage.homedirInput.Cursor.BlinkCmd()
+		}
+		if isDialogTextKey(keyMsg) {
+			fleetPage.dialogFieldActive = true
+			fleetPage.syncEditFleetFocus()
+			blinkCmd := fleetPage.homedirInput.Cursor.BlinkCmd()
+			var inputCmd tea.Cmd
+			fleetPage.homedirInput, inputCmd = fleetPage.homedirInput.Update(msg)
+			return tea.Batch(blinkCmd, inputCmd)
+		}
 	}
 	return nil
 }
@@ -749,7 +990,7 @@ func (fleetPage *fleetPage) handleHomedirDetected(msg homedirDetectedMsg) {
 // when that row is the currently selected row. Other rows have no
 // editable text so the input must blur to avoid a stray cursor.
 func (fleetPage *fleetPage) syncEditFleetFocus() {
-	if fleetPage.dialogRow == editFleetRowHomeDir {
+	if fleetPage.dialogFieldActive && fleetPage.dialogRow == editFleetRowHomeDir {
 		fleetPage.homedirInput.Focus()
 	} else {
 		fleetPage.homedirInput.Blur()
@@ -764,6 +1005,7 @@ func (fleetPage *fleetPage) saveFleetEdits(m *model) tea.Cmd {
 	f, ok := m.st.Fleets[fleetPage.dialogFleet]
 	if !ok {
 		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
 		m.message = fmt.Sprintf("Fleet %s not found", fleetPage.dialogFleet)
 		return nil
 	}
@@ -773,7 +1015,7 @@ func (fleetPage *fleetPage) saveFleetEdits(m *model) tea.Cmd {
 	_ = state.Save(m.st)
 
 	fleetPage.mode = viewNormal
-	fleetPage.homedirInput.Blur()
+	fleetPage.blurDialogFields()
 	m.message = fmt.Sprintf("Updated %s settings", f.Name)
 	return nil
 }
@@ -788,27 +1030,26 @@ func (fleetPage *fleetPage) updatePortForward(m *model, msg tea.Msg) tea.Cmd {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		if fleetPage.dialogFieldActive {
+			switch msg.String() {
+			case "enter":
+				return fleetPage.addPortForward(m, key)
+			case "esc":
+				fleetPage.deactivateTextInput()
+				return nil
+			case "ctrl+c":
+				return fleetPage.closePortForward(m, key)
+			}
+			var cmd tea.Cmd
+			fleetPage.textInput, cmd = fleetPage.textInput.Update(msg)
+			return cmd
+		}
+
 		switch msg.String() {
 		case "enter":
-			raw := strings.TrimSpace(fleetPage.textInput.Value())
-			if raw == "" {
-				return nil
-			}
-			local, remote, err := parsePortMapping(raw)
-			if err != nil {
-				m.message = err.Error()
-				return nil
-			}
-
-			instanceBackend := m.instanceBackend(&fleet.Instance{Backend: fleetPage.instanceBackendType(m)})
-			if err := m.portForwards.Add(key, local, remote, instanceBackend.PortForwardCommand, fleetPage.pfContainerID, instanceBackend.ResolveHostname); err != nil {
-				m.message = err.Error()
-				return nil
-			}
-
-			fleetPage.textInput.SetValue("")
-			m.message = fmt.Sprintf("Forwarding localhost:%d -> %s:%d", local, fleetPage.dialogInst, remote)
-			return nil
+			return fleetPage.activateTextInput()
+		case " ":
+			return fleetPage.activateTextInput()
 
 		case "d":
 			fwds := m.portForwards.List(key)
@@ -835,22 +1076,49 @@ func (fleetPage *fleetPage) updatePortForward(m *model, msg tea.Msg) tea.Cmd {
 			}
 			return nil
 
-		case "esc", "ctrl+c":
-			fleetPage.mode = viewNormal
-			fleetPage.textInput.Blur()
-			fwds := m.portForwards.List(key)
-			if len(fwds) > 0 {
-				m.message = fmt.Sprintf("%d port forward(s) active on %s", len(fwds), fleetPage.dialogInst)
-			} else {
-				m.message = ""
-			}
-			return nil
+		case "esc", "q", "Q", "ctrl+c":
+			return fleetPage.closePortForward(m, key)
+		}
+		if isDialogTextKey(msg) {
+			return fleetPage.activateTextInputWithMsg(msg)
 		}
 	}
 
-	var cmd tea.Cmd
-	fleetPage.textInput, cmd = fleetPage.textInput.Update(msg)
-	return cmd
+	return nil
+}
+
+func (fleetPage *fleetPage) addPortForward(m *model, key string) tea.Cmd {
+	raw := strings.TrimSpace(fleetPage.textInput.Value())
+	if raw == "" {
+		return nil
+	}
+	local, remote, err := parsePortMapping(raw)
+	if err != nil {
+		m.message = err.Error()
+		return nil
+	}
+
+	instanceBackend := m.instanceBackend(&fleet.Instance{Backend: fleetPage.instanceBackendType(m)})
+	if err := m.portForwards.Add(key, local, remote, instanceBackend.PortForwardCommand, fleetPage.pfContainerID, instanceBackend.ResolveHostname); err != nil {
+		m.message = err.Error()
+		return nil
+	}
+
+	fleetPage.textInput.SetValue("")
+	m.message = fmt.Sprintf("Forwarding localhost:%d -> %s:%d", local, fleetPage.dialogInst, remote)
+	return nil
+}
+
+func (fleetPage *fleetPage) closePortForward(m *model, key string) tea.Cmd {
+	fleetPage.mode = viewNormal
+	fleetPage.blurDialogFields()
+	fwds := m.portForwards.List(key)
+	if len(fwds) > 0 {
+		m.message = fmt.Sprintf("%d port forward(s) active on %s", len(fwds), fleetPage.dialogInst)
+	} else {
+		m.message = ""
+	}
+	return nil
 }
 
 // parsePortMapping splits a "local:remote" string into two port numbers.
@@ -892,7 +1160,7 @@ func (fleetPage *fleetPage) updateCodespacesAuth(m *model, msg tea.Msg) tea.Cmd 
 					return execDoneMsg{}
 				},
 			)
-		case "esc", "ctrl+c":
+		case "esc", "q", "Q", "ctrl+c":
 			fleetPage.mode = viewNormal
 			m.message = "Auth cancelled — codespace creation requires the codespace scope"
 		}
@@ -910,7 +1178,7 @@ func (fleetPage *fleetPage) updateCodespacesMachine(m *model, msg tea.Msg) tea.C
 			fleetPage.mode = viewNormal
 			m.message = "Set the Machine field, then retry instance creation"
 			return m.ChangeRoute(routeSettings)
-		case "esc", "ctrl+c":
+		case "esc", "q", "Q", "ctrl+c":
 			fleetPage.mode = viewNormal
 			m.message = ""
 		}
@@ -924,7 +1192,7 @@ func (fleetPage *fleetPage) updateCodespacesLimit(m *model, msg tea.Msg) tea.Cmd
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "enter", "esc", "ctrl+c":
+		case "enter", "esc", "q", "Q", "ctrl+c":
 			fleetPage.mode = viewNormal
 			m.message = ""
 		}
@@ -955,102 +1223,138 @@ func (fleetPage *fleetPage) instanceBackendType(m *model) fleet.BackendType {
 func (fleetPage *fleetPage) updateCreateSession(m *model, msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		if fleetPage.dialogFieldActive {
+			switch msg.String() {
+			case "enter":
+				return fleetPage.saveCreateSession(m)
+			case "esc":
+				fleetPage.deactivateTextInput()
+				return nil
+			case "ctrl+c":
+				return fleetPage.cancelTextDialog(m)
+			}
+			var cmd tea.Cmd
+			fleetPage.textInput, cmd = fleetPage.textInput.Update(msg)
+			return cmd
+		}
+
 		switch msg.String() {
 		case "enter":
-			name := strings.TrimSpace(fleetPage.textInput.Value())
-			ref := InstanceRef{Fleet: fleetPage.dialogFleet, Instance: fleetPage.dialogInst}
-			if name == "" {
-				name = nextSessionName(m.sessionStore.Sessions(ref))
-			}
-			name = SanitizeSessionName(name)
-
-			f, ok := m.st.Fleets[fleetPage.dialogFleet]
-			if !ok {
-				fleetPage.mode = viewNormal
-				fleetPage.textInput.Blur()
-				return nil
-			}
-			instance, err := f.GetInstance(fleetPage.dialogInst)
-			if err != nil {
-				fleetPage.mode = viewNormal
-				fleetPage.textInput.Blur()
-				return nil
-			}
-
-			sanitized := SanitizeSessionName(instance.Name)
-			fullName := groupSessionName(sanitized, name)
-
-			fleetPage.mode = viewNormal
-			fleetPage.textInput.Blur()
-			m.message = fmt.Sprintf("Creating session %s...", name)
-			instanceBackend := m.instanceBackend(instance)
-			return createSessionCmd(instanceBackend, instance.WorkspaceDir, ref, fullName)
-
-		case "esc", "ctrl+c":
-			fleetPage.mode = viewNormal
-			fleetPage.textInput.Blur()
-			m.message = "Cancelled"
-			return nil
+			return fleetPage.activateTextInput()
+		case " ":
+			return fleetPage.activateTextInput()
+		case "esc", "q", "Q", "ctrl+c":
+			return fleetPage.cancelTextDialog(m)
+		}
+		if isDialogTextKey(msg) {
+			return fleetPage.activateTextInputWithMsg(msg)
 		}
 	}
 
-	var cmd tea.Cmd
-	fleetPage.textInput, cmd = fleetPage.textInput.Update(msg)
-	return cmd
+	return nil
+}
+
+func (fleetPage *fleetPage) saveCreateSession(m *model) tea.Cmd {
+	name := strings.TrimSpace(fleetPage.textInput.Value())
+	ref := InstanceRef{Fleet: fleetPage.dialogFleet, Instance: fleetPage.dialogInst}
+	if name == "" {
+		name = nextSessionName(m.sessionStore.Sessions(ref))
+	}
+	name = SanitizeSessionName(name)
+
+	f, ok := m.st.Fleets[fleetPage.dialogFleet]
+	if !ok {
+		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
+		return nil
+	}
+	instance, err := f.GetInstance(fleetPage.dialogInst)
+	if err != nil {
+		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
+		return nil
+	}
+
+	sanitized := SanitizeSessionName(instance.Name)
+	fullName := groupSessionName(sanitized, name)
+
+	fleetPage.mode = viewNormal
+	fleetPage.blurDialogFields()
+	m.message = fmt.Sprintf("Creating session %s...", name)
+	instanceBackend := m.instanceBackend(instance)
+	return createSessionCmd(instanceBackend, instance.WorkspaceDir, ref, fullName)
 }
 
 // updateRenameSession handles the dialog for renaming a tmux session.
 func (fleetPage *fleetPage) updateRenameSession(m *model, msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		if fleetPage.dialogFieldActive {
+			switch msg.String() {
+			case "enter":
+				return fleetPage.saveRenameSession(m)
+			case "esc":
+				fleetPage.deactivateTextInput()
+				return nil
+			case "ctrl+c":
+				return fleetPage.cancelTextDialog(m)
+			}
+			var cmd tea.Cmd
+			fleetPage.textInput, cmd = fleetPage.textInput.Update(msg)
+			return cmd
+		}
+
 		switch msg.String() {
 		case "enter":
-			newName := strings.TrimSpace(fleetPage.textInput.Value())
-			if newName == "" {
-				m.message = "Name cannot be empty"
-				fleetPage.mode = viewNormal
-				fleetPage.textInput.Blur()
-				return nil
-			}
-			newName = SanitizeSessionName(newName)
-
-			ref := InstanceRef{Fleet: fleetPage.dialogFleet, Instance: fleetPage.dialogInst}
-
-			f, ok := m.st.Fleets[fleetPage.dialogFleet]
-			if !ok {
-				fleetPage.mode = viewNormal
-				fleetPage.textInput.Blur()
-				return nil
-			}
-			instance, err := f.GetInstance(fleetPage.dialogInst)
-			if err != nil {
-				fleetPage.mode = viewNormal
-				fleetPage.textInput.Blur()
-				return nil
-			}
-
-			sanitized := SanitizeSessionName(instance.Name)
-			oldName := fleetPage.dialogSession
-			oldGID, isGrouped := parseGroupID(sanitized, oldName)
-
-			fleetPage.mode = viewNormal
-			fleetPage.textInput.Blur()
-			instanceBackend := m.instanceBackend(instance)
-
-			if isGrouped {
-				return renameGroupCmd(instanceBackend, instance.WorkspaceDir, ref, sanitized, oldGID, newName)
-			}
-			return renameSessionCmd(instanceBackend, instance.WorkspaceDir, ref, oldName, newName)
-
-		case "esc", "ctrl+c":
-			fleetPage.mode = viewNormal
-			fleetPage.textInput.Blur()
-			m.message = "Cancelled"
-			return nil
+			return fleetPage.activateTextInput()
+		case " ":
+			return fleetPage.activateTextInput()
+		case "esc", "q", "Q", "ctrl+c":
+			return fleetPage.cancelTextDialog(m)
+		}
+		if isDialogTextKey(msg) {
+			return fleetPage.activateTextInputWithMsg(msg)
 		}
 	}
 
-	var cmd tea.Cmd
-	fleetPage.textInput, cmd = fleetPage.textInput.Update(msg)
-	return cmd
+	return nil
+}
+
+func (fleetPage *fleetPage) saveRenameSession(m *model) tea.Cmd {
+	newName := strings.TrimSpace(fleetPage.textInput.Value())
+	if newName == "" {
+		m.message = "Name cannot be empty"
+		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
+		return nil
+	}
+	newName = SanitizeSessionName(newName)
+
+	ref := InstanceRef{Fleet: fleetPage.dialogFleet, Instance: fleetPage.dialogInst}
+
+	f, ok := m.st.Fleets[fleetPage.dialogFleet]
+	if !ok {
+		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
+		return nil
+	}
+	instance, err := f.GetInstance(fleetPage.dialogInst)
+	if err != nil {
+		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
+		return nil
+	}
+
+	sanitized := SanitizeSessionName(instance.Name)
+	oldName := fleetPage.dialogSession
+	oldGID, isGrouped := parseGroupID(sanitized, oldName)
+
+	fleetPage.mode = viewNormal
+	fleetPage.blurDialogFields()
+	instanceBackend := m.instanceBackend(instance)
+
+	if isGrouped {
+		return renameGroupCmd(instanceBackend, instance.WorkspaceDir, ref, sanitized, oldGID, newName)
+	}
+	return renameSessionCmd(instanceBackend, instance.WorkspaceDir, ref, oldName, newName)
 }

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -193,7 +193,14 @@ func isDialogRightKey(key string) bool {
 }
 
 func isDialogTextKey(msg tea.KeyMsg) bool {
-	if msg.Type != tea.KeyRunes || len(msg.Runes) == 0 || msg.Alt {
+	if msg.Alt {
+		return false
+	}
+	switch msg.Type {
+	case tea.KeyBackspace, tea.KeyDelete:
+		return true
+	}
+	if msg.Type != tea.KeyRunes || len(msg.Runes) == 0 {
 		return false
 	}
 	switch msg.String() {

--- a/internal/tui/keybindings.go
+++ b/internal/tui/keybindings.go
@@ -75,9 +75,11 @@ func keybindingsData() []keybindingGroup {
 			Title: "Dialogs",
 			Entries: []keybindingEntry{
 				{"enter", "Confirm action"},
-				{"esc", "Cancel / close"},
+				{"q / esc", "Cancel / close"},
+				{"j / k", "Navigate dialog rows"},
+				{"h / l", "Cycle dialog values"},
 				{"y / n", "Yes / no (delete)"},
-				{"tab", "Cycle backend (add)"},
+				{"enter", "Activate selected text field"},
 			},
 		},
 	}

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -447,8 +447,7 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 				fleetPage.textInput.SetValue(displayName)
 				fleetPage.textInput.Placeholder = "new-session-name"
 				fleetPage.textInput.CharLimit = 64
-				fleetPage.deactivateTextInput()
-				return nil
+				return fleetPage.activateTextInput()
 			}
 			m.reload()
 			fleetPage.buildRows(m)
@@ -526,8 +525,7 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 				fleetPage.textInput.SetValue("")
 				fleetPage.textInput.Placeholder = "session-name (or empty for auto)"
 				fleetPage.textInput.CharLimit = 64
-				fleetPage.deactivateTextInput()
-				return nil
+				return fleetPage.activateTextInput()
 			}
 			fleetName := fleetPage.currentFleetName()
 			if fleetName == "" {
@@ -562,16 +560,14 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			fleetPage.branchInput.SetValue("")
 			fleetPage.branchInput.Placeholder = "default branch"
 			fleetPage.branchInput.CharLimit = 128
-			fleetPage.syncAddInstanceFocus()
-			return nil
+			return fleetPage.activateAddInstanceField()
 
 		case "n":
 			fleetPage.mode = viewAddFleet
 			fleetPage.textInput.SetValue("")
 			fleetPage.textInput.Placeholder = "git@github.com:org/repo.git"
 			fleetPage.textInput.CharLimit = 256
-			fleetPage.deactivateTextInput()
-			return nil
+			return fleetPage.activateTextInput()
 
 		case "pgup", "pgdown":
 			if m.inHostTmux && fleetPage.splitRef.Valid() && !fleetPage.activeGroup.Empty() {
@@ -734,8 +730,7 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 		fleetPage.textInput.SetValue("")
 		fleetPage.textInput.Placeholder = "session-name (or empty for auto)"
 		fleetPage.textInput.CharLimit = 64
-		fleetPage.deactivateTextInput()
-		return nil
+		return fleetPage.activateTextInput()
 
 	case rowSession:
 		instance := r.instance

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -40,6 +40,7 @@ type fleetPage struct {
 	dialogColor       string
 	dialogRow         int
 	dialogEditing     bool
+	dialogFieldActive bool
 	dialogGroupID     string
 	dialogSession     string
 	dialogClaudeMount bool
@@ -446,8 +447,8 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 				fleetPage.textInput.SetValue(displayName)
 				fleetPage.textInput.Placeholder = "new-session-name"
 				fleetPage.textInput.CharLimit = 64
-				fleetPage.textInput.Focus()
-				return fleetPage.textInput.Cursor.BlinkCmd()
+				fleetPage.deactivateTextInput()
+				return nil
 			}
 			m.reload()
 			fleetPage.buildRows(m)
@@ -525,8 +526,8 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 				fleetPage.textInput.SetValue("")
 				fleetPage.textInput.Placeholder = "session-name (or empty for auto)"
 				fleetPage.textInput.CharLimit = 64
-				fleetPage.textInput.Focus()
-				return fleetPage.textInput.Cursor.BlinkCmd()
+				fleetPage.deactivateTextInput()
+				return nil
 			}
 			fleetName := fleetPage.currentFleetName()
 			if fleetName == "" {
@@ -554,23 +555,23 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			fleetPage.dialogColor = instanceColorWhite
 			fleetPage.dialogRow = addInstanceRowName
 			fleetPage.dialogEditing = false
+			fleetPage.dialogFieldActive = false
 			fleetPage.textInput.SetValue("")
 			fleetPage.textInput.Placeholder = "instance-name"
 			fleetPage.textInput.CharLimit = 64
-			fleetPage.textInput.Focus()
 			fleetPage.branchInput.SetValue("")
 			fleetPage.branchInput.Placeholder = "default branch"
 			fleetPage.branchInput.CharLimit = 128
-			fleetPage.branchInput.Blur()
-			return fleetPage.textInput.Cursor.BlinkCmd()
+			fleetPage.syncAddInstanceFocus()
+			return nil
 
 		case "n":
 			fleetPage.mode = viewAddFleet
 			fleetPage.textInput.SetValue("")
 			fleetPage.textInput.Placeholder = "git@github.com:org/repo.git"
 			fleetPage.textInput.CharLimit = 256
-			fleetPage.textInput.Focus()
-			return fleetPage.textInput.Cursor.BlinkCmd()
+			fleetPage.deactivateTextInput()
+			return nil
 
 		case "pgup", "pgdown":
 			if m.inHostTmux && fleetPage.splitRef.Valid() && !fleetPage.activeGroup.Empty() {
@@ -656,8 +657,8 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			fleetPage.textInput.SetValue(instance.Tag)
 			fleetPage.textInput.Placeholder = "short description"
 			fleetPage.textInput.CharLimit = 128
-			fleetPage.textInput.Focus()
-			return fleetPage.textInput.Cursor.BlinkCmd()
+			fleetPage.deactivateTextInput()
+			return nil
 
 		case "l":
 			_, instance := fleetPage.selectedInstance(m)
@@ -689,8 +690,8 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			fleetPage.textInput.SetValue("")
 			fleetPage.textInput.Placeholder = "local:remote (e.g. 8080:80)"
 			fleetPage.textInput.CharLimit = 11
-			fleetPage.textInput.Focus()
-			return fleetPage.textInput.Cursor.BlinkCmd()
+			fleetPage.deactivateTextInput()
+			return nil
 		}
 
 	case execDoneMsg:
@@ -733,8 +734,8 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 		fleetPage.textInput.SetValue("")
 		fleetPage.textInput.Placeholder = "session-name (or empty for auto)"
 		fleetPage.textInput.CharLimit = 64
-		fleetPage.textInput.Focus()
-		return fleetPage.textInput.Cursor.BlinkCmd()
+		fleetPage.deactivateTextInput()
+		return nil
 
 	case rowSession:
 		instance := r.instance
@@ -1185,7 +1186,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			"%s\n\n%s\n\n%s",
 			dialogTitle.Render(title),
 			dialogLabel.Render(body),
-			dialogHint.Render("[y] Yes  [n] No"),
+			dialogHint.Render("[y] Yes  [n/q/esc] No"),
 		)
 		b.WriteString(dialogBox.Render(dialog))
 		b.WriteString("\n")
@@ -1204,7 +1205,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 				fleetPage.dialogFleet, count,
 			)),
 			errorStyle.Render("This action cannot be undone."),
-			dialogHint.Render("[y] Confirm destroy  [n] Cancel"),
+			dialogHint.Render("[y] Confirm destroy  [n/q/esc] Cancel"),
 		)
 		b.WriteString(warnBox.Render(warnDialog))
 		b.WriteString("\n")
@@ -1223,7 +1224,11 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 		var title, hint, nameField, branchField, deployField string
 		if fleetPage.dialogEditing {
 			title = "Edit instance"
-			hint = "[↑↓] Select  [←→/space] Cycle color  [shift+tab] Color  [enter] Save  [esc] Cancel"
+			if fleetPage.dialogFieldActive {
+				hint = "[enter] Save  [esc] Done editing  [ctrl+c] Cancel"
+			} else {
+				hint = "[j/k] Select  [h/l/space] Cycle color  [shift+tab] Color  [enter] Edit/Save  [q/esc] Cancel"
+			}
 			nameField = fleetPage.textInput.View()
 			branchDisplay := fleetPage.branchInput.Value()
 			if branchDisplay == "" {
@@ -1233,9 +1238,13 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			deployField = dimStyle.Render(fmt.Sprintf("[ %s ]", backendTypeLabel(backendType)))
 		} else {
 			title = "New instance"
-			hint = "[↑↓] Select  [←→/space] Cycle  [shift+tab] Color  [enter] Create  [esc] Cancel"
-			if len(fleetPage.availableBackendTypes(m)) > 1 {
-				hint = "[↑↓] Select  [←→/space/tab] Cycle  [shift+tab] Color  [enter] Create  [esc] Cancel"
+			if fleetPage.dialogFieldActive {
+				hint = "[enter] Create  [esc] Done editing  [ctrl+c] Cancel"
+			} else {
+				hint = "[j/k] Select  [h/l/space] Cycle  [shift+tab] Color  [enter] Edit/Create  [q/esc] Cancel"
+				if len(fleetPage.availableBackendTypes(m)) > 1 {
+					hint = "[j/k] Select  [h/l/space/tab] Cycle  [shift+tab] Color  [enter] Edit/Create  [q/esc] Cancel"
+				}
 			}
 			nameField = fleetPage.textInput.View()
 			branchField = fleetPage.branchInput.View()
@@ -1282,7 +1291,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			dialogTitle.Render("New fleet"),
 			dialogLabel.Render("Repo:"),
 			fleetPage.textInput.View(),
-			dialogHint.Render("[enter] Add  [esc] Cancel"),
+			dialogHint.Render(fleetPage.textDialogHint("Add")),
 		)
 		b.WriteString(dialogBox.Render(dialog))
 		b.WriteString("\n")
@@ -1307,7 +1316,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 		// running so the user knows the field will fill in soon (or
 		// can be safely typed over to discard the result).
 		var homedirField string
-		if fleetPage.dialogRow == editFleetRowHomeDir {
+		if fleetPage.dialogFieldActive && fleetPage.dialogRow == editFleetRowHomeDir {
 			homedirField = fleetPage.homedirInput.View()
 		} else {
 			value := fleetPage.homedirInput.Value()
@@ -1336,7 +1345,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			dialogLabel.Render("Home dir: "),
 			homedirField,
 			dimStyle.Render("Mounts apply on supported backends only"),
-			dialogHint.Render("[↑↓] Select  [space] Toggle  [enter] Save  [esc] Cancel"),
+			dialogHint.Render(fleetPage.editFleetHint()),
 		)
 		b.WriteString(dialogBox.Render(dialog))
 		b.WriteString("\n")
@@ -1350,7 +1359,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			fleetExpandedStyle.Render(fleetPage.dialogFleet+"/"+fleetPage.dialogInst),
 			dialogLabel.Render("Tag:     "),
 			fleetPage.textInput.View(),
-			dialogHint.Render("[enter] Save  [esc] Cancel"),
+			dialogHint.Render(fleetPage.textDialogHint("Save")),
 		)
 		b.WriteString(dialogBox.Render(dialog))
 		b.WriteString("\n")
@@ -1384,7 +1393,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			strings.TrimRight(fwdLines.String(), "\n"),
 			dialogLabel.Render("Add:"),
 			fleetPage.textInput.View(),
-			dialogHint.Render("[enter] Add  [d] Delete selected  [j/k] Navigate  [esc] Close"),
+			dialogHint.Render(fleetPage.portForwardHint()),
 		)
 		b.WriteString(portForwardBox.Render(dialog))
 		b.WriteString("\n")
@@ -1399,7 +1408,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 					"required. Press Enter to log in and grant the required scope.",
 			),
 			dimStyle.Render("gh auth login -h github.com -s codespace"),
-			dialogHint.Render("[enter] Authenticate  [esc] Cancel"),
+			dialogHint.Render("[enter] Authenticate  [q/esc] Cancel"),
 		)
 		b.WriteString(warnBox.Render(dialog))
 		b.WriteString("\n")
@@ -1413,7 +1422,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 				"GitHub Codespaces requires a machine type but none is\n"+
 					"configured. Press Enter to open Settings and set one.",
 			),
-			dialogHint.Render("[enter] Open Settings  [esc] Cancel"),
+			dialogHint.Render("[enter] Open Settings  [q/esc] Cancel"),
 		)
 		b.WriteString(warnBox.Render(dialog))
 		b.WriteString("\n")
@@ -1428,7 +1437,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 					"Please stop some before creating a new instance,\n"+
 					"or use a different instance backend.",
 			),
-			dialogHint.Render("[enter/esc] Dismiss"),
+			dialogHint.Render("[enter/q/esc] Dismiss"),
 		)
 		b.WriteString(warnBox.Render(dialog))
 		b.WriteString("\n")
@@ -1442,7 +1451,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			fleetExpandedStyle.Render(fleetPage.dialogFleet+"/"+fleetPage.dialogInst),
 			dialogLabel.Render("Name:    "),
 			fleetPage.textInput.View(),
-			dialogHint.Render("[enter] Create (empty for auto-name)  [esc] Cancel"),
+			dialogHint.Render(fleetPage.textDialogHint("Create (empty for auto-name)")),
 		)
 		b.WriteString(dialogBox.Render(dialog))
 		b.WriteString("\n")
@@ -1458,7 +1467,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			sessionStyle.Render(fleetPage.dialogSession),
 			dialogLabel.Render("New:     "),
 			fleetPage.textInput.View(),
-			dialogHint.Render("[enter] Rename  [esc] Cancel"),
+			dialogHint.Render(fleetPage.textDialogHint("Rename")),
 		)
 		b.WriteString(dialogBox.Render(dialog))
 		b.WriteString("\n")
@@ -1474,7 +1483,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			dialogTitle.Render("Delete session"),
 			dialogLabel.Render(fmt.Sprintf("Remove session %s from %s/%s?",
 				displayName, fleetPage.dialogFleet, fleetPage.dialogInst)),
-			dialogHint.Render("[y] Yes  [n] No"),
+			dialogHint.Render("[y] Yes  [n/q/esc] No"),
 		)
 		b.WriteString(dialogBox.Render(dialog))
 		b.WriteString("\n")
@@ -1490,6 +1499,27 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 	}
 
 	return b.String()
+}
+
+func (fleetPage *fleetPage) textDialogHint(action string) string {
+	if fleetPage.dialogFieldActive {
+		return fmt.Sprintf("[enter] %s  [esc] Done editing  [ctrl+c] Cancel", action)
+	}
+	return "[enter] Edit  [q/esc] Cancel"
+}
+
+func (fleetPage *fleetPage) editFleetHint() string {
+	if fleetPage.dialogFieldActive {
+		return "[enter] Save  [esc] Done editing  [ctrl+c] Cancel"
+	}
+	return "[j/k] Select  [h/l/space] Toggle  [enter] Edit/Save  [q/esc] Cancel"
+}
+
+func (fleetPage *fleetPage) portForwardHint() string {
+	if fleetPage.dialogFieldActive {
+		return "[enter] Add  [esc] List  [ctrl+c] Close"
+	}
+	return "[j/k] Navigate  [d] Delete selected  [enter] Edit add field  [q/esc] Close"
 }
 
 // ===========================================

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -169,8 +169,8 @@ func TestViewFleetListShowsBranchItemForInstance(t *testing.T) {
 			},
 		},
 		sessionStore: NewSessionStore(),
-		stats:             map[string]*backend.ContainerStats{},
-		fleetPage:         fp,
+		stats:        map[string]*backend.ContainerStats{},
+		fleetPage:    fp,
 	}
 
 	prevResolveBranch := resolveWorkspaceBranch
@@ -284,8 +284,8 @@ func TestViewFleetListOmitsBranchItemWhenBranchIsUnavailable(t *testing.T) {
 			},
 		},
 		sessionStore: NewSessionStore(),
-		stats:             map[string]*backend.ContainerStats{},
-		fleetPage:         fp,
+		stats:        map[string]*backend.ContainerStats{},
+		fleetPage:    fp,
 	}
 
 	prevResolveBranch := resolveWorkspaceBranch
@@ -325,8 +325,8 @@ func TestViewFleetListShowsAgentWorkingIndicator(t *testing.T) {
 			map[string]state.AgentTool{"abc123": state.AgentToolClaude},
 		),
 		sessionStore: NewSessionStore(),
-		stats:             map[string]*backend.ContainerStats{},
-		fleetPage:         fp,
+		stats:        map[string]*backend.ContainerStats{},
+		fleetPage:    fp,
 	}
 
 	prevResolveBranch := resolveWorkspaceBranch
@@ -366,8 +366,8 @@ func TestViewFleetListShowsAgentWaitingIndicator(t *testing.T) {
 			map[string]state.AgentTool{"abc123": state.AgentToolClaude},
 		),
 		sessionStore: NewSessionStore(),
-		stats:             map[string]*backend.ContainerStats{},
-		fleetPage:         fp,
+		stats:        map[string]*backend.ContainerStats{},
+		fleetPage:    fp,
 	}
 
 	prevResolveBranch := resolveWorkspaceBranch
@@ -407,8 +407,8 @@ func TestViewFleetListShowsAgentOffIndicator(t *testing.T) {
 			nil,
 		),
 		sessionStore: NewSessionStore(),
-		stats:             map[string]*backend.ContainerStats{},
-		fleetPage:         fp,
+		stats:        map[string]*backend.ContainerStats{},
+		fleetPage:    fp,
 	}
 
 	prevResolveBranch := resolveWorkspaceBranch
@@ -446,10 +446,10 @@ func TestViewFleetListNoAgentIndicatorForStoppedInstance(t *testing.T) {
 		config: &state.Config{
 			AgentSettings: state.AgentSettings{ToolSelection: state.AgentToolClaude},
 		},
-		activity:          NewActivityTracker(),
+		activity:     NewActivityTracker(),
 		sessionStore: NewSessionStore(),
-		stats:             map[string]*backend.ContainerStats{},
-		fleetPage:         fp,
+		stats:        map[string]*backend.ContainerStats{},
+		fleetPage:    fp,
 	}
 
 	prevResolveBranch := resolveWorkspaceBranch
@@ -483,8 +483,8 @@ func TestEditInstanceRenamesViaDisplayName(t *testing.T) {
 			},
 		},
 		sessionStore: NewSessionStore(),
-		stats:             map[string]*backend.ContainerStats{},
-		fleetPage:         fp,
+		stats:        map[string]*backend.ContainerStats{},
+		fleetPage:    fp,
 	}
 
 	// Press 'e' on the instance row to open the edit dialog.
@@ -500,7 +500,11 @@ func TestEditInstanceRenamesViaDisplayName(t *testing.T) {
 		t.Fatalf("prefilled input = %q, want %q", got, "agent-1")
 	}
 
-	// Type a new name and submit.
+	// First Enter activates the name field, then type and submit with another Enter.
+	fp.updateAddInstance(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if !fp.dialogFieldActive {
+		t.Fatalf("expected name field to activate after first enter")
+	}
 	fp.textInput.SetValue("auth-fix")
 	fp.updateAddInstance(m, tea.KeyMsg{Type: tea.KeyEnter})
 
@@ -540,6 +544,8 @@ func TestEditInstanceRejectsEmptyName(t *testing.T) {
 	}
 
 	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	// Activate the name field, then submit an empty value.
+	fp.updateAddInstance(m, tea.KeyMsg{Type: tea.KeyEnter})
 	fp.textInput.SetValue("   ")
 	fp.updateAddInstance(m, tea.KeyMsg{Type: tea.KeyEnter})
 
@@ -734,6 +740,97 @@ func TestEditFleetEscDiscardsChanges(t *testing.T) {
 	}
 	if f.Settings.ClaudeCodeMount {
 		t.Fatalf("ClaudeCodeMount = true, expected esc to discard the toggle")
+	}
+}
+
+func TestAddInstanceDialogVimKeysRespectActiveField(t *testing.T) {
+	fp := newFleetPage()
+	fp.mode = viewAddInstance
+	fp.dialogFleet = "alpha"
+	fp.dialogBackend = fleet.BackendDevcontainer
+	fp.dialogColor = instanceColorWhite
+	fp.dialogRow = addInstanceRowName
+	fp.dialogFieldActive = true
+	fp.textInput.Focus()
+	m := &model{}
+
+	fp.updateAddInstance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if got := fp.textInput.Value(); got != "k" {
+		t.Fatalf("active name input = %q, want k", got)
+	}
+	if fp.dialogRow != addInstanceRowName {
+		t.Fatalf("dialogRow moved while input active: got %d", fp.dialogRow)
+	}
+
+	fp.updateAddInstance(m, tea.KeyMsg{Type: tea.KeyEsc})
+	if fp.dialogFieldActive {
+		t.Fatal("dialogFieldActive should be false after esc from active field")
+	}
+
+	fp.updateAddInstance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if fp.dialogRow != addInstanceRowBranch {
+		t.Fatalf("dialogRow = %d, want branch row", fp.dialogRow)
+	}
+	fp.updateAddInstance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if fp.dialogRow != addInstanceRowColor {
+		t.Fatalf("dialogRow = %d, want color row", fp.dialogRow)
+	}
+	fp.updateAddInstance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if fp.dialogColor != "red" {
+		t.Fatalf("dialogColor = %q, want red after l", fp.dialogColor)
+	}
+	fp.updateAddInstance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if fp.mode != viewNormal {
+		t.Fatalf("mode after q = %v, want viewNormal", fp.mode)
+	}
+}
+
+func TestEditFleetDialogVimKeysAndActiveHomedir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	f := &fleet.Fleet{Name: "alpha", Instances: []*fleet.Instance{}}
+	fp := newFleetPage()
+	fp.mode = viewEditFleet
+	fp.dialogFleet = "alpha"
+	fp.dialogRow = editFleetRowClaude
+	m := &model{
+		st:        &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}},
+		fleetPage: fp,
+	}
+
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if fp.dialogRow != editFleetRowCodex {
+		t.Fatalf("dialogRow = %d, want codex row", fp.dialogRow)
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if !fp.dialogCodexMount {
+		t.Fatal("l should toggle selected codex row")
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if fp.dialogRow != editFleetRowHomeDir {
+		t.Fatalf("dialogRow = %d, want home-dir row", fp.dialogRow)
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if !fp.dialogFieldActive {
+		t.Fatal("enter on home-dir row should activate text field")
+	}
+
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if got := fp.homedirInput.Value(); got != "k" {
+		t.Fatalf("active home-dir input = %q, want k", got)
+	}
+	if fp.dialogRow != editFleetRowHomeDir {
+		t.Fatalf("dialogRow moved while home-dir active: got %d", fp.dialogRow)
+	}
+
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEsc})
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if fp.dialogRow != editFleetRowCodex {
+		t.Fatalf("dialogRow = %d, want codex row after inactive k", fp.dialogRow)
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if fp.mode != viewNormal {
+		t.Fatalf("mode after q = %v, want viewNormal", fp.mode)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Dialogs now use the same vim-style scheme as the settings page: `j/k` navigate rows, `h/l` cycle values, `q` cancels alongside `esc`.
- Text fields have an active/editing mode so `h/j/k/l/q` can be typed without moving selection or closing the dialog. `enter` activates the field; printable typing auto-activates too.
- Applies to add/edit instance, edit fleet (including HomeDir text row), new fleet, tag instance, port forwards (add field), new/rename session, and the codespaces warning dialogs.
- Keybindings dialog updated to advertise `q/esc`, `j/k`, and `h/l`.

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`
- [ ] Manually: open add-instance, navigate with j/k, cycle color/deploy with h/l, activate name with enter, type, submit with enter, cancel with q
- [ ] Manually: open edit-fleet, toggle Claude/Codex with h/l/space, navigate to HomeDir, type to auto-activate, submit
- [ ] Manually: tag/new-fleet/new-session/rename-session/port-forward — start typing a printable char and confirm the field activates

🤖 Generated with [Claude Code](https://claude.com/claude-code)