### PR TITLE
fix/claude-hook-self-heal Reinstall Claude state hook when missing

### DIFF
--- a/internal/agentdetect/claude_settings_test.go
+++ b/internal/agentdetect/claude_settings_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 )
 
 // ===========================================
@@ -490,5 +492,19 @@ func TestInjectFleetManHooks_AllManagedEventsCovered(t *testing.T) {
 		if _, ok := hooks[event]; !ok {
 			t.Errorf("managed event %q missing from output", event)
 		}
+	}
+}
+
+// TestCaptureAllScript_HookPathInLockstep guards against drift between
+// FleetManScriptSuffix (the canonical hook-script home-relative path)
+// and the literal embedded in backend.CaptureAllScript. The capture
+// script cannot import this package, so the path is duplicated; this
+// test fails fast if someone updates one without the other and would
+// otherwise leave the host triggering reprovisions for a perfectly
+// healthy container, or silently failing to detect a missing script.
+func TestCaptureAllScript_HookPathInLockstep(t *testing.T) {
+	want := "$HOME/" + FleetManScriptSuffix
+	if !strings.Contains(backend.CaptureAllScript, want) {
+		t.Errorf("backend.CaptureAllScript does not reference %q — it must check the same path the provisioner installs to", want)
 	}
 }

--- a/internal/backend/all_sessions.go
+++ b/internal/backend/all_sessions.go
@@ -12,8 +12,13 @@ package backend
 //     /tmp/fleet-man/*-state files present at capture time. Detectors
 //     read their own state file by path; missing entries simply mean
 //     the file did not exist.
+//   - ClaudeHookMissing is true only when CaptureAllScript explicitly
+//     observed that the Claude state-detection hook script is gone
+//     from the container. Default false means "no signal to act on" —
+//     a transient capture failure does NOT trigger re-provisioning.
 type AllSessions struct {
-	Sessions   map[string]ScreenCapture // sessionName → capture
-	ExtraFiles map[string]string        // containerPath → contents
-	OK         bool
+	Sessions          map[string]ScreenCapture // sessionName → capture
+	ExtraFiles        map[string]string        // containerPath → contents
+	ClaudeHookMissing bool
+	OK                bool
 }

--- a/internal/backend/coder/coder_backend.go
+++ b/internal/backend/coder/coder_backend.go
@@ -232,8 +232,13 @@ func (coderBackend *CoderBackend) CaptureAllSessions(containerID string) backend
 	if err != nil {
 		return backend.AllSessions{OK: false}
 	}
-	sessions, files := backend.ParseCaptureOutput(string(out))
-	return backend.AllSessions{Sessions: sessions, ExtraFiles: files, OK: true}
+	sessions, files, hookMissing := backend.ParseCaptureOutput(string(out))
+	return backend.AllSessions{
+		Sessions:          sessions,
+		ExtraFiles:        files,
+		ClaudeHookMissing: hookMissing,
+		OK:                true,
+	}
 }
 
 // AgentToolProbe detects which agent tool is running inside a Coder workspace.

--- a/internal/backend/codespaces/codespaces_backend.go
+++ b/internal/backend/codespaces/codespaces_backend.go
@@ -257,8 +257,13 @@ func (codespacesBackend *CodespacesBackend) CaptureAllSessions(containerID strin
 	if err != nil {
 		return backend.AllSessions{OK: false}
 	}
-	sessions, files := backend.ParseCaptureOutput(string(out))
-	return backend.AllSessions{Sessions: sessions, ExtraFiles: files, OK: true}
+	sessions, files, hookMissing := backend.ParseCaptureOutput(string(out))
+	return backend.AllSessions{
+		Sessions:          sessions,
+		ExtraFiles:        files,
+		ClaudeHookMissing: hookMissing,
+		OK:                true,
+	}
 }
 
 // AgentToolProbe detects which agent tool is running inside a codespace.

--- a/internal/backend/devcontainer/devcontainer_backend.go
+++ b/internal/backend/devcontainer/devcontainer_backend.go
@@ -264,8 +264,13 @@ func (devcontainerBackend *DevcontainerBackend) CaptureAllSessions(containerID s
 	if err != nil {
 		return backend.AllSessions{OK: false}
 	}
-	sessions, files := backend.ParseCaptureOutput(string(out))
-	return backend.AllSessions{Sessions: sessions, ExtraFiles: files, OK: true}
+	sessions, files, hookMissing := backend.ParseCaptureOutput(string(out))
+	return backend.AllSessions{
+		Sessions:          sessions,
+		ExtraFiles:        files,
+		ClaudeHookMissing: hookMissing,
+		OK:                true,
+	}
 }
 
 // AgentToolProbe detects which agent tool is running inside a container.

