### PR TITLE
feat(agentdetect): Claude Code state detection via lifecycle hooks

### DIFF
--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -12,7 +12,11 @@ on:
 jobs:
   integration-wsl:
     runs-on: windows-latest
-    timeout-minutes: 40
+    # Healthy WSL CI runs sit around 25–28 minutes; WSL2-on-Windows
+    # is materially slower than the Linux job and individual runs
+    # can drift another ~10 minutes on a noisy runner. 60 minutes
+    # gives comfortable headroom without masking real regressions.
+    timeout-minutes: 60
     # WSLENV tells wsl.exe which Windows env vars to surface inside WSL.
     # The /p flag rewrites the path from D:\...  to /mnt/d/..., so
     # run.sh can write the markdown step summary to the real file the

--- a/internal/agentdetect/backend_executor.go
+++ b/internal/agentdetect/backend_executor.go
@@ -1,0 +1,64 @@
+package agentdetect
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// ===========================================
+// BackendExecutor
+// ===========================================
+
+// BackendExecutor adapts a backend.Backend's ExecCommand into the
+// ContainerExecutor surface the provisioner consumes.
+//
+// The provisioner is deliberately decoupled from the backend
+// package — it knows nothing about devcontainer vs Coder vs
+// Codespaces — so this adapter is the single place that concrete
+// transport details (which exec wrapper, which workspace dir) get
+// wired in.
+type BackendExecutor struct {
+	backend      backend.Backend
+	workspaceDir string
+}
+
+// ===========================================
+// Constructors
+// ===========================================
+
+// NewBackendExecutor returns a ContainerExecutor that runs commands
+// against the given backend's ExecCommand surface, anchored at the
+// given workspace directory (the same wsDir create.Run uses for
+// dotfiles install and other setup steps).
+func NewBackendExecutor(target backend.Backend, workspaceDir string) *BackendExecutor {
+	return &BackendExecutor{backend: target, workspaceDir: workspaceDir}
+}
+
+// ===========================================
+// ContainerExecutor implementation
+// ===========================================
+
+// Run delegates to backend.ExecCommand with stdin / stdout / stderr
+// wired into in-memory buffers. On non-zero exit the wrapped error
+// includes the trimmed stderr so callers have a useful diagnostic
+// without having to manage pipes themselves.
+func (b *BackendExecutor) Run(args []string, stdin []byte) ([]byte, error) {
+	cmd := b.backend.ExecCommand(b.workspaceDir, args)
+	if stdin != nil {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		detail := strings.TrimSpace(stderr.String())
+		if detail != "" {
+			return nil, fmt.Errorf("%w: %s", err, detail)
+		}
+		return nil, err
+	}
+	return stdout.Bytes(), nil
+}

--- a/internal/agentdetect/claude_detector.go
+++ b/internal/agentdetect/claude_detector.go
@@ -1,0 +1,64 @@
+package agentdetect
+
+import (
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// ===========================================
+// ClaudeHookDetector
+// ===========================================
+
+// ClaudeHookDetector derives Claude Code's run state from the state
+// file the in-container fleet-man-state-hook script writes on every
+// hook event we register (UserPromptSubmit, PreToolUse, PostToolUse,
+// Notification, Stop).
+//
+// Stateless by design: every Detect call inspects only the latest
+// state-file contents from the capture. The hook script is the
+// source of truth — fleet-man does not try to second-guess Claude's
+// own lifecycle.
+//
+// Fallback semantics for the "no signal" cases (file absent, empty,
+// or unparseable):
+//
+//   The activity tracker only routes captures to a detector after
+//   the agent-tool probe has confirmed Claude is alive. Reaching
+//   Detect with an empty state file therefore means "Claude is
+//   running but has not yet emitted a hook event" — fresh
+//   container, hook script not yet provisioned (pre-Phase-4), or
+//   fresh session with no UserPromptSubmit yet. In all of those the
+//   safe display is StateWaiting (Claude exists, idle from our
+//   perspective) rather than StateNotRunning (which would
+//   contradict the probe).
+type ClaudeHookDetector struct{}
+
+// ===========================================
+// Constructors
+// ===========================================
+
+// NewClaudeHookDetector returns a fresh detector instance. The type
+// holds no state, but a constructor is provided for symmetry with
+// the rest of the package and to leave room for future per-instance
+// configuration (e.g., an alternate state file path for tests).
+func NewClaudeHookDetector() *ClaudeHookDetector {
+	return &ClaudeHookDetector{}
+}
+
+// ===========================================
+// Detector implementation
+// ===========================================
+
+// Detect reads the Claude state file out of the capture's ExtraFiles
+// and decodes it. The time argument is unused — the hook script
+// already stamps each transition; the detector simply reports the
+// most recent value.
+func (d *ClaudeHookDetector) Detect(capture backend.AllSessions, _ time.Time) State {
+	content := capture.ExtraFiles[ClaudeStateFilePath]
+	reading, ok := ParseClaudeStateFile(content)
+	if !ok {
+		return StateWaiting
+	}
+	return reading.State
+}

--- a/internal/agentdetect/claude_detector_test.go
+++ b/internal/agentdetect/claude_detector_test.go
@@ -1,0 +1,113 @@
+package agentdetect
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// TestCaptureScriptCoversClaudeStatePath is the cross-package
+// contract test: the backend's CaptureAllScript must read from a
+// directory that includes the path the hook script writes to. If
+// either side is renamed without the other, the integration breaks
+// silently — Detect() would always see empty ExtraFiles and
+// indefinitely report StateWaiting.
+func TestCaptureScriptCoversClaudeStatePath(t *testing.T) {
+	if !strings.Contains(backend.CaptureAllScript, ClaudeStateDir) {
+		t.Errorf("backend.CaptureAllScript does not reference ClaudeStateDir %q",
+			ClaudeStateDir)
+	}
+	if !strings.HasPrefix(ClaudeStateFilePath, ClaudeStateDir+"/") {
+		t.Errorf("ClaudeStateFilePath %q is not under ClaudeStateDir %q",
+			ClaudeStateFilePath, ClaudeStateDir)
+	}
+}
+
+// captureWithFile builds a minimal AllSessions snapshot containing
+// only one ExtraFiles entry — enough to exercise the detector
+// without entangling tmux-session shape.
+func captureWithFile(path, content string) backend.AllSessions {
+	return backend.AllSessions{
+		ExtraFiles: map[string]string{path: content},
+		OK:         true,
+	}
+}
+
+// TestClaudeHookDetector_DecodesState exercises the round-trip from
+// state-file content to the detector's reported State for every
+// shape the file can take in the wild.
+func TestClaudeHookDetector_DecodesState(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    State
+	}{
+		{"working", "working 1700000000\n", StateWorking},
+		{"waiting", "waiting 1700000000\n", StateWaiting},
+		{"empty content (no signal yet)", "", StateWaiting},
+		{"unparseable content", "garbled@#$\n", StateWaiting},
+		{"unknown sentinel from script", "unknown 100\n", StateWaiting},
+		{"future state we don't yet handle", "thinking 100\n", StateWaiting},
+		{"missing timestamp", "working\n", StateWaiting},
+	}
+
+	detector := NewClaudeHookDetector()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			capture := captureWithFile(ClaudeStateFilePath, tc.content)
+			got := detector.Detect(capture, time.Now())
+			if got != tc.want {
+				t.Errorf("Detect = %d, want %d (content=%q)", got, tc.want, tc.content)
+			}
+		})
+	}
+}
+
+// TestClaudeHookDetector_HandlesNilExtraFiles verifies the detector
+// safely tolerates a capture where ExtraFiles was never populated —
+// the zero-value path before any state file has been captured.
+func TestClaudeHookDetector_HandlesNilExtraFiles(t *testing.T) {
+	detector := NewClaudeHookDetector()
+	capture := backend.AllSessions{OK: true} // ExtraFiles is nil
+	if got := detector.Detect(capture, time.Now()); got != StateWaiting {
+		t.Errorf("Detect with nil ExtraFiles = %d, want StateWaiting", got)
+	}
+}
+
+// TestClaudeHookDetector_IgnoresOtherFiles guards against the
+// detector accidentally reading from another tool's state file
+// (e.g., a future codex-state) and reporting Claude state derived
+// from it. Only the Claude-specific path counts.
+func TestClaudeHookDetector_IgnoresOtherFiles(t *testing.T) {
+	detector := NewClaudeHookDetector()
+	capture := backend.AllSessions{
+		ExtraFiles: map[string]string{
+			"/tmp/fleet-man/codex-state": "working 1700000000",
+			"/tmp/some/unrelated":        "waiting 1700000000",
+		},
+		OK: true,
+	}
+	if got := detector.Detect(capture, time.Now()); got != StateWaiting {
+		t.Errorf("Detect = %d, want StateWaiting (Claude file absent)", got)
+	}
+}
+
+// TestClaudeHookDetector_StatelessAcrossCalls verifies the detector
+// does not retain memory between calls — switching the file
+// content between calls flips the state reliably, with no smoothing
+// or hysteresis.
+func TestClaudeHookDetector_StatelessAcrossCalls(t *testing.T) {
+	detector := NewClaudeHookDetector()
+
+	if got := detector.Detect(captureWithFile(ClaudeStateFilePath, "working 100"), time.Now()); got != StateWorking {
+		t.Fatalf("first call: got %d, want StateWorking", got)
+	}
+	if got := detector.Detect(captureWithFile(ClaudeStateFilePath, "waiting 200"), time.Now()); got != StateWaiting {
+		t.Fatalf("second call: got %d, want StateWaiting", got)
+	}
+	if got := detector.Detect(captureWithFile(ClaudeStateFilePath, "working 300"), time.Now()); got != StateWorking {
+		t.Fatalf("third call: got %d, want StateWorking", got)
+	}
+}

--- a/internal/agentdetect/claude_hook_script.go
+++ b/internal/agentdetect/claude_hook_script.go
@@ -1,0 +1,39 @@
+package agentdetect
+
+import _ "embed"
+
+// ===========================================
+// Embedded hook script
+// ===========================================
+//
+// fleet-man-state-hook is a tiny POSIX-sh script that Claude Code
+// invokes on every lifecycle event we register hooks for. The script
+// writes a single line of "<state> <unix-secs>" to ClaudeStateFilePath
+// inside the container, which the host then reads via the existing
+// container-exec capture path.
+//
+// The script is embedded into the fleet-man binary at build time so
+// there is exactly one source of truth and shipping fleet-man drops
+// nothing else on the user's host. Phase 3 / 4 of this feature will
+// copy these bytes into the container and chmod them executable.
+
+// ClaudeHookScript is the embedded shell script that runs as the
+// command for every fleet-man-managed Claude Code hook entry.
+//
+//go:embed claude_hook_script.sh
+var ClaudeHookScript []byte
+
+// ===========================================
+// Container-side paths
+// ===========================================
+
+// ClaudeStateDir is the directory inside each container where the
+// hook script writes its state file. Must match the default
+// STATE_DIR in claude_hook_script.sh — they are the wire contract
+// between host and container.
+const ClaudeStateDir = "/tmp/fleet-man"
+
+// ClaudeStateFilePath is the absolute path inside each container of
+// the single-line state file the hook script writes. The host reads
+// this path back to derive the agent's run state.
+const ClaudeStateFilePath = ClaudeStateDir + "/claude-state"

--- a/internal/agentdetect/claude_hook_script.sh
+++ b/internal/agentdetect/claude_hook_script.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# fleet-man-state-hook — Claude Code lifecycle event handler.
+#
+# Invoked by Claude Code via the hook entries fleet-man installs in
+# ~/.claude/settings.json. Writes a single-line "<state> <unix-secs>"
+# file that the host reads back via `docker exec cat` to derive the
+# activity tracker's per-container view of Claude's run state.
+#
+# Usage: fleet-man-state-hook <EventName>
+#
+# Stdin receives a JSON event payload from Claude Code. We drain it
+# without parsing because fleet-man only cares which event fired,
+# not the per-event details — and not draining risks SIGPIPE on the
+# Claude side once the pipe buffer fills.
+#
+# Output file format:
+#
+#   <state> <unix-secs>\n
+#
+#   state    one of: working, waiting, unknown
+#   secs     seconds since epoch when this event was processed
+#
+# State mapping rationale:
+#
+#   UserPromptSubmit / PreToolUse / PostToolUse → working
+#       Claude is mid-turn: the user just kicked it off, a tool is
+#       about to run, or a tool just finished and Claude is
+#       processing the result.
+#
+#   Notification / Stop → waiting
+#       Claude finished its turn (Stop) or paused for user attention
+#       (Notification — permission prompts, idle prompts, etc.).
+#
+# Environment overrides (test/debug only):
+#
+#   FLEET_MAN_STATE_DIR — alternate state directory. Defaults to
+#                        /tmp/fleet-man. The host reads from the
+#                        default; overriding it in production will
+#                        decouple the writer and reader.
+
+set -eu
+
+# Drain stdin so Claude Code never blocks on a write to our pipe.
+cat > /dev/null
+
+EVENT="${1:-unknown}"
+STATE_DIR="${FLEET_MAN_STATE_DIR:-/tmp/fleet-man}"
+STATE_FILE="${STATE_DIR}/claude-state"
+
+case "$EVENT" in
+  UserPromptSubmit|PreToolUse|PostToolUse) STATE="working" ;;
+  Notification|Stop)                       STATE="waiting" ;;
+  *)                                       STATE="unknown" ;;
+esac
+
+NOW=$(date +%s)
+mkdir -p "$STATE_DIR"
+
+# Atomic write: same-directory tmp + rename, so a concurrent reader
+# never sees a half-written line.
+TMP="${STATE_FILE}.tmp.$$"
+printf '%s %s\n' "$STATE" "$NOW" > "$TMP"
+mv -f "$TMP" "$STATE_FILE"

