### PR TITLE
fix/devcontainer-mount-override Override duplicate mounts in devcontainer.json

### DIFF
--- a/internal/backend/devcontainer/conflicting_mounts.go
+++ b/internal/backend/devcontainer/conflicting_mounts.go
@@ -1,0 +1,204 @@
+package devcontainer
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// neutralizeConflictingMounts ensures that any mount entries in the
+// workspace's devcontainer.json whose container target collides with a
+// fleet-supplied mount are removed for the duration of `devcontainer
+// up`. Without this, the devcontainer CLI passes both the user's mount
+// and fleet's mount to `docker run`, which rejects the command with
+// "Duplicate mount point".
+//
+// fleet's mounts win: the user's conflicting entries are stripped out
+// of the on-disk file before Up runs. The original file contents are
+// captured up front, and the returned restore func rewrites them back
+// verbatim so the workspace (which is a real git working tree the user
+// will commit from) is left exactly as it was found.
+//
+// A no-op restore is returned when there is no devcontainer.json, when
+// the file declares no conflicting mounts, or when parsing fails — in
+// those cases the file is never touched. Callers should defer the
+// restore unconditionally.
+func neutralizeConflictingMounts(workspaceDir string, fleetMounts []backend.Mount) (func(), error) {
+	noop := func() {}
+	if len(fleetMounts) == 0 {
+		return noop, nil
+	}
+
+	configPath, original, err := findDevcontainerJSON(workspaceDir)
+	if err != nil {
+		// No config to fight with: nothing to do.
+		if errors.Is(err, os.ErrNotExist) {
+			return noop, nil
+		}
+		return noop, err
+	}
+
+	rewritten, conflicts, err := stripConflictingMounts(original, fleetMounts)
+	if err != nil {
+		// Parse failures are non-fatal: leave the file alone and let
+		// devcontainer up surface its own error if there really is a
+		// conflict. Erroring here would block instance creation for
+		// users with valid-but-exotic JSONC the CLI accepts.
+		return noop, nil
+	}
+	if len(conflicts) == 0 {
+		return noop, nil
+	}
+
+	if err := os.WriteFile(configPath, rewritten, 0644); err != nil {
+		return noop, fmt.Errorf("rewriting %s: %w", configPath, err)
+	}
+
+	restore := func() {
+		_ = os.WriteFile(configPath, original, 0644)
+	}
+	return restore, nil
+}
+
+// findDevcontainerJSON returns the path and raw bytes of the
+// devcontainer.json that `devcontainer up --workspace-folder
+// workspaceDir` will use. Search order matches the CLI: the canonical
+// .devcontainer/devcontainer.json first, then the repo-root
+// .devcontainer.json. The subfolder multi-config layout requires the
+// caller to pass --config, which fleet does not do, so it is not
+// covered here.
+func findDevcontainerJSON(workspaceDir string) (string, []byte, error) {
+	candidates := []string{
+		filepath.Join(workspaceDir, ".devcontainer", "devcontainer.json"),
+		filepath.Join(workspaceDir, ".devcontainer.json"),
+	}
+	for _, candidate := range candidates {
+		configBytes, err := os.ReadFile(candidate)
+		if err == nil {
+			return candidate, configBytes, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", nil, err
+		}
+	}
+	return "", nil, os.ErrNotExist
+}
+
+// stripConflictingMounts removes every mount entry in original whose
+// container target equals the ContainerPath of one of fleetMounts.
+// Returns the rewritten bytes, the list of removed target paths (so
+// callers can report what was overridden), and an error only when the
+// file cannot be parsed as JSONC.
+//
+// The rewrite goes through json.Marshal, which loses comments and
+// original formatting. That is acceptable because the caller restores
+// the original bytes once `devcontainer up` returns — the rewritten
+// file only lives on disk for the duration of that call.
+func stripConflictingMounts(original []byte, fleetMounts []backend.Mount) ([]byte, []string, error) {
+	conflictingTargets := make(map[string]struct{}, len(fleetMounts))
+	for _, mount := range fleetMounts {
+		if mount.ContainerPath == "" {
+			continue
+		}
+		conflictingTargets[mount.ContainerPath] = struct{}{}
+	}
+	if len(conflictingTargets) == 0 {
+		return original, nil, nil
+	}
+
+	var config map[string]any
+	if err := json.Unmarshal(toStrictJSON(original), &config); err != nil {
+		return nil, nil, err
+	}
+	rawMounts, ok := config["mounts"].([]any)
+	if !ok {
+		return original, nil, nil
+	}
+
+	var removed []string
+	kept := make([]any, 0, len(rawMounts))
+	for _, entry := range rawMounts {
+		target := mountEntryTarget(entry)
+		if _, conflict := conflictingTargets[target]; conflict {
+			removed = append(removed, target)
+			continue
+		}
+		kept = append(kept, entry)
+	}
+	if len(removed) == 0 {
+		return original, nil, nil
+	}
+
+	if len(kept) == 0 {
+		delete(config, "mounts")
+	} else {
+		config["mounts"] = kept
+	}
+
+	rewritten, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return nil, nil, err
+	}
+	return rewritten, removed, nil
+}
+
+// mountEntryTarget extracts the container target path from one element
+// of the devcontainer.json `mounts` array. Two shapes are recognised:
+//
+//   - string form: "source=...,target=...,type=bind" — the
+//     comma-separated key=value syntax accepted by docker run --mount.
+//     `target`, `dst`, and `destination` are all valid spellings for
+//     the destination path.
+//   - object form: {"target": "...", "source": "...", "type": "bind"}.
+//     `destination` is also accepted as an alias for `target`.
+//
+// Returns an empty string when the entry shape is unrecognised so the
+// caller leaves it alone rather than guessing.
+func mountEntryTarget(entry any) string {
+	switch value := entry.(type) {
+	case string:
+		for part := range strings.SplitSeq(value, ",") {
+			keyVal := strings.SplitN(part, "=", 2)
+			if len(keyVal) != 2 {
+				continue
+			}
+			switch strings.TrimSpace(keyVal[0]) {
+			case "target", "dst", "destination":
+				return strings.TrimSpace(keyVal[1])
+			}
+		}
+	case map[string]any:
+		for _, key := range []string{"target", "destination"} {
+			if target, ok := value[key].(string); ok {
+				return target
+			}
+		}
+	}
+	return ""
+}
+
+// toStrictJSON converts a JSONC payload (the dialect devcontainer.json
+// uses — line comments, block comments, trailing commas) into strict
+// JSON that encoding/json can parse. The implementation intentionally
+// matches the simplified approach in
+// inspector/check/homedir/homedir.go: comment markers inside string
+// literals are not respected, on the assumption that real
+// devcontainer.json values do not contain those sequences.
+func toStrictJSON(jsoncBytes []byte) []byte {
+	jsoncBytes = blockCommentRegex.ReplaceAll(jsoncBytes, nil)
+	jsoncBytes = lineCommentRegex.ReplaceAll(jsoncBytes, nil)
+	jsoncBytes = trailingCommaRegex.ReplaceAll(jsoncBytes, []byte("$1"))
+	return jsoncBytes
+}
+
+var (
+	blockCommentRegex   = regexp.MustCompile(`(?s)/\*.*?\*/`)
+	lineCommentRegex    = regexp.MustCompile(`//[^\n]*`)
+	trailingCommaRegex  = regexp.MustCompile(`,(\s*[}\]])`)
+)

