### PR TITLE
fix(devcontainer): prune stale containers before devcontainer up (#51)

### DIFF
--- a/integration/tests/055_recreate_reuses_name.sh
+++ b/integration/tests/055_recreate_reuses_name.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Description: `fleet up` with a reused name prunes any stale container left behind, so `fleet exec` does not hit runc's mount-namespace check (#51).
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test
+fleet_up alpha
+
+old_container=$(grep -oE '"container_id":\s*"[^"]+"' "${HOME}/.fleet/state.json" | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
+[ -n "${old_container}" ] || fail "could not read container_id from state"
+ws_dir="${HOME}/.fleet/workspaces/${FIXTURE_REPO_NAME}/alpha/${FIXTURE_REPO_NAME}"
+info "first container: ${old_container}"
+
+# Sanity check: the container is labelled with the workspace path the
+# devcontainer CLI uses to match it. This is the same label the fix
+# queries, so if this assertion fails the test is no longer covering
+# the right thing.
+label=$(docker inspect --format '{{ index .Config.Labels "devcontainer.local_folder" }}' "${old_container}")
+assert_equals "${ws_dir}" "${label}" "container should carry the devcontainer.local_folder label"
+
+# Simulate a failed Down: drop fleet's state + workspace clone but leave
+# the docker container behind. This matches the failure path that
+# triggers issue #51 — the next `fleet up` finds a container under the
+# expected label and would otherwise silently reuse it.
+info "wiping fleet state but leaving container ${old_container} alive"
+rm -rf "${HOME}/.fleet/state.json" "${HOME}/.fleet/workspaces"
+mkdir -p "${HOME}/.fleet"
+if ! docker inspect "${old_container}" >/dev/null 2>&1; then
+  fail "precondition failed: stale container ${old_container} should still exist"
+fi
+
+info "fleet up alpha again — pre-prune should drop ${old_container} and provision a fresh container"
+fleet_up alpha
+
+new_container=$(grep -oE '"container_id":\s*"[^"]+"' "${HOME}/.fleet/state.json" | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
+[ -n "${new_container}" ] || fail "could not read new container_id from state"
+info "new container: ${new_container}"
+
+if [ "${old_container}" = "${new_container}" ]; then
+  fail "new container should be different from the stale one — pre-prune did not run"
+fi
+
+if docker inspect "${old_container}" >/dev/null 2>&1; then
+  fail "stale container ${old_container} should have been pruned"
+fi
+
+# Final regression check: `fleet exec` must succeed against the fresh
+# container. Pre-fix this is the call that surfaced runc's "current
+# working directory is outside of container mount namespace root"
+# error, because devcontainer was reusing the stale container instead
+# of creating a fresh one.
+info "fleet exec alpha -- uname -s"
+uname_out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- uname -s)
+assert_equals "Linux" "${uname_out}" "exec inside fresh container"
+
+pass "stale container pruned on instance re-create"

--- a/internal/backend/devcontainer/devcontainer_backend.go
+++ b/internal/backend/devcontainer/devcontainer_backend.go
@@ -70,6 +70,17 @@ func (devcontainerBackend *DevcontainerBackend) containerUser(containerID string
 // flags so they appear inside the container alongside the SSH agent
 // socket and the workspace itself.
 func (devcontainerBackend *DevcontainerBackend) Up(workspaceDir string, mounts []backend.Mount) (*backend.UpResult, error) {
+	// Drop any docker container still labelled with this workspace
+	// folder before provisioning. The devcontainer CLI matches existing
+	// containers by `devcontainer.local_folder=<wsDir>` and silently
+	// reuses one when found — if a previous instance under the same
+	// name left a container behind (failed Down, mid-creation crash,
+	// hand-edited state), reuse binds the new instance to a container
+	// whose workspace mount no longer maps anywhere, and subsequent
+	// `devcontainer exec` calls fail with runc's "current working
+	// directory is outside of container mount namespace root" check.
+	devcontainerBackend.pruneStaleContainers(workspaceDir)
+
 	args := []string{"up", "--workspace-folder", workspaceDir}
 	var err error
 	args, err = devcontainerUpArgs(args)
@@ -158,6 +169,32 @@ func (devcontainerBackend *DevcontainerBackend) Exec(workspaceDir string, comman
 func (devcontainerBackend *DevcontainerBackend) ExecCommand(workspaceDir string, command []string) *exec.Cmd {
 	args := execArgs(workspaceDir, command)
 	return exec.Command("devcontainer", args...)
+}
+
+// pruneStaleContainers force-removes any docker container labelled
+// `devcontainer.local_folder=<workspaceDir>`. Called from Up() so that
+// reusing an instance name (same wsDir on disk) never silently rebinds
+// to a leftover container with a broken workspace mount. Errors are
+// logged but non-fatal: if cleanup genuinely fails, the subsequent
+// `devcontainer up` will surface a real error.
+func (devcontainerBackend *DevcontainerBackend) pruneStaleContainers(workspaceDir string) {
+	if workspaceDir == "" {
+		return
+	}
+	listCmd := exec.Command("docker", "ps", "-a", "-q",
+		"--filter", "label=devcontainer.local_folder="+workspaceDir)
+	out, err := listCmd.Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to list stale containers for %s: %v\n", workspaceDir, err)
+		return
+	}
+	for _, id := range strings.Fields(string(out)) {
+		rmCmd := exec.Command("docker", "rm", "-f", id)
+		if rmOut, err := rmCmd.CombinedOutput(); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to remove stale container %s: %v\n%s\n",
+				id, err, strings.TrimSpace(string(rmOut)))
+		}
+	}
 }
 
 // Down stops and removes a container by ID using docker directly.


### PR DESCRIPTION
## Summary
- Fixes #51 — `fleet shell` intermittently failed with runc's *"current working directory is outside of container mount namespace root"* after a destroy + re-up under the same name.
- Root cause: `devcontainer up` matches existing containers by the `devcontainer.local_folder=<wsDir>` label and silently *reuses* one when found. If a previous instance left a container behind (failed `Down`, mid-creation crash, hand-edited state), the new instance got bound to a container whose workspace bind mount no longer mapped anywhere, and the next `devcontainer exec` tripped runc's CVE-2024-21626 check.
- Fix: `DevcontainerBackend.Up` now force-removes any container carrying the matching label before invoking `devcontainer up`, so re-creates always provision against a clean slate regardless of how the previous container leaked.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all green.
- [x] Added integration test `055_recreate_reuses_name.sh` that does `up → drop state but leak container → up → exec` and asserts:
  - the new container ID differs from the leaked one,
  - the leaked container has been removed,
  - `fleet exec` succeeds against the new container.
- [x] Verified the test **fails** against the pre-fix binary (devcontainer reused the stale container — same ID returned twice) and **passes** with the fix.
- [ ] CI confirms the full integration suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)