--- a/internal/agentdetect/claude_hook_script_test.go
+++ b/internal/agentdetect/claude_hook_script_test.go
@@ -1,0 +1,121 @@
+package agentdetect
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestClaudeHookScript_RunnableEndToEnd executes the embedded hook
+// script in a real subprocess, then parses the resulting state file
+// with ParseClaudeStateFile. This is the canary that locks the
+// wire-format contract between the script and the parser: rename
+// either side without updating the other and this test fails.
+//
+// We exercise every event fleet-man manages plus an unknown event
+// (which the script must classify as "unknown" and the parser must
+// then refuse to interpret).
+func TestClaudeHookScript_RunnableEndToEnd(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh not available on this host: %v", err)
+	}
+
+	cases := []struct {
+		event     string
+		wantOK    bool
+		wantState State
+	}{
+		{"UserPromptSubmit", true, StateWorking},
+		{"PreToolUse", true, StateWorking},
+		{"PostToolUse", true, StateWorking},
+		{"Notification", true, StateWaiting},
+		{"Stop", true, StateWaiting},
+		{"SomeUnknownEvent", false, StateNotRunning},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.event, func(t *testing.T) {
+			tmp := t.TempDir()
+			scriptPath := filepath.Join(tmp, "fleet-man-state-hook.sh")
+			stateDir := filepath.Join(tmp, "state")
+
+			if err := os.WriteFile(scriptPath, ClaudeHookScript, 0o755); err != nil {
+				t.Fatalf("write script: %v", err)
+			}
+
+			cmd := exec.Command(sh, scriptPath, tc.event)
+			cmd.Env = append(os.Environ(), "FLEET_MAN_STATE_DIR="+stateDir)
+			// Simulate Claude Code piping a JSON event payload — the
+			// script must drain stdin without parsing.
+			cmd.Stdin = strings.NewReader(`{"hook_event_name":"` + tc.event + `","cwd":"/x"}`)
+
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("script exited non-zero: %v\noutput: %s", err, out)
+			}
+
+			stateFile := filepath.Join(stateDir, "claude-state")
+			content, err := os.ReadFile(stateFile)
+			if err != nil {
+				t.Fatalf("read state file: %v", err)
+			}
+
+			reading, ok := ParseClaudeStateFile(string(content))
+			if ok != tc.wantOK {
+				t.Errorf("parser ok=%v, want %v (raw=%q)", ok, tc.wantOK, content)
+			}
+			if ok && reading.State != tc.wantState {
+				t.Errorf("state=%d, want %d (raw=%q)", reading.State, tc.wantState, content)
+			}
+		})
+	}
+}
+
+// TestClaudeHookScript_AtomicReplace verifies that running the
+// script a second time replaces the file contents rather than
+// appending. The script writes via mv; an accidental append would
+// produce two lines and the parser would still read the first
+// (stale) one.
+func TestClaudeHookScript_AtomicReplace(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh not available: %v", err)
+	}
+
+	tmp := t.TempDir()
+	scriptPath := filepath.Join(tmp, "fleet-man-state-hook.sh")
+	stateDir := filepath.Join(tmp, "state")
+
+	if err := os.WriteFile(scriptPath, ClaudeHookScript, 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	run := func(event string) {
+		cmd := exec.Command(sh, scriptPath, event)
+		cmd.Env = append(os.Environ(), "FLEET_MAN_STATE_DIR="+stateDir)
+		cmd.Stdin = strings.NewReader("{}")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("script(%s) failed: %v\noutput: %s", event, err, out)
+		}
+	}
+
+	run("PreToolUse")
+	run("Stop")
+
+	content, err := os.ReadFile(filepath.Join(stateDir, "claude-state"))
+	if err != nil {
+		t.Fatalf("read state file: %v", err)
+	}
+	// File should contain exactly one line: the most recent write.
+	lines := strings.Split(strings.TrimRight(string(content), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected 1 line after second run, got %d: %q", len(lines), content)
+	}
+	reading, ok := ParseClaudeStateFile(string(content))
+	if !ok || reading.State != StateWaiting {
+		t.Errorf("second write did not replace first: state=%d ok=%v raw=%q",
+			reading.State, ok, content)
+	}
+}

--- a/internal/agentdetect/claude_integration_test.go
+++ b/internal/agentdetect/claude_integration_test.go
@@ -1,0 +1,266 @@
+package agentdetect
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// ===========================================
+// Local executor for end-to-end testing
+// ===========================================
+
+// localExecutor is a test ContainerExecutor that runs commands on
+// the host machine with an overridden HOME. It mirrors the
+// production BackendExecutor's stdin/stdout/stderr wiring so the
+// provisioner exercises the real code paths it would in a live
+// container; only the transport (process exec vs container exec)
+// differs.
+type localExecutor struct {
+	home string
+}
+
+// Run satisfies ContainerExecutor.
+func (l *localExecutor) Run(args []string, stdin []byte) ([]byte, error) {
+	if len(args) == 0 {
+		return nil, fmt.Errorf("localExecutor: empty args")
+	}
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Env = append(os.Environ(), "HOME="+l.home)
+	if stdin != nil {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
+// ===========================================
+// End-to-end pipeline test
+// ===========================================
+
+// TestEndToEnd_ClaudeStateDetection exercises the entire Phase
+// 1-through-4 pipeline against the host filesystem:
+//
+//	provisioner ──▶ drops script  ──┐
+//	             ──▶ writes settings─┘
+//	                                 ▼
+//	(test simulating Claude Code fires hook for each event)
+//	                                 │
+//	                                 ▼
+//	                         /tmp-equivalent/claude-state
+//	                                 │
+//	                                 ▼
+//	            (test reads state file → constructs capture)
+//	                                 │
+//	                                 ▼
+//	                      ClaudeHookDetector.Detect → State
+//
+// Each Claude Code lifecycle event we install a hook for is fired
+// in turn, and the detector's reported state is asserted against
+// the expected mapping. The test "container" is the host with
+// $HOME redirected to a temp dir; FLEET_MAN_STATE_DIR likewise
+// points at a temp dir so we never touch /tmp/fleet-man on the
+// real host.
+func TestEndToEnd_ClaudeStateDetection(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("sh not available on this host: %v", err)
+	}
+
+	home := t.TempDir()
+	stateDir := t.TempDir()
+
+	// Phase 4: provisioner
+	if err := NewClaudeProvisioner(&localExecutor{home: home}).Provision(); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	// Phase 4 contract: script lives at $HOME/<suffix> and is
+	// executable.
+	scriptPath := filepath.Join(home, FleetManScriptSuffix)
+	info, err := os.Stat(scriptPath)
+	if err != nil {
+		t.Fatalf("hook script not at %s: %v", scriptPath, err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Errorf("hook script lacks executable bit: %v", info.Mode())
+	}
+
+	// Phase 1 / 4 contract: settings.json contains our hook entry
+	// for every managed event, with the resolved absolute path.
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	settingsBytes, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	settings := string(settingsBytes)
+	for _, event := range fleetManManagedEvents {
+		marker := scriptPath + " " + event
+		if !strings.Contains(settings, marker) {
+			t.Errorf("settings.json missing entry %q\n%s", marker, settings)
+		}
+	}
+
+	// Phase 2 / 3 / 4 contract: Claude firing each event must
+	// produce a state file the detector decodes correctly.
+	detector := NewClaudeHookDetector()
+	cases := []struct {
+		event string
+		want  State
+	}{
+		{"UserPromptSubmit", StateWorking},
+		{"PreToolUse", StateWorking},
+		{"PostToolUse", StateWorking},
+		{"Stop", StateWaiting},
+		{"Notification", StateWaiting},
+	}
+	for _, tc := range cases {
+		t.Run(tc.event, func(t *testing.T) {
+			fireHookAsClaude(t, scriptPath, stateDir, tc.event)
+
+			content, err := os.ReadFile(filepath.Join(stateDir, "claude-state"))
+			if err != nil {
+				t.Fatalf("read state file: %v", err)
+			}
+
+			// Build the synthetic capture the backend would produce.
+			// The map key is ClaudeStateFilePath (the production
+			// path) — only the contents matter for the detector.
+			capture := backend.AllSessions{
+				ExtraFiles: map[string]string{
+					ClaudeStateFilePath: string(content),
+				},
+				OK: true,
+			}
+			got := detector.Detect(capture, time.Now())
+			if got != tc.want {
+				t.Errorf("event=%s: detector=%d, want=%d (state file: %q)",
+					tc.event, got, tc.want, content)
+			}
+		})
+	}
+}
+
+// TestEndToEnd_LifecycleTransitions simulates a realistic Claude
+// session — UserPromptSubmit → tool calls → Stop, then a second
+// turn — and asserts the detector tracks the transitions in real
+// time. This is the closest test to "watch fleet-man's TUI report
+// the right state as a real conversation happens".
+func TestEndToEnd_LifecycleTransitions(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("sh not available: %v", err)
+	}
+
+	home := t.TempDir()
+	stateDir := t.TempDir()
+
+	if err := NewClaudeProvisioner(&localExecutor{home: home}).Provision(); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	scriptPath := filepath.Join(home, FleetManScriptSuffix)
+
+	detector := NewClaudeHookDetector()
+	stateAfter := func(event string) State {
+		fireHookAsClaude(t, scriptPath, stateDir, event)
+		content, err := os.ReadFile(filepath.Join(stateDir, "claude-state"))
+		if err != nil {
+			t.Fatalf("read state file after %s: %v", event, err)
+		}
+		return detector.Detect(backend.AllSessions{
+			ExtraFiles: map[string]string{ClaudeStateFilePath: string(content)},
+			OK:         true,
+		}, time.Now())
+	}
+
+	// Conversation turn 1: user submits, Claude runs tools, finishes.
+	if got := stateAfter("UserPromptSubmit"); got != StateWorking {
+		t.Errorf("after UserPromptSubmit: got %d, want StateWorking", got)
+	}
+	if got := stateAfter("PreToolUse"); got != StateWorking {
+		t.Errorf("after PreToolUse: got %d, want StateWorking", got)
+	}
+	if got := stateAfter("PostToolUse"); got != StateWorking {
+		t.Errorf("after PostToolUse: got %d, want StateWorking", got)
+	}
+	if got := stateAfter("Stop"); got != StateWaiting {
+		t.Errorf("after Stop: got %d, want StateWaiting", got)
+	}
+
+	// Conversation turn 2: user submits again, Claude pauses for
+	// permission (Notification), then completes.
+	if got := stateAfter("UserPromptSubmit"); got != StateWorking {
+		t.Errorf("turn 2 UserPromptSubmit: got %d, want StateWorking", got)
+	}
+	if got := stateAfter("Notification"); got != StateWaiting {
+		t.Errorf("after Notification (permission prompt): got %d, want StateWaiting", got)
+	}
+	if got := stateAfter("PostToolUse"); got != StateWorking {
+		t.Errorf("after permission granted (PostToolUse): got %d, want StateWorking", got)
+	}
+	if got := stateAfter("Stop"); got != StateWaiting {
+		t.Errorf("turn 2 Stop: got %d, want StateWaiting", got)
+	}
+}
+
+// TestEndToEnd_ProvisionIdempotent asserts running Provision a
+// second time against an already-provisioned directory leaves
+// settings.json byte-identical and the hook script unchanged. This
+// is what fleet-man relies on to safely re-provision on every
+// instance create without risk of file growth or drift.
+func TestEndToEnd_ProvisionIdempotent(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("sh not available: %v", err)
+	}
+
+	home := t.TempDir()
+	executor := &localExecutor{home: home}
+
+	if err := NewClaudeProvisioner(executor).Provision(); err != nil {
+		t.Fatalf("first Provision: %v", err)
+	}
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	scriptPath := filepath.Join(home, FleetManScriptSuffix)
+
+	settingsBefore, _ := os.ReadFile(settingsPath)
+	scriptBefore, _ := os.ReadFile(scriptPath)
+
+	if err := NewClaudeProvisioner(executor).Provision(); err != nil {
+		t.Fatalf("second Provision: %v", err)
+	}
+
+	settingsAfter, _ := os.ReadFile(settingsPath)
+	scriptAfter, _ := os.ReadFile(scriptPath)
+
+	if !bytes.Equal(settingsBefore, settingsAfter) {
+		t.Errorf("settings.json changed on re-provision\nbefore:\n%s\nafter:\n%s",
+			settingsBefore, settingsAfter)
+	}
+	if !bytes.Equal(scriptBefore, scriptAfter) {
+		t.Errorf("hook script changed on re-provision")
+	}
+}
+
+// fireHookAsClaude exec's the hook script the way Claude Code
+// would — pass the event name as argv[1] and pipe a JSON payload
+// on stdin.
+func fireHookAsClaude(t *testing.T, scriptPath, stateDir, event string) {
+	t.Helper()
+	cmd := exec.Command(scriptPath, event)
+	cmd.Env = append(os.Environ(), "FLEET_MAN_STATE_DIR="+stateDir)
+	cmd.Stdin = strings.NewReader(`{"hook_event_name":"` + event + `","cwd":"/workspace"}`)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("hook script failed for event %s: %v\noutput: %s", event, err, out)
+	}
+}

