### PR TITLE
feat(tui): devcontainer setup helper for new fleets

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -8,11 +8,13 @@ real docker daemon.
 
 ```
 integration/
-├── run.sh              # driver: builds binary, runs every test, teardown between
-├── common.sh           # shared helpers: assertions, setup/teardown, fleet_up
-├── fixture/            # minimal devcontainer fixture cloned via file:// per test
+├── run.sh                      # driver: builds binary, runs every test, teardown between
+├── common.sh                   # shared helpers: assertions, setup/teardown, fleet_up
+├── fixture/                    # minimal devcontainer fixture cloned via file:// per test
 │   └── .devcontainer/
 │       └── devcontainer.json
+├── fixture-no-devcontainer/    # repo template deliberately missing a devcontainer
+│                               # config, used by new-fleet check-flow tests
 └── tests/
     ├── 010_up_and_ls.sh        # CLI — up + ls
     ├── 020_exec.sh             # CLI — exec

--- a/integration/common.sh
+++ b/integration/common.sh
@@ -233,6 +233,39 @@ seed_fleet_settings() {
 EOF
 }
 
+# install_stub_agent <marker_path>
+#
+# Drop a fake `claude` binary onto PATH ahead of any real one and have
+# it record its invocation to <marker_path>. Used by the new-fleet
+# devcontainer-check tests so the Setup branch behaves identically
+# regardless of whether the runner happens to have a real claude / codex
+# install on PATH.
+#
+# The stub exits 0 immediately so bubbletea regains the terminal after
+# tea.ExecProcess hands off — without a real agent the test would
+# otherwise hang waiting for an interactive prompt.
+#
+# Side-effects:
+#   - Writes the stub at $TEST_SCRATCH_DIR/stubs/claude
+#   - Prepends that dir to PATH for the current shell. tmux inherits the
+#     environment, so a subsequent tui_spawn will see the stub first.
+install_stub_agent() {
+  local marker="$1"
+  local stub_dir="${TEST_SCRATCH_DIR}/stubs"
+  mkdir -p "${stub_dir}"
+  cat > "${stub_dir}/claude" <<EOF
+#!/usr/bin/env bash
+# Stub agent installed by install_stub_agent — used by integration tests
+# to assert the Setup branch of the new-fleet devcontainer dialog
+# actually launches an agent. Records its argv to the marker file and
+# exits cleanly so the TUI repaints.
+printf '%s\n' "\$*" > "${marker}"
+exit 0
+EOF
+  chmod +x "${stub_dir}/claude"
+  export PATH="${stub_dir}:${PATH}"
+}
+
 # teardown_test best-effort cleans up any containers spawned by a test.
 # It tears down every fleet in state, then wipes state files. Called by
 # run.sh after each test whether it passed or failed.

--- a/integration/fixture-no-devcontainer/README.md
+++ b/integration/fixture-no-devcontainer/README.md
@@ -1,0 +1,11 @@
+# fleet-man integration fixture — no devcontainer
+
+A bare repository deliberately missing `.devcontainer/devcontainer.json`,
+used by the new-fleet devcontainer-check tests to exercise the "no
+devcontainer" dialog (Abort / Setup branches). The check-flow tests
+copy this directory into a throwaway git repo and feed its `file://`
+URL into the TUI's new-fleet dialog.
+
+Keeping it disjoint from the default fixture means the present-fixture
+happy path and the missing-fixture dialog path can each ship a focused
+test without one mutating the other's repo.

--- a/integration/tests/171_tui_new_fleet_with_devcontainer.sh
+++ b/integration/tests/171_tui_new_fleet_with_devcontainer.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Description: TUI new-fleet check passes through when repo has a devcontainer.json
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+
+info "spawning TUI on empty fleet list"
+tui_spawn
+tui_wait_for "No instances" 15
+
+info "opening new-fleet dialog and submitting a repo that already has a devcontainer.json"
+tui_send n
+tui_wait_for "New fleet" 5
+
+tui_send_text "${FIXTURE_REPO_URL}"
+tui_send Enter
+
+info "verifying the no-devcontainer dialog is NEVER shown"
+# Inspecting + add are both fast on a file:// clone, so the next visible
+# state should be the "Added fleet" status message — not the warn
+# dialog. The repo URL contains the fleet name, so we anchor on the
+# explicit success message rather than the bare fleet name (which would
+# also match the transient "Inspecting <URL>..." message).
+tui_wait_for "Added fleet ${FIXTURE_REPO_NAME}" 15
+tui_assert_not_contains "No devcontainer.json found" \
+  "warn dialog appeared even though repo has a devcontainer.json"
+
+info "verifying state persistence"
+# `fleet ls` only lists instances, so a freshly-added empty fleet does
+# not show up there. Read state.json directly instead.
+assert_file_exists "${HOME}/.fleet/state.json"
+state=$(cat "${HOME}/.fleet/state.json")
+assert_contains "${state}" "\"${FIXTURE_REPO_NAME}\"" "fleet should be persisted to state.json"
+
+pass "TUI new-fleet check passes through when devcontainer.json is present"

