### PR TITLE
feat(mounts): gh CLI mount — share GitHub CLI auth across instances

### DIFF
--- a/integration/common.sh
+++ b/integration/common.sh
@@ -208,12 +208,16 @@ setup_agent_test() {
 # the settings-driven code paths without driving the TUI.
 #
 # Usage:
-#   seed_fleet_settings <fleet_name> <claude:true|false> <codex:true|false> <homedir>
+#   seed_fleet_settings <fleet_name> <claude:true|false> <codex:true|false> <homedir> [<gh:true|false>]
+#
+# gh defaults to false so older callers that pre-date the GhMount setting
+# keep working unchanged.
 seed_fleet_settings() {
   local fleet_name="$1"
   local claude="${2:-false}"
   local codex="${3:-false}"
   local homedir="${4:-/home/node}"
+  local gh="${5:-false}"
   mkdir -p "${HOME}/.fleet"
   cat > "${HOME}/.fleet/state.json" <<EOF
 {
@@ -224,6 +228,7 @@ seed_fleet_settings() {
       "settings": {
         "claudeCodeMount": ${claude},
         "codexMount": ${codex},
+        "ghMount": ${gh},
         "homeDir": "${homedir}"
       },
       "instances": []

--- a/integration/tests/415_mounts_gh.sh
+++ b/integration/tests/415_mounts_gh.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Description: gh CLI mount appears in the container at the expected path
+# and persists a host-written file across the bind boundary.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_agent_test
+seed_fleet_settings "${FIXTURE_REPO_NAME}" false false /home/node true
+
+info "seeding host-side gh config dir with a stand-in hosts.yml"
+host_gh_dir="${HOME}/.fleet/workspaces/${FIXTURE_REPO_NAME}/.config/gh"
+mkdir -p "${host_gh_dir}"
+cat > "${host_gh_dir}/hosts.yml" <<'EOF'
+github.com:
+    user: fleet-integration
+    oauth_token: ghp_dummy_integration_token
+    git_protocol: https
+EOF
+
+info "fleet up alpha (gh mount enabled)"
+fleet_up alpha
+
+info "asserting /home/node/.config/gh is a directory inside the container"
+"${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- test -d /home/node/.config/gh \
+  || fail "/home/node/.config/gh is missing or not a directory"
+
+info "asserting /home/node/.config/gh is a real bind mount"
+mountinfo=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- cat /proc/self/mountinfo)
+assert_contains "${mountinfo}" " /home/node/.config/gh " "gh dir is not a mount point"
+
+info "asserting host-seeded hosts.yml is visible inside the container"
+container_hosts=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- cat /home/node/.config/gh/hosts.yml)
+assert_contains "${container_hosts}" "ghp_dummy_integration_token" \
+  "host-seeded hosts.yml did not appear inside the container"
+
+info "asserting a container-side write propagates back to the host"
+"${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- \
+  sh -c 'printf "editor: nano\n" > /home/node/.config/gh/config.yml'
+assert_file_exists "${host_gh_dir}/config.yml"
+host_config=$(cat "${host_gh_dir}/config.yml")
+assert_contains "${host_config}" "editor: nano" \
+  "container-side write did not reach the host file"
+
+info "asserting host-side fleet mount root exists"
+assert_file_exists "${host_gh_dir}"
+
+pass "gh mount applied"

--- a/internal/fleet/fleet_settings.go
+++ b/internal/fleet/fleet_settings.go
@@ -23,6 +23,14 @@ type FleetSettings struct {
 	// instances and across sessions.
 	CodexMount bool `json:"codexMount,omitempty"`
 
+	// GhMount enables a shared host directory at
+	// ~/.fleet/workspaces/<fleet>/.config/gh that is bind-mounted into
+	// every instance of this fleet at <containerHome>/.config/gh, so the
+	// GitHub CLI stays logged in across instances and across instance
+	// churn. The directory holds gh's hosts.yml (oauth_token + user) and
+	// config.yml.
+	GhMount bool `json:"ghMount,omitempty"`
+
 	// HomeDir is the absolute path inside the container that should be
 	// treated as the home directory when computing mount targets — e.g.
 	// "/home/vscode" so a Claude Code mount lands at "/home/vscode/.claude".

--- a/internal/mounts/resolver/dir_mount_spec.go
+++ b/internal/mounts/resolver/dir_mount_spec.go
@@ -34,5 +34,12 @@ func dirMountSpecsFor(fleetSettings fleet.FleetSettings, containerHome string) [
 			containerPath: containerHome + "/.codex",
 		})
 	}
+	if fleetSettings.GhMount {
+		specs = append(specs, dirMountSpec{
+			name:          "GitHub CLI",
+			hostSubdir:    ".config/gh",
+			containerPath: containerHome + "/.config/gh",
+		})
+	}
 	return specs
 }

