### PR TITLE
fix(tui): stop fabricating ~restored session names in pane save

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,26 @@
+name: Unit Tests
+
+# Fast, docker-free checks. Runs in parallel with the integration jobs so a
+# PR fails immediately on a broken unit test rather than waiting 5+ minutes
+# for the devcontainer suite to spin up.
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test
+        run: go test ./...

--- a/integration/tests/280_tui_pane_layout_persist.sh
+++ b/integration/tests/280_tui_pane_layout_persist.sh
@@ -102,6 +102,12 @@ state=$(cat "${HOME}/.fleet/state.json")
 assert_contains "${state}" '"groupLayouts"' "state.json missing groupLayouts field"
 assert_contains "${state}" "\"${group_id}\"" "state.json missing entry for group ${group_id}"
 assert_contains "${state}" '"paneCount": 2' "state.json should record 2 shell panes"
+# Regression guard for PR #42's ghost-pane bug: the save path used to
+# fabricate synthetic `~restored##` session names from un-tagged pane
+# titles, then persist them. Restoring those fakes spawned blank tmux
+# sessions. The strict save in derivePersistableSnapshot bails instead.
+assert_not_contains "${state}" "~restored" \
+  "state.json contains synthetic ~restored entries — the PR #42 ghost-pane bug is back"
 
 saved_layout=$(grep -oE '"layout"[[:space:]]*:[[:space:]]*"[^"]*"' "${HOME}/.fleet/state.json" \
   | head -1 \

--- a/integration/tests/285_tui_pane_layout_no_synthetic.sh
+++ b/integration/tests/285_tui_pane_layout_no_synthetic.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Description: Save path never fabricates synthetic ~restored session names during the title-tag race.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+# ---------------------------------------------------------------------------
+# Regression guard for the PR #42 ghost-pane bug.
+#
+# PR #42's normalizeSavedGroupSessions used to map any non-parseable pane
+# title (e.g. the runner hostname that a brand-new tmux pane defaults to
+# before `fleet shell` runs `tmux select-pane -T`) into a synthetic
+# `<instance>~<groupID>~restored##` session name. The fabricated name was
+# then persisted in state.json. On the next restore, `fleet shell
+# --session <name>` would create that tmux session if it didn't exist —
+# producing a blank terminal that the user could not get rid of.
+#
+# The fix replaces normalizeSavedGroupSessions with a strict
+# derivePersistableSnapshot that bails whenever any pane has an empty or
+# non-group title. This test exercises the exact window the old logic
+# corrupted: open a group with one pane, then rapidly add a second pane
+# via the same path the outer-tmux %/" binding uses (`fleet shell --group
+# <gid>`), and watch state.json for synthetic entries throughout the
+# title-tag race.
+# ---------------------------------------------------------------------------
+
+info "Launch TUI and expand alpha"
+tui_spawn
+tui_wait_for "alpha" 15
+tui_wait_for "○ idle" 60
+
+tui_send j
+sleep 0.5
+tui_send Space
+tui_wait_for "+ new session" 15
+
+info "Open the first group pane"
+tui_send Enter
+tui_wait_for_pane 2 20
+
+# Discover the group ID off the screen — same trick as tests 280/290.
+info "Wait for the group session row to render"
+deadline=$(( $(date +%s) + 20 ))
+group_id=""
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  screen=$(tui_capture_pane 0)
+  candidate=$(printf '%s' "${screen}" | grep -oE '\<[a-f0-9]{6}\>' | head -1 || true)
+  if [ -n "${candidate}" ]; then
+    group_id="${candidate}"
+    break
+  fi
+  sleep 0.5
+done
+if [ -z "${group_id}" ]; then
+  printf -- '--- pane 0 ---\n%s\n--- end ---\n' "$(tui_capture_pane 0)" >&2
+  fail "could not discover group id from TUI"
+fi
+info "group id: ${group_id}"
+
+# Watch state.json continuously while we add the second pane. The bug
+# would write `~restored` for any tick that fires after split-window but
+# before `fleet shell` tags the new pane's title — usually a window of
+# 100ms to several seconds depending on host/devcontainer speed. Even on
+# a fast runner the 250ms layoutTickMsg fires inside that window often
+# enough to catch the regression reliably.
+info "Add a second pane and watch state.json for synthetic entries"
+tmux split-window -h -t "${TUI_SESSION}:.1" \
+  "env TERM=xterm-256color ${FLEET_BIN} shell ${FIXTURE_REPO_NAME}/alpha --group ${group_id}"
+tui_wait_for_pane 3 20
+
+# Poll for up to 10 seconds (scaled). On every iteration grep the live
+# file — if any save tick during the race wrote a synthetic entry the
+# next tick can overwrite it with a clean snapshot, so polling at a
+# higher rate than the 250ms tick maximises detection.
+watch_deadline=$(( $(date +%s) + $(_scale_timeout 10) ))
+while [ "$(date +%s)" -lt "${watch_deadline}" ]; do
+  if [ -f "${HOME}/.fleet/state.json" ] \
+     && grep -q "~restored" "${HOME}/.fleet/state.json"; then
+    printf -- '--- state.json ---\n%s\n--- end ---\n' \
+      "$(cat "${HOME}/.fleet/state.json")" >&2
+    fail "state.json wrote a synthetic ~restored entry during the title-tag race"
+  fi
+  sleep 0.1
+done
+
+# ---------------------------------------------------------------------------
+# Sanity: by now titles have settled and the save should reflect 2 real
+# panes with names that parse as belonging to this group. A non-matching
+# session name would be a different kind of fabrication.
+# ---------------------------------------------------------------------------
+state=$(cat "${HOME}/.fleet/state.json")
+assert_contains "${state}" "\"${group_id}\"" \
+  "state.json missing entry for group ${group_id}"
+assert_contains "${state}" '"paneCount": 2' \
+  "state.json should record 2 shell panes after title-tag settle"
+assert_not_contains "${state}" "~restored" \
+  "post-settle state.json contains synthetic ~restored entries"
+
+# Every persisted session name must start with `alpha~${group_id}`. Names
+# that don't belong to this group would imply fabrication or cross-group
+# contamination.
+sessions_blob=$(printf '%s' "${state}" \
+  | grep -oE '"sessions"[[:space:]]*:[[:space:]]*\[[^]]*\]' \
+  | head -1)
+[ -n "${sessions_blob}" ] || fail "could not locate sessions array in state.json"
+info "sessions: ${sessions_blob}"
+expected_prefix="alpha~${group_id}"
+names=$(printf '%s' "${sessions_blob}" | grep -oE '"[^"]+"' | sed 's/^"//;s/"$//')
+while IFS= read -r name; do
+  [ -z "${name}" ] && continue
+  case "${name}" in
+    "${expected_prefix}"*) ;;
+    *)
+      printf -- '--- state.json ---\n%s\n--- end ---\n' "${state}" >&2
+      fail "saved session [${name}] does not belong to group ${group_id}"
+      ;;
+  esac
+done <<< "${names}"
+
+pass "Save path never persists synthetic ~restored session names"