--- a/internal/agentdetect/claude_provisioner.go
+++ b/internal/agentdetect/claude_provisioner.go
@@ -1,0 +1,156 @@
+package agentdetect
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// ===========================================
+// ClaudeProvisioner
+// ===========================================
+//
+// ClaudeProvisioner installs the two pieces of in-container state
+// fleet-man needs to read Claude Code's run state from hooks:
+//
+//   1. The state-writing shell script at FleetManHookCommand,
+//      copied from ClaudeHookScript bytes embedded in the binary
+//      and made executable.
+//
+//   2. Hook entries in ~/.claude/settings.json that point at that
+//      script for every event we care about, merged into the
+//      user's existing settings via the safe-edit logic in
+//      claude_settings.go.
+//
+// Idempotent: re-running Provision against a fully-provisioned
+// container produces the same end state. The hook script is
+// rewritten verbatim (cheap; bytes are identical) and
+// InjectFleetManHooks is itself idempotent on its own output.
+//
+// Atomicity: settings.json is written to a same-directory tmp file
+// then renamed, so a reader is never exposed to a partially-written
+// document. The hook script itself is dropped in two steps (mkdir
+// + cat); a crash between them just leaves a non-existent file the
+// next Provision call recreates.
+
+// ClaudeProvisioner orchestrates installation of the in-container
+// state-hook script and hook entries.
+type ClaudeProvisioner struct {
+	exec ContainerExecutor
+}
+
+// ===========================================
+// Constructors
+// ===========================================
+
+// NewClaudeProvisioner returns a provisioner that runs commands
+// inside the target container via the given executor.
+func NewClaudeProvisioner(exec ContainerExecutor) *ClaudeProvisioner {
+	return &ClaudeProvisioner{exec: exec}
+}
+
+// ===========================================
+// Public API
+// ===========================================
+
+// Provision drops the hook script and edits settings.json. Errors
+// are wrapped with phase context so a partial failure tells the
+// caller which step did not complete; the caller may choose to
+// surface them as warnings rather than aborting container
+// creation.
+//
+// The first step is a $HOME query — the hook script lives under
+// $HOME/<FleetManScriptSuffix>, which varies per container because
+// different devcontainer remoteUsers have different home dirs.
+// Doing this query once at provision time and baking the absolute
+// path into settings.json keeps Claude Code's hook command field
+// independent of any shell expansion behaviour.
+func (p *ClaudeProvisioner) Provision() error {
+	scriptPath, err := p.resolveScriptPath()
+	if err != nil {
+		return fmt.Errorf("resolve script path: %w", err)
+	}
+	if err := p.dropHookScript(scriptPath); err != nil {
+		return fmt.Errorf("install hook script: %w", err)
+	}
+	if err := p.injectSettings(scriptPath); err != nil {
+		return fmt.Errorf("edit settings.json: %w", err)
+	}
+	return nil
+}
+
+// ===========================================
+// Private helpers
+// ===========================================
+
+// resolveScriptPath asks the container for $HOME and joins it with
+// FleetManScriptSuffix to produce the absolute path the hook script
+// will be dropped at and that settings.json will reference.
+func (p *ClaudeProvisioner) resolveScriptPath() (string, error) {
+	out, err := p.exec.Run([]string{"sh", "-c", "echo \"$HOME\""}, nil)
+	if err != nil {
+		return "", err
+	}
+	home := strings.TrimSpace(string(out))
+	if home == "" {
+		return "", fmt.Errorf("container reported empty $HOME")
+	}
+	return path.Join(home, FleetManScriptSuffix), nil
+}
+
+// dropHookScript writes the embedded hook script bytes to scriptPath
+// and sets the executable bit. mkdir of the parent directory
+// guarantees the path exists even on a fresh container that has
+// never had ~/.fleet/scripts before.
+//
+// All three operations are bundled into a single shell invocation
+// to minimise round-trips to the container exec layer.
+func (p *ClaudeProvisioner) dropHookScript(scriptPath string) error {
+	parentDir := path.Dir(scriptPath)
+	script := fmt.Sprintf(
+		`mkdir -p %q && cat > %q && chmod +x %q`,
+		parentDir, scriptPath, scriptPath,
+	)
+	_, err := p.exec.Run([]string{"sh", "-c", script}, ClaudeHookScript)
+	return err
+}
+
+// injectSettings reads the current settings.json (or treats it as
+// absent), passes it through InjectFleetManHooks, and writes the
+// result back atomically.
+func (p *ClaudeProvisioner) injectSettings(scriptPath string) error {
+	current, err := p.readSettings()
+	if err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+	updated, err := InjectFleetManHooks(current, scriptPath)
+	if err != nil {
+		return fmt.Errorf("compute: %w", err)
+	}
+	if err := p.writeSettings(updated); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	return nil
+}
+
+// readSettings cats ~/.claude/settings.json. A missing file
+// produces empty bytes (treated by InjectFleetManHooks as "the file
+// does not exist"), not an error — distinguishing "missing" from
+// "present and empty" inside a shell pipeline is not worth the
+// complexity since both yield the same downstream behaviour.
+func (p *ClaudeProvisioner) readSettings() ([]byte, error) {
+	const script = `if [ -f "$HOME/.claude/settings.json" ]; then cat "$HOME/.claude/settings.json"; fi`
+	return p.exec.Run([]string{"sh", "-c", script}, nil)
+}
+
+// writeSettings writes content to ~/.claude/settings.json
+// atomically: same-directory tmp file then rename. mkdir of
+// ~/.claude handles the first-time case where Claude Code has
+// never been run in this container.
+func (p *ClaudeProvisioner) writeSettings(content []byte) error {
+	const script = `mkdir -p "$HOME/.claude" && ` +
+		`cat > "$HOME/.claude/settings.json.tmp" && ` +
+		`mv "$HOME/.claude/settings.json.tmp" "$HOME/.claude/settings.json"`
+	_, err := p.exec.Run([]string{"sh", "-c", script}, content)
+	return err
+}