--- a/integration/tests/172_tui_new_fleet_no_devcontainer_abort.sh
+++ b/integration/tests/172_tui_new_fleet_no_devcontainer_abort.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Description: TUI new-fleet abort path when repo lacks a devcontainer.json
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+# Use the dedicated no-devcontainer fixture for this test instead of the
+# default debian fixture. setup_test reads $FIXTURE_SRC, so overriding
+# it inline is enough.
+FIXTURE_SRC="${INTEGRATION_DIR}/fixture-no-devcontainer" setup_test
+
+info "spawning TUI on empty fleet list"
+tui_spawn
+tui_wait_for "No instances" 15
+
+info "opening new-fleet dialog and submitting a repo without a devcontainer.json"
+tui_send n
+tui_wait_for "New fleet" 5
+
+tui_send_text "${FIXTURE_REPO_URL}"
+tui_send Enter
+
+info "waiting for the no-devcontainer warning to appear"
+tui_wait_for "No devcontainer.json found" 15
+tui_assert_contains "Abort" "Abort option missing from warn dialog"
+tui_assert_contains "Setup" "Setup option missing from warn dialog"
+
+info "choosing Abort with 'a'"
+tui_send a
+tui_wait_for_absent "No devcontainer.json found" 5
+
+info "verifying the empty state is preserved and no fleet was added"
+tui_wait_for "No instances" 5
+# A fresh fleet with no instances would be invisible to `fleet ls`, so
+# the only reliable signal that Abort really refused to persist is to
+# look at state.json itself.
+if [ -f "${HOME}/.fleet/state.json" ]; then
+  state=$(cat "${HOME}/.fleet/state.json")
+  assert_not_contains "${state}" "\"${FIXTURE_REPO_NAME}\"" \
+    "no fleet should have been persisted after Abort"
+fi
+
+pass "TUI new-fleet abort leaves no trace when devcontainer.json is missing"

--- a/integration/tests/173_tui_new_fleet_no_devcontainer_setup.sh
+++ b/integration/tests/173_tui_new_fleet_no_devcontainer_setup.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Description: TUI new-fleet Setup branch adds the fleet and launches the agent
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+FIXTURE_SRC="${INTEGRATION_DIR}/fixture-no-devcontainer" setup_test
+
+# Install a stub `claude` binary that records its argv and exits 0. The
+# stub fronts any real claude/codex/copilot install on the runner so the
+# Setup path is deterministic: we can assert the agent ran without
+# needing a real interactive session and without the test hanging.
+AGENT_MARKER="${TEST_SCRATCH_DIR}/agent-invoked"
+install_stub_agent "${AGENT_MARKER}"
+
+info "spawning TUI on empty fleet list"
+tui_spawn
+tui_wait_for "No instances" 15
+
+info "opening new-fleet dialog and submitting a repo without a devcontainer.json"
+tui_send n
+tui_wait_for "New fleet" 5
+
+tui_send_text "${FIXTURE_REPO_URL}"
+tui_send Enter
+
+info "waiting for the no-devcontainer warning dialog"
+tui_wait_for "No devcontainer.json found" 15
+
+info "choosing Setup with 's'"
+tui_send s
+
+# The TUI hands the terminal off to the stub agent via tea.ExecProcess.
+# The stub exits immediately, so bubbletea regains control and rerenders
+# the fleet list with the new fleet visible. Assert both outcomes:
+#   1. The agent was actually invoked (stub wrote its marker).
+#   2. The fleet was persisted optimistically before the agent ran.
+
+info "waiting for the stub agent to be invoked"
+deadline=$(( $(date +%s) + $(_scale_timeout 15) ))
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  [ -f "${AGENT_MARKER}" ] && break
+  sleep 0.25
+done
+assert_file_exists "${AGENT_MARKER}"
+
+marker_contents=$(cat "${AGENT_MARKER}")
+assert_contains "${marker_contents}" "${FIXTURE_REPO_URL}" \
+  "agent prompt should reference the repo URL it must clone"
+assert_contains "${marker_contents}" "DEVCONTAINER_SETUP.md" \
+  "agent prompt should reference the devcontainer setup skill URL"
+
+info "verifying the fleet was added immediately on Setup (before the agent finished)"
+# `fleet ls` only lists instances — a new empty fleet does not surface
+# there. Probe state.json directly: addPendingFleet persists the record
+# synchronously before tea.ExecProcess hands off to the agent, so the
+# write must be visible on disk by the time the stub exited.
+assert_file_exists "${HOME}/.fleet/state.json"
+state=$(cat "${HOME}/.fleet/state.json")
+assert_contains "${state}" "\"${FIXTURE_REPO_NAME}\"" \
+  "fleet should be persisted as soon as Setup is chosen"
+
+pass "TUI new-fleet Setup branch adds the fleet and launches the configured agent"