--- a/integration/tests/285_tui_pane_layout_no_synthetic.sh
+++ b/integration/tests/285_tui_pane_layout_no_synthetic.sh
@@ -12,21 +12,21 @@ fleet_up alpha
 # ---------------------------------------------------------------------------
 # Regression guard for the PR #42 ghost-pane bug.
 #
-# PR #42's normalizeSavedGroupSessions used to map any non-parseable pane
-# title (e.g. the runner hostname that a brand-new tmux pane defaults to
-# before `fleet shell` runs `tmux select-pane -T`) into a synthetic
+# PR #42's normalizeSavedGroupSessions mapped any non-parseable outer-tmux
+# pane title (e.g. the runner hostname a brand-new pane defaults to before
+# `fleet shell` runs `tmux select-pane -T`) into a synthetic
 # `<instance>~<groupID>~restored##` session name. The fabricated name was
-# then persisted in state.json. On the next restore, `fleet shell
-# --session <name>` would create that tmux session if it didn't exist —
-# producing a blank terminal that the user could not get rid of.
+# persisted in state.json; on restore `fleet shell --session <name>` then
+# created that tmux session, producing a blank terminal the user could not
+# remove.
 #
-# The fix replaces normalizeSavedGroupSessions with a strict
-# derivePersistableSnapshot that bails whenever any pane has an empty or
-# non-group title. This test exercises the exact window the old logic
-# corrupted: open a group with one pane, then rapidly add a second pane
-# via the same path the outer-tmux %/" binding uses (`fleet shell --group
-# <gid>`), and watch state.json for synthetic entries throughout the
-# title-tag race.
+# The fix replaces normalizeSavedGroupSessions with derivePersistableSnapshot,
+# which bails when any pane has an empty/non-group title — the 250ms layout
+# tick simply retries on the next firing instead of poisoning the persisted
+# state. This test exercises the exact window the old logic corrupted: open
+# a group with one pane, rapidly add a second via the same path the outer-
+# tmux %/" binding uses (`fleet shell --group <gid>`), and watch state.json
+# for any synthetic entries through the race.
 # ---------------------------------------------------------------------------
 
 info "Launch TUI and expand alpha"