--- a/internal/backend/scripts.go
+++ b/internal/backend/scripts.go
@@ -78,12 +78,24 @@ const sessionMarker = "\x1eFLEET_SESSION_8f4a2b1c\x1e"
 // payload type so the parser knows which map the body belongs to.
 const fileMarker = "\x1eFLEET_FILE_8f4a2b1c\x1e"
 
+// hookMissingMarker is emitted by CaptureAllScript when the Claude
+// state-detection hook script is not present (or not executable) in
+// the container. The host uses this signal to re-install the script
+// — without it, fleet-man's Claude detector silently sticks at
+// "waiting" because Claude has no way to write the state file.
+const hookMissingMarker = "\x1eFLEET_HOOK_MISSING_8f4a2b1c\x1e"
+
 // CaptureAllScript runs every per-container read fleet-man needs in a
 // single shell invocation:
 //
 //  1. List tmux sessions and capture each pane's visible content.
 //  2. Cat any /tmp/fleet-man/*-state files written by in-container
 //     hook scripts (today: Claude Code's fleet-man-state-hook).
+//  3. Verify the Claude state-detection hook script is still present
+//     in $HOME, emitting a marker line when it is not so the host can
+//     re-provision it. The path matches FleetManScriptSuffix in the
+//     agentdetect package; the literal is duplicated here because the
+//     backend package cannot import agentdetect.
 //
 // Each block is preceded by a marker line so the Go side can
 // demultiplex back into typed maps. The script is tolerant of