--- a/internal/mounts/resolver/resolver_test.go
+++ b/internal/mounts/resolver/resolver_test.go
@@ -178,6 +178,44 @@ func TestResolveUsesHomeDirSetting(t *testing.T) {
 	}
 }
 
+// TestResolveCreatesGhMount verifies that enabling GhMount produces a
+// directory mount at <containerHome>/.config/gh backed by a host dir
+// under the fleet's mount root, and that no symlinks are involved
+// (gh's config dir is self-contained).
+func TestResolveCreatesGhMount(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	resolved, err := Resolve("gamma", fleet.FleetSettings{GhMount: true})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	if len(resolved.Symlinks) != 0 {
+		t.Errorf("len(Symlinks) = %d, want 0", len(resolved.Symlinks))
+	}
+	if len(resolved.Mounts) != 1 {
+		t.Fatalf("len(Mounts) = %d, want 1", len(resolved.Mounts))
+	}
+
+	wantHost := filepath.Join(home, ".fleet", "workspaces", "gamma", ".config", "gh")
+	mount := resolved.Mounts[0]
+	if mount.LocalPath != wantHost {
+		t.Errorf("LocalPath = %q, want %q", mount.LocalPath, wantHost)
+	}
+	if mount.ContainerPath != "/home/vscode/.config/gh" {
+		t.Errorf("ContainerPath = %q, want %q", mount.ContainerPath, "/home/vscode/.config/gh")
+	}
+
+	info, err := os.Stat(wantHost)
+	if err != nil {
+		t.Fatalf("expected host dir %s to exist: %v", wantHost, err)
+	}
+	if !info.IsDir() {
+		t.Errorf("%s is not a directory", wantHost)
+	}
+}
+
 // TestResolveOnlyEnabledMountsAreReturned ensures disabled toggles do
 // not produce mounts, symlinks, or host-side artefacts.
 func TestResolveOnlyEnabledMountsAreReturned(t *testing.T) {

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -942,6 +942,7 @@ func (fleetPage *fleetPage) updateAddFleetNoDevcontainer(m *model, msg tea.Msg) 
 const (
 	editFleetRowClaude = iota
 	editFleetRowCodex
+	editFleetRowGh
 	editFleetRowHomeDir
 	editFleetRowCount
 )
@@ -1002,6 +1003,7 @@ func (fleetPage *fleetPage) openEditFleetDialog(m *model) tea.Cmd {
 	fleetPage.dialogFleet = f.Name
 	fleetPage.dialogClaudeMount = f.Settings.ClaudeCodeMount
 	fleetPage.dialogCodexMount = f.Settings.CodexMount
+	fleetPage.dialogGhMount = f.Settings.GhMount
 	fleetPage.dialogRow = editFleetRowClaude
 	fleetPage.dialogDetecting = false
 	fleetPage.dialogFieldActive = false
@@ -1075,7 +1077,7 @@ func (fleetPage *fleetPage) updateEditFleet(m *model, msg tea.Msg) tea.Cmd {
 
 	// Toggle / character input is row-specific.
 	switch fleetPage.dialogRow {
-	case editFleetRowClaude, editFleetRowCodex:
+	case editFleetRowClaude, editFleetRowCodex, editFleetRowGh:
 		switch keyMsg.String() {
 		case " ", "left", "right", "h", "l", "x":
 			return fleetPage.toggleEditFleetRow(m)
@@ -1113,6 +1115,9 @@ func (fleetPage *fleetPage) toggleEditFleetRow(m *model) tea.Cmd {
 	case editFleetRowCodex:
 		fleetPage.dialogCodexMount = !fleetPage.dialogCodexMount
 		turnedOn = fleetPage.dialogCodexMount
+	case editFleetRowGh:
+		fleetPage.dialogGhMount = !fleetPage.dialogGhMount
+		turnedOn = fleetPage.dialogGhMount
 	}
 	if !turnedOn {
 		return nil
@@ -1138,7 +1143,7 @@ func (fleetPage *fleetPage) shouldKickHomedirDetect(f *fleet.Fleet) bool {
 	if strings.TrimSpace(fleetPage.homedirInput.Value()) != "" {
 		return false
 	}
-	if !fleetPage.dialogClaudeMount && !fleetPage.dialogCodexMount {
+	if !fleetPage.dialogClaudeMount && !fleetPage.dialogCodexMount && !fleetPage.dialogGhMount {
 		return false
 	}
 	return strings.TrimSpace(f.Remote) != ""
@@ -1198,6 +1203,7 @@ func (fleetPage *fleetPage) saveFleetEdits(m *model) tea.Cmd {
 	}
 	f.Settings.ClaudeCodeMount = fleetPage.dialogClaudeMount
 	f.Settings.CodexMount = fleetPage.dialogCodexMount
+	f.Settings.GhMount = fleetPage.dialogGhMount
 	f.Settings.HomeDir = strings.TrimSpace(fleetPage.homedirInput.Value())
 	_ = state.Save(m.st)
 

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -46,6 +46,7 @@ type fleetPage struct {
 	dialogSession     string
 	dialogClaudeMount bool
 	dialogCodexMount  bool
+	dialogGhMount     bool
 	dialogDetecting   bool // true while a homedir auto-detect cmd is in flight
 
 	// dialogPendingRepoURL is the repo URL the user submitted in the
@@ -1387,7 +1388,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 		}
 
 		dialog := fmt.Sprintf(
-			"%s\n\n  %s %s\n%s%s %s\n%s%s %s\n%s%s %s\n\n  %s\n\n%s",
+			"%s\n\n  %s %s\n%s%s %s\n%s%s %s\n%s%s %s\n%s%s %s\n\n  %s\n\n%s",
 			dialogTitle.Render("Edit fleet"),
 			dialogLabel.Render("Fleet:    "),
 			fleetExpandedStyle.Render(fleetPage.dialogFleet),
@@ -1397,6 +1398,9 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			rowMarker(editFleetRowCodex),
 			checkbox(fleetPage.dialogCodexMount),
 			dialogLabel.Render("Codex mount"),
+			rowMarker(editFleetRowGh),
+			checkbox(fleetPage.dialogGhMount),
+			dialogLabel.Render("GitHub CLI mount"),
 			rowMarker(editFleetRowHomeDir),
 			dialogLabel.Render("Home dir: "),
 			homedirField,

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -942,6 +942,14 @@ func TestEditFleetDialogVimKeysAndActiveHomedir(t *testing.T) {
 		t.Fatal("l should toggle selected codex row")
 	}
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if fp.dialogRow != editFleetRowGh {
+		t.Fatalf("dialogRow = %d, want gh row", fp.dialogRow)
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if !fp.dialogGhMount {
+		t.Fatal("l should toggle selected gh row")
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	if fp.dialogRow != editFleetRowHomeDir {
 		t.Fatalf("dialogRow = %d, want home-dir row", fp.dialogRow)
 	}
@@ -960,8 +968,12 @@ func TestEditFleetDialogVimKeysAndActiveHomedir(t *testing.T) {
 
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEsc})
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if fp.dialogRow != editFleetRowGh {
+		t.Fatalf("dialogRow = %d, want gh row after inactive k", fp.dialogRow)
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
 	if fp.dialogRow != editFleetRowCodex {
-		t.Fatalf("dialogRow = %d, want codex row after inactive k", fp.dialogRow)
+		t.Fatalf("dialogRow = %d, want codex row after second inactive k", fp.dialogRow)
 	}
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 	if fp.mode != viewNormal {


### PR DESCRIPTION
## Summary

Builds on #45's agentic-mount machinery to add a **GitHub CLI mount** — a per-fleet toggle that bind-mounts `~/.config/gh` from the host into every instance at `<containerHome>/.config/gh`, so the `gh` CLI stays logged in across instances and across instance churn.

- **New fleet setting** `GhMount` (JSON: `ghMount`), persisted in `state.json` alongside the existing Claude/Codex mount toggles.
- **New dir mount spec** in `internal/mounts/resolver/dir_mount_spec.go` mapping `.config/gh` (host) → `<containerHome>/.config/gh` (container). No single-file/symlink trickery: the gh config dir is self-contained (`hosts.yml` holds the oauth_token + user; `config.yml` holds prefs), so a plain directory mount is sufficient.
- **TUI dialog row** "GitHub CLI mount" in the edit-fleet dialog, slotted between Codex and Home dir; reuses the existing toggle / homedir-detect plumbing.
- **No startup script needed** — unlike Claude/Codex, `gh` is pre-installed in most devcontainer images and just reads the mounted config on first use.

### Why a directory mount, not a single-file mount

Inside a headless devcontainer there's no keyring service available, so `gh` falls back to plaintext storage in `hosts.yml`. The whole `~/.config/gh` tree is self-contained, so we mount the directory directly rather than going through the `~/.claude.json`-style parent-dir-bind + symlink workaround.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all packages pass (new `TestResolveCreatesGhMount` plus extended vim-nav test for the new dialog row)
- [x] New integration test `integration/tests/415_mounts_gh.sh` — seeds a host-side `hosts.yml`, brings up a fleet with `ghMount: true`, verifies the dir appears as a real bind mount inside the container, verifies the host-seeded `hosts.yml` is readable from inside (host → container persistence), and writes a `config.yml` from inside that propagates back to the host (container → host persistence)
- [ ] Manual: enable GitHub CLI mount on a fleet → create instance → `gh auth login` inside → destroy → recreate → `gh auth status` still shows logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)