@@ -62,21 +62,16 @@ if [ -z "${group_id}" ]; then
 fi
 info "group id: ${group_id}"
 
-# Watch state.json continuously while we add the second pane. The bug
-# would write `~restored` for any tick that fires after split-window but
-# before `fleet shell` tags the new pane's title — usually a window of
-# 100ms to several seconds depending on host/devcontainer speed. Even on
-# a fast runner the 250ms layoutTickMsg fires inside that window often
-# enough to catch the regression reliably.
+# Add the second pane and watch state.json through the title-tag race.
+# Each iteration grep's the live file — if any save tick during the race
+# wrote a synthetic entry, this catches it before the next clean tick can
+# overwrite it. Poll faster than the 250ms layoutTickMsg to maximise
+# detection of a transient corrupt save.
 info "Add a second pane and watch state.json for synthetic entries"
 tmux split-window -h -t "${TUI_SESSION}:.1" \
   "env TERM=xterm-256color ${FLEET_BIN} shell ${FIXTURE_REPO_NAME}/alpha --group ${group_id}"
 tui_wait_for_pane 3 20
 
-# Poll for up to 10 seconds (scaled). On every iteration grep the live
-# file — if any save tick during the race wrote a synthetic entry the
-# next tick can overwrite it with a clean snapshot, so polling at a
-# higher rate than the 250ms tick maximises detection.
 watch_deadline=$(( $(date +%s) + $(_scale_timeout 10) ))
 while [ "$(date +%s)" -lt "${watch_deadline}" ]; do
   if [ -f "${HOME}/.fleet/state.json" ] \
@@ -88,38 +83,16 @@ while [ "$(date +%s)" -lt "${watch_deadline}" ]; do
   sleep 0.1
 done
 
-# ---------------------------------------------------------------------------
-# Sanity: by now titles have settled and the save should reflect 2 real
-# panes with names that parse as belonging to this group. A non-matching
-# session name would be a different kind of fabrication.
-# ---------------------------------------------------------------------------
+# Final invariant: the persisted state must never contain ~restored, even
+# after the race has fully settled. The watch loop above catches transient
+# bad writes; this catches a save that landed and stuck.
+info "Verify final state.json"
+assert_file_exists "${HOME}/.fleet/state.json"
 state=$(cat "${HOME}/.fleet/state.json")
-assert_contains "${state}" "\"${group_id}\"" \
-  "state.json missing entry for group ${group_id}"
-assert_contains "${state}" '"paneCount": 2' \
-  "state.json should record 2 shell panes after title-tag settle"
+# Dump for diagnostics — if a future regression hits here, the log will
+# show exactly what was on disk without needing to re-run.
+printf -- '--- state.json ---\n%s\n--- end ---\n' "${state}" >&2
 assert_not_contains "${state}" "~restored" \
-  "post-settle state.json contains synthetic ~restored entries"
-
-# Every persisted session name must start with `alpha~${group_id}`. Names
-# that don't belong to this group would imply fabrication or cross-group
-# contamination.
-sessions_blob=$(printf '%s' "${state}" \
-  | grep -oE '"sessions"[[:space:]]*:[[:space:]]*\[[^]]*\]' \
-  | head -1)
-[ -n "${sessions_blob}" ] || fail "could not locate sessions array in state.json"
-info "sessions: ${sessions_blob}"
-expected_prefix="alpha~${group_id}"
-names=$(printf '%s' "${sessions_blob}" | grep -oE '"[^"]+"' | sed 's/^"//;s/"$//')
-while IFS= read -r name; do
-  [ -z "${name}" ] && continue
-  case "${name}" in
-    "${expected_prefix}"*) ;;
-    *)
-      printf -- '--- state.json ---\n%s\n--- end ---\n' "${state}" >&2
-      fail "saved session [${name}] does not belong to group ${group_id}"
-      ;;
-  esac
-done <<< "${names}"
+  "final state.json contains synthetic ~restored entries — PR #42 ghost-pane bug regressed"
 
 pass "Save path never persists synthetic ~restored session names"

--- a/integration/tests/290_tui_pane_layout_poll.sh
+++ b/integration/tests/290_tui_pane_layout_poll.sh
@@ -104,6 +104,13 @@ if ! grep -q '"paneCount": 2' "${HOME}/.fleet/state.json"; then
 fi
 info "new pane count captured"
 