--- a/internal/devcontainersetup/devcontainersetup.go
+++ b/internal/devcontainersetup/devcontainersetup.go
@@ -1,0 +1,73 @@
+// Package devcontainersetup hands the user off to a local coding-agent
+// CLI for guided creation of a devcontainer.json. It mirrors
+// internal/doctor: the only meaningful difference is the prompt the
+// agent receives — instead of diagnosing fleet-man itself, the agent
+// clones the user's repository, walks them through writing a basic
+// devcontainer, and consults the live Microsoft docs so the result
+// reflects current schema rather than stale training data.
+package devcontainersetup
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/agent"
+)
+
+// ===========================================
+// Constants
+// ===========================================
+
+// skillURL points at the skill markdown describing the step-by-step
+// devcontainer-setup workflow. Hosting the instructions on GitHub —
+// rather than baking them into the binary — lets us iterate on the
+// workflow without shipping a new fleet-man release every time.
+const skillURL = "https://raw.githubusercontent.com/BenjaminBenetti/fleet-man/main/skills/DEVCONTAINER_SETUP.md"
+
+// ===========================================
+// Public API
+// ===========================================
+
+// Prompt returns the instruction sent to the coding agent.
+// remoteURL is the git remote of the fleet's repository — the agent
+// will clone it locally so the user can collaboratively author the
+// new .devcontainer/devcontainer.json before pushing.
+func Prompt(remoteURL string) string {
+	return fmt.Sprintf(
+		"Read %s and follow the instructions. The repository to set up is %s. "+
+			"Make sure to consult the latest devcontainer documentation on the web "+
+			"so the configuration you produce reflects the current schema and features.",
+		skillURL, remoteURL,
+	)
+}
+
+// FindAgent returns the name and binary of the first available coding
+// agent on PATH. Returns an error if none are found. Re-exposed at this
+// layer so the TUI can render an "agent: claude" hint without importing
+// the lower-level agent package directly.
+func FindAgent() (name string, binary string, err error) {
+	return agent.FindAgent()
+}
+
+// Command returns an unstarted *exec.Cmd that launches the first
+// available coding agent with the setup prompt for remoteURL.
+// The caller is responsible for attaching I/O (e.g. via tea.ExecProcess).
+func Command(remoteURL string) (*exec.Cmd, error) {
+	return agent.CommandWithPrompt(Prompt(remoteURL))
+}
+
+// Run finds the first available coding agent and launches it
+// interactively with the setup prompt. Blocks until the agent exits.
+// Intended for non-TUI callers; the TUI uses Command + tea.ExecProcess
+// so bubbletea can yield the terminal cleanly.
+func Run(remoteURL string) error {
+	cmd, err := Command(remoteURL)
+	if err != nil {
+		return err
+	}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/inspector/check/devcontainer/devcontainer.go
+++ b/internal/inspector/check/devcontainer/devcontainer.go
@@ -1,0 +1,33 @@
+// Package devcontainer is an inspector check: given an *inspector.Repo
+// it reports whether the repository contains a devcontainer
+// configuration that fleet-man can provision.
+//
+// The actual file-system search is delegated to
+// inspector.Repo.FindDevcontainerJSON so this package stays a thin
+// boolean wrapper — new checks can stack on top of the same Repo handle
+// without each having to reimplement the lookup.
+package devcontainer
+
+import (
+	"errors"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/inspector"
+)
+
+// Present reports whether repo declares a devcontainer.json in any of
+// the locations recognised by the devcontainer CLI.
+//
+// A missing file returns (false, nil) — that is an expected, non-error
+// state that the caller surfaces to the user. Any other I/O failure is
+// returned as-is so the caller can decide whether to retry or fall
+// back.
+func Present(repo *inspector.Repo) (bool, error) {
+	_, _, err := repo.FindDevcontainerJSON()
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, inspector.ErrNoDevcontainerConfig) {
+		return false, nil
+	}
+	return false, err
+}