--- a/internal/agentdetect/claude_provisioner_test.go
+++ b/internal/agentdetect/claude_provisioner_test.go
@@ -1,0 +1,370 @@
+package agentdetect
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// ===========================================
+// Stub executor
+// ===========================================
+
+// fakeCall captures one Run invocation against the stub executor.
+type fakeCall struct {
+	args  []string
+	stdin []byte
+}
+
+// fakeResponse pairs canned stdout with an optional error so the
+// stub can replay backend behaviour deterministically.
+type fakeResponse struct {
+	stdout []byte
+	err    error
+}
+
+// fakeExec is a ContainerExecutor that records calls and returns
+// pre-seeded responses in order. Tests use it to assert both that
+// the provisioner issued the expected sequence of shell
+// invocations AND that error paths short-circuit the right way.
+type fakeExec struct {
+	calls     []fakeCall
+	responses []fakeResponse
+}
+
+// Run satisfies ContainerExecutor.
+func (f *fakeExec) Run(args []string, stdin []byte) ([]byte, error) {
+	f.calls = append(f.calls, fakeCall{args: append([]string(nil), args...), stdin: append([]byte(nil), stdin...)})
+	if len(f.calls) > len(f.responses) {
+		return nil, errors.New("fakeExec: unexpected extra call")
+	}
+	resp := f.responses[len(f.calls)-1]
+	return resp.stdout, resp.err
+}
+
+// callKind classifies a recorded call by inspecting its shell
+// payload — this lets tests assert "the third call wrote
+// settings.json" without depending on the exact wording of the
+// shell snippet.
+func callKind(call fakeCall) string {
+	if len(call.args) < 3 {
+		return "unknown"
+	}
+	body := call.args[2]
+	switch {
+	case strings.Contains(body, "echo") && strings.Contains(body, "$HOME"):
+		return "query-home"
+	case strings.Contains(body, "chmod +x"):
+		return "drop-script"
+	case strings.Contains(body, "if [ -f") && strings.Contains(body, "settings.json"):
+		return "read-settings"
+	case strings.Contains(body, "settings.json.tmp") && strings.Contains(body, "mv"):
+		return "write-settings"
+	}
+	return "unknown"
+}
+
+// homeStdout is the canned response to the queryHome call — used by
+// every happy-path test so the resolved script path is predictable.
+const homeStdout = "/home/test\n"
+
+// ===========================================
+// Provisioning happy paths
+// ===========================================
+
+// TestProvision_FreshContainer covers the most common case: a brand
+// new container with no settings.json. The provisioner should query
+// $HOME, drop the script, read (empty), and write a freshly-
+// generated settings.json.
+func TestProvision_FreshContainer(t *testing.T) {
+	exec := &fakeExec{
+		responses: []fakeResponse{
+			{stdout: []byte(homeStdout), err: nil}, // query home
+			{stdout: nil, err: nil},                // drop script
+			{stdout: nil, err: nil},                // read settings (empty file)
+			{stdout: nil, err: nil},                // write settings
+		},
+	}
+	if err := NewClaudeProvisioner(exec).Provision(); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	if len(exec.calls) != 4 {
+		t.Fatalf("expected 4 exec calls, got %d", len(exec.calls))
+	}
+	wantKinds := []string{"query-home", "drop-script", "read-settings", "write-settings"}
+	for i, want := range wantKinds {
+		if got := callKind(exec.calls[i]); got != want {
+			t.Errorf("call %d kind = %q, want %q", i, got, want)
+		}
+	}
+
+	// The hook script payload sent over stdin must match the
+	// embedded bytes — proves the wrong file isn't being shipped.
+	if !bytes.Equal(exec.calls[1].stdin, ClaudeHookScript) {
+		t.Errorf("drop-script stdin does not match embedded ClaudeHookScript")
+	}
+
+	// The drop-script command must reference the resolved absolute
+	// path, which is $HOME (from query) joined with the suffix.
+	expectedScriptPath := "/home/test/" + FleetManScriptSuffix
+	dropBody := exec.calls[1].args[2]
+	if !strings.Contains(dropBody, expectedScriptPath) {
+		t.Errorf("drop-script missing resolved path %q:\n%s", expectedScriptPath, dropBody)
+	}
+
+	// The written settings.json must contain our hook command path
+	// for every managed event, using the resolved absolute path.
+	written := string(exec.calls[3].stdin)
+	for _, event := range fleetManManagedEvents {
+		marker := expectedScriptPath + " " + event
+		if !strings.Contains(written, marker) {
+			t.Errorf("written settings.json missing %q\nbody:\n%s", marker, written)
+		}
+	}
+}
+
+// TestProvision_PreservesExistingSettings verifies that user
+// content in settings.json round-trips through the provisioner
+// unchanged — critical safety property for editing a user file.
+func TestProvision_PreservesExistingSettings(t *testing.T) {
+	existing := []byte(`{"theme":"dark","hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/u/audit.sh"}]}]}}`)
+
+	exec := &fakeExec{
+		responses: []fakeResponse{
+			{stdout: []byte(homeStdout), err: nil},
+			{stdout: nil, err: nil},
+			{stdout: existing, err: nil},
+			{stdout: nil, err: nil},
+		},
+	}
+	if err := NewClaudeProvisioner(exec).Provision(); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	written := string(exec.calls[3].stdin)
+	if !strings.Contains(written, `"theme"`) || !strings.Contains(written, `"dark"`) {
+		t.Errorf("user theme key dropped from output:\n%s", written)
+	}
+	if !strings.Contains(written, "/u/audit.sh") {
+		t.Errorf("user PreToolUse audit hook dropped from output:\n%s", written)
+	}
+}
+
+// TestProvision_Idempotent runs the provisioner twice (with the
+// second read returning the first write's output) and asserts the
+// settings written on the second pass match the first byte-for-
+// byte. End-to-end idempotency, not just InjectFleetManHooks's.
+func TestProvision_Idempotent(t *testing.T) {
+	first := &fakeExec{
+		responses: []fakeResponse{
+			{stdout: []byte(homeStdout), err: nil},
+			{stdout: nil, err: nil},
+			{stdout: nil, err: nil},
+			{stdout: nil, err: nil},
+		},
+	}
+	if err := NewClaudeProvisioner(first).Provision(); err != nil {
+		t.Fatalf("first Provision: %v", err)
+	}
+	firstWritten := first.calls[3].stdin
+
+	second := &fakeExec{
+		responses: []fakeResponse{
+			{stdout: []byte(homeStdout), err: nil},
+			{stdout: nil, err: nil},
+			{stdout: firstWritten, err: nil},
+			{stdout: nil, err: nil},
+		},
+	}
+	if err := NewClaudeProvisioner(second).Provision(); err != nil {
+		t.Fatalf("second Provision: %v", err)
+	}
+	secondWritten := second.calls[3].stdin
+
+	if !bytes.Equal(firstWritten, secondWritten) {
+		t.Errorf("not idempotent\nfirst:  %s\nsecond: %s", firstWritten, secondWritten)
+	}
+}
+
+// TestProvision_ScriptUsesCanonicalSuffix asserts the drop-script
+// command embeds the canonical script suffix derived from $HOME,
+// guarding against drift between the script path used to write the
+// file and the path written into settings.json.
+func TestProvision_ScriptUsesCanonicalSuffix(t *testing.T) {
+	exec := &fakeExec{
+		responses: []fakeResponse{
+			{stdout: []byte(homeStdout), err: nil},
+			{stdout: nil, err: nil},
+			{stdout: nil, err: nil},
+			{stdout: nil, err: nil},
+		},
+	}
+	if err := NewClaudeProvisioner(exec).Provision(); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	dropBody := exec.calls[1].args[2]
+	if !strings.Contains(dropBody, FleetManScriptSuffix) {
+		t.Errorf("drop-script body missing FleetManScriptSuffix %q:\n%s",
+			FleetManScriptSuffix, dropBody)
+	}
+}
+
+// TestProvision_HomeWithTrailingWhitespace verifies the queryHome
+// step trims shell-typical trailing newlines/whitespace before
+// using the value. A bare `echo "$HOME"` always produces a trailing
+// newline and we must not bake that into a path.
+func TestProvision_HomeWithTrailingWhitespace(t *testing.T) {
+	exec := &fakeExec{
+		responses: []fakeResponse{
+			{stdout: []byte("/home/vscode  \n"), err: nil}, // padded
+			{stdout: nil, err: nil},
+			{stdout: nil, err: nil},
+			{stdout: nil, err: nil},
+		},
+	}
+	if err := NewClaudeProvisioner(exec).Provision(); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	dropBody := exec.calls[1].args[2]
+	expected := "/home/vscode/" + FleetManScriptSuffix
+	if !strings.Contains(dropBody, expected) {
+		t.Errorf("expected trimmed path %q in drop body:\n%s", expected, dropBody)
+	}
+	// And no whitespace bleed through.
+	if strings.Contains(dropBody, "/home/vscode  /") || strings.Contains(dropBody, "/home/vscode\n") {
+		t.Errorf("queryHome whitespace leaked into resolved path:\n%s", dropBody)
+	}
+}
+
+// ===========================================
+// Provisioning failure modes
+// ===========================================
+
+// TestProvision_HomeQueryFailureAborts verifies the provisioner
+// aborts cleanly if it cannot determine $HOME — without that we
+// would not know where to drop the script, so attempting subsequent
+// steps would corrupt either /tmp or some incorrect path.
+func TestProvision_HomeQueryFailureAborts(t *testing.T) {
+	exec := &fakeExec{
+		responses: []fakeResponse{
+			{stdout: nil, err: errors.New("exec lost")},
+		},
+	}
+	err := NewClaudeProvisioner(exec).Provision()
+	if err == nil {
+		t.Fatal("expected error when home query fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "resolve script path") {
+		t.Errorf("error not phase-tagged: %v", err)
+	}
+	if len(exec.calls) != 1 {
+		t.Errorf("expected 1 call (home query only), got %d", len(exec.calls))
+	}
+}
+
+// TestProvision_EmptyHomeAborts verifies that a successful but
+// empty home query is also treated as an abort condition — without
+// a valid path we cannot proceed.
+func TestProvision_EmptyHomeAborts(t *testing.T) {
+	exec := &fakeExec{
+		responses: []fakeResponse{
+			{stdout: []byte("\n"), err: nil}, // empty after trim
+		},
+	}
+	err := NewClaudeProvisioner(exec).Provision()
+	if err == nil {
+		t.Fatal("expected error when home is empty")
+	}
+}
+
+// TestProvision_DropFailureSkipsSettings verifies the provisioner
+// short-circuits when the script-drop fails: settings are not
+// touched. Important so a permission failure does not leave the
+// file in an inconsistent in-between state.
+func TestProvision_DropFailureSkipsSettings(t *testing.T) {
+	exec := &fakeExec{
+		responses: []fakeResponse{
+			{stdout: []byte(homeStdout), err: nil},
+			{stdout: nil, err: errors.New("chmod denied")},
+		},
+	}
+	err := NewClaudeProvisioner(exec).Provision()
+	if err == nil {
+		t.Fatal("expected error from drop failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "install hook script") {
+		t.Errorf("error not phase-tagged: %v", err)
+	}
+	if len(exec.calls) != 2 {
+		t.Errorf("expected 2 calls (home, drop), got %d", len(exec.calls))
+	}
+}
+
+// TestProvision_ReadFailureSurfaces verifies a read error (e.g.,
+// permission issue on settings.json) is surfaced rather than
+// silently swallowed.
+func TestProvision_ReadFailureSurfaces(t *testing.T) {
+	exec := &fakeExec{
+		responses: []fakeResponse{
+			{stdout: []byte(homeStdout), err: nil},
+			{stdout: nil, err: nil},
+			{stdout: nil, err: errors.New("perm denied")},
+		},
+	}
+	err := NewClaudeProvisioner(exec).Provision()
+	if err == nil {
+		t.Fatal("expected error from read failure")
+	}
+	if !strings.Contains(err.Error(), "edit settings.json") {
+		t.Errorf("error not phase-tagged: %v", err)
+	}
+	if len(exec.calls) != 3 {
+		t.Errorf("expected 3 calls (home, drop, read), got %d", len(exec.calls))
+	}
+}
+
+// TestProvision_MalformedExistingSettingsSurfaces verifies a
+// settings.json that fails to parse causes Provision to abort
+// before writing anything — never overwriting the user's possibly-
+// hand-edited (or corrupted) file with our generated one.
+func TestProvision_MalformedExistingSettingsSurfaces(t *testing.T) {
+	exec := &fakeExec{
+		responses: []fakeResponse{
+			{stdout: []byte(homeStdout), err: nil},
+			{stdout: nil, err: nil},
+			{stdout: []byte(`{not valid json`), err: nil},
+		},
+	}
+	err := NewClaudeProvisioner(exec).Provision()
+	if err == nil {
+		t.Fatal("expected parse error to bubble up")
+	}
+	// No write call should have been issued.
+	if len(exec.calls) != 3 {
+		t.Errorf("write should not have been attempted, got %d calls", len(exec.calls))
+	}
+}
+
+// TestProvision_WriteFailureSurfaces verifies that even if read &
+// compute succeed, a write error bubbles up with phase context.
+func TestProvision_WriteFailureSurfaces(t *testing.T) {
+	exec := &fakeExec{
+		responses: []fakeResponse{
+			{stdout: []byte(homeStdout), err: nil},
+			{stdout: nil, err: nil},
+			{stdout: nil, err: nil},
+			{stdout: nil, err: errors.New("disk full")},
+		},
+	}
+	err := NewClaudeProvisioner(exec).Provision()
+	if err == nil {
+		t.Fatal("expected write error")
+	}
+	if !strings.Contains(err.Error(), "edit settings.json") {
+		t.Errorf("error not phase-tagged: %v", err)
+	}
+}

--- a/internal/agentdetect/claude_settings.go
+++ b/internal/agentdetect/claude_settings.go
@@ -1,0 +1,265 @@
+package agentdetect
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ===========================================
+// Claude Code settings.json injection
+// ===========================================
+//
+// fleet-man detects Claude Code's run state by installing hooks into the
+// container's ~/.claude/settings.json that fire on lifecycle events
+// (UserPromptSubmit, PreToolUse, PostToolUse, Notification, Stop) and
+// write a single-line state file the host then reads.
+//
+// settings.json is a user file that may contain unrelated keys, the
+// user's own hooks, plugin hooks, organization policy, or future fields
+// fleet-man has never heard of. The reconciliation logic in this file
+// is therefore strictly EDIT-IN-PLACE:
+//
+//   - The document is parsed into map[string]any, never into a typed
+//     struct, so unknown fields round-trip untouched.
+//   - We identify our own hook entries solely by the command path of
+//     the inner hook (FleetManHookCommand). Anything not bearing that
+//     marker is foreign and is left exactly as we found it.
+//   - Every parent path is created lazily (the file may be missing,
+//     empty, contain only "{}", contain "hooks": null, etc.).
+//   - The function is a pure transformation on bytes; the caller does
+//     the atomic write.
+//
+// Hook entries fleet-man manages have this canonical shape:
+//
+//   {
+//     "matcher": "*",
+//     "hooks": [
+//       {"type": "command", "command": "<FleetManHookCommand> <Event>"}
+//     ]
+//   }
+
+// ===========================================
+// Constants
+// ===========================================
+
+// FleetManScriptSuffix is the home-relative path of the state-writing
+// hook script. The absolute path is `$HOME/<suffix>` and varies per
+// container (different remoteUser → different $HOME), so settings
+// reconciliation receives the absolute path as a parameter rather
+// than reading it from a constant.
+//
+// Suffix-based recognition (rather than full-path equality) lets us
+// identify "our" entries without knowing the absolute path:
+// installations whose home dir differs from ours still produce a
+// command that ends in this suffix, so a fleet-man entry written by
+// any version is still recognisably ours and gets updated rather
+// than duplicated.
+const FleetManScriptSuffix = ".fleet/scripts/claude-state-hook.sh"
+
+// fleetManManagedEvents lists the Claude Code lifecycle events
+// fleet-man installs handlers for. Order here governs the order in
+// which our entries are first inserted; subsequent reconciliations
+// preserve whatever position our entry already occupies in each
+// event's array.
+var fleetManManagedEvents = []string{
+	"UserPromptSubmit",
+	"PreToolUse",
+	"PostToolUse",
+	"Notification",
+	"Stop",
+}
+
+// ===========================================
+// Public API
+// ===========================================
+
+// InjectFleetManHooks upserts fleet-man's state-writing hook entries
+// into a Claude Code settings.json document, returning the new bytes.
+//
+// current is the current contents of settings.json. nil, an empty
+// slice, or whitespace-only input is treated as "the file does not
+// exist yet" and yields a fresh document containing only our hooks.
+//
+// scriptPath is the absolute path of the in-container hook script.
+// The provisioner computes this from the container's $HOME plus
+// FleetManScriptSuffix. Tests pass any path ending in the suffix.
+//
+// Guarantees:
+//
+//   - Every key, value, and hook entry that fleet-man does not own is
+//     preserved exactly as it appeared in the input. Ownership is
+//     determined by suffix-matching the command path against
+//     FleetManScriptSuffix, so any prior fleet-man entry — even one
+//     written under a different $HOME — is recognised and updated.
+//   - Idempotent: running the function on its own output produces the
+//     same output.
+//   - Position-stable: when our entry already exists in an event's
+//     array we update it in place rather than moving it.
+//   - Never writes to disk. The caller is responsible for atomic
+//     write semantics.
+//
+// Returns an error only when current is non-empty and is not valid
+// JSON, or when the parsed structure conflicts with the schema in a
+// way we cannot safely repair (for example "hooks" is an array
+// instead of an object). In every error case the original bytes are
+// safe to leave on disk untouched.
+func InjectFleetManHooks(current []byte, scriptPath string) ([]byte, error) {
+	root := map[string]any{}
+	trimmed := bytes.TrimSpace(current)
+	if len(trimmed) > 0 {
+		if err := json.Unmarshal(trimmed, &root); err != nil {
+			return nil, fmt.Errorf("parse settings.json: %w", err)
+		}
+	}
+
+	hooks, err := getOrCreateHooksMap(root)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, event := range fleetManManagedEvents {
+		if err := upsertEvent(hooks, event, scriptPath); err != nil {
+			return nil, err
+		}
+	}
+
+	root["hooks"] = hooks
+
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal settings.json: %w", err)
+	}
+	return append(out, '\n'), nil
+}
+
+// ===========================================
+// Private Helpers
+// ===========================================
+
+// getOrCreateHooksMap returns the "hooks" object from root, creating
+// an empty one if the key is absent or explicitly null. Returns an
+// error when "hooks" is present with an incompatible type — we never
+// silently overwrite a user value of unexpected shape.
+func getOrCreateHooksMap(root map[string]any) (map[string]any, error) {
+	raw, present := root["hooks"]
+	if !present || raw == nil {
+		return map[string]any{}, nil
+	}
+	hooks, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf(`"hooks" must be a JSON object, got %T`, raw)
+	}
+	return hooks, nil
+}
+
+// upsertEvent reconciles fleet-man's matcher group inside the array
+// at hooks[event].
+//
+// Behaviour:
+//   - If our group is present, it is replaced in place (preserving
+//     its position relative to foreign entries).
+//   - Any duplicate fleet-man groups are collapsed into a single
+//     entry at the position of the first occurrence.
+//   - If our group is absent, it is appended after all existing
+//     entries.
+//   - Foreign matcher groups are passed through unchanged.
+//
+// Returns an error if hooks[event] exists with a non-array type.
+func upsertEvent(hooks map[string]any, event, scriptPath string) error {
+	raw, present := hooks[event]
+	var groups []any
+	if present && raw != nil {
+		existing, ok := raw.([]any)
+		if !ok {
+			return fmt.Errorf(`hooks[%q] must be a JSON array, got %T`, event, raw)
+		}
+		groups = existing
+	}
+
+	desired := desiredGroup(event, scriptPath)
+
+	result := make([]any, 0, len(groups)+1)
+	foundOurs := false
+	for _, group := range groups {
+		if isFleetManGroup(group) {
+			if !foundOurs {
+				result = append(result, desired)
+				foundOurs = true
+			}
+			continue
+		}
+		result = append(result, group)
+	}
+	if !foundOurs {
+		result = append(result, desired)
+	}
+	hooks[event] = result
+	return nil
+}
+
+// desiredGroup returns the canonical fleet-man matcher group for the
+// given event. Building a fresh map every call means later mutations
+// (during reconciliation of subsequent events, or by the caller) can
+// never bleed back into shared state.
+func desiredGroup(event, scriptPath string) map[string]any {
+	return map[string]any{
+		"matcher": "*",
+		"hooks": []any{
+			map[string]any{
+				"type":    "command",
+				"command": scriptPath + " " + event,
+			},
+		},
+	}
+}
+
+// isFleetManGroup reports whether the given matcher-group entry
+// belongs to fleet-man, identified by the command path of any of
+// its inner hooks. Robust to malformed entries: anything that does
+// not match the expected shape simply returns false (treat as
+// foreign, leave alone).
+func isFleetManGroup(group any) bool {
+	groupMap, ok := group.(map[string]any)
+	if !ok {
+		return false
+	}
+	inner, ok := groupMap["hooks"].([]any)
+	if !ok {
+		return false
+	}
+	for _, hookEntry := range inner {
+		hookMap, ok := hookEntry.(map[string]any)
+		if !ok {
+			continue
+		}
+		cmd, ok := hookMap["command"].(string)
+		if !ok {
+			continue
+		}
+		if isFleetManCommand(cmd) {
+			return true
+		}
+	}
+	return false
+}
+
+// isFleetManCommand reports whether a hook command string was
+// installed by fleet-man. Matching by the home-relative
+// FleetManScriptSuffix (rather than a full absolute path) means
+// entries written by an installation under a different $HOME — for
+// example a different remoteUser between fleet-man versions or
+// re-provisioning passes — are still recognised as ours and get
+// updated rather than duplicated.
+func isFleetManCommand(cmd string) bool {
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" {
+		return false
+	}
+	first := cmd
+	if idx := strings.IndexAny(cmd, " \t"); idx >= 0 {
+		first = cmd[:idx]
+	}
+	return strings.HasSuffix(first, "/"+FleetManScriptSuffix)
+}