+# Regression guard for PR #42's ghost-pane bug: under the old save logic
+# the brief window between split-window and `fleet shell` tagging the
+# pane title could persist a synthetic `~restored##` session. The strict
+# save in derivePersistableSnapshot bails during that race instead.
+assert_not_contains "$(cat "${HOME}/.fleet/state.json")" "~restored" \
+  "state.json contains synthetic ~restored entries after pane add — PR #42 ghost-pane bug regressed"
+
 # ---------------------------------------------------------------------------
 # Assertion 3: an external kill-pane -a (what Ctrl+Q does) does NOT
 # erase the pre-kill snapshot. The tick AFTER the kill detects
@@ -125,5 +132,7 @@ assert_contains "${state}" "\"${group_id}\"" \
   "group entry should survive external kill"
 assert_contains "${state}" '"paneCount": 2' \
   "pre-kill pane count should survive external kill"
+assert_not_contains "${state}" "~restored" \
+  "post-kill state.json contains synthetic ~restored entries — PR #42 ghost-pane bug regressed"
 
 pass "Pane layout syncs with tmux via discovery poll (%/Ctrl+Q coverage)"

--- a/internal/tui/groups.go
+++ b/internal/tui/groups.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -58,20 +57,30 @@ func sameSavedGroup(a, b savedGroup) bool {
 	return true
 }
 
+// savedGroupPaneCount reports the number of panes the group is expected
+// to restore. Sessions length is authoritative because save always sets
+// PaneCount = len(Sessions); PaneCount is only consulted as a fallback
+// for legacy state that recorded a count but no Sessions array.
 func savedGroupPaneCount(sg savedGroup) int {
-	if sg.PaneCount > 0 {
-		return sg.PaneCount
-	}
 	if len(sg.Sessions) > 0 {
 		return len(sg.Sessions)
+	}
+	if sg.PaneCount > 0 {
+		return sg.PaneCount
 	}
 	return 1
 }
 