--- a/internal/inspector/check/devcontainer/devcontainer_test.go
+++ b/internal/inspector/check/devcontainer/devcontainer_test.go
@@ -1,0 +1,53 @@
+package devcontainer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/inspector"
+)
+
+// TestPresentReturnsTrueForCanonicalLocation verifies the common case:
+// a .devcontainer/devcontainer.json sitting at the repo root.
+func TestPresentReturnsTrueForCanonicalLocation(t *testing.T) {
+	repo := makeRepo(t)
+	dcDir := filepath.Join(repo.Root, ".devcontainer")
+	if err := os.MkdirAll(dcDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dcDir, "devcontainer.json"), []byte("{}"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	present, err := Present(repo)
+	if err != nil {
+		t.Fatalf("Present: %v", err)
+	}
+	if !present {
+		t.Fatalf("Present = false, want true")
+	}
+}
+
+// TestPresentReturnsFalseWhenMissing makes sure an absent devcontainer
+// config surfaces as (false, nil) rather than an error — callers branch
+// on the bool to decide whether to prompt the user.
+func TestPresentReturnsFalseWhenMissing(t *testing.T) {
+	repo := makeRepo(t)
+	present, err := Present(repo)
+	if err != nil {
+		t.Fatalf("Present: %v", err)
+	}
+	if present {
+		t.Fatalf("Present = true, want false")
+	}
+}
+
+// makeRepo creates a temporary directory and returns it wrapped in an
+// *inspector.Repo so tests can drive Present without going through the
+// real shallow-clone path.
+func makeRepo(t *testing.T) *inspector.Repo {
+	t.Helper()
+	dir := t.TempDir()
+	return &inspector.Repo{Root: dir}
+}

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/BenjaminBenetti/fleet-man/internal/devcontainersetup"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/inspector"
+	devcontainercheck "github.com/BenjaminBenetti/fleet-man/internal/inspector/check/devcontainer"
 	homedircheck "github.com/BenjaminBenetti/fleet-man/internal/inspector/check/homedir"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	tea "github.com/charmbracelet/bubbletea"
@@ -508,6 +510,12 @@ func (fleetPage *fleetPage) updateTagInstance(m *model, msg tea.Msg) tea.Cmd {
 // ===========================================
 
 // updateAddFleet handles the add-fleet dialog.
+//
+// Pressing enter does not immediately persist the fleet — instead, it
+// kicks off an asynchronous inspection (clone + .devcontainer lookup)
+// and switches to viewAddFleetInspecting so the user sees a spinner
+// while the network work runs. The inspect result is delivered via
+// devcontainerInspectedMsg and resumed in handleDevcontainerInspected.
 func (fleetPage *fleetPage) updateAddFleet(m *model, msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
@@ -525,13 +533,13 @@ func (fleetPage *fleetPage) updateAddFleet(m *model, msg tea.Msg) tea.Cmd {
 				fleetPage.mode = viewNormal
 				return nil
 			}
-			m.st.GetOrCreateFleet(fleetName, repoURL)
-			_ = state.Save(m.st)
-			fleetPage.buildRows(m)
-			fleetPage.mode = viewNormal
+
+			fleetPage.dialogPendingRepoURL = repoURL
+			fleetPage.dialogPendingFleetName = fleetName
+			fleetPage.mode = viewAddFleetInspecting
 			fleetPage.textInput.Blur()
-			m.message = fmt.Sprintf("Added fleet %s", fleetName)
-			return nil
+			m.message = fmt.Sprintf("Inspecting %s...", repoURL)
+			return inspectDevcontainerCmd(fleetName, repoURL)
 
 		case "esc", "ctrl+c":
 			fleetPage.mode = viewNormal
@@ -544,6 +552,172 @@ func (fleetPage *fleetPage) updateAddFleet(m *model, msg tea.Msg) tea.Cmd {
 	var cmd tea.Cmd
 	fleetPage.textInput, cmd = fleetPage.textInput.Update(msg)
 	return cmd
+}
+
+// ===========================================
+// Devcontainer Inspection (new fleet)
+// ===========================================
+
+// devcontainerInspectedMsg is delivered when the asynchronous repo
+// clone + devcontainer.json lookup completes. The fleetName is echoed
+// back so a stale result (the user dismissed the dialog before the
+// clone finished) can be discarded.
+type devcontainerInspectedMsg struct {
+	fleetName       string
+	hasDevcontainer bool
+	err             error
+}
+
+// inspectDevcontainerCmd runs a shallow clone and a devcontainer-check
+// in a background goroutine. The Repo handle is closed before the
+// message is returned so the temp clone never outlives the command.
+//
+// A clone failure surfaces with err set so the caller can report it
+// rather than blindly assuming the repo lacks a devcontainer — an
+// unreachable URL is a different problem than a configured-but-missing
+// devcontainer, and the user almost certainly wants to fix the URL
+// before being offered a setup workflow.
+func inspectDevcontainerCmd(fleetName, remoteURL string) tea.Cmd {
+	return func() tea.Msg {
+		repo, err := inspector.Open(remoteURL, "")
+		if err != nil {
+			return devcontainerInspectedMsg{fleetName: fleetName, err: err}
+		}
+		defer repo.Close()
+		present, err := devcontainercheck.Present(repo)
+		return devcontainerInspectedMsg{
+			fleetName:       fleetName,
+			hasDevcontainer: present,
+			err:             err,
+		}
+	}
+}
+
+// handleDevcontainerInspected resumes the new-fleet flow once the
+// asynchronous inspection has completed. There are three branches:
+//
+//  1. clone failed → surface the error, drop back to the URL input so
+//     the user can correct it. The fleet is not persisted.
+//  2. devcontainer present → persist the fleet immediately and dismiss.
+//  3. devcontainer missing → switch to the no-devcontainer dialog so
+//     the user can choose to abort or launch the setup agent.
+//
+// Stale results from a dialog the user has already abandoned are
+// dropped silently.
+func (fleetPage *fleetPage) handleDevcontainerInspected(m *model, msg devcontainerInspectedMsg) tea.Cmd {
+	if fleetPage.mode != viewAddFleetInspecting || fleetPage.dialogPendingFleetName != msg.fleetName {
+		return nil
+	}
+
+	if msg.err != nil {
+		fleetPage.mode = viewAddFleet
+		fleetPage.textInput.Focus()
+		m.message = fmt.Sprintf("Could not inspect repo: %v", msg.err)
+		return fleetPage.textInput.Cursor.BlinkCmd()
+	}
+
+	if msg.hasDevcontainer {
+		fleetPage.addPendingFleet(m)
+		m.message = fmt.Sprintf("Added fleet %s", fleetPage.dialogPendingFleetName)
+		fleetPage.clearPendingFleet()
+		fleetPage.mode = viewNormal
+		return nil
+	}
+
+	fleetPage.mode = viewAddFleetNoDevcontainer
+	return nil
+}
+
+// addPendingFleet creates the fleet record for whichever URL is
+// currently pending and rebuilds the row list. Used by both the
+// "devcontainer present → just add it" success path and the
+// "user picked Setup → optimistically add then hand off to agent"
+// branch.
+func (fleetPage *fleetPage) addPendingFleet(m *model) {
+	m.st.GetOrCreateFleet(fleetPage.dialogPendingFleetName, fleetPage.dialogPendingRepoURL)
+	_ = state.Save(m.st)
+	fleetPage.buildRows(m)
+}
+
+// clearPendingFleet wipes the per-dialog scratch fields once the
+// inspect/setup workflow finishes (success, abort, or error). The
+// values are not load-bearing after the dialog closes; resetting them
+// keeps a future open-this-dialog-again from seeing stale data.
+func (fleetPage *fleetPage) clearPendingFleet() {
+	fleetPage.dialogPendingRepoURL = ""
+	fleetPage.dialogPendingFleetName = ""
+}
+
+// ===========================================
+// No-Devcontainer Dialog
+// ===========================================
+
+// updateAddFleetInspecting handles input while the
+// "Inspecting <repo>..." spinner is on screen. The user can press esc /
+// ctrl+c to bail out of the new-fleet flow without waiting for the
+// clone to finish (the goroutine will still complete and the result
+// will be dropped by the stale-mode guard in
+// handleDevcontainerInspected).
+func (fleetPage *fleetPage) updateAddFleetInspecting(m *model, msg tea.Msg) tea.Cmd {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return nil
+	}
+	switch keyMsg.String() {
+	case "esc", "ctrl+c":
+		fleetPage.mode = viewNormal
+		fleetPage.clearPendingFleet()
+		m.message = "Cancelled"
+	}
+	return nil
+}
+
+// updateAddFleetNoDevcontainer handles the dialog shown when the
+// inspected repo has no devcontainer.json. Two paths:
+//
+//   - Abort (default; esc / n / a / enter): drop the pending fleet
+//     and return to the fleet list without persisting anything.
+//   - Setup (s): persist the fleet optimistically (so the user can see
+//     it in the list while they work) and hand off to the local
+//     coding agent with a devcontainer-authoring prompt. The agent's
+//     stdio takes over the terminal; when it exits (ctrl+c / ctrl+d)
+//     bubbletea repaints and we are back in the fleet list.
+func (fleetPage *fleetPage) updateAddFleetNoDevcontainer(m *model, msg tea.Msg) tea.Cmd {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return nil
+	}
+	switch keyMsg.String() {
+	case "s", "S":
+		repoURL := fleetPage.dialogPendingRepoURL
+		fleetName := fleetPage.dialogPendingFleetName
+
+		cmd, err := devcontainersetup.Command(repoURL)
+		if err != nil {
+			fleetPage.mode = viewNormal
+			fleetPage.clearPendingFleet()
+			m.message = fmt.Sprintf("No coding agent available: %v", err)
+			return nil
+		}
+
+		// Add the fleet immediately, before launching the agent. The
+		// issue spec is explicit: assume the user follows through. If
+		// they bail mid-setup the fleet still appears in the list so
+		// they can return to it (or delete it) later.
+		fleetPage.addPendingFleet(m)
+		m.message = fmt.Sprintf("Added fleet %s — launching setup agent...", fleetName)
+		fleetPage.clearPendingFleet()
+		fleetPage.mode = viewNormal
+
+		return tea.ExecProcess(cmd, func(err error) tea.Msg { return execDoneMsg{err} })
+
+	case "a", "A", "n", "N", "esc", "ctrl+c", "enter":
+		fleetPage.mode = viewNormal
+		fleetPage.clearPendingFleet()
+		m.message = "Cancelled — fleet not added"
+		return nil
+	}
+	return nil
 }
 
 // ===========================================

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -9,6 +9,7 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/agentdetect"
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/deps"
+	"github.com/BenjaminBenetti/fleet-man/internal/devcontainersetup"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/gitutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/instanceops"
@@ -45,9 +46,18 @@ type fleetPage struct {
 	dialogClaudeMount bool
 	dialogCodexMount  bool
 	dialogDetecting   bool // true while a homedir auto-detect cmd is in flight
-	textInput         textinput.Model
-	branchInput       textinput.Model
-	homedirInput      textinput.Model
+
+	// dialogPendingRepoURL is the repo URL the user submitted in the
+	// new-fleet dialog. It is held here across the asynchronous
+	// devcontainer inspection so the inspect-result handler can fall
+	// through into either adding the fleet or showing the
+	// no-devcontainer prompt without re-asking the user.
+	dialogPendingRepoURL   string
+	dialogPendingFleetName string
+
+	textInput    textinput.Model
+	branchInput  textinput.Model
+	homedirInput textinput.Model
 
 	pfCursor      int
 	pfContainerID string
@@ -180,6 +190,9 @@ func (fleetPage *fleetPage) Update(m *model, msg tea.Msg) tea.Cmd {
 	case homedirDetectedMsg:
 		fleetPage.handleHomedirDetected(msg.(homedirDetectedMsg))
 		return nil
+
+	case devcontainerInspectedMsg:
+		return fleetPage.handleDevcontainerInspected(m, msg.(devcontainerInspectedMsg))
 	}
 
 	// Mode-specific dispatch
@@ -192,6 +205,10 @@ func (fleetPage *fleetPage) Update(m *model, msg tea.Msg) tea.Cmd {
 		return fleetPage.updateAddInstance(m, msg)
 	case viewAddFleet:
 		return fleetPage.updateAddFleet(m, msg)
+	case viewAddFleetInspecting:
+		return fleetPage.updateAddFleetInspecting(m, msg)
+	case viewAddFleetNoDevcontainer:
+		return fleetPage.updateAddFleetNoDevcontainer(m, msg)
 	case viewEditFleet:
 		return fleetPage.updateEditFleet(m, msg)
 	case viewTagInstance:
@@ -1285,6 +1302,50 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			dialogHint.Render("[enter] Add  [esc] Cancel"),
 		)
 		b.WriteString(dialogBox.Render(dialog))
+		b.WriteString("\n")
+
+	case viewAddFleetInspecting:
+		b.WriteString("\n")
+		dialog := fmt.Sprintf(
+			"%s\n\n%s %s\n\n%s %s\n\n%s",
+			dialogTitle.Render("New fleet"),
+			dialogLabel.Render("Repo: "),
+			fleetExpandedStyle.Render(fleetPage.dialogPendingRepoURL),
+			m.spinner.View(),
+			dialogLabel.Render("Inspecting for devcontainer.json..."),
+			dialogHint.Render("[esc] Cancel"),
+		)
+		b.WriteString(dialogBox.Render(dialog))
+		b.WriteString("\n")
+
+	case viewAddFleetNoDevcontainer:
+		b.WriteString("\n")
+		agentName, _, agentErr := devcontainersetup.FindAgent()
+		var setupLine string
+		if agentErr != nil {
+			setupLine = statusCreatingStyle.Render("no agent found") +
+				"  " + dimStyle.Render("install claude, codex, gemini, or copilot to use Setup")
+		} else {
+			setupLine = statusRunningStyle.Render(agentName) +
+				"  " + dimStyle.Render("will clone the repo and walk you through configuration")
+		}
+		dialog := fmt.Sprintf(
+			"%s\n\n%s\n\n%s %s\n\n%s\n\n%s\n\n%s",
+			warnBanner.Render("  No devcontainer.json found  "),
+			dialogLabel.Render(
+				"This repository has no .devcontainer/devcontainer.json.\n"+
+					"fleet-man needs one before it can provision instances.",
+			),
+			dialogLabel.Render("Repo:"),
+			fleetExpandedStyle.Render(fleetPage.dialogPendingRepoURL),
+			dialogLabel.Render("Setup agent: ")+setupLine,
+			dialogLabel.Render(
+				"[a] Abort — do not add the fleet (default)\n"+
+					"[s] Setup — add the fleet now and launch a guided agent to write the devcontainer",
+			),
+			dialogHint.Render("[a/enter/esc] Abort  [s] Setup"),
+		)
+		b.WriteString(warnBox.Render(dialog))
 		b.WriteString("\n")
 
 	case viewEditFleet:

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -737,6 +737,141 @@ func TestEditFleetEscDiscardsChanges(t *testing.T) {
 	}
 }
 
+// TestAddFleetInspectedPresentAddsFleet verifies the happy path: an
+// inspection that finds a devcontainer.json persists the fleet and
+// dismisses the dialog.
+func TestAddFleetInspectedPresentAddsFleet(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fp := newFleetPage()
+	m := &model{
+		st:        &state.State{Fleets: map[string]*fleet.Fleet{}},
+		fleetPage: fp,
+	}
+
+	fp.mode = viewAddFleetInspecting
+	fp.dialogPendingFleetName = "alpha"
+	fp.dialogPendingRepoURL = "git@example.com:org/alpha.git"
+
+	fp.handleDevcontainerInspected(m, devcontainerInspectedMsg{
+		fleetName:       "alpha",
+		hasDevcontainer: true,
+	})
+
+	if fp.mode != viewNormal {
+		t.Fatalf("mode = %v, want viewNormal", fp.mode)
+	}
+	if _, ok := m.st.Fleets["alpha"]; !ok {
+		t.Fatalf("expected fleet alpha to be persisted")
+	}
+	if fp.dialogPendingFleetName != "" || fp.dialogPendingRepoURL != "" {
+		t.Fatalf("pending fields not cleared: %q %q", fp.dialogPendingFleetName, fp.dialogPendingRepoURL)
+	}
+}
+
+// TestAddFleetInspectedMissingShowsDialog verifies that a "no
+// devcontainer" result switches to the choice dialog rather than
+// silently persisting the fleet.
+func TestAddFleetInspectedMissingShowsDialog(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fp := newFleetPage()
+	m := &model{
+		st:        &state.State{Fleets: map[string]*fleet.Fleet{}},
+		fleetPage: fp,
+	}
+
+	fp.mode = viewAddFleetInspecting
+	fp.dialogPendingFleetName = "alpha"
+	fp.dialogPendingRepoURL = "git@example.com:org/alpha.git"
+
+	fp.handleDevcontainerInspected(m, devcontainerInspectedMsg{
+		fleetName:       "alpha",
+		hasDevcontainer: false,
+	})
+
+	if fp.mode != viewAddFleetNoDevcontainer {
+		t.Fatalf("mode = %v, want viewAddFleetNoDevcontainer", fp.mode)
+	}
+	if _, ok := m.st.Fleets["alpha"]; ok {
+		t.Fatalf("fleet was persisted before user chose Abort/Setup")
+	}
+	// Pending fields must survive — the no-devcontainer dialog reads
+	// them to know which fleet to add/launch the agent for.
+	if fp.dialogPendingFleetName != "alpha" {
+		t.Fatalf("pending fleet name dropped: %q", fp.dialogPendingFleetName)
+	}
+}
+
+// TestAddFleetNoDevcontainerAbortDoesNotPersist verifies that the
+// default Abort action — covered by [a], [n], [enter], and [esc] —
+// leaves no trace of the fleet in state.
+func TestAddFleetNoDevcontainerAbortDoesNotPersist(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	for _, key := range []string{"a", "n", "esc", "enter"} {
+		fp := newFleetPage()
+		m := &model{
+			st:        &state.State{Fleets: map[string]*fleet.Fleet{}},
+			fleetPage: fp,
+		}
+		fp.mode = viewAddFleetNoDevcontainer
+		fp.dialogPendingFleetName = "alpha"
+		fp.dialogPendingRepoURL = "git@example.com:org/alpha.git"
+
+		var keyMsg tea.KeyMsg
+		switch key {
+		case "esc":
+			keyMsg = tea.KeyMsg{Type: tea.KeyEsc}
+		case "enter":
+			keyMsg = tea.KeyMsg{Type: tea.KeyEnter}
+		default:
+			keyMsg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)}
+		}
+
+		fp.updateAddFleetNoDevcontainer(m, keyMsg)
+
+		if fp.mode != viewNormal {
+			t.Fatalf("key %q: mode = %v, want viewNormal", key, fp.mode)
+		}
+		if _, ok := m.st.Fleets["alpha"]; ok {
+			t.Fatalf("key %q: fleet was added by Abort path", key)
+		}
+		if fp.dialogPendingFleetName != "" {
+			t.Fatalf("key %q: pending fields not cleared", key)
+		}
+	}
+}
+
+// TestAddFleetInspectStaleResultDropped verifies a result for a
+// different fleet (the user dismissed the dialog and started a new
+// one in the meantime) is ignored.
+func TestAddFleetInspectStaleResultDropped(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	fp := newFleetPage()
+	m := &model{
+		st:        &state.State{Fleets: map[string]*fleet.Fleet{}},
+		fleetPage: fp,
+	}
+	fp.mode = viewAddFleetInspecting
+	fp.dialogPendingFleetName = "beta"
+	fp.dialogPendingRepoURL = "git@example.com:org/beta.git"
+
+	// Result is for "alpha" — must not mutate state or change the mode.
+	fp.handleDevcontainerInspected(m, devcontainerInspectedMsg{
+		fleetName:       "alpha",
+		hasDevcontainer: true,
+	})
+
+	if fp.mode != viewAddFleetInspecting {
+		t.Fatalf("mode changed to %v on stale result", fp.mode)
+	}
+	if _, ok := m.st.Fleets["alpha"]; ok {
+		t.Fatalf("stale result persisted unexpected fleet")
+	}
+}
+
 // TestMoveCursorToInstanceSkipsBetweenInstances verifies that shift-jump
 // navigation lands on the next instance row, skipping sessions, headers,
 // and settings rows in between.