--- a/internal/agentdetect/claude_settings_test.go
+++ b/internal/agentdetect/claude_settings_test.go
@@ -1,0 +1,494 @@
+package agentdetect
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// ===========================================
+// Test helpers
+// ===========================================
+
+// testScriptPath is the absolute hook-script path tests pretend the
+// provisioner resolved from $HOME. The trailing component matches
+// FleetManScriptSuffix so suffix-based recognition treats entries
+// referencing it as fleet-man's.
+const testScriptPath = "/home/test/" + FleetManScriptSuffix
+
+// mustInject runs InjectFleetManHooks against testScriptPath and
+// fails the test on any error. Returns the produced bytes.
+func mustInject(t *testing.T, input []byte) []byte {
+	t.Helper()
+	out, err := InjectFleetManHooks(input, testScriptPath)
+	if err != nil {
+		t.Fatalf("InjectFleetManHooks(%q) returned error: %v", input, err)
+	}
+	return out
+}
+
+// parseRoot decodes settings JSON bytes into a map[string]any.
+func parseRoot(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	var root map[string]any
+	if err := json.Unmarshal(raw, &root); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nbytes: %s", err, raw)
+	}
+	return root
+}
+
+// hooksMap pulls root["hooks"] as a map, failing the test if absent
+// or wrong-typed.
+func hooksMap(t *testing.T, root map[string]any) map[string]any {
+	t.Helper()
+	raw, ok := root["hooks"]
+	if !ok {
+		t.Fatalf(`expected "hooks" key in root, got: %v`, root)
+	}
+	hooks, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf(`expected "hooks" to be an object, got %T`, raw)
+	}
+	return hooks
+}
+
+// eventGroups returns hooks[event] as []any, failing the test if
+// missing or wrong-typed.
+func eventGroups(t *testing.T, hooks map[string]any, event string) []any {
+	t.Helper()
+	raw, ok := hooks[event]
+	if !ok {
+		t.Fatalf("expected event %q in hooks, got: %v", event, hooks)
+	}
+	groups, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("expected hooks[%q] to be an array, got %T", event, raw)
+	}
+	return groups
+}
+
+// canonicalGroup returns the matcher-group entry fleet-man would
+// produce on a fresh insertion for a given event when the
+// provisioner resolved testScriptPath.
+func canonicalGroup(event string) map[string]any {
+	return map[string]any{
+		"matcher": "*",
+		"hooks": []any{
+			map[string]any{
+				"type":    "command",
+				"command": testScriptPath + " " + event,
+			},
+		},
+	}
+}
+
+// findOurGroupIndex returns the position of fleet-man's group inside
+// a matcher-group list, or -1 if absent.
+func findOurGroupIndex(groups []any) int {
+	for i, group := range groups {
+		if isFleetManGroup(group) {
+			return i
+		}
+	}
+	return -1
+}
+
+// ===========================================
+// Zero-state tests
+// ===========================================
+
+// TestInjectFleetManHooks_ZeroStates covers every "the file is in some
+// pre-installation state" shape: missing entirely, empty, whitespace,
+// empty object, hooks-null, hooks-empty, event-null, event-empty.
+func TestInjectFleetManHooks_ZeroStates(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []byte
+	}{
+		{"nil input", nil},
+		{"empty bytes", []byte{}},
+		{"whitespace only", []byte("   \n\t  ")},
+		{"empty object", []byte(`{}`)},
+		{"hooks key null", []byte(`{"hooks": null}`)},
+		{"hooks key empty object", []byte(`{"hooks": {}}`)},
+		{"event key null", []byte(`{"hooks": {"PreToolUse": null}}`)},
+		{"event key empty array", []byte(`{"hooks": {"PreToolUse": []}}`)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := mustInject(t, tc.input)
+			root := parseRoot(t, out)
+			hooks := hooksMap(t, root)
+
+			for _, event := range fleetManManagedEvents {
+				groups := eventGroups(t, hooks, event)
+				if len(groups) != 1 {
+					t.Fatalf("event %q: got %d groups, want 1", event, len(groups))
+				}
+				if !reflect.DeepEqual(groups[0], canonicalGroup(event)) {
+					t.Errorf("event %q group mismatch:\n got: %#v\nwant: %#v",
+						event, groups[0], canonicalGroup(event))
+				}
+			}
+		})
+	}
+}
+
+// ===========================================
+// Foreign-content preservation tests
+// ===========================================
+
+// TestInjectFleetManHooks_PreservesUnrelatedTopLevelKeys verifies that
+// keys at the document root that fleet-man knows nothing about
+// survive a reconciliation pass byte-for-value.
+func TestInjectFleetManHooks_PreservesUnrelatedTopLevelKeys(t *testing.T) {
+	input := []byte(`{
+		"theme": "dark",
+		"telemetry": false,
+		"customField": {"nested": [1, 2, 3]},
+		"plugins": ["one", "two"]
+	}`)
+
+	out := mustInject(t, input)
+	root := parseRoot(t, out)
+
+	if got := root["theme"]; got != "dark" {
+		t.Errorf("theme: got %v, want dark", got)
+	}
+	if got := root["telemetry"]; got != false {
+		t.Errorf("telemetry: got %v, want false", got)
+	}
+	if got, ok := root["customField"].(map[string]any); !ok {
+		t.Errorf("customField: not preserved as object, got %T", root["customField"])
+	} else if nested, ok := got["nested"].([]any); !ok || len(nested) != 3 {
+		t.Errorf("customField.nested: got %v", got["nested"])
+	}
+	if got, ok := root["plugins"].([]any); !ok || len(got) != 2 {
+		t.Errorf("plugins: got %v", root["plugins"])
+	}
+	hooksMap(t, root) // hooks key was added
+}
+
+// TestInjectFleetManHooks_PreservesUnrelatedEvents verifies that hook
+// events fleet-man does not manage are passed through verbatim.
+func TestInjectFleetManHooks_PreservesUnrelatedEvents(t *testing.T) {
+	input := []byte(`{
+		"hooks": {
+			"SessionStart": [
+				{"matcher": "startup", "hooks": [{"type": "command", "command": "/bin/user-script"}]}
+			],
+			"FileChanged": [
+				{"matcher": "*", "hooks": [{"type": "command", "command": "/usr/local/bin/watcher"}]}
+			]
+		}
+	}`)
+
+	out := mustInject(t, input)
+	hooks := hooksMap(t, parseRoot(t, out))
+
+	sessionStart := eventGroups(t, hooks, "SessionStart")
+	if len(sessionStart) != 1 {
+		t.Fatalf("SessionStart: got %d groups, want 1", len(sessionStart))
+	}
+	sessionGroup := sessionStart[0].(map[string]any)
+	if sessionGroup["matcher"] != "startup" {
+		t.Errorf("SessionStart matcher: got %v, want startup", sessionGroup["matcher"])
+	}
+
+	fileChanged := eventGroups(t, hooks, "FileChanged")
+	if len(fileChanged) != 1 {
+		t.Fatalf("FileChanged: got %d groups, want 1", len(fileChanged))
+	}
+}
+
+// TestInjectFleetManHooks_AppendsAlongsideForeignEntries verifies
+// that when the user already has hook entries for an event we
+// manage, our entry is appended without disturbing theirs.
+func TestInjectFleetManHooks_AppendsAlongsideForeignEntries(t *testing.T) {
+	input := []byte(`{
+		"hooks": {
+			"PreToolUse": [
+				{"matcher": "Bash", "hooks": [{"type": "command", "command": "/home/user/audit.sh"}]},
+				{"matcher": "Edit", "hooks": [{"type": "command", "command": "/home/user/lint.sh"}]}
+			]
+		}
+	}`)
+
+	out := mustInject(t, input)
+	groups := eventGroups(t, hooksMap(t, parseRoot(t, out)), "PreToolUse")
+
+	if len(groups) != 3 {
+		t.Fatalf("PreToolUse: got %d groups, want 3 (2 user + 1 ours)", len(groups))
+	}
+	// User's entries unchanged at positions 0 and 1.
+	if group := groups[0].(map[string]any); group["matcher"] != "Bash" {
+		t.Errorf("position 0: matcher got %v, want Bash", group["matcher"])
+	}
+	if group := groups[1].(map[string]any); group["matcher"] != "Edit" {
+		t.Errorf("position 1: matcher got %v, want Edit", group["matcher"])
+	}
+	// Ours appended at the end.
+	if !reflect.DeepEqual(groups[2], canonicalGroup("PreToolUse")) {
+		t.Errorf("position 2: got %#v, want canonical fleet-man entry", groups[2])
+	}
+}
+
+// ===========================================
+// Idempotency tests
+// ===========================================
+
+// TestInjectFleetManHooks_Idempotent verifies that running the
+// reconciliation twice produces identical bytes the second time —
+// the canonical correctness guarantee for any reconcile loop.
+func TestInjectFleetManHooks_Idempotent(t *testing.T) {
+	first := mustInject(t, nil)
+	second := mustInject(t, first)
+	if !reflect.DeepEqual(first, second) {
+		t.Errorf("output not idempotent\nfirst:  %s\nsecond: %s", first, second)
+	}
+}
+
+// TestInjectFleetManHooks_IdempotentOnComplexInput exercises
+// idempotency through a document containing foreign entries
+// alongside ours.
+func TestInjectFleetManHooks_IdempotentOnComplexInput(t *testing.T) {
+	input := []byte(`{
+		"theme": "dark",
+		"hooks": {
+			"PreToolUse": [
+				{"matcher": "Bash", "hooks": [{"type": "command", "command": "/u/audit.sh"}]}
+			],
+			"SessionStart": [
+				{"matcher": "*", "hooks": [{"type": "command", "command": "/u/init.sh"}]}
+			]
+		}
+	}`)
+
+	first := mustInject(t, input)
+	second := mustInject(t, first)
+	if !reflect.DeepEqual(first, second) {
+		t.Errorf("not idempotent on complex input\nfirst:  %s\nsecond: %s", first, second)
+	}
+}
+
+// ===========================================
+// Stale-entry replacement tests
+// ===========================================
+
+// TestInjectFleetManHooks_ReplacesStaleEntry verifies that an
+// existing fleet-man entry with outdated content (e.g. an old event
+// argument) is replaced rather than duplicated.
+func TestInjectFleetManHooks_ReplacesStaleEntry(t *testing.T) {
+	input := fmt.Appendf(nil, `{
+		"hooks": {
+			"PreToolUse": [
+				{
+					"matcher": "old-matcher",
+					"hooks": [{"type": "command", "command": "%s OldEventName"}]
+				}
+			]
+		}
+	}`, testScriptPath)
+
+	out := mustInject(t, input)
+	groups := eventGroups(t, hooksMap(t, parseRoot(t, out)), "PreToolUse")
+
+	if len(groups) != 1 {
+		t.Fatalf("got %d groups, want 1 (replacement, no duplicate)", len(groups))
+	}
+	if !reflect.DeepEqual(groups[0], canonicalGroup("PreToolUse")) {
+		t.Errorf("entry not refreshed: got %#v", groups[0])
+	}
+}
+
+// TestInjectFleetManHooks_PreservesPositionDuringReplace verifies that
+// when our stale entry is sandwiched between foreign entries, the
+// fresh entry takes the same position rather than moving to the end.
+func TestInjectFleetManHooks_PreservesPositionDuringReplace(t *testing.T) {
+	input := fmt.Appendf(nil, `{
+		"hooks": {
+			"PreToolUse": [
+				{"matcher": "Bash", "hooks": [{"type": "command", "command": "/u/before.sh"}]},
+				{"matcher": "old", "hooks": [{"type": "command", "command": "%s stale"}]},
+				{"matcher": "Edit", "hooks": [{"type": "command", "command": "/u/after.sh"}]}
+			]
+		}
+	}`, testScriptPath)
+
+	out := mustInject(t, input)
+	groups := eventGroups(t, hooksMap(t, parseRoot(t, out)), "PreToolUse")
+
+	if len(groups) != 3 {
+		t.Fatalf("got %d groups, want 3", len(groups))
+	}
+	if findOurGroupIndex(groups) != 1 {
+		t.Errorf("our group moved: index = %d, want 1", findOurGroupIndex(groups))
+	}
+	if group := groups[0].(map[string]any); group["matcher"] != "Bash" {
+		t.Errorf("position 0 corrupted: %v", group)
+	}
+	if group := groups[2].(map[string]any); group["matcher"] != "Edit" {
+		t.Errorf("position 2 corrupted: %v", group)
+	}
+}
+
+// TestInjectFleetManHooks_DedupesMultipleStaleEntries verifies that
+// if the file somehow ended up with several fleet-man entries for
+// the same event, reconciliation collapses them to one at the
+// position of the first occurrence.
+func TestInjectFleetManHooks_DedupesMultipleStaleEntries(t *testing.T) {
+	input := fmt.Appendf(nil, `{
+		"hooks": {
+			"PreToolUse": [
+				{"matcher": "*", "hooks": [{"type": "command", "command": "%[1]s v1"}]},
+				{"matcher": "Bash", "hooks": [{"type": "command", "command": "/u/audit.sh"}]},
+				{"matcher": "*", "hooks": [{"type": "command", "command": "%[1]s v2"}]},
+				{"matcher": "*", "hooks": [{"type": "command", "command": "%[1]s v3"}]}
+			]
+		}
+	}`, testScriptPath)
+
+	out := mustInject(t, input)
+	groups := eventGroups(t, hooksMap(t, parseRoot(t, out)), "PreToolUse")
+
+	// Three duplicates collapse to one; foreign entry preserved.
+	if len(groups) != 2 {
+		t.Fatalf("got %d groups, want 2 (dedupe to one + foreign)", len(groups))
+	}
+	if findOurGroupIndex(groups) != 0 {
+		t.Errorf("dedup landed at wrong index: %d, want 0 (first occurrence)", findOurGroupIndex(groups))
+	}
+	if group := groups[1].(map[string]any); group["matcher"] != "Bash" {
+		t.Errorf("foreign entry corrupted: %v", group)
+	}
+}
+
+// ===========================================
+// Recognition tests
+// ===========================================
+
+// TestIsFleetManCommand verifies the suffix-based command-path
+// matcher does not false-positive on look-alike paths and does not
+// false-negative on our own command with arguments. Also covers the
+// cross-home-dir case: a path under a different $HOME but with the
+// same FleetManScriptSuffix is recognised, which is what makes
+// re-provisioning safe across remoteUser changes.
+func TestIsFleetManCommand(t *testing.T) {
+	otherHomePath := "/root/" + FleetManScriptSuffix
+	cases := []struct {
+		name string
+		cmd  string
+		want bool
+	}{
+		{"exact match no args", testScriptPath, true},
+		{"with single arg", testScriptPath + " PreToolUse", true},
+		{"with multiple args", testScriptPath + " PreToolUse extra", true},
+		{"tab-separated arg", testScriptPath + "\tPreToolUse", true},
+		{"leading whitespace", "  " + testScriptPath + " Stop", true},
+		{"different $HOME, same suffix", otherHomePath + " Stop", true},
+		{"prefix lookalike", testScriptPath + "-other", false},
+		{"empty", "", false},
+		{"unrelated path", "/home/user/some-script.sh", false},
+		{"shell wrapper", "sh -c " + testScriptPath, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isFleetManCommand(tc.cmd); got != tc.want {
+				t.Errorf("isFleetManCommand(%q) = %v, want %v", tc.cmd, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestInjectFleetManHooks_LookalikeNotConfusedAsOurs ensures a user
+// hook whose path merely shares a prefix with ours is left alone
+// rather than being treated as a stale fleet-man entry.
+func TestInjectFleetManHooks_LookalikeNotConfusedAsOurs(t *testing.T) {
+	input := fmt.Appendf(nil, `{
+		"hooks": {
+			"PreToolUse": [
+				{
+					"matcher": "*",
+					"hooks": [{"type": "command", "command": "%s-impostor"}]
+				}
+			]
+		}
+	}`, testScriptPath)
+
+	out := mustInject(t, input)
+	groups := eventGroups(t, hooksMap(t, parseRoot(t, out)), "PreToolUse")
+
+	if len(groups) != 2 {
+		t.Fatalf("got %d groups, want 2 (lookalike preserved + ours appended)", len(groups))
+	}
+	// Lookalike still at position 0.
+	group := groups[0].(map[string]any)
+	inner := group["hooks"].([]any)
+	cmd := inner[0].(map[string]any)["command"].(string)
+	if !strings.HasSuffix(cmd, "impostor") {
+		t.Errorf("lookalike entry mutated: command=%q", cmd)
+	}
+}
+
+// ===========================================
+// Error tests
+// ===========================================
+
+// TestInjectFleetManHooks_RejectsMalformedInput verifies that the
+// function refuses to operate on inputs whose structure could not be
+// safely repaired in place. The contract is to return an error, so
+// the caller leaves the file untouched on disk.
+func TestInjectFleetManHooks_RejectsMalformedInput(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []byte
+	}{
+		{"not json", []byte("this is not json")},
+		{"truncated json", []byte(`{"hooks":`)},
+		{"hooks is string", []byte(`{"hooks": "wat"}`)},
+		{"hooks is array", []byte(`{"hooks": []}`)},
+		{"event is string", []byte(`{"hooks": {"PreToolUse": "wat"}}`)},
+		{"event is object", []byte(`{"hooks": {"PreToolUse": {"matcher": "*"}}}`)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := InjectFleetManHooks(tc.input, testScriptPath); err == nil {
+				t.Fatalf("InjectFleetManHooks(%q) = nil, want error", tc.input)
+			}
+		})
+	}
+}
+
+// ===========================================
+// Output format tests
+// ===========================================
+
+// TestInjectFleetManHooks_OutputIsValidIndentedJSON sanity-checks that
+// the result is parseable, indented for readability, and ends with a
+// trailing newline (POSIX file convention so editors don't whine).
+func TestInjectFleetManHooks_OutputIsValidIndentedJSON(t *testing.T) {
+	out := mustInject(t, nil)
+	if len(out) == 0 || out[len(out)-1] != '\n' {
+		t.Errorf("output should end with newline, got: %q", out)
+	}
+	if !strings.Contains(string(out), "  ") {
+		t.Error("output should be indented (2 spaces), got compact JSON")
+	}
+	parseRoot(t, out)
+}
+
+// TestInjectFleetManHooks_AllManagedEventsCovered guards against
+// silent regressions if fleetManManagedEvents is edited — every
+// listed event must end up in the output.
+func TestInjectFleetManHooks_AllManagedEventsCovered(t *testing.T) {
+	out := mustInject(t, nil)
+	hooks := hooksMap(t, parseRoot(t, out))
+	for _, event := range fleetManManagedEvents {
+		if _, ok := hooks[event]; !ok {
+			t.Errorf("managed event %q missing from output", event)
+		}
+	}
+}

--- a/internal/agentdetect/claude_state_file.go
+++ b/internal/agentdetect/claude_state_file.go
@@ -1,0 +1,140 @@
+package agentdetect
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ===========================================
+// Claude state file parsing
+// ===========================================
+//
+// The hook script writes a single line of the form:
+//
+//   <state> <unix-secs>\n
+//
+// where <state> is one of the wire-format strings below. Parsing is
+// permissive on the read side: any unrecognised content is treated as
+// "no signal" rather than an error, because the file may legitimately
+// be empty, partially written (despite the atomic rename — different
+// filesystem semantics), or written by a future hook script version
+// that emits new state values we do not yet understand.
+
+// ===========================================
+// Constants
+// ===========================================
+//
+// These wire-format strings MUST match the values written by
+// claude_hook_script.sh. Tests in this package execute the embedded
+// script and assert the file content matches, guarding against drift.
+
+const (
+	stateValueWorking = "working"
+	stateValueWaiting = "waiting"
+	stateValueUnknown = "unknown"
+)
+
+// ===========================================
+// Types
+// ===========================================
+
+// ClaudeStateReading is the parsed contents of the Claude state file
+// at ClaudeStateFilePath.
+type ClaudeStateReading struct {
+	// State is the run-state derived from the most recent hook event.
+	State State
+	// Timestamp is when the hook script wrote the file (truncated to
+	// second precision — that is all the wire format carries).
+	Timestamp time.Time
+}
+
+// ===========================================
+// Public API
+// ===========================================
+
+// ParseClaudeStateFile parses the content of the Claude state file
+// written by the hook script. Returns ok=false (not an error) when
+// the content is empty, malformed, or carries an unrecognised state
+// value — the caller treats that as "Claude has not yet emitted a
+// usable hook signal in this session".
+//
+// Permissive on purpose: future hook script versions may emit new
+// state values, and we never want a forwards-compatibility mismatch
+// to surface as an error to the user.
+func ParseClaudeStateFile(content string) (ClaudeStateReading, bool) {
+	line := firstNonEmptyLine(content)
+	if line == "" {
+		return ClaudeStateReading{}, false
+	}
+
+	stateToken, secsToken, ok := splitStateLine(line)
+	if !ok {
+		return ClaudeStateReading{}, false
+	}
+
+	state, ok := decodeStateToken(stateToken)
+	if !ok {
+		return ClaudeStateReading{}, false
+	}
+
+	secs, err := strconv.ParseInt(secsToken, 10, 64)
+	if err != nil || secs < 0 {
+		return ClaudeStateReading{}, false
+	}
+
+	return ClaudeStateReading{
+		State:     state,
+		Timestamp: time.Unix(secs, 0),
+	}, true
+}
+
+// ===========================================
+// Private helpers
+// ===========================================
+
+// firstNonEmptyLine returns the first non-empty, trimmed line from
+// content. Returns "" when content has no usable line. Tolerates
+// trailing newlines, leading whitespace, and stray blank lines so a
+// future hook script that decides to add a header line still
+// produces parseable output.
+func firstNonEmptyLine(content string) string {
+	for raw := range strings.SplitSeq(content, "\n") {
+		if line := strings.TrimSpace(raw); line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+// splitStateLine splits a "<state> <secs>" line into its two
+// whitespace-separated tokens. Returns ok=false when the line does
+// not have at least two tokens; trailing tokens beyond the second
+// are silently ignored to leave room for forwards-compatible
+// extensions.
+func splitStateLine(line string) (state, secs string, ok bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return "", "", false
+	}
+	return fields[0], fields[1], true
+}
+
+// decodeStateToken maps the wire-format state string to the
+// agentdetect.State enum. The explicit "unknown" sentinel the hook
+// script writes for unrecognised events is matched by name (rather
+// than falling into default) to make the contract with the script
+// readable in one glance, and to ensure renaming the constant
+// trips the test that scans the embedded script for it.
+func decodeStateToken(token string) (State, bool) {
+	switch token {
+	case stateValueWorking:
+		return StateWorking, true
+	case stateValueWaiting:
+		return StateWaiting, true
+	case stateValueUnknown:
+		return StateNotRunning, false
+	default:
+		return StateNotRunning, false
+	}
+}

--- a/internal/agentdetect/claude_state_file_test.go
+++ b/internal/agentdetect/claude_state_file_test.go
@@ -1,0 +1,183 @@
+package agentdetect
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestParseClaudeStateFile covers the parser against every shape the
+// state file can take in the wild: well-formed lines, empty content,
+// partial/malformed lines, unknown tokens, trailing newlines, and a
+// forward-compatible scenario where the file carries extra trailing
+// fields a future hook script version might add.
+func TestParseClaudeStateFile(t *testing.T) {
+	cases := []struct {
+		name      string
+		content   string
+		wantOK    bool
+		wantState State
+		wantSecs  int64
+	}{
+		{
+			name:      "well-formed working",
+			content:   "working 1234567890\n",
+			wantOK:    true,
+			wantState: StateWorking,
+			wantSecs:  1234567890,
+		},
+		{
+			name:      "well-formed waiting",
+			content:   "waiting 1717000000\n",
+			wantOK:    true,
+			wantState: StateWaiting,
+			wantSecs:  1717000000,
+		},
+		{
+			name:    "no trailing newline still parses",
+			content: "working 42",
+			wantOK:  true, wantState: StateWorking, wantSecs: 42,
+		},
+		{
+			name:    "leading whitespace tolerated",
+			content: "   working 100\n",
+			wantOK:  true, wantState: StateWorking, wantSecs: 100,
+		},
+		{
+			name:    "extra fields ignored (forward compatible)",
+			content: "waiting 500 future-field-we-do-not-yet-know\n",
+			wantOK:  true, wantState: StateWaiting, wantSecs: 500,
+		},
+		{
+			name:    "second line ignored",
+			content: "working 9\nspurious extra line\n",
+			wantOK:  true, wantState: StateWorking, wantSecs: 9,
+		},
+		{
+			name:    "blank lines skipped",
+			content: "\n\nwaiting 1\n",
+			wantOK:  true, wantState: StateWaiting, wantSecs: 1,
+		},
+		{name: "empty string", content: "", wantOK: false},
+		{name: "whitespace only", content: "   \n\t\n", wantOK: false},
+		{name: "missing timestamp", content: "working\n", wantOK: false},
+		{name: "non-numeric timestamp", content: "working notanumber\n", wantOK: false},
+		{name: "negative timestamp", content: "working -1\n", wantOK: false},
+		{name: "unknown sentinel", content: "unknown 100\n", wantOK: false},
+		{name: "unrecognised future state", content: "thinking 100\n", wantOK: false},
+		{name: "garbled content", content: "@#$ %^&\n", wantOK: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ParseClaudeStateFile(tc.content)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (got %+v)", ok, tc.wantOK, got)
+			}
+			if !ok {
+				return
+			}
+			if got.State != tc.wantState {
+				t.Errorf("state = %d, want %d", got.State, tc.wantState)
+			}
+			if got.Timestamp.Unix() != tc.wantSecs {
+				t.Errorf("timestamp = %d, want %d", got.Timestamp.Unix(), tc.wantSecs)
+			}
+		})
+	}
+}
+
+// TestParseClaudeStateFile_TimestampHasSecondPrecision verifies the
+// parser produces a time.Time that round-trips cleanly to the unix
+// second value the hook script wrote — sub-second precision is not
+// part of the wire format, so the Time should land exactly on a
+// second boundary in UTC.
+func TestParseClaudeStateFile_TimestampHasSecondPrecision(t *testing.T) {
+	got, ok := ParseClaudeStateFile("working 1234567890\n")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got.Timestamp.Nanosecond() != 0 {
+		t.Errorf("timestamp has sub-second component: %v", got.Timestamp)
+	}
+	if got.Timestamp.Unix() != 1234567890 {
+		t.Errorf("timestamp drifted: %d", got.Timestamp.Unix())
+	}
+}
+
+// TestClaudeHookScript_Embedded verifies the script bytes are
+// actually embedded into the binary and contain the wire-format
+// strings the parser expects. This is the canary for "someone
+// edited the .sh without telling the parser".
+func TestClaudeHookScript_Embedded(t *testing.T) {
+	if len(ClaudeHookScript) == 0 {
+		t.Fatal("ClaudeHookScript is empty — go:embed directive broken?")
+	}
+	body := string(ClaudeHookScript)
+	for _, marker := range []string{
+		stateValueWorking,
+		stateValueWaiting,
+		stateValueUnknown,
+		"UserPromptSubmit",
+		"PreToolUse",
+		"PostToolUse",
+		"Notification",
+		"Stop",
+		"FLEET_MAN_STATE_DIR",
+		ClaudeStateDir,
+	} {
+		if !strings.Contains(body, marker) {
+			t.Errorf("embedded script missing required marker %q", marker)
+		}
+	}
+}
+
+// TestClaudeStateFilePath_DerivedFromDir locks the relationship
+// between the state directory and the state file path: tests and
+// callers depend on the file living directly inside the directory.
+func TestClaudeStateFilePath_DerivedFromDir(t *testing.T) {
+	if !strings.HasPrefix(ClaudeStateFilePath, ClaudeStateDir+"/") {
+		t.Errorf("ClaudeStateFilePath %q does not live under ClaudeStateDir %q",
+			ClaudeStateFilePath, ClaudeStateDir)
+	}
+}
+
+// TestParseClaudeStateFile_TimestampUsesUnixOrigin sanity-checks the
+// parser interprets the field as unix seconds, not some other
+// epoch — a 5-second-old timestamp from "now" should round-trip
+// within a few seconds.
+func TestParseClaudeStateFile_TimestampUsesUnixOrigin(t *testing.T) {
+	now := time.Now().Unix()
+	got, ok := ParseClaudeStateFile("working " + itoa(now-5) + "\n")
+	if !ok {
+		t.Fatal("parse failed")
+	}
+	delta := time.Since(got.Timestamp)
+	if delta < 4*time.Second || delta > 6*time.Second {
+		t.Errorf("time delta = %v, want ~5s — parser may be using wrong epoch", delta)
+	}
+}
+
+// itoa avoids pulling strconv into the test wire just for one int
+// formatting call.
+func itoa(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/internal/agentdetect/container_executor.go
+++ b/internal/agentdetect/container_executor.go
@@ -1,0 +1,19 @@
+package agentdetect
+
+// ===========================================
+// ContainerExecutor abstraction
+// ===========================================
+
+// ContainerExecutor is the minimal "run a command inside the target
+// container" surface the provisioner depends on. Backends supply an
+// implementation via NewBackendExecutor; tests supply a stub.
+//
+// Run executes args (already in argv form — typically
+// []{"sh", "-c", "..."}) and returns the stdout bytes. When stdin
+// is non-nil it is fed to the command's standard input. Any non-zero
+// exit or transport error is returned as err with stderr included
+// in the wrapped message so the caller has something diagnostic to
+// surface to the user.
+type ContainerExecutor interface {
+	Run(args []string, stdin []byte) ([]byte, error)
+}

--- a/internal/agentdetect/factory.go
+++ b/internal/agentdetect/factory.go
@@ -7,14 +7,15 @@ import (
 // NewDetector returns the appropriate Detector strategy for a given
 // agent tool.
 //
-// Today every tool falls back to TmuxPaneChangeDetector — the generic
-// pane-diffing strategy works for any CLI agent that draws into a
-// tmux pane. As tool-specific signals are added (e.g., parsing a
-// known agent's status line, watching its log files, hitting an
-// exposed status endpoint) new branches can be added here without
-// touching the call sites.
+// Per-tool branches plug in tool-specific signals when they are
+// available (e.g., Claude Code's lifecycle hooks). Tools without a
+// dedicated strategy fall back to TmuxPaneChangeDetector — the
+// generic pane-diffing strategy that works for any CLI agent
+// drawing into a tmux pane.
 func NewDetector(tool state.AgentTool) Detector {
 	switch tool {
+	case state.AgentToolClaude:
+		return NewClaudeHookDetector()
 	default:
 		return NewTmuxPaneChangeDetector()
 	}

--- a/internal/backend/all_sessions.go
+++ b/internal/backend/all_sessions.go
@@ -1,12 +1,19 @@
 package backend
 
-// AllSessions holds tmux screen captures for every session discovered
-// inside a single container in one shell invocation.
+// AllSessions holds the per-container snapshot collected in a single
+// shell invocation: tmux pane captures, plus auxiliary state files
+// produced by tool-specific in-container hooks (Claude Code's
+// fleet-man-state-hook is the first consumer).
 //
 //   - OK=false means the exec itself failed (transient — preserve prev state)
 //   - OK=true with empty Sessions means tmux has no sessions (agent not running)
 //   - OK=true with populated Sessions means each named session has a capture
+//   - ExtraFiles maps absolute container path → file contents for any
+//     /tmp/fleet-man/*-state files present at capture time. Detectors
+//     read their own state file by path; missing entries simply mean
+//     the file did not exist.
 type AllSessions struct {
-	Sessions map[string]ScreenCapture // sessionName → capture
-	OK       bool
+	Sessions   map[string]ScreenCapture // sessionName → capture
+	ExtraFiles map[string]string        // containerPath → contents
+	OK         bool
 }

--- a/internal/backend/coder/coder_backend.go
+++ b/internal/backend/coder/coder_backend.go
@@ -25,8 +25,8 @@ type CoderBackend struct {
 // New creates a new CoderBackend.
 func New(opts ...Option) *CoderBackend {
 	coderBackend := &CoderBackend{}
-	for _, o := range opts {
-		o(coderBackend)
+	for _, opt := range opts {
+		opt(coderBackend)
 	}
 	return coderBackend
 }
@@ -232,7 +232,8 @@ func (coderBackend *CoderBackend) CaptureAllSessions(containerID string) backend
 	if err != nil {
 		return backend.AllSessions{OK: false}
 	}
-	return backend.AllSessions{Sessions: backend.ParseAllSessionsOutput(string(out)), OK: true}
+	sessions, files := backend.ParseCaptureOutput(string(out))
+	return backend.AllSessions{Sessions: sessions, ExtraFiles: files, OK: true}
 }
 
 // AgentToolProbe detects which agent tool is running inside a Coder workspace.
@@ -280,14 +281,14 @@ func (coderBackend *CoderBackend) Status(containerID string) backend.LiveStatus 
 	if name == "" {
 		return backend.LiveStatusUnknown
 	}
-	ws, err := coderBackend.getWorkspace(name)
+	workspace, err := coderBackend.getWorkspace(name)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			return backend.LiveStatusMissing
 		}
 		return backend.LiveStatusUnknown
 	}
-	switch ws.LatestBuild.Status {
+	switch workspace.LatestBuild.Status {
 	case "running", "started":
 		return backend.LiveStatusRunning
 	case "stopped", "canceled":

--- a/internal/backend/codespaces/codespaces_backend.go
+++ b/internal/backend/codespaces/codespaces_backend.go
@@ -46,8 +46,8 @@ func New(opts ...Option) *CodespacesBackend {
 		nameCache:  make(map[string]string),
 		sshConfigs: make(map[string]sshConfig),
 	}
-	for _, o := range opts {
-		o(codespacesBackend)
+	for _, opt := range opts {
+		opt(codespacesBackend)
 	}
 	return codespacesBackend
 }
@@ -257,7 +257,8 @@ func (codespacesBackend *CodespacesBackend) CaptureAllSessions(containerID strin
 	if err != nil {
 		return backend.AllSessions{OK: false}
 	}
-	return backend.AllSessions{Sessions: backend.ParseAllSessionsOutput(string(out)), OK: true}
+	sessions, files := backend.ParseCaptureOutput(string(out))
+	return backend.AllSessions{Sessions: sessions, ExtraFiles: files, OK: true}
 }
 
 // AgentToolProbe detects which agent tool is running inside a codespace.

--- a/internal/backend/devcontainer/devcontainer_backend.go
+++ b/internal/backend/devcontainer/devcontainer_backend.go
@@ -26,8 +26,8 @@ type DevcontainerBackend struct {
 // New creates a new DevcontainerBackend.
 func New(opts ...Option) *DevcontainerBackend {
 	devcontainerBackend := &DevcontainerBackend{userCache: make(map[string]string)}
-	for _, o := range opts {
-		o(devcontainerBackend)
+	for _, opt := range opts {
+		opt(devcontainerBackend)
 	}
 	return devcontainerBackend
 }
@@ -264,7 +264,8 @@ func (devcontainerBackend *DevcontainerBackend) CaptureAllSessions(containerID s
 	if err != nil {
 		return backend.AllSessions{OK: false}
 	}
-	return backend.AllSessions{Sessions: backend.ParseAllSessionsOutput(string(out)), OK: true}
+	sessions, files := backend.ParseCaptureOutput(string(out))
+	return backend.AllSessions{Sessions: sessions, ExtraFiles: files, OK: true}
 }
 
 // AgentToolProbe detects which agent tool is running inside a container.

--- a/internal/backend/scripts.go
+++ b/internal/backend/scripts.go
@@ -65,7 +65,7 @@ func ParseToolProbeOutput(output string) (string, bool) {
 }
 
 // ===========================================
-// Session Capture
+// Capture (sessions + per-tool state files)
 // ===========================================
 
 // sessionMarker is emitted before each session's capture inside
@@ -73,28 +73,61 @@ func ParseToolProbeOutput(output string) (string, bool) {
 // output, so splitting on this marker is unambiguous.
 const sessionMarker = "\x1eFLEET_SESSION_8f4a2b1c\x1e"
 
-// CaptureAllScript lists every tmux session and captures each pane's
-// visible content in a single shell invocation. The session name
-// precedes each capture on its own marker line so the Go side can
-// demultiplex the output back into per-session captures.
+// fileMarker is emitted before each captured auxiliary file inside
+// CaptureAllScript. Same marker scheme as sessions but a distinct
+// payload type so the parser knows which map the body belongs to.
+const fileMarker = "\x1eFLEET_FILE_8f4a2b1c\x1e"
+
+// CaptureAllScript runs every per-container read fleet-man needs in a
+// single shell invocation:
+//
+//  1. List tmux sessions and capture each pane's visible content.
+//  2. Cat any /tmp/fleet-man/*-state files written by in-container
+//     hook scripts (today: Claude Code's fleet-man-state-hook).
+//
+// Each block is preceded by a marker line so the Go side can
+// demultiplex back into typed maps. The script is tolerant of
+// "nothing to capture" at every step: missing tmux server, missing
+// /tmp/fleet-man directory, missing state files all reduce to silent
+// no-ops.
 const CaptureAllScript = `sessions=$(tmux list-sessions -F "#{session_name}" 2>/dev/null)
-[ -z "$sessions" ] && exit 0
-printf '%s\n' "$sessions" | while IFS= read -r sess; do
-  [ -z "$sess" ] && continue
-  printf '\036FLEET_SESSION_8f4a2b1c\036%s\n' "$sess"
-  tmux capture-pane -t "$sess" -p 2>/dev/null
+if [ -n "$sessions" ]; then
+  printf '%s\n' "$sessions" | while IFS= read -r sess; do
+    [ -z "$sess" ] && continue
+    printf '\036FLEET_SESSION_8f4a2b1c\036%s\n' "$sess"
+    tmux capture-pane -t "$sess" -p 2>/dev/null
+  done
+fi
+for f in /tmp/fleet-man/*-state; do
+  [ -e "$f" ] || continue
+  printf '\036FLEET_FILE_8f4a2b1c\036%s\n' "$f"
+  cat "$f" 2>/dev/null || true
 done
 `
 
-// ParseAllSessionsOutput parses CaptureAllScript output into
-// per-session captures. Returns an empty map when the output has no
-// session markers (tmux server not running or no sessions).
-func ParseAllSessionsOutput(output string) map[string]ScreenCapture {
-	result := make(map[string]ScreenCapture)
+// ParseCaptureOutput demultiplexes CaptureAllScript output into its
+// two payload kinds:
+//
+//   - sessions: tmux sessionName → ScreenCapture
+//   - files:    containerPath    → file contents
+//
+// Lines preceding the first marker are ignored (the script may emit
+// stray output if tmux is misbehaving and we want to fail soft).
+// Returns empty maps when the output has no markers.
+func ParseCaptureOutput(output string) (map[string]ScreenCapture, map[string]string) {
+	sessions := make(map[string]ScreenCapture)
+	files := make(map[string]string)
 	if output == "" {
-		return result
+		return sessions, files
 	}
 
+	const (
+		modeNone = iota
+		modeSession
+		modeFile
+	)
+
+	mode := modeNone
 	var currentName string
 	var currentBuf strings.Builder
 	flush := func() {
@@ -102,22 +135,35 @@ func ParseAllSessionsOutput(output string) map[string]ScreenCapture {
 			return
 		}
 		content := strings.TrimRight(currentBuf.String(), "\n")
-		result[currentName] = ScreenCapture{Content: content, OK: true}
+		switch mode {
+		case modeSession:
+			sessions[currentName] = ScreenCapture{Content: content, OK: true}
+		case modeFile:
+			files[currentName] = content
+		}
 	}
 
 	for _, line := range strings.SplitAfter(output, "\n") {
 		trimmed := strings.TrimRight(line, "\n")
-		if strings.HasPrefix(trimmed, sessionMarker) {
+		switch {
+		case strings.HasPrefix(trimmed, sessionMarker):
 			flush()
 			currentName = strings.TrimPrefix(trimmed, sessionMarker)
+			mode = modeSession
+			currentBuf.Reset()
+			continue
+		case strings.HasPrefix(trimmed, fileMarker):
+			flush()
+			currentName = strings.TrimPrefix(trimmed, fileMarker)
+			mode = modeFile
 			currentBuf.Reset()
 			continue
 		}
-		if currentName == "" {
+		if mode == modeNone {
 			continue
 		}
 		currentBuf.WriteString(line)
 	}
 	flush()
-	return result
+	return sessions, files
 }

--- a/internal/backend/scripts_test.go
+++ b/internal/backend/scripts_test.go
@@ -30,81 +30,165 @@ func TestParseToolProbeOutput(t *testing.T) {
 	}
 }
 
-func TestParseAllSessionsOutput(t *testing.T) {
+// ===========================================
+// ParseCaptureOutput — sessions
+// ===========================================
+
+func TestParseCaptureOutput_Sessions(t *testing.T) {
 	mk := func(name, content string) string {
 		return sessionMarker + name + "\n" + content
 	}
 
 	t.Run("empty input means no sessions", func(t *testing.T) {
-		got := ParseAllSessionsOutput("")
-		if len(got) != 0 {
-			t.Fatalf("expected 0 sessions, got %d", len(got))
+		sessions, files := ParseCaptureOutput("")
+		if len(sessions) != 0 {
+			t.Fatalf("expected 0 sessions, got %d", len(sessions))
+		}
+		if len(files) != 0 {
+			t.Fatalf("expected 0 files, got %d", len(files))
 		}
 	})
 
 	t.Run("single session with content", func(t *testing.T) {
 		input := mk("main", "line1\nline2\n")
-		got := ParseAllSessionsOutput(input)
-		if len(got) != 1 {
-			t.Fatalf("expected 1 session, got %d", len(got))
+		sessions, _ := ParseCaptureOutput(input)
+		if len(sessions) != 1 {
+			t.Fatalf("expected 1 session, got %d", len(sessions))
 		}
-		sc, ok := got["main"]
+		capture, ok := sessions["main"]
 		if !ok {
 			t.Fatalf("session 'main' missing")
 		}
-		if !sc.OK {
+		if !capture.OK {
 			t.Fatal("expected OK=true")
 		}
-		if sc.Content != "line1\nline2" {
-			t.Fatalf("got content %q", sc.Content)
+		if capture.Content != "line1\nline2" {
+			t.Fatalf("got content %q", capture.Content)
 		}
 	})
 
 	t.Run("multiple sessions are demultiplexed", func(t *testing.T) {
 		input := mk("main", "alpha\n") + mk("session-2", "beta\nbeta2\n") + mk("hex-abc", "")
-		got := ParseAllSessionsOutput(input)
-		if len(got) != 3 {
-			t.Fatalf("expected 3 sessions, got %d", len(got))
+		sessions, _ := ParseCaptureOutput(input)
+		if len(sessions) != 3 {
+			t.Fatalf("expected 3 sessions, got %d", len(sessions))
 		}
-		if got["main"].Content != "alpha" {
-			t.Fatalf("main content: %q", got["main"].Content)
+		if sessions["main"].Content != "alpha" {
+			t.Fatalf("main content: %q", sessions["main"].Content)
 		}
-		if got["session-2"].Content != "beta\nbeta2" {
-			t.Fatalf("session-2 content: %q", got["session-2"].Content)
+		if sessions["session-2"].Content != "beta\nbeta2" {
+			t.Fatalf("session-2 content: %q", sessions["session-2"].Content)
 		}
-		if got["hex-abc"].Content != "" {
-			t.Fatalf("hex-abc should be empty, got %q", got["hex-abc"].Content)
+		if sessions["hex-abc"].Content != "" {
+			t.Fatalf("hex-abc should be empty, got %q", sessions["hex-abc"].Content)
 		}
 	})
 
 	t.Run("session names with special characters survive", func(t *testing.T) {
-		// Group sessions use ~ as separator; any printable ASCII
-		// other than RS (\x1e) must round-trip through the marker.
 		input := mk("fleet~abc123~def", "content")
-		got := ParseAllSessionsOutput(input)
-		sc, ok := got["fleet~abc123~def"]
+		sessions, _ := ParseCaptureOutput(input)
+		capture, ok := sessions["fleet~abc123~def"]
 		if !ok {
-			t.Fatalf("expected fleet~abc123~def in result; got keys: %v", keys(got))
+			t.Fatalf("expected fleet~abc123~def in result; got keys: %v", sessionKeys(sessions))
 		}
-		if sc.Content != "content" {
-			t.Fatalf("got content %q", sc.Content)
+		if capture.Content != "content" {
+			t.Fatalf("got content %q", capture.Content)
 		}
 	})
 
 	t.Run("output without markers is ignored", func(t *testing.T) {
-		// tmux server not running → script exits with no output
-		// before any marker — nothing to record.
-		got := ParseAllSessionsOutput("orphan content with no marker\n")
-		if len(got) != 0 {
-			t.Fatalf("expected 0 sessions, got %d", len(got))
+		sessions, files := ParseCaptureOutput("orphan content with no marker\n")
+		if len(sessions) != 0 || len(files) != 0 {
+			t.Fatalf("expected empty results, got sessions=%d files=%d", len(sessions), len(files))
 		}
 	})
 }
 
-func keys(m map[string]ScreenCapture) []string {
-	ks := make([]string, 0, len(m))
-	for k := range m {
-		ks = append(ks, k)
+// ===========================================
+// ParseCaptureOutput — files
+// ===========================================
+
+func TestParseCaptureOutput_Files(t *testing.T) {
+	mkFile := func(path, content string) string {
+		return fileMarker + path + "\n" + content
 	}
-	return ks
+	mkSession := func(name, content string) string {
+		return sessionMarker + name + "\n" + content
+	}
+
+	t.Run("single file capture", func(t *testing.T) {
+		input := mkFile("/tmp/fleet-man/claude-state", "working 1700000000\n")
+		_, files := ParseCaptureOutput(input)
+		if got := files["/tmp/fleet-man/claude-state"]; got != "working 1700000000" {
+			t.Errorf("got %q, want %q", got, "working 1700000000")
+		}
+	})
+
+	t.Run("multiple files demultiplexed", func(t *testing.T) {
+		input := mkFile("/tmp/fleet-man/claude-state", "working 100\n") +
+			mkFile("/tmp/fleet-man/codex-state", "waiting 200\n")
+		_, files := ParseCaptureOutput(input)
+		if len(files) != 2 {
+			t.Fatalf("got %d files, want 2", len(files))
+		}
+		if files["/tmp/fleet-man/claude-state"] != "working 100" {
+			t.Errorf("claude-state: %q", files["/tmp/fleet-man/claude-state"])
+		}
+		if files["/tmp/fleet-man/codex-state"] != "waiting 200" {
+			t.Errorf("codex-state: %q", files["/tmp/fleet-man/codex-state"])
+		}
+	})
+
+	t.Run("empty file content is captured as empty string", func(t *testing.T) {
+		// State files exist but were empty (race between mkdir and
+		// first hook fire) — must produce an entry, not an absence.
+		input := mkFile("/tmp/fleet-man/claude-state", "")
+		_, files := ParseCaptureOutput(input)
+		if _, present := files["/tmp/fleet-man/claude-state"]; !present {
+			t.Fatalf("expected entry for empty file, got: %v", files)
+		}
+	})
+
+	t.Run("sessions and files coexist in one output", func(t *testing.T) {
+		// This is the normal CaptureAllScript shape: sessions first,
+		// then state files. Both must demultiplex cleanly.
+		input := mkSession("main", "tmux pane content\n") +
+			mkFile("/tmp/fleet-man/claude-state", "working 42\n")
+		sessions, files := ParseCaptureOutput(input)
+		if got := sessions["main"].Content; got != "tmux pane content" {
+			t.Errorf("session content: %q", got)
+		}
+		if got := files["/tmp/fleet-man/claude-state"]; got != "working 42" {
+			t.Errorf("file content: %q", got)
+		}
+	})
+
+	t.Run("file content survives newlines and special chars", func(t *testing.T) {
+		body := "line1\nline2\n  indented\n"
+		input := mkFile("/tmp/fleet-man/claude-state", body)
+		_, files := ParseCaptureOutput(input)
+		if got := files["/tmp/fleet-man/claude-state"]; got != "line1\nline2\n  indented" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("file marker followed by session marker switches mode", func(t *testing.T) {
+		input := mkFile("/tmp/fleet-man/claude-state", "working 1\n") +
+			mkSession("main", "pane\n")
+		sessions, files := ParseCaptureOutput(input)
+		if files["/tmp/fleet-man/claude-state"] != "working 1" {
+			t.Errorf("file content: %q", files["/tmp/fleet-man/claude-state"])
+		}
+		if sessions["main"].Content != "pane" {
+			t.Errorf("session content: %q", sessions["main"].Content)
+		}
+	})
+}
+
+func sessionKeys(captures map[string]ScreenCapture) []string {
+	keys := make([]string, 0, len(captures))
+	for key := range captures {
+		keys = append(keys, key)
+	}
+	return keys
 }

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/BenjaminBenetti/fleet-man/internal/agentdetect"
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 	coderbackend "github.com/BenjaminBenetti/fleet-man/internal/backend/coder"
 	codespacesbackend "github.com/BenjaminBenetti/fleet-man/internal/backend/codespaces"
@@ -114,6 +115,20 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backen
 	// failures are non-fatal — the instance is still usable, so we
 	// surface them as a warning rather than aborting creation.
 	runStartupScripts(instanceBackend, wsDir, fleetName, instanceName)
+
+	// Install Claude Code state-detection hooks. Runs after the
+	// startup scripts so any per-fleet Claude Code install above
+	// has had a chance to land before we drop our hooks alongside
+	// it. Like dotfiles, this is non-fatal: if hook installation
+	// fails the user can still use the instance — fleet-man's
+	// per-instance Detector falls back to a safe default for
+	// Claude state. We always install (regardless of which agent
+	// the user actually runs) because we don't know the choice at
+	// creation time, and the cost of unused hooks is negligible.
+	executor := agentdetect.NewBackendExecutor(instanceBackend, wsDir)
+	if err := agentdetect.NewClaudeProvisioner(executor).Provision(); err != nil {
+		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("claude hook install failed: %v", err))
+	}
 
 	// Success: update state (instance is running even if dotfiles failed)
 	st, err := state.Load()
@@ -255,28 +270,28 @@ func buildCoderBackend(fleetName, instanceName, remoteURL, branch string, verbos
 		return coderbackend.New(opts...)
 	}
 
-	cs := config.CoderSettings
-	if cs.Template != "" {
-		opts = append(opts, coderbackend.WithTemplate(cs.Template))
+	coderSettings := config.CoderSettings
+	if coderSettings.Template != "" {
+		opts = append(opts, coderbackend.WithTemplate(coderSettings.Template))
 	}
-	if cs.Preset != "" {
-		opts = append(opts, coderbackend.WithPreset(cs.Preset))
+	if coderSettings.Preset != "" {
+		opts = append(opts, coderbackend.WithPreset(coderSettings.Preset))
 	}
 
 	// Resolve parameters with variable substitution
-	if len(cs.Parameters) > 0 {
+	if len(coderSettings.Parameters) > 0 {
 		wsName := fleetName + "-" + instanceName
-		resolved := make(map[string]string, len(cs.Parameters))
-		for _, p := range cs.Parameters {
-			value := p.Value
+		resolved := make(map[string]string, len(coderSettings.Parameters))
+		for _, param := range coderSettings.Parameters {
+			value := param.Value
 			if value == "" {
-				value = p.DefaultValue
+				value = param.DefaultValue
 			}
 			value = strings.ReplaceAll(value, "${GIT_URL}", remoteURL)
 			value = strings.ReplaceAll(value, "${GIT_BRANCH}", branch)
 			value = strings.ReplaceAll(value, "${INSTANCE_NAME}", wsName)
 			if value != "" {
-				resolved[p.Name] = value
+				resolved[param.Name] = value
 			}
 		}
 		opts = append(opts, coderbackend.WithParameters(resolved))
@@ -310,15 +325,15 @@ func buildCodespacesBackend(remoteURL, branch string, verbose bool) backend.Back
 		return codespacesbackend.New(opts...)
 	}
 
-	cs := config.CodespacesSettings
-	if cs.Machine != "" {
-		opts = append(opts, codespacesbackend.WithMachine(cs.Machine))
+	codespacesSettings := config.CodespacesSettings
+	if codespacesSettings.Machine != "" {
+		opts = append(opts, codespacesbackend.WithMachine(codespacesSettings.Machine))
 	}
-	if cs.IdleTimeout != "" {
-		opts = append(opts, codespacesbackend.WithIdleTimeout(cs.IdleTimeout))
+	if codespacesSettings.IdleTimeout != "" {
+		opts = append(opts, codespacesbackend.WithIdleTimeout(codespacesSettings.IdleTimeout))
 	}
-	if cs.DevcontainerPath != "" {
-		opts = append(opts, codespacesbackend.WithDevcontainerPath(cs.DevcontainerPath))
+	if codespacesSettings.DevcontainerPath != "" {
+		opts = append(opts, codespacesbackend.WithDevcontainerPath(codespacesSettings.DevcontainerPath))
 	}
 
 	return codespacesbackend.New(opts...)


### PR DESCRIPTION
## Summary

- Adds a Claude-Code-specific `Detector` strategy that reads run state directly from Claude's own lifecycle events (UserPromptSubmit / PreToolUse / PostToolUse / Notification / Stop) instead of relying on tmux pane diffing.
- A small POSIX-sh hook script (`~/.fleet/scripts/claude-state-hook.sh`, embedded into the fleet-man binary) writes a single-line `<state> <unix-secs>` file the host reads each tick via the existing per-container capture path.
- `~/.claude/settings.json` is **edited in place**: parsed into `map[string]any`, our entries upserted by suffix-matching the script path, everything else round-trips untouched. Zero-state, foreign-content preservation, idempotency, and position-stable replacement are all covered by tests.

## Architecture

```
┌─────────────── fleet-man (host) ───────────────┐
│  ClaudeHookDetector ◄── ExtraFiles ◄── capture │
│         ▲                                       │
│  factory.NewDetector(AgentToolClaude)           │
│                                                 │
│  ClaudeProvisioner (runs on create.Run)         │
│   1. echo \$HOME   → resolve script path        │
│   2. drop script  → \$HOME/.fleet/scripts/...   │
│   3. read+edit+atomic-write ~/.claude/settings  │
└────────────────────┬────────────────────────────┘
                     │ docker exec / devcontainer exec
                     ▼
┌──────────────── container ─────────────────────┐
│  Claude Code  ──hook event──▶  state-hook.sh   │
│                                       │         │
│                                       ▼         │
│                       /tmp/fleet-man/claude-state│
└─────────────────────────────────────────────────┘
```

## What's covered

- **Phase 1** — safe settings.json editor (28 tests: zero-states, preservation, idempotency, position-stable replace, dedup, lookalike-not-confused, error cases)
- **Phase 2** — embedded POSIX-sh hook script + permissive state-file parser (25 tests including subprocess execution)
- **Phase 3** — `ClaudeHookDetector` strategy + backend capture extension for state-file content (`ExtraFiles` field on `AllSessions`, `ParseCaptureOutput` returning sessions + files)
- **Phase 4** — `ClaudeProvisioner` orchestrator + `BackendExecutor` adapter + non-fatal wiring into `create.Run` (matches dotfiles install pattern)
- **End-to-end integration test** exercising provisioner → real hook script → state file → detector against a temp `\$HOME`, including a simulated two-turn Claude conversation with a permission notification

## Test plan

- [ ] `go build ./...`
- [ ] `go test ./...`
- [ ] Create a fresh devcontainer instance via fleet-man, verify `~/.fleet/scripts/claude-state-hook.sh` is dropped with +x and `~/.claude/settings.json` contains our hook entries for all 5 events
- [ ] Run Claude Code in the instance; observe fleet-man TUI reports `working` during a turn and `waiting` after Stop
- [ ] Trigger a permission prompt in Claude; verify state moves to `waiting`
- [ ] Re-provision the same instance; verify settings.json round-trips byte-identical
- [ ] Manually add a foreign hook to settings.json (e.g. user's own PreToolUse audit script); verify it survives a fleet-man re-provision

🤖 Generated with [Claude Code](https://claude.com/claude-code)