@@ -103,22 +115,31 @@ for f in /tmp/fleet-man/*-state; do
   printf '\036FLEET_FILE_8f4a2b1c\036%s\n' "$f"
   cat "$f" 2>/dev/null || true
 done
+if [ ! -x "$HOME/.fleet/scripts/claude-state-hook.sh" ]; then
+  printf '\036FLEET_HOOK_MISSING_8f4a2b1c\036\n'
+fi
 `
 
 // ParseCaptureOutput demultiplexes CaptureAllScript output into its
-// two payload kinds:
+// payload kinds:
 //
-//   - sessions: tmux sessionName → ScreenCapture
-//   - files:    containerPath    → file contents
+//   - sessions:    tmux sessionName → ScreenCapture
+//   - files:       containerPath    → file contents
+//   - hookMissing: true when the Claude hook-script absence marker
+//                  was present in the output (default false: assume
+//                  installed unless we have direct evidence otherwise,
+//                  so a parse with no markers does not trigger
+//                  unnecessary re-provisioning)
 //
 // Lines preceding the first marker are ignored (the script may emit
 // stray output if tmux is misbehaving and we want to fail soft).
 // Returns empty maps when the output has no markers.
-func ParseCaptureOutput(output string) (map[string]ScreenCapture, map[string]string) {
+func ParseCaptureOutput(output string) (map[string]ScreenCapture, map[string]string, bool) {
 	sessions := make(map[string]ScreenCapture)
 	files := make(map[string]string)
+	hookMissing := false
 	if output == "" {
-		return sessions, files
+		return sessions, files, hookMissing
 	}
 
 	const (
@@ -158,6 +179,12 @@ func ParseCaptureOutput(output string) (map[string]ScreenCapture, map[string]str
 			mode = modeFile
 			currentBuf.Reset()
 			continue
+		case strings.HasPrefix(trimmed, hookMissingMarker):
+			flush()
+			currentName = ""
+			mode = modeNone
+			hookMissing = true
+			continue
 		}
 		if mode == modeNone {
 			continue
@@ -165,5 +192,5 @@ func ParseCaptureOutput(output string) (map[string]ScreenCapture, map[string]str
 		currentBuf.WriteString(line)
 	}
 	flush()
-	return sessions, files
+	return sessions, files, hookMissing
 }

--- a/internal/backend/scripts_test.go
+++ b/internal/backend/scripts_test.go
@@ -40,7 +40,7 @@ func TestParseCaptureOutput_Sessions(t *testing.T) {
 	}
 
 	t.Run("empty input means no sessions", func(t *testing.T) {
-		sessions, files := ParseCaptureOutput("")
+		sessions, files, _ := ParseCaptureOutput("")
 		if len(sessions) != 0 {
 			t.Fatalf("expected 0 sessions, got %d", len(sessions))
 		}
@@ -51,7 +51,7 @@ func TestParseCaptureOutput_Sessions(t *testing.T) {
 
 	t.Run("single session with content", func(t *testing.T) {
 		input := mk("main", "line1\nline2\n")
-		sessions, _ := ParseCaptureOutput(input)
+		sessions, _, _ := ParseCaptureOutput(input)
 		if len(sessions) != 1 {
 			t.Fatalf("expected 1 session, got %d", len(sessions))
 		}
@@ -69,7 +69,7 @@ func TestParseCaptureOutput_Sessions(t *testing.T) {
 
 	t.Run("multiple sessions are demultiplexed", func(t *testing.T) {
 		input := mk("main", "alpha\n") + mk("session-2", "beta\nbeta2\n") + mk("hex-abc", "")
-		sessions, _ := ParseCaptureOutput(input)
+		sessions, _, _ := ParseCaptureOutput(input)
 		if len(sessions) != 3 {
 			t.Fatalf("expected 3 sessions, got %d", len(sessions))
 		}
@@ -86,7 +86,7 @@ func TestParseCaptureOutput_Sessions(t *testing.T) {
 
 	t.Run("session names with special characters survive", func(t *testing.T) {
 		input := mk("fleet~abc123~def", "content")
-		sessions, _ := ParseCaptureOutput(input)
+		sessions, _, _ := ParseCaptureOutput(input)
 		capture, ok := sessions["fleet~abc123~def"]
 		if !ok {
 			t.Fatalf("expected fleet~abc123~def in result; got keys: %v", sessionKeys(sessions))
@@ -97,7 +97,7 @@ func TestParseCaptureOutput_Sessions(t *testing.T) {
 	})
 
 	t.Run("output without markers is ignored", func(t *testing.T) {
-		sessions, files := ParseCaptureOutput("orphan content with no marker\n")
+		sessions, files, _ := ParseCaptureOutput("orphan content with no marker\n")
 		if len(sessions) != 0 || len(files) != 0 {
 			t.Fatalf("expected empty results, got sessions=%d files=%d", len(sessions), len(files))
 		}
@@ -118,7 +118,7 @@ func TestParseCaptureOutput_Files(t *testing.T) {
 
 	t.Run("single file capture", func(t *testing.T) {
 		input := mkFile("/tmp/fleet-man/claude-state", "working 1700000000\n")
-		_, files := ParseCaptureOutput(input)
+		_, files, _ := ParseCaptureOutput(input)
 		if got := files["/tmp/fleet-man/claude-state"]; got != "working 1700000000" {
 			t.Errorf("got %q, want %q", got, "working 1700000000")
 		}
@@ -127,7 +127,7 @@ func TestParseCaptureOutput_Files(t *testing.T) {
 	t.Run("multiple files demultiplexed", func(t *testing.T) {
 		input := mkFile("/tmp/fleet-man/claude-state", "working 100\n") +
 			mkFile("/tmp/fleet-man/codex-state", "waiting 200\n")
-		_, files := ParseCaptureOutput(input)
+		_, files, _ := ParseCaptureOutput(input)
 		if len(files) != 2 {
 			t.Fatalf("got %d files, want 2", len(files))
 		}
@@ -143,7 +143,7 @@ func TestParseCaptureOutput_Files(t *testing.T) {
 		// State files exist but were empty (race between mkdir and
 		// first hook fire) — must produce an entry, not an absence.
 		input := mkFile("/tmp/fleet-man/claude-state", "")
-		_, files := ParseCaptureOutput(input)
+		_, files, _ := ParseCaptureOutput(input)
 		if _, present := files["/tmp/fleet-man/claude-state"]; !present {
 			t.Fatalf("expected entry for empty file, got: %v", files)
 		}
@@ -154,7 +154,7 @@ func TestParseCaptureOutput_Files(t *testing.T) {
 		// then state files. Both must demultiplex cleanly.
 		input := mkSession("main", "tmux pane content\n") +
 			mkFile("/tmp/fleet-man/claude-state", "working 42\n")
-		sessions, files := ParseCaptureOutput(input)
+		sessions, files, _ := ParseCaptureOutput(input)
 		if got := sessions["main"].Content; got != "tmux pane content" {
 			t.Errorf("session content: %q", got)
 		}
@@ -166,7 +166,7 @@ func TestParseCaptureOutput_Files(t *testing.T) {
 	t.Run("file content survives newlines and special chars", func(t *testing.T) {
 		body := "line1\nline2\n  indented\n"
 		input := mkFile("/tmp/fleet-man/claude-state", body)
-		_, files := ParseCaptureOutput(input)
+		_, files, _ := ParseCaptureOutput(input)
 		if got := files["/tmp/fleet-man/claude-state"]; got != "line1\nline2\n  indented" {
 			t.Errorf("got %q", got)
 		}
@@ -175,12 +175,56 @@ func TestParseCaptureOutput_Files(t *testing.T) {
 	t.Run("file marker followed by session marker switches mode", func(t *testing.T) {
 		input := mkFile("/tmp/fleet-man/claude-state", "working 1\n") +
 			mkSession("main", "pane\n")
-		sessions, files := ParseCaptureOutput(input)
+		sessions, files, _ := ParseCaptureOutput(input)
 		if files["/tmp/fleet-man/claude-state"] != "working 1" {
 			t.Errorf("file content: %q", files["/tmp/fleet-man/claude-state"])
 		}
 		if sessions["main"].Content != "pane" {
 			t.Errorf("session content: %q", sessions["main"].Content)
+		}
+	})
+}
+
+// ===========================================
+// ParseCaptureOutput — hook-missing marker
+// ===========================================
+
+func TestParseCaptureOutput_HookMissing(t *testing.T) {
+	mkSession := func(name, content string) string {
+		return sessionMarker + name + "\n" + content
+	}
+	mkFile := func(path, content string) string {
+		return fileMarker + path + "\n" + content
+	}
+
+	t.Run("marker alone sets hookMissing=true", func(t *testing.T) {
+		_, _, hookMissing := ParseCaptureOutput(hookMissingMarker + "\n")
+		if !hookMissing {
+			t.Fatal("expected hookMissing=true")
+		}
+	})
+
+	t.Run("marker absent sets hookMissing=false", func(t *testing.T) {
+		input := mkSession("main", "pane\n") + mkFile("/tmp/fleet-man/claude-state", "working 1\n")
+		_, _, hookMissing := ParseCaptureOutput(input)
+		if hookMissing {
+			t.Fatal("expected hookMissing=false when marker absent")
+		}
+	})
+
+	t.Run("marker after sessions and files does not corrupt them", func(t *testing.T) {
+		input := mkSession("main", "pane\n") +
+			mkFile("/tmp/fleet-man/claude-state", "working 1\n") +
+			hookMissingMarker + "\n"
+		sessions, files, hookMissing := ParseCaptureOutput(input)
+		if !hookMissing {
+			t.Fatal("expected hookMissing=true")
+		}
+		if sessions["main"].Content != "pane" {
+			t.Errorf("session content: %q", sessions["main"].Content)
+		}
+		if files["/tmp/fleet-man/claude-state"] != "working 1" {
+			t.Errorf("file content: %q", files["/tmp/fleet-man/claude-state"])
 		}
 	})
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -6,9 +6,11 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
+	"github.com/BenjaminBenetti/fleet-man/internal/agentdetect"
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 	codespacesbackend "github.com/BenjaminBenetti/fleet-man/internal/backend/codespaces"
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
@@ -41,6 +43,15 @@ type model struct {
 	backends map[fleet.BackendType]backend.Backend // one per backend type, lazily created
 	stats    map[string]*backend.ContainerStats    // containerID → stats
 	activity *ActivityTracker                      // agent working/waiting/idle detection
+
+	// reprovisioning dedupes in-flight Claude hook reinstall attempts
+	// per containerID. The capture loop fires every few seconds, and a
+	// reinstall on a slow backend can outlast one tick — without
+	// dedup we'd stack concurrent provisions for the same container.
+	// LoadOrStore inserts a sentinel; the goroutine clears it on exit.
+	// Pointer-typed because the bubbletea model is passed by value,
+	// which would otherwise copy the sync.Map's internal lock.
+	reprovisioning *sync.Map // containerID → struct{}
 
 	coderPresets        []string // available preset names (in-memory, from API)
 	coderFetchingParams bool     // true while fetching template parameters
@@ -95,15 +106,16 @@ func newModel() model {
 	agentSpinnerModel.Style = agentWorkingStyle
 
 	m := model{
-		creating:     make(map[string]bool),
-		backends:     make(map[fleet.BackendType]backend.Backend),
-		stats:        make(map[string]*backend.ContainerStats),
-		activity:     NewActivityTracker(),
-		portForwards: portforward.NewManager(),
-		sessionStore: NewSessionStore(),
-		spinner:      spinnerModel,
-		agentSpinner: agentSpinnerModel,
-		inHostTmux:   os.Getenv("TMUX") != "",
+		creating:       make(map[string]bool),
+		backends:       make(map[fleet.BackendType]backend.Backend),
+		stats:          make(map[string]*backend.ContainerStats),
+		activity:       NewActivityTracker(),
+		reprovisioning: &sync.Map{},
+		portForwards:   portforward.NewManager(),
+		sessionStore:   NewSessionStore(),
+		spinner:        spinnerModel,
+		agentSpinner:   agentSpinnerModel,
+		inHostTmux:     os.Getenv("TMUX") != "",
 	}
 
 	// Create the fleet page (persistent — background handlers reference it)
@@ -339,6 +351,60 @@ func (m *model) containersByBackend() map[fleet.BackendType]*backendGroup {
 	return groups
 }
 
+// reinstallMissingClaudeHooks scans the latest captures for the
+// "Claude hook script missing" signal and re-runs the provisioner
+// for any container that reports it. Fire-and-forget: each reinstall
+// runs in its own goroutine so the TUI message loop is never
+// blocked, and a sync.Map dedupes concurrent attempts per container
+// in case provisioning takes longer than the capture interval.
+//
+// Failures are non-fatal — the next capture tick will trigger
+// another attempt — but each failure is surfaced as a per-instance
+// warning so the user can spot a persistently-failing reinstall.
+func (m *model) reinstallMissingClaudeHooks(screens map[string]backend.AllSessions) {
+	if m.st == nil {
+		return
+	}
+	for cid, capture := range screens {
+		if !capture.OK || !capture.ClaudeHookMissing {
+			continue
+		}
+		fleetName, instance := m.findInstanceByContainerID(cid)
+		if instance == nil {
+			continue
+		}
+		if _, busy := m.reprovisioning.LoadOrStore(cid, struct{}{}); busy {
+			continue
+		}
+		backendImpl := m.instanceBackend(instance)
+		wsDir := instance.WorkspaceDir
+		instanceName := instance.Name
+		go func(id string) {
+			defer m.reprovisioning.Delete(id)
+			executor := agentdetect.NewBackendExecutor(backendImpl, wsDir)
+			if err := agentdetect.NewClaudeProvisioner(executor).Provision(); err != nil {
+				state.WriteWarn(fleetName, instanceName, fmt.Sprintf("claude hook reinstall failed: %v", err))
+			}
+		}(cid)
+	}
+}
+
+// findInstanceByContainerID returns the fleet name and instance for
+// the given containerID, or "", nil when no running instance matches.
+func (m *model) findInstanceByContainerID(containerID string) (string, *fleet.Instance) {
+	if m.st == nil {
+		return "", nil
+	}
+	for fleetName, f := range m.st.Fleets {
+		for _, instance := range f.Instances {
+			if instance.ContainerID == containerID {
+				return fleetName, instance
+			}
+		}
+	}
+	return "", nil
+}
+
 // ===========================================
 // Session Discovery
 // ===========================================
@@ -554,6 +620,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if msg.screens != nil {
 			m.activity.Update(msg.screens, msg.probes, msg.containerIDs, time.Now())
+			m.reinstallMissingClaudeHooks(msg.screens)
 		}
 		return m, tea.Batch(spinCmd, m.fetchAllStatsCmd(true))
 


### PR DESCRIPTION
## Summary

- PR #50 installs `~/.fleet/scripts/claude-state-hook.sh` once at instance creation. On some instances the script later disappears (rebuilds, image churn, manual cleanup), and Claude state detection silently sticks at "waiting" because Claude has no script to invoke.
- `CaptureAllScript` now also probes for the hook script and emits a `FLEET_HOOK_MISSING` marker line when it's gone. The marker rides the same single-shot exec that already collects tmux captures and state files — no extra round trip per poll.
- `AllSessions` gained `ClaudeHookMissing bool`; the three backends (devcontainer, coder, codespaces) propagate it from `ParseCaptureOutput`.
- The TUI's `statsMsg` handler reacts to the flag by re-running `ClaudeProvisioner.Provision()` in a goroutine. A `sync.Map` dedupes per-container so a slow reinstall doesn't get refired every poll tick. Failures are non-fatal and surface as per-instance warnings; the next tick retries.
- The hook-script path is duplicated as a literal in the capture script (the `backend` package can't import `agentdetect`); a new test in `agentdetect` (`TestCaptureAllScript_HookPathInLockstep`) fails fast if the two ever drift.
- New parser tests cover the marker absent / present / interleaved-with-other-markers cases.