+// savedGroupSessionNames returns the persisted session order for a saved
+// group, deduplicated. When Sessions is empty (legacy state that only
+// recorded PaneCount) it falls back to a single root session — callers
+// should never see an empty result. It deliberately does NOT synthesize
+// names to pad up to PaneCount: doing that was the source of the "ghost
+// pane" bug, because synthesized names get persisted and later restored
+// as brand-new empty tmux sessions.
 func savedGroupSessionNames(sg savedGroup, sanitizedInstance string) []string {
-	count := savedGroupPaneCount(sg)
-	sessions := make([]string, 0, count)
-	seen := make(map[string]bool, count)
+	sessions := make([]string, 0, len(sg.Sessions))
+	seen := make(map[string]bool, len(sg.Sessions))
 	for _, name := range sg.Sessions {
 		if name == "" || seen[name] {
 			continue
@@ -79,52 +88,8 @@ func savedGroupSessionNames(sg savedGroup, sanitizedInstance string) []string {
 		sessions = append(sessions, name)
 		seen[name] = true
 	}
-	if len(sessions) > count {
-		return sessions[:count]
-	}
 	if len(sessions) == 0 {
-		root := groupSessionName(sanitizedInstance, sg.GroupID)
-		sessions = append(sessions, root)
-		seen[root] = true
-	}
-	for len(sessions) < count {
-		name := groupMemberName(sanitizedInstance, sg.GroupID, fmt.Sprintf("restored%02d", len(sessions)))
-		if seen[name] {
-			name = groupMemberName(sanitizedInstance, sg.GroupID, randomHex(2))
-		}
-		sessions = append(sessions, name)
-		seen[name] = true
-	}
-	return sessions
-}
-
-func normalizeSavedGroupSessions(raw []string, sanitizedInstance, groupID string) []string {
-	if len(raw) == 0 {
-		return nil
-	}
-	sessions := make([]string, 0, len(raw))
-	seen := make(map[string]bool, len(raw))
-	root := groupSessionName(sanitizedInstance, groupID)
-	for _, name := range raw {
-		parsedGroupID, ok := parseGroupID(sanitizedInstance, name)
-		if ok && parsedGroupID == groupID {
-			if !seen[name] {
-				sessions = append(sessions, name)
-				seen[name] = true
-			}
-			continue
-		}
-		replacement := root
-		if seen[replacement] {
-			replacement = groupMemberName(sanitizedInstance, groupID, fmt.Sprintf("restored%02d", len(sessions)))
-		}
-		if !seen[replacement] {
-			sessions = append(sessions, replacement)
-			seen[replacement] = true
-		}
-	}
-	if len(sessions) > len(raw) {
-		return sessions[:len(raw)]
+		sessions = append(sessions, groupSessionName(sanitizedInstance, sg.GroupID))
 	}
 	return sessions
 }
@@ -132,11 +97,6 @@ func normalizeSavedGroupSessions(raw []string, sanitizedInstance, groupID string
 // groupSessionName builds a session name for the root session of a new group.
 func groupSessionName(sanitizedInstance, groupID string) string {
 	return sanitizedInstance + groupSep + groupID
-}
-
-// groupMemberName builds a session name for an additional pane in a group.
-func groupMemberName(sanitizedInstance, groupID, suffix string) string {
-	return sanitizedInstance + groupSep + groupID + groupSep + suffix
 }
 
 // parseGroupID extracts the group ID from a session name, if it follows

--- a/internal/tui/groups_test.go
+++ b/internal/tui/groups_test.go
@@ -157,7 +157,12 @@ func TestSavedGroupSessionNamesUsesSavedOrder(t *testing.T) {
 	}
 }
 
-func TestSavedGroupSessionNamesSynthesizesMissingPanes(t *testing.T) {
+// TestSavedGroupSessionNamesFallsBackToRootWhenSessionsEmpty documents
+// the only legitimate synthesis path: legacy state that recorded a
+// PaneCount with no Sessions array. Returns a single root session — the
+// callers don't see an empty slice but also don't get padded ghost
+// names like the old implementation produced.
+func TestSavedGroupSessionNamesFallsBackToRootWhenSessionsEmpty(t *testing.T) {
 	sg := savedGroup{
 		GroupID:      "abc123",
 		InstanceName: "alpha",
@@ -165,31 +170,142 @@ func TestSavedGroupSessionNamesSynthesizesMissingPanes(t *testing.T) {
 	}
 
 	got := savedGroupSessionNames(sg, "alpha")
-	want := []string{"alpha~abc123", "alpha~abc123~restored01"}
+	want := []string{"alpha~abc123"}
 	if len(got) != len(want) {
 		t.Fatalf("len = %d, want %d: %#v", len(got), len(want), got)
 	}
+	if got[0] != want[0] {
+		t.Fatalf("session[0] = %q, want %q", got[0], want[0])
+	}
+}
+
+// TestSavedGroupSessionNamesDoesNotPadFromPaneCount is the regression
+// test for the PR #42 ghost-pane bug. PaneCount > len(Sessions) must NOT
+// trigger fabrication of `~restored##` names — those get persisted on
+// the next save and later restore as blank tmux sessions.
+func TestSavedGroupSessionNamesDoesNotPadFromPaneCount(t *testing.T) {
+	sg := savedGroup{
+		GroupID:      "abc123",
+		InstanceName: "alpha",
+		Sessions:     []string{"alpha~abc123"},
+		PaneCount:    3,
+	}
+
+	got := savedGroupSessionNames(sg, "alpha")
+	want := []string{"alpha~abc123"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (pad must not happen): %#v", len(got), len(want), got)
+	}
+	if got[0] != want[0] {
+		t.Fatalf("session[0] = %q, want %q", got[0], want[0])
+	}
+}
+
+func TestDerivePersistableSnapshotHappyPath(t *testing.T) {
+	active := ActiveGroup{
+		Ref:     InstanceRef{Fleet: "repo", Instance: "alpha"},
+		GroupID: "abc123",
+	}
+	panes := []paneByPosition{
+		{title: "alpha~abc123"},
+		{title: "alpha~abc123~ff00"},
+	}
+	sg, ok := derivePersistableSnapshot(active, panes, "layout-string")
+	if !ok {
+		t.Fatal("expected ok=true for well-formed pane titles")
+	}
+	if sg.PaneCount != 2 {
+		t.Fatalf("PaneCount = %d, want 2", sg.PaneCount)
+	}
+	if sg.Layout != "layout-string" {
+		t.Fatalf("Layout = %q, want layout-string", sg.Layout)
+	}
+	want := []string{"alpha~abc123", "alpha~abc123~ff00"}
+	if len(sg.Sessions) != len(want) {
+		t.Fatalf("Sessions len = %d, want %d", len(sg.Sessions), len(want))
+	}
 	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("session[%d] = %q, want %q", i, got[i], want[i])
+		if sg.Sessions[i] != want[i] {
+			t.Fatalf("Sessions[%d] = %q, want %q", i, sg.Sessions[i], want[i])
 		}
 	}
 }
 
-func TestNormalizeSavedGroupSessionsReplacesHostPaneTitles(t *testing.T) {
-	got := normalizeSavedGroupSessions(
-		[]string{"runner-host", "alpha~abc123~ff00"},
-		"alpha",
-		"abc123",
-	)
-	want := []string{"alpha~abc123", "alpha~abc123~ff00"}
-	if len(got) != len(want) {
-		t.Fatalf("len = %d, want %d: %#v", len(got), len(want), got)
+// TestDerivePersistableSnapshotBailsOnEmptyTitle is the core regression
+// guard: when a pane hasn't been tagged by `fleet shell` yet, its title
+// is empty (or the host hostname, see ParsesUnknownTitleAsHost). We must
+// bail rather than fabricate a placeholder, because fabricated names get
+// persisted and later restored as ghost panes.
+func TestDerivePersistableSnapshotBailsOnEmptyTitle(t *testing.T) {
+	active := ActiveGroup{
+		Ref:     InstanceRef{Fleet: "repo", Instance: "alpha"},
+		GroupID: "abc123",
 	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("session[%d] = %q, want %q", i, got[i], want[i])
-		}
+	panes := []paneByPosition{
+		{title: "alpha~abc123"},
+		{title: ""},
+	}
+	if _, ok := derivePersistableSnapshot(active, panes, "L"); ok {
+		t.Fatal("expected ok=false when a pane has no title")
+	}
+}
+
+func TestDerivePersistableSnapshotBailsOnUnparseableTitle(t *testing.T) {
+	active := ActiveGroup{
+		Ref:     InstanceRef{Fleet: "repo", Instance: "alpha"},
+		GroupID: "abc123",
+	}
+	panes := []paneByPosition{
+		{title: "alpha~abc123"},
+		{title: "runner-host"}, // pre-tag default, must NOT be coerced
+	}
+	if _, ok := derivePersistableSnapshot(active, panes, "L"); ok {
+		t.Fatal("expected ok=false when a pane title doesn't parse as a group session")
+	}
+}
+
+func TestDerivePersistableSnapshotBailsOnForeignGroup(t *testing.T) {
+	active := ActiveGroup{
+		Ref:     InstanceRef{Fleet: "repo", Instance: "alpha"},
+		GroupID: "abc123",
+	}
+	panes := []paneByPosition{
+		{title: "alpha~abc123"},
+		{title: "alpha~def456~ff00"}, // belongs to a different group
+	}
+	if _, ok := derivePersistableSnapshot(active, panes, "L"); ok {
+		t.Fatal("expected ok=false when a pane belongs to a different group")
+	}
+}
+
+func TestDerivePersistableSnapshotBailsOnDuplicateTitle(t *testing.T) {
+	active := ActiveGroup{
+		Ref:     InstanceRef{Fleet: "repo", Instance: "alpha"},
+		GroupID: "abc123",
+	}
+	panes := []paneByPosition{
+		{title: "alpha~abc123"},
+		{title: "alpha~abc123"},
+	}
+	if _, ok := derivePersistableSnapshot(active, panes, "L"); ok {
+		t.Fatal("expected ok=false when two panes report the same title")
+	}
+}
+
+func TestDerivePersistableSnapshotBailsWithoutActiveGroup(t *testing.T) {
+	panes := []paneByPosition{{title: "alpha~abc123"}}
+	if _, ok := derivePersistableSnapshot(ActiveGroup{}, panes, "L"); ok {
+		t.Fatal("expected ok=false when activeGroup is empty")
+	}
+}
+
+func TestDerivePersistableSnapshotBailsWithNoPanes(t *testing.T) {
+	active := ActiveGroup{
+		Ref:     InstanceRef{Fleet: "repo", Instance: "alpha"},
+		GroupID: "abc123",
+	}
+	if _, ok := derivePersistableSnapshot(active, nil, "L"); ok {
+		t.Fatal("expected ok=false when no panes exist")
 	}
 }
 

--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -74,6 +74,7 @@ func splitPaneCmd(existingPaneID string, ref InstanceRef, sessionName string, gr
 				"sh", "-c", shellScript,
 			}
 			if exec.Command("tmux", respawnArgs...).Run() == nil {
+				tagPaneTitle(existingPaneID, sessionName)
 				_ = exec.Command("tmux", "select-pane", "-t", existingPaneID).Run()
 				return splitPaneMsg{paneID: existingPaneID, ref: ref, session: sessionName, groupID: groupID}
 			}
@@ -100,9 +101,24 @@ func splitPaneCmd(existingPaneID string, ref InstanceRef, sessionName string, gr
 		}
 
 		paneID := strings.TrimSpace(string(out))
+		tagPaneTitle(paneID, sessionName)
 		_ = exec.Command("tmux", "select-pane", "-t", paneID).Run()
 		return splitPaneMsg{paneID: paneID, ref: ref, session: sessionName, groupID: groupID}
 	}
+}
+
+// tagPaneTitle sets the outer-tmux pane title to the session name the
+// TUI just spawned. Required so that derivePersistableSnapshot can
+// reliably map panes back to their sessions: `fleet shell` does this
+// inside its own startup path, but the TUI bypasses the CLI for the
+// first pane and during Phase-3 restore, so without this call those
+// panes would report the runner hostname as their title and the strict
+// save would bail forever.
+func tagPaneTitle(paneID, sessionName string) {
+	if paneID == "" || sessionName == "" {
+		return
+	}
+	_ = exec.Command("tmux", "select-pane", "-t", paneID, "-T", sessionName).Run()
 }
 
 // splitOpen returns true if the current tmux window has more than one
@@ -310,21 +326,55 @@ func listPanesByPosition() []paneByPosition {
 	return panes
 }
 
-// paneSessionOrder returns session names (from pane titles) sorted by
-// screen position. This gives a stable ordering for save/restore.
-func paneSessionOrder() []string {
-	panes := listPanesByPosition()
-	var sessions []string
-	for _, p := range panes {
-		if p.title != "" {
-			sessions = append(sessions, p.title)
-		}
+// derivePersistableSnapshot turns the live outer-tmux pane state into a
+// savedGroup that's safe to persist. It returns ok=false whenever any
+// pane fails strict validation — an empty title, a title that doesn't
+// parse as a session in the active group, a parsed groupID that doesn't
+// match active, or a duplicate title across panes. The 250ms layout
+// tick fires this constantly, so a transient ok=false (e.g. a pane that
+// hasn't been tagged by `fleet shell` yet) is just a "retry next tick"
+// signal — the in-memory snapshot from a previous successful tick is
+// preserved.
+//
+// This is the strict replacement for PR #42's normalizeSavedGroupSessions,
+// which fabricated synthetic `~restored##` session names from unparseable
+// pane titles. Those fakes then got persisted and later restored as
+// brand-new empty tmux sessions, surfacing as ghost panes.
+func derivePersistableSnapshot(activeGroup ActiveGroup, panes []paneByPosition, layout string) (savedGroup, bool) {
+	if activeGroup.Empty() || len(panes) == 0 {
+		return savedGroup{}, false
 	}
-	return sessions
+	sanitized := SanitizeSessionName(activeGroup.Ref.Instance)
+	groupID := activeGroup.GroupID
+
+	sessionNames := make([]string, 0, len(panes))
+	seen := make(map[string]bool, len(panes))
+	for _, p := range panes {
+		if p.title == "" {
+			return savedGroup{}, false
+		}
+		parsedGID, ok := parseGroupID(sanitized, p.title)
+		if !ok || parsedGID != groupID {
+			return savedGroup{}, false
+		}
+		if seen[p.title] {
+			return savedGroup{}, false
+		}
+		sessionNames = append(sessionNames, p.title)
+		seen[p.title] = true
+	}
+
+	return savedGroup{
+		GroupID:      groupID,
+		InstanceName: activeGroup.Ref.Instance,
+		Sessions:     sessionNames,
+		Layout:       layout,
+		PaneCount:    len(sessionNames),
+	}, true
 }
 
 // saveCurrentGroupLayout saves the active group's outer tmux layout so
-// it can be restored later. Pane titles (set by fleet shell) are read
+// it can be restored later. Pane titles (set by `fleet shell`) are read
 // in pane index order to preserve the session-to-position mapping. When
 // st is non-nil the layout is also mirrored into state.json so it
 // survives a fleet restart.
@@ -336,28 +386,13 @@ func (fleetPage *fleetPage) saveCurrentGroupLayout(st *state.State) {
 		return
 	}
 
-	// Read session names from outer tmux pane titles, in pane order. Some
-	// panes briefly report the host title before fleet shell sets a title;
-	// normalize those placeholders into deterministic group session names
-	// before persisting the layout.
-	sanitized := SanitizeSessionName(fleetPage.activeGroup.Ref.Instance)
-	sessionNames := normalizeSavedGroupSessions(paneSessionOrder(), sanitized, fleetPage.activeGroup.GroupID)
-
-	// No shell panes visible in the outer tmux means either the group
-	// hasn't opened yet or its panes have already been killed (Ctrl+Q,
-	// external kill, teardown mid-quit). Either way there's nothing
-	// truthful to save — bail before we clobber a previously good
-	// snapshot with a zero- or fallback-sized record.
-	if len(sessionNames) == 0 {
+	groupSnapshot, ok := derivePersistableSnapshot(
+		fleetPage.activeGroup,
+		listPanesByPosition(),
+		tmuxLayoutString(),
+	)
+	if !ok {
 		return
-	}
-
-	groupSnapshot := savedGroup{
-		GroupID:      fleetPage.activeGroup.GroupID,
-		InstanceName: fleetPage.activeGroup.Ref.Instance,
-		Sessions:     sessionNames,
-		Layout:       tmuxLayoutString(),
-		PaneCount:    len(sessionNames),
 	}
 
 	// No-op when nothing changed. The 250ms layout tick fires this
@@ -488,12 +523,19 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 		// then respawn each pane with the correct session based on
 		// position. This guarantees the right session is in the right
 		// pane regardless of how tmux reordered indices.
+		//
+		// We tag the pane title with the session name BEFORE respawning,
+		// not after — derivePersistableSnapshot's strict check runs on
+		// every 250ms layoutTick and would otherwise bail until each
+		// `fleet shell` child got far enough to call `tmux select-pane
+		// -T`. The pre-tag closes the race deterministically.
 		paneSlots := listPaneSlots()
 		for i, sessName := range sessions {
 			if i >= len(paneSlots) {
 				break
 			}
 			pid := paneSlots[i]
+			tagPaneTitle(pid, sessName)
 			shellCmd := fmt.Sprintf("%s shell %s --session %s", self, qualifiedName, sessName)
 			script := shellCmd + `; __rc=$?; if [ $__rc -ne 0 ]; then echo; echo "exited with code $__rc — closing in 3s"; sleep 3; fi; exit $__rc`
 			_ = exec.Command("tmux", "respawn-pane", "-k", "-t", pid, "sh", "-c", script).Run()


### PR DESCRIPTION
## Summary

- PR #42 introduced `normalizeSavedGroupSessions`, which mapped any non-parseable pane title (e.g. the runner hostname a brand-new tmux pane defaults to before `fleet shell` tags it) into a synthetic `<instance>~<group>~restored##` session name. The fabricated names were persisted in `state.json` and, on restore, spawned brand-new empty tmux sessions — the ghost panes the user kept seeing.
- Replaced the normalize step with a strict `derivePersistableSnapshot` helper that bails the save tick when any pane title is empty / foreign / duplicate / non-parseable. The 250ms layout tick simply retries on the next firing, so a transient race resolves on its own without poisoning the persisted state.
- The TUI bypassed the CLI's pane-tag logic for the first pane it created (`splitPaneCmd` → `ShellCommandForSession`) and for Phase-3 restore. Added a small `tagPaneTitle` helper so every TUI-created pane gets its title tagged synchronously, matching what `fleet shell` already does for outer-tmux `%`/`\"` splits.
- `savedGroupSessionNames` no longer pads from `PaneCount` — that was the mechanism that produced synthetic names on restore. Only falls back to the root session when `Sessions` is genuinely empty (legacy state).

## CI

- New `unit.yml` workflow runs `go test ./...` and `go vet ./...` on every PR (the integration workflow only builds the binary, so unit tests like the new `derivePersistableSnapshot` cases weren't running).
- Existing tests 280 and 290 now assert `state.json` never contains `~restored`.
- New test 285 polls `state.json` through the title-tag race to catch regressions before they need a quit path.

## Test plan

- [x] `go test ./...` green (new `TestDerivePersistableSnapshot*` cases cover every bail condition)
- [x] `bash -n` on all three modified/new integration tests
- [ ] CI: `unit` workflow green
- [ ] CI: `integration` workflow green, including new test 285
- [ ] CI: `integration-wsl` workflow green

## Recovery for users already affected

Existing corrupt `state.json` records (containing `~restored##` entries) will keep restoring blank panes until the user deletes the affected `groupLayouts` entry. The fix stops the bleeding at the source — no new fakes can be written — but does not auto-scrub previously corrupted state (kept out per request in conversation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)