--- a/internal/backend/devcontainer/conflicting_mounts.go
+++ b/internal/backend/devcontainer/conflicting_mounts.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
@@ -49,7 +48,10 @@ func neutralizeConflictingMounts(workspaceDir string, fleetMounts []backend.Moun
 		// Parse failures are non-fatal: leave the file alone and let
 		// devcontainer up surface its own error if there really is a
 		// conflict. Erroring here would block instance creation for
-		// users with valid-but-exotic JSONC the CLI accepts.
+		// users with valid-but-exotic JSONC the CLI accepts. But log
+		// to stderr so the failure mode is visible — silently
+		// skipping is what previously hid a regex bug.
+		fmt.Fprintf(os.Stderr, "fleet: could not parse %s to neutralise conflicting mounts (continuing anyway): %v\n", configPath, err)
 		return noop, nil
 	}
 	if len(conflicts) == 0 {
@@ -59,6 +61,8 @@ func neutralizeConflictingMounts(workspaceDir string, fleetMounts []backend.Moun
 	if err := os.WriteFile(configPath, rewritten, 0644); err != nil {
 		return noop, fmt.Errorf("rewriting %s: %w", configPath, err)
 	}
+
+	fmt.Fprintf(os.Stderr, "fleet: overriding %d mount(s) in %s: %s\n", len(conflicts), configPath, strings.Join(conflicts, ", "))
 
 	restore := func() {
 		_ = os.WriteFile(configPath, original, 0644)
@@ -185,20 +189,131 @@ func mountEntryTarget(entry any) string {
 
 // toStrictJSON converts a JSONC payload (the dialect devcontainer.json
 // uses — line comments, block comments, trailing commas) into strict
-// JSON that encoding/json can parse. The implementation intentionally
-// matches the simplified approach in
-// inspector/check/homedir/homedir.go: comment markers inside string
-// literals are not respected, on the assumption that real
-// devcontainer.json values do not contain those sequences.
+// JSON that encoding/json can parse.
+//
+// Implemented as two string-aware passes rather than a regex pipeline
+// because real devcontainer.json files routinely contain URL values
+// like "http://localhost:81/" inside `customizations`, port
+// attributes, and so on. A naive `//[^\n]*` regex would strip the
+// rest of those lines, producing invalid JSON and a silent no-op
+// upstream — that is exactly how the original implementation of this
+// function masked a real conflict.
+//
+// Pass 1 strips comments; pass 2 elides trailing commas. The two
+// passes are kept separate so a comma followed by a line comment
+// followed by `]` (which only looks like a trailing comma AFTER pass
+// 1 has removed the comment) is correctly handled. Both passes track
+// string state so any `//`, `/*`, or `,` byte inside a string literal
+// is preserved verbatim.
 func toStrictJSON(jsoncBytes []byte) []byte {
-	jsoncBytes = blockCommentRegex.ReplaceAll(jsoncBytes, nil)
-	jsoncBytes = lineCommentRegex.ReplaceAll(jsoncBytes, nil)
-	jsoncBytes = trailingCommaRegex.ReplaceAll(jsoncBytes, []byte("$1"))
-	return jsoncBytes
+	return stripTrailingCommas(stripJSONCComments(jsoncBytes))
 }
 
-var (
-	blockCommentRegex   = regexp.MustCompile(`(?s)/\*.*?\*/`)
-	lineCommentRegex    = regexp.MustCompile(`//[^\n]*`)
-	trailingCommaRegex  = regexp.MustCompile(`,(\s*[}\]])`)
-)
+// stripJSONCComments removes // line comments and /* block comments
+// from a JSONC payload, leaving comment markers inside string
+// literals untouched. Line endings of stripped line comments are
+// preserved so error line numbers stay aligned with the original
+// file; block-comment line counts may shift.
+func stripJSONCComments(jsoncBytes []byte) []byte {
+	out := make([]byte, 0, len(jsoncBytes))
+	inString := false
+	escaped := false
+
+	for i := 0; i < len(jsoncBytes); i++ {
+		current := jsoncBytes[i]
+
+		if inString {
+			out = append(out, current)
+			switch {
+			case escaped:
+				escaped = false
+			case current == '\\':
+				escaped = true
+			case current == '"':
+				inString = false
+			}
+			continue
+		}
+
+		if current == '"' {
+			inString = true
+			out = append(out, current)
+			continue
+		}
+
+		if current == '/' && i+1 < len(jsoncBytes) && jsoncBytes[i+1] == '/' {
+			for i < len(jsoncBytes) && jsoncBytes[i] != '\n' {
+				i++
+			}
+			if i < len(jsoncBytes) {
+				out = append(out, jsoncBytes[i])
+			}
+			continue
+		}
+
+		if current == '/' && i+1 < len(jsoncBytes) && jsoncBytes[i+1] == '*' {
+			i += 2
+			for i+1 < len(jsoncBytes) && !(jsoncBytes[i] == '*' && jsoncBytes[i+1] == '/') {
+				i++
+			}
+			i++ // step past the closing '/'
+			continue
+		}
+
+		out = append(out, current)
+	}
+	return out
+}
+
+// stripTrailingCommas drops every comma that is followed only by
+// whitespace and a closing `]` or `}`, anywhere outside a string
+// literal. Commas inside string values are preserved verbatim — a
+// blind regex `,(\s*[}\]])` would silently corrupt strings like
+// "foo,]" otherwise.
+func stripTrailingCommas(jsonBytes []byte) []byte {
+	out := make([]byte, 0, len(jsonBytes))
+	inString := false
+	escaped := false
+
+	for i := 0; i < len(jsonBytes); i++ {
+		current := jsonBytes[i]
+
+		if inString {
+			out = append(out, current)
+			switch {
+			case escaped:
+				escaped = false
+			case current == '\\':
+				escaped = true
+			case current == '"':
+				inString = false
+			}
+			continue
+		}
+
+		if current == '"' {
+			inString = true
+			out = append(out, current)
+			continue
+		}
+
+		if current == ',' {
+			lookahead := i + 1
+			for lookahead < len(jsonBytes) && isJSONWhitespace(jsonBytes[lookahead]) {
+				lookahead++
+			}
+			if lookahead < len(jsonBytes) && (jsonBytes[lookahead] == ']' || jsonBytes[lookahead] == '}') {
+				continue
+			}
+		}
+
+		out = append(out, current)
+	}
+	return out
+}
+
+// isJSONWhitespace reports whether b is one of the four whitespace
+// bytes recognised by JSON (space, tab, newline, carriage return).
+func isJSONWhitespace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}

--- a/internal/backend/devcontainer/conflicting_mounts_test.go
+++ b/internal/backend/devcontainer/conflicting_mounts_test.go
@@ -270,6 +270,108 @@ func TestNeutralizePrefersDotDevcontainerSubdir(t *testing.T) {
 	}
 }
 
+// TestStripConflictingMountsPreservesURLsInStrings is the regression
+// test for a real-world failure: devcontainer.json values like
+// "http://localhost:81/" caused a naive `//[^\n]*` comment regex to
+// truncate the string, json.Unmarshal to fail, and the neutraliser to
+// silently no-op — so the duplicate mount was never stripped and
+// docker rejected the run. The fix is a string-aware JSONC scanner,
+// and this test pins it: a URL inside any string value must NOT cause
+// a parse failure or content change.
+func TestStripConflictingMountsPreservesURLsInStrings(t *testing.T) {
+	original := []byte(`{
+  "name": "demo",
+  "mounts": [
+    "source=${localWorkspaceFolder}/.claude,target=/home/vscode/.claude,type=bind"
+  ],
+  "customizations": {
+    "coder": {
+      "apps": [
+        { "url": "http://localhost:81/" },
+        { "url": "https://example.com/path//double-slash" }
+      ]
+    }
+  }
+}`)
+	rewritten, removed, err := stripConflictingMounts(original, []backend.Mount{
+		{ContainerPath: "/home/vscode/.claude"},
+	})
+	if err != nil {
+		t.Fatalf("stripConflictingMounts on JSON with URLs = %v, want nil", err)
+	}
+	if len(removed) != 1 || removed[0] != "/home/vscode/.claude" {
+		t.Fatalf("removed = %v, want [/home/vscode/.claude]", removed)
+	}
+	// The URLs must survive the rewrite verbatim — proves comment
+	// stripping respected string boundaries.
+	for _, mustKeep := range []string{"http://localhost:81/", "https://example.com/path//double-slash"} {
+		if !strings.Contains(string(rewritten), mustKeep) {
+			t.Fatalf("rewritten lost URL %q:\n%s", mustKeep, rewritten)
+		}
+	}
+}
+
+// TestStripConflictingMountsRealWorldDevcontainerJSON exercises the
+// exact shape of a failing real-world config (URLs in coder
+// customizations, line comments at the top, ${localEnv:...} mount
+// substitutions). Locks in the end-to-end behaviour: parse succeeds,
+// the .claude entry is stripped, the .ssh entry is kept.
+func TestStripConflictingMountsRealWorldDevcontainerJSON(t *testing.T) {
+	original := []byte(`// For format details, see https://aka.ms/devcontainer.json.
+{
+  "name": "Cloud Development Environment",
+  "mounts": [
+    "source=/home/${localEnv:USER}/.ssh,target=/home/vscode/.ssh,type=bind",
+    "source=${localWorkspaceFolder}/.claude,target=/home/vscode/.claude,type=bind"
+  ],
+  "customizations": {
+    "coder": {
+      "apps": [
+        {
+          "url": "http://localhost:81/",
+          "healthCheck": { "url": "http://localhost:81/" }
+        }
+      ]
+    }
+  }
+}`)
+	_, removed, err := stripConflictingMounts(original, []backend.Mount{
+		{ContainerPath: "/home/vscode/.claude"},
+		{ContainerPath: "/home/vscode/.codex"},
+	})
+	if err != nil {
+		t.Fatalf("stripConflictingMounts on real-world config = %v, want nil", err)
+	}
+	if len(removed) != 1 || removed[0] != "/home/vscode/.claude" {
+		t.Fatalf("removed = %v, want [/home/vscode/.claude]", removed)
+	}
+}
+
+// TestToStrictJSONHandlesStringEscapes guards against a class of
+// state-machine bugs: an escaped quote inside a string must not be
+// treated as the closing quote, or the scanner would think it's
+// outside the string and start interpreting subsequent `//` as a
+// comment.
+func TestToStrictJSONHandlesStringEscapes(t *testing.T) {
+	input := []byte(`{"a":"quote\"//notacomment","b":"x"}`)
+	got := toStrictJSON(input)
+	if string(got) != string(input) {
+		t.Fatalf("escaped quotes were misparsed:\nwant: %s\ngot:  %s", input, got)
+	}
+}
+
+// TestToStrictJSONTrailingCommaInStringIsPreserved verifies the
+// trailing-comma elision is string-aware: a comma followed by `]`
+// inside a string literal must NOT be stripped, or the string's
+// content changes.
+func TestToStrictJSONTrailingCommaInStringIsPreserved(t *testing.T) {
+	input := []byte(`{"odd":"foo,]bar"}`)
+	got := toStrictJSON(input)
+	if string(got) != string(input) {
+		t.Fatalf("comma inside string was elided:\nwant: %s\ngot:  %s", input, got)
+	}
+}
+
 // TestMountEntryTargetUnknownShape pins the contract that an
 // unrecognised entry shape (e.g. a number, or an object missing both
 // target and destination) returns "" rather than mis-attributing it to

--- a/internal/backend/devcontainer/conflicting_mounts_test.go
+++ b/internal/backend/devcontainer/conflicting_mounts_test.go
@@ -1,0 +1,289 @@
+package devcontainer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// TestNeutralizeMissingDevcontainerIsNoop verifies that a workspace
+// without a devcontainer.json still produces a callable restore func
+// (so the caller's `defer restore()` is always safe) and never touches
+// the filesystem.
+func TestNeutralizeMissingDevcontainerIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	restore, err := neutralizeConflictingMounts(dir, []backend.Mount{
+		{LocalPath: "/host/.claude", ContainerPath: "/home/vscode/.claude"},
+	})
+	if err != nil {
+		t.Fatalf("neutralize on missing config = %v, want nil", err)
+	}
+	if restore == nil {
+		t.Fatal("restore is nil; callers cannot defer it")
+	}
+	restore()
+}
+
+// TestNeutralizeNoConflictLeavesFileUntouched verifies the
+// optimisation: when no fleet mount targets any of the user's declared
+// mounts, the file content is left byte-identical so a deferred
+// restore is unnecessary.
+func TestNeutralizeNoConflictLeavesFileUntouched(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".devcontainer", "devcontainer.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	original := []byte(`{
+  // user comment
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "mounts": [
+    "source=/host/secrets,target=/run/secrets,type=bind"
+  ]
+}`)
+	if err := os.WriteFile(configPath, original, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	restore, err := neutralizeConflictingMounts(dir, []backend.Mount{
+		{LocalPath: "/host/.claude", ContainerPath: "/home/vscode/.claude"},
+	})
+	if err != nil {
+		t.Fatalf("neutralize = %v, want nil", err)
+	}
+	restore()
+
+	got, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("file was modified despite no conflict:\nwant: %s\ngot:  %s", original, got)
+	}
+}
+
+// TestStripConflictingMountsStringForm covers the docker-mount-string
+// syntax (`source=...,target=...,type=bind`) for all three legal
+// destination keys: target, dst, destination.
+func TestStripConflictingMountsStringForm(t *testing.T) {
+	tests := []struct {
+		name      string
+		entry     string
+		fleetPath string
+		wantKeep  bool
+	}{
+		{
+			name:      "target= conflicts",
+			entry:     "source=/host/.claude,target=/home/vscode/.claude,type=bind",
+			fleetPath: "/home/vscode/.claude",
+			wantKeep:  false,
+		},
+		{
+			name:      "dst= conflicts",
+			entry:     "type=bind,src=/host/.codex,dst=/home/vscode/.codex",
+			fleetPath: "/home/vscode/.codex",
+			wantKeep:  false,
+		},
+		{
+			name:      "destination= conflicts",
+			entry:     "source=/host/x,destination=/home/vscode/.claude,type=bind",
+			fleetPath: "/home/vscode/.claude",
+			wantKeep:  false,
+		},
+		{
+			name:      "non-matching target is kept",
+			entry:     "source=/host/secrets,target=/run/secrets,type=bind",
+			fleetPath: "/home/vscode/.claude",
+			wantKeep:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := []byte(`{"mounts":["` + tt.entry + `"]}`)
+			rewritten, removed, err := stripConflictingMounts(original, []backend.Mount{
+				{ContainerPath: tt.fleetPath},
+			})
+			if err != nil {
+				t.Fatalf("stripConflictingMounts = %v, want nil", err)
+			}
+			if tt.wantKeep {
+				if len(removed) != 0 {
+					t.Fatalf("removed = %v, want empty", removed)
+				}
+				return
+			}
+			if len(removed) != 1 || removed[0] != tt.fleetPath {
+				t.Fatalf("removed = %v, want [%s]", removed, tt.fleetPath)
+			}
+			if strings.Contains(string(rewritten), tt.entry) {
+				t.Fatalf("rewritten still contains the conflicting entry: %s", rewritten)
+			}
+		})
+	}
+}
+
+// TestStripConflictingMountsObjectForm covers the object-style mount
+// syntax that devcontainer.json also accepts.
+func TestStripConflictingMountsObjectForm(t *testing.T) {
+	original := []byte(`{
+  "mounts": [
+    {"source": "/host/.claude", "target": "/home/vscode/.claude", "type": "bind"},
+    {"source": "/host/keep", "destination": "/opt/keep", "type": "bind"}
+  ]
+}`)
+	rewritten, removed, err := stripConflictingMounts(original, []backend.Mount{
+		{ContainerPath: "/home/vscode/.claude"},
+	})
+	if err != nil {
+		t.Fatalf("stripConflictingMounts = %v, want nil", err)
+	}
+	if len(removed) != 1 || removed[0] != "/home/vscode/.claude" {
+		t.Fatalf("removed = %v, want [/home/vscode/.claude]", removed)
+	}
+	if strings.Contains(string(rewritten), "/home/vscode/.claude") {
+		t.Fatalf("rewritten still references the stripped target: %s", rewritten)
+	}
+	if !strings.Contains(string(rewritten), "/opt/keep") {
+		t.Fatalf("rewritten dropped the unrelated mount: %s", rewritten)
+	}
+}
+
+// TestStripConflictingMountsTolerantOfJSONC verifies the JSONC
+// preprocessor (line/block comments, trailing commas) so users with
+// real-world devcontainer.json files do not see their file silently
+// left alone because of a parse error.
+func TestStripConflictingMountsTolerantOfJSONC(t *testing.T) {
+	original := []byte(`{
+  // a line comment
+  "image": "ubuntu", /* a block comment */
+  "mounts": [
+    "source=/host/.claude,target=/home/vscode/.claude,type=bind", // trailing line comment
+  ],
+}`)
+	_, removed, err := stripConflictingMounts(original, []backend.Mount{
+		{ContainerPath: "/home/vscode/.claude"},
+	})
+	if err != nil {
+		t.Fatalf("stripConflictingMounts on JSONC = %v, want nil", err)
+	}
+	if len(removed) != 1 {
+		t.Fatalf("removed = %v, want one entry", removed)
+	}
+}
+
+// TestNeutralizeRestoresOriginalBytes is the load-bearing guarantee for
+// callers: after restore() runs, the on-disk file matches the original
+// byte-for-byte. Otherwise the user's repo carries a phantom diff and
+// a `git commit -a` from inside the workspace would capture it.
+func TestNeutralizeRestoresOriginalBytes(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, ".devcontainer")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(configDir, "devcontainer.json")
+	// Include comments and trailing commas so the test catches any
+	// accidental re-serialisation through json.Marshal.
+	original := []byte(`{
+  // keep me
+  "image": "ubuntu",
+  "mounts": [
+    "source=/host/.claude,target=/home/vscode/.claude,type=bind",
+  ],
+}`)
+	if err := os.WriteFile(configPath, original, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	restore, err := neutralizeConflictingMounts(dir, []backend.Mount{
+		{LocalPath: "/fleet/.claude", ContainerPath: "/home/vscode/.claude"},
+	})
+	if err != nil {
+		t.Fatalf("neutralize = %v, want nil", err)
+	}
+
+	stripped, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(stripped), "/home/vscode/.claude") {
+		t.Fatalf("file still contains the conflicting mount mid-Up: %s", stripped)
+	}
+
+	restore()
+
+	restored, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(restored) != string(original) {
+		t.Fatalf("restore() did not reproduce the original bytes:\nwant: %s\ngot:  %s", original, restored)
+	}
+}
+
+// TestNeutralizePrefersDotDevcontainerSubdir verifies the search order
+// matches the devcontainer CLI's: the canonical
+// .devcontainer/devcontainer.json wins over a repo-root .devcontainer.json
+// when both are present.
+func TestNeutralizePrefersDotDevcontainerSubdir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".devcontainer"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	subdirConfig := filepath.Join(dir, ".devcontainer", "devcontainer.json")
+	rootConfig := filepath.Join(dir, ".devcontainer.json")
+
+	conflicting := []byte(`{"mounts":["source=/h,target=/home/vscode/.claude,type=bind"]}`)
+	clean := []byte(`{"image":"ubuntu"}`)
+	if err := os.WriteFile(subdirConfig, conflicting, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rootConfig, clean, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	restore, err := neutralizeConflictingMounts(dir, []backend.Mount{
+		{ContainerPath: "/home/vscode/.claude"},
+	})
+	if err != nil {
+		t.Fatalf("neutralize = %v, want nil", err)
+	}
+	defer restore()
+
+	got, err := os.ReadFile(subdirConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "/home/vscode/.claude") {
+		t.Fatalf("subdir config was not neutralised: %s", got)
+	}
+
+	rootGot, err := os.ReadFile(rootConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(rootGot) != string(clean) {
+		t.Fatalf("root config was touched but should have been ignored:\nwant: %s\ngot:  %s", clean, rootGot)
+	}
+}
+
+// TestMountEntryTargetUnknownShape pins the contract that an
+// unrecognised entry shape (e.g. a number, or an object missing both
+// target and destination) returns "" rather than mis-attributing it to
+// a fleet mount and stripping unrelated user config.
+func TestMountEntryTargetUnknownShape(t *testing.T) {
+	cases := []any{
+		42,
+		nil,
+		map[string]any{"source": "/h"},
+		"source=/h,type=bind",
+	}
+	for _, entry := range cases {
+		if got := mountEntryTarget(entry); got != "" {
+			t.Errorf("mountEntryTarget(%v) = %q, want \"\"", entry, got)
+		}
+	}
+}

--- a/internal/backend/devcontainer/devcontainer_backend.go
+++ b/internal/backend/devcontainer/devcontainer_backend.go
@@ -69,9 +69,23 @@ func (devcontainerBackend *DevcontainerBackend) containerUser(containerID string
 // in the slice are translated into `--mount type=bind,source=L,target=C`
 // flags so they appear inside the container alongside the SSH agent
 // socket and the workspace itself.
+//
+// When the workspace's devcontainer.json declares its own mount at the
+// same container path as one of the fleet-supplied mounts, the user's
+// entry is temporarily stripped from the file before launching the
+// devcontainer CLI and restored once Up returns. Without this, docker
+// rejects the resulting `docker run` invocation with "Duplicate mount
+// point" and the instance enters StatusFailed. Fleet's mount wins by
+// design — the user's per-fleet agent state should override whatever
+// the repo's devcontainer.json was pointing at.
 func (devcontainerBackend *DevcontainerBackend) Up(workspaceDir string, mounts []backend.Mount) (*backend.UpResult, error) {
+	restore, err := neutralizeConflictingMounts(workspaceDir, mounts)
+	if err != nil {
+		return nil, err
+	}
+	defer restore()
+
 	args := []string{"up", "--workspace-folder", workspaceDir}
-	var err error
 	args, err = devcontainerUpArgs(args)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- **Bug.** PR #45 added auto-mounts for `~/.claude` and `~/.codex` under the container's home dir. When the workspace's `devcontainer.json` already declares a mount targeting the same container path, the devcontainer CLI passes both `--mount` flags to `docker run`, which fails with `Duplicate mount point: /home/vscode/.claude` and the instance enters StatusFailed.
- **Fix.** Before launching `devcontainer up`, fleet now reads the workspace's `devcontainer.json`, parses the `mounts` array (JSONC-tolerant; both string-form `target=...` and object-form `"target": "..."` are recognised, including `dst` / `destination` aliases), and removes any entry whose container target collides with a fleet-supplied mount. A deferred `restore()` rewrites the original bytes verbatim once `Up` returns — so the workspace (a real git working tree the user will commit from) is left byte-identical.
- **Design choice.** Fleet wins over the user's devcontainer.json mount, per request. The user's per-fleet agent state (Claude / Codex auth) is what the auto-mount feature is for; honouring a repo-declared mount at the same path would defeat it.
- **Scope.** All changes live under `internal/backend/devcontainer/`. No-ops cleanly when the file is missing, has no conflicts, or fails to parse (so users with valid-but-exotic JSONC the CLI accepts are never blocked).
- **Tests.** New `conflicting_mounts_test.go` covers: missing file, no-conflict no-touch, string-form (all three destination keys), object-form, JSONC comments / trailing commas, byte-exact restore, subfolder-vs-root config preference, unknown-shape safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)