--- a/internal/tui/view_mode.go
+++ b/internal/tui/view_mode.go
@@ -15,6 +15,8 @@ const (
 	viewConfirmDeleteFleetWarn
 	viewAddInstance
 	viewAddFleet
+	viewAddFleetInspecting
+	viewAddFleetNoDevcontainer
 	viewEditFleet
 	viewTagInstance
 	viewPortForward

--- a/skills/DEVCONTAINER_SETUP.md
+++ b/skills/DEVCONTAINER_SETUP.md
@@ -1,0 +1,151 @@
+# Fleet-Man Devcontainer Setup
+
+You are a setup assistant helping the user add a **devcontainer** configuration to a repository so it can be used as a fleet-man fleet. fleet-man provisions containers from `.devcontainer/devcontainer.json`, so a repo without one cannot be used until this file exists.
+
+The repository URL is provided in your invocation prompt.
+
+## How to Use This Guide
+
+1. Work through each step **in order**.
+2. Before writing any configuration, **fetch the latest devcontainer documentation from the web** so your output reflects the current schema and features. Do not rely on training-data knowledge alone — the spec evolves, and stale fields will silently break the build.
+3. Ask the user questions at each decision point rather than guessing. The goal is a configuration they understand, not the most elaborate one.
+4. At the end, commit the new files on a branch and push so the user can open a pull request.
+
+---
+
+## 1. Clone the Repository
+
+Clone the repository into the current working directory:
+
+```bash
+git clone <repo-url>
+cd <repo-name>
+```
+
+Verify there is no existing devcontainer:
+
+```bash
+ls -la .devcontainer 2>/dev/null
+ls -la .devcontainer.json 2>/dev/null
+```
+
+If either exists, **stop** and tell the user the repo is already configured. They should re-run `fleet up` instead.
+
+---
+
+## 2. Consult the Current Devcontainer Documentation
+
+Before writing anything, fetch the latest reference material so your output matches the live schema:
+
+- The official spec: https://containers.dev/implementors/json_reference/
+- Microsoft's guide: https://code.visualstudio.com/docs/devcontainers/create-dev-container
+- The Features index: https://containers.dev/features
+- Pre-built images: https://github.com/devcontainers/images
+
+Skim each page now. Note any fields that have changed, been deprecated, or added since your training cutoff.
+
+---
+
+## 3. Understand the Project
+
+Look at the repository to figure out what language(s) and tools it uses:
+
+```bash
+ls
+cat README.md 2>/dev/null | head -50
+```
+
+Identify:
+- **Primary language** (Go, Node, Python, Rust, Java, etc.)
+- **Package manager(s)** (npm/pnpm/yarn, pip/poetry/uv, cargo, go modules, …)
+- **Required system tools** (docker-in-docker? git? a database client?)
+- **Existing CI configuration** in `.github/workflows/` — it often hints at the expected toolchain versions
+
+Confirm your reading with the user before proceeding.
+
+---
+
+## 4. Choose a Base Image
+
+Prefer an official pre-built devcontainer image whenever one matches the language. They include sensible non-root user setup, common shell tooling, and feature compatibility:
+
+- Go: `mcr.microsoft.com/devcontainers/go:1-<version>`
+- Node: `mcr.microsoft.com/devcontainers/javascript-node:<version>`
+- Python: `mcr.microsoft.com/devcontainers/python:<version>`
+- Universal: `mcr.microsoft.com/devcontainers/universal:latest`
+
+Cross-reference the tag list on the devcontainer image documentation — pin to a major version rather than `latest` so the environment is reproducible.
+
+---
+
+## 5. Pick Features
+
+Add devcontainer Features for cross-cutting tools instead of installing them in `postCreateCommand`. Common ones:
+
+- `ghcr.io/devcontainers/features/docker-in-docker` — when the project uses Docker.
+- `ghcr.io/devcontainers/features/common-utils` — adds zsh, oh-my-zsh, non-root user. Most images include this already.
+- `ghcr.io/devcontainers/features/github-cli` — needed by anything that scripts `gh`.
+
+Confirm the latest version tags from the Features index before adding them.
+
+---
+
+## 6. Write `.devcontainer/devcontainer.json`
+
+Create the file. A minimal example shape:
+
+```jsonc
+{
+  "name": "<project name>",
+  "image": "mcr.microsoft.com/devcontainers/<language>:<version>",
+  "features": {
+    // chosen features here
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        // language-appropriate extensions
+      ]
+    }
+  },
+  "postCreateCommand": "<install dependencies, e.g. npm install / go mod download>",
+  "remoteUser": "vscode"
+}
+```
+
+Tailor every field to the project. Ask the user before adding anything they did not explicitly request.
+
+---
+
+## 7. Verify Locally (Optional)
+
+If the user has the devcontainer CLI installed (`devcontainer --version`), offer to test the build:
+
+```bash
+devcontainer up --workspace-folder .
+```
+
+A successful build prints the container ID. Investigate and fix any errors before declaring the setup complete.
+
+---
+
+## 8. Commit and Push
+
+Create a branch, commit the new files, and push:
+
+```bash
+git checkout -b add-devcontainer
+git add .devcontainer/
+git commit -m "Add devcontainer configuration"
+git push -u origin add-devcontainer
+```
+
+Tell the user the branch name and suggest they open a pull request. Once merged into the default branch, they can re-run `fleet up` (or use the TUI) to provision the fleet.
+
+---
+
+## 9. Hand Back to Fleet-Man
+
+When you are done, tell the user:
+
+> Press Ctrl+C or Ctrl+D to return to fleet-man. Your fleet was already added to the list — once the devcontainer is on the default branch, you can create instances normally.


### PR DESCRIPTION
Closes #33.

## Summary
- New-fleet flow now inspects the repo for `.devcontainer/devcontainer.json` before persisting. If missing, the user gets an Abort/Setup dialog; Setup adds the fleet optimistically and hands off to the local coding agent (Claude / Codex / Gemini / Copilot) with a prompt that points at `skills/DEVCONTAINER_SETUP.md`.
- Built on the existing inspector package (`internal/inspector/check/devcontainer/`) following the OCP pattern already used by the homedir check.
- New `internal/devcontainersetup/` mirrors `internal/doctor/` — same agent invocation pattern, different prompt.

## Test plan
- [x] `go test ./...` — all unit tests pass, including 4 new tests in `internal/tui` covering happy path, missing-devcontainer dialog, all four Abort keys, and stale-result drop.
- [x] Local integration runs of `171`, `172`, `173` — all pass. (CI will exercise the full suite.)
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)