### PR TITLE
feature/clone-instance Clone instance preserving filesystem state

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -20,6 +20,25 @@ type Backend interface {
 	// should return false.
 	SupportsCustomMounts() bool
 
+	// Clone snapshots an existing workspace and starts a new one from
+	// that snapshot bound to destWorkspaceDir. The clone must preserve
+	// state inside the source container (e.g. manually installed
+	// packages) — callers rely on this to fan out hand-configured
+	// instances. mounts carry the same caller-supplied bind mounts as
+	// Up; backends that return false from SupportsCustomMounts may
+	// ignore them.
+	//
+	// Returns the same shape of UpResult as Up so callers can persist
+	// ContainerID identically. Backends that cannot clone should
+	// return false from SupportsClone and an error from Clone.
+	Clone(sourceContainerID, destWorkspaceDir string, mounts []Mount) (*UpResult, error)
+
+	// SupportsClone reports whether this backend implements Clone.
+	// Callers should check this before offering a clone action; cloning
+	// is unavailable for managed cloud backends whose snapshot
+	// primitives live outside fleet-man's control.
+	SupportsClone() bool
+
 	// Down stops and removes a container permanently.
 	Down(containerID string) error
 

--- a/internal/backend/coder/coder_backend.go
+++ b/internal/backend/coder/coder_backend.go
@@ -275,6 +275,17 @@ func (coderBackend *CoderBackend) SupportsCustomMounts() bool {
 	return false
 }
 
+// SupportsClone reports false: Coder workspaces are cloned at the
+// template level by the control plane, not by fleet-man.
+func (coderBackend *CoderBackend) SupportsClone() bool {
+	return false
+}
+
+// Clone is unsupported for Coder workspaces.
+func (coderBackend *CoderBackend) Clone(sourceContainerID, destWorkspaceDir string, mounts []backend.Mount) (*backend.UpResult, error) {
+	return nil, fmt.Errorf("coder backend does not support cloning")
+}
+
 // Status reports the live state of a Coder workspace by reading
 // `coder list`'s LatestBuild.Status. Lifecycle: running/started →
 // running; stopped/canceled → stopped; transitional builds (starting,

--- a/internal/backend/codespaces/codespaces_backend.go
+++ b/internal/backend/codespaces/codespaces_backend.go
@@ -310,6 +310,17 @@ func (codespacesBackend *CodespacesBackend) SupportsCustomMounts() bool {
 	return false
 }
 
+// SupportsClone reports false: GitHub Codespaces have no clone
+// primitive — they are managed by GitHub and ephemeral by design.
+func (codespacesBackend *CodespacesBackend) SupportsClone() bool {
+	return false
+}
+
+// Clone is unsupported for GitHub Codespaces.
+func (codespacesBackend *CodespacesBackend) Clone(sourceContainerID, destWorkspaceDir string, mounts []backend.Mount) (*backend.UpResult, error) {
+	return nil, fmt.Errorf("codespaces backend does not support cloning")
+}
+
 // Status reports the live state of a GitHub Codespace via
 // `gh codespace view`. GitHub's lifecycle: Available → running;
 // Shutdown/Archived → stopped (the most common drift the live probe

--- a/internal/backend/devcontainer/clone.go
+++ b/internal/backend/devcontainer/clone.go
@@ -1,0 +1,283 @@
+package devcontainer
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// cloneImageLabel marks the docker image produced by `docker commit`
+// during Clone. Down uses this label to identify and remove the
+// committed image so cloned-instance teardown does not leak images.
+const cloneImageLabel = "fleet.clone.image"
+
+// devcontainerLocalFolderLabel and devcontainerConfigFileLabel are the
+// two labels the devcontainer CLI uses to locate an existing container
+// for a given workspace. Both must match the destination paths on the
+// cloned container, otherwise `devcontainer exec` reports "Cannot find
+// Dev Container" even though the container is running.
+const (
+	devcontainerLocalFolderLabel = "devcontainer.local_folder"
+	devcontainerConfigFileLabel  = "devcontainer.config_file"
+)
+
+// inspectedContainer holds just the fields Clone needs from
+// `docker inspect`. Decoded from the JSON array docker emits.
+type inspectedContainer struct {
+	Mounts []struct {
+		Type        string `json:"Type"`
+		Source      string `json:"Source"`
+		Destination string `json:"Destination"`
+	} `json:"Mounts"`
+	Config struct {
+		Labels map[string]string `json:"Labels"`
+	} `json:"Config"`
+	HostConfig struct {
+		Privileged  bool     `json:"Privileged"`
+		CapAdd      []string `json:"CapAdd"`
+		SecurityOpt []string `json:"SecurityOpt"`
+		NetworkMode string   `json:"NetworkMode"`
+		ExtraHosts  []string `json:"ExtraHosts"`
+		Devices     []struct {
+			PathOnHost        string `json:"PathOnHost"`
+			PathInContainer   string `json:"PathInContainer"`
+			CgroupPermissions string `json:"CgroupPermissions"`
+		} `json:"Devices"`
+	} `json:"HostConfig"`
+}
+
+// SupportsClone reports that the devcontainer backend can duplicate
+// an instance via `docker commit` + `docker run`.
+func (devcontainerBackend *DevcontainerBackend) SupportsClone() bool {
+	return true
+}
+
+// Clone commits the source container into a private image, then runs a
+// fresh container from that image with destWorkspaceDir bind-mounted at
+// the same target path the source used. The committed image carries
+// label fleet.clone.image=<tag> so Down can remove it on teardown.
+//
+// Source container state is irrelevant — `docker commit` works on
+// running, paused, or stopped containers. The caller is expected to
+// have already copied the source's workspace tree onto destWorkspaceDir
+// before calling Clone, since bind mounts overlay the image layer.
+func (devcontainerBackend *DevcontainerBackend) Clone(sourceContainerID, destWorkspaceDir string, mounts []backend.Mount) (*backend.UpResult, error) {
+	if sourceContainerID == "" {
+		return nil, fmt.Errorf("clone: source container ID is empty")
+	}
+	if destWorkspaceDir == "" {
+		return nil, fmt.Errorf("clone: destination workspace dir is empty")
+	}
+
+	// Drop any docker container labelled with this dest workspace folder
+	// before provisioning, mirroring Up's pruneStaleContainers contract
+	// so a re-cloned name never silently binds to a leftover container.
+	devcontainerBackend.pruneStaleContainers(destWorkspaceDir)
+
+	inspected, err := inspectContainer(sourceContainerID)
+	if err != nil {
+		return nil, fmt.Errorf("clone: inspect source: %w", err)
+	}
+
+	workspaceTarget := findWorkspaceMountTarget(inspected)
+	if workspaceTarget == "" {
+		return nil, fmt.Errorf("clone: could not locate workspace mount target on source container %s", sourceContainerID)
+	}
+
+	imageTag, err := newCloneImageTag()
+	if err != nil {
+		return nil, fmt.Errorf("clone: generate image tag: %w", err)
+	}
+
+	commitCmd := exec.Command("docker", "commit", sourceContainerID, imageTag)
+	commitCmd.Stdout = os.Stdout
+	commitCmd.Stderr = os.Stderr
+	if err := commitCmd.Run(); err != nil {
+		return nil, fmt.Errorf("clone: docker commit failed: %w", err)
+	}
+
+	runArgs := buildCloneRunArgs(imageTag, destWorkspaceDir, workspaceTarget, inspected, mounts)
+	runCmd := exec.Command("docker", runArgs...)
+	out, err := runCmd.Output()
+	if err != nil {
+		// Best-effort cleanup of the committed image; ignore its error.
+		_ = exec.Command("docker", "rmi", imageTag).Run()
+		detail := ""
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			detail = strings.TrimSpace(string(exitErr.Stderr))
+		}
+		if detail != "" {
+			return nil, fmt.Errorf("clone: docker run failed: %w\n%s", err, detail)
+		}
+		return nil, fmt.Errorf("clone: docker run failed: %w", err)
+	}
+
+	newContainerID := strings.TrimSpace(string(out))
+	if newContainerID == "" {
+		_ = exec.Command("docker", "rmi", imageTag).Run()
+		return nil, fmt.Errorf("clone: docker run returned empty container ID")
+	}
+
+	return &backend.UpResult{
+		Outcome:               "success",
+		ContainerID:           newContainerID,
+		RemoteWorkspaceFolder: workspaceTarget,
+	}, nil
+}
+
+// inspectContainer decodes the relevant slice of `docker inspect <id>`.
+func inspectContainer(containerID string) (*inspectedContainer, error) {
+	cmd := exec.Command("docker", "inspect", containerID)
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return nil, err
+	}
+	var inspected []inspectedContainer
+	if err := json.Unmarshal(out, &inspected); err != nil {
+		return nil, fmt.Errorf("parse docker inspect: %w", err)
+	}
+	if len(inspected) == 0 {
+		return nil, fmt.Errorf("docker inspect returned no entries")
+	}
+	return &inspected[0], nil
+}
+
+// rebaseConfigFileLabel computes the destination's
+// devcontainer.config_file label value by taking the source's
+// config_file path (an absolute host path under the source's workspace
+// folder) and rewriting it to live under destWorkspaceDir. Preserves
+// the relative path of the config inside the workspace tree (typically
+// .devcontainer/devcontainer.json, but the source may have used a
+// custom location).
+//
+// Returns an empty string when the source has no config_file label or
+// when the source's config path is not nested under the source's
+// local_folder — both signal "skip the override" and let devcontainer
+// CLI match by local_folder alone.
+func rebaseConfigFileLabel(inspected *inspectedContainer, destWorkspaceDir string) string {
+	if inspected.Config.Labels == nil {
+		return ""
+	}
+	sourceConfigFile := inspected.Config.Labels[devcontainerConfigFileLabel]
+	sourceLocalFolder := inspected.Config.Labels[devcontainerLocalFolderLabel]
+	if sourceConfigFile == "" || sourceLocalFolder == "" {
+		return ""
+	}
+	rel, err := filepath.Rel(sourceLocalFolder, sourceConfigFile)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return ""
+	}
+	return filepath.Join(destWorkspaceDir, rel)
+}
+
+// findWorkspaceMountTarget returns the container-side target path of the
+// devcontainer workspace mount. The devcontainer CLI bind-mounts the
+// workspace folder at /workspaces/<project>; we identify it by looking
+// for a bind mount targeting a /workspaces/* path. Falls back to any
+// bind mount under /workspaces/ if more than one is present.
+func findWorkspaceMountTarget(inspected *inspectedContainer) string {
+	for _, mount := range inspected.Mounts {
+		if mount.Type != "bind" {
+			continue
+		}
+		if strings.HasPrefix(mount.Destination, "/workspaces/") {
+			return mount.Destination
+		}
+	}
+	return ""
+}
+
+// buildCloneRunArgs assembles the `docker run` argv that starts a
+// container from the committed image. Inherits CapAdd / SecurityOpt /
+// Devices / Privileged / NetworkMode from the source's HostConfig so
+// dev environments that needed extra privileges (docker-in-docker,
+// ptrace, etc.) still work in the clone. Port bindings are
+// deliberately not propagated — keeping them would collide with the
+// source container if both are running.
+func buildCloneRunArgs(imageTag, destWorkspaceDir, workspaceTarget string, inspected *inspectedContainer, mounts []backend.Mount) []string {
+	args := []string{"run", "-d",
+		"--label", devcontainerLocalFolderLabel + "=" + destWorkspaceDir,
+		"--label", cloneImageLabel + "=" + imageTag,
+		"--mount", "type=bind,source=" + destWorkspaceDir + ",target=" + workspaceTarget,
+	}
+
+	// Rebase the devcontainer.config_file label onto destWorkspaceDir.
+	// The devcontainer CLI filters existing containers by BOTH
+	// local_folder and config_file labels; without this override the
+	// new container inherits the source's config_file path (committed
+	// into the image) and `devcontainer exec` reports "Cannot find Dev
+	// Container" even though the container is running. If the source
+	// has no config_file label (unusual), skip — devcontainer CLI will
+	// still match on local_folder alone in that case.
+	if rebased := rebaseConfigFileLabel(inspected, destWorkspaceDir); rebased != "" {
+		args = append(args, "--label", devcontainerConfigFileLabel+"="+rebased)
+	}
+
+	if inspected.HostConfig.Privileged {
+		args = append(args, "--privileged")
+	}
+	for _, cap := range inspected.HostConfig.CapAdd {
+		args = append(args, "--cap-add", cap)
+	}
+	for _, opt := range inspected.HostConfig.SecurityOpt {
+		args = append(args, "--security-opt", opt)
+	}
+	for _, dev := range inspected.HostConfig.Devices {
+		spec := dev.PathOnHost
+		if dev.PathInContainer != "" {
+			spec += ":" + dev.PathInContainer
+		}
+		if dev.CgroupPermissions != "" {
+			spec += ":" + dev.CgroupPermissions
+		}
+		args = append(args, "--device", spec)
+	}
+	for _, host := range inspected.HostConfig.ExtraHosts {
+		args = append(args, "--add-host", host)
+	}
+	if mode := inspected.HostConfig.NetworkMode; mode != "" && mode != "default" && mode != "bridge" {
+		args = append(args, "--network", mode)
+	}
+
+	if sock := hostSSHAuthSock(); sock != "" {
+		args = append(args, "--mount", "type=bind,source="+sock+",target="+containerSSHSocketPath)
+	}
+
+	args = append(args, customMountArgs(mounts)...)
+	args = append(args, imageTag)
+	return args
+}
+
+// newCloneImageTag returns a unique image tag of the form
+// fleet-clone-<hex>:latest.
+func newCloneImageTag() (string, error) {
+	var raw [6]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	return "fleet-clone-" + hex.EncodeToString(raw[:]) + ":latest", nil
+}
+
+// cloneImageForContainer returns the fleet.clone.image label value for a
+// container, or an empty string if the container does not carry the
+// label (i.e. it was not produced by Clone). Used by Down to clean up
+// committed images.
+func cloneImageForContainer(containerID string) string {
+	cmd := exec.Command("docker", "inspect", "--format",
+		"{{ index .Config.Labels \""+cloneImageLabel+"\" }}", containerID)
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/backend/devcontainer/devcontainer_backend.go
+++ b/internal/backend/devcontainer/devcontainer_backend.go
@@ -212,10 +212,28 @@ func (devcontainerBackend *DevcontainerBackend) pruneStaleContainers(workspaceDi
 }
 
 // Down stops and removes a container by ID using docker directly.
+// If the container was produced by Clone (carries the fleet.clone.image
+// label), the committed image is removed afterwards so cloned-instance
+// teardown does not leak intermediate images. Image-rm failures are
+// logged but non-fatal — the container is already gone, which is what
+// callers actually need.
 func (devcontainerBackend *DevcontainerBackend) Down(containerID string) error {
+	cloneImage := cloneImageForContainer(containerID)
+
 	cmd := exec.Command("docker", "rm", "-f", containerID)
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	if cloneImage != "" {
+		rmiCmd := exec.Command("docker", "rmi", cloneImage)
+		if rmiOut, err := rmiCmd.CombinedOutput(); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to remove clone image %s: %v\n%s\n",
+				cloneImage, err, strings.TrimSpace(string(rmiOut)))
+		}
+	}
+	return nil
 }
 
 // Stop stops a container by ID without removing it.

--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/create"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+	"github.com/spf13/cobra"
+)
+
+// newCloneCmd returns the `fleet clone` command which duplicates an
+// existing instance, preserving manually-installed software inside the
+// source container. Only backends that report SupportsClone == true
+// can be cloned; the rest fail fast inside create.RunClone.
+func newCloneCmd() *cobra.Command {
+	var repoFlag string
+
+	cmd := &cobra.Command{
+		Use:   "clone <source> <destination>",
+		Short: "Clone an existing instance into a new one",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			srcName := args[0]
+			destName := args[1]
+
+			srcTarget, err := fleet.Resolve(srcName, repoFlag)
+			if err != nil {
+				return err
+			}
+
+			st, err := state.Load()
+			if err != nil {
+				return err
+			}
+
+			f, ok := st.Fleets[srcTarget.Fleet]
+			if !ok {
+				return fmt.Errorf("fleet %q not found", srcTarget.Fleet)
+			}
+			src, err := f.GetInstance(srcTarget.Instance)
+			if err != nil {
+				return err
+			}
+			if _, err := f.GetInstance(destName); err == nil {
+				return fmt.Errorf("instance %s/%s already exists", srcTarget.Fleet, destName)
+			}
+
+			destWorkspaceDir := filepath.Join(state.WorkspacesDir(), srcTarget.Fleet, destName, srcTarget.Fleet)
+			instance := &fleet.Instance{
+				Name:         destName,
+				DisplayName:  destName,
+				Config:       src.Config,
+				WorkspaceDir: destWorkspaceDir,
+				CreatedAt:    time.Now(),
+				Status:       fleet.StatusCloning,
+				Backend:      src.Backend,
+				Tag:          src.Tag,
+				Color:        src.Color,
+				Branch:       src.Branch,
+			}
+			if err := f.AddInstance(instance); err != nil {
+				return err
+			}
+			if err := state.Save(st); err != nil {
+				return err
+			}
+
+			fmt.Printf("Cloning %s/%s -> %s/%s (backend: %s)...\n",
+				srcTarget.Fleet, srcTarget.Instance, srcTarget.Fleet, destName, src.Backend)
+			if err := create.RunClone(srcTarget.Fleet, srcTarget.Instance, destName, true); err != nil {
+				return err
+			}
+
+			st, err = state.Load()
+			if err != nil {
+				return err
+			}
+			if f, ok := st.Fleets[srcTarget.Fleet]; ok {
+				if cloned, err := f.GetInstance(destName); err == nil && cloned.ContainerID != "" {
+					fmt.Printf("Instance %s/%s is running (container: %s)\n",
+						srcTarget.Fleet, destName, cloned.ContainerID[:min(12, len(cloned.ContainerID))])
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&repoFlag, "repo", "", "Git remote URL identifying the fleet (defaults to the source's fleet)")
+	return cmd
+}

--- a/internal/cli/clone_instance.go
+++ b/internal/cli/clone_instance.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"github.com/BenjaminBenetti/fleet-man/internal/create"
+	"github.com/spf13/cobra"
+)
+
+// newCloneInstanceCmd returns the hidden `_clone-instance` subcommand
+// the TUI spawns as a detached child to clone an instance in the
+// background. The destination instance record is expected to already
+// exist in state.json with StatusCloning so the TUI can render
+// progress; this subcommand simply hands off to create.RunClone.
+func newCloneInstanceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "_clone-instance",
+		Short:  "Internal: clone an instance in the background",
+		Hidden: true,
+		Args:   cobra.ExactArgs(3), // fleetName srcInstance destInstance
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return create.RunClone(args[0], args[1], args[2], false)
+		},
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -45,6 +45,8 @@ func NewRootCmd() *cobra.Command {
 		newLogsCmd(),
 		newStatusCmd(),
 		newCreateInstanceCmd(),
+		newCloneCmd(),
+		newCloneInstanceCmd(),
 		newPortForwardCmd(),
 		newShellCmd(),
 	)

--- a/internal/create/clone.go
+++ b/internal/create/clone.go
@@ -1,0 +1,141 @@
+package create
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// RunClone duplicates an existing instance into destInstance. The
+// destination record must already exist in state.json with
+// StatusCloning (the CLI and TUI both pre-create it that way so the
+// operation is visible in the UI while the docker commit + run is in
+// flight).
+//
+// The flow:
+//
+//  1. Look up the source instance from state and build its backend.
+//  2. Refuse early if the backend does not support cloning so the
+//     caller surfaces a clear error instead of partial work.
+//  3. Copy the source workspace directory onto the destination
+//     workspace dir. Bind mounts overlay the committed image layer, so
+//     the workspace tree must exist on disk before the new container
+//     starts.
+//  4. Hand off to backend.Clone, which captures the source's filesystem
+//     state and starts the new container.
+//  5. Persist the new ContainerID and flip the instance to
+//     StatusRunning.
+//
+// Unlike create.Run, RunClone does NOT re-run dotfiles / startup
+// scripts: the source already executed those, and the committed image
+// carries their effects. Running them again would diverge the clone
+// from the source.
+func RunClone(fleetName, srcInstance, destInstance string, verbose bool) error {
+	st, err := state.Load()
+	if err != nil {
+		setFailed(fleetName, destInstance, err)
+		return err
+	}
+	f, ok := st.Fleets[fleetName]
+	if !ok {
+		err := fmt.Errorf("fleet %q not found", fleetName)
+		setFailed(fleetName, destInstance, err)
+		return err
+	}
+	src, err := f.GetInstance(srcInstance)
+	if err != nil {
+		setFailed(fleetName, destInstance, err)
+		return err
+	}
+	if src.ContainerID == "" {
+		err := fmt.Errorf("source instance %s/%s has no container id (status: %s)", fleetName, srcInstance, src.Status)
+		setFailed(fleetName, destInstance, err)
+		return err
+	}
+
+	instanceBackend := backendutil.NewForInstance(src, verbose)
+	if !instanceBackend.SupportsClone() {
+		err := fmt.Errorf("backend %q does not support cloning", src.Backend)
+		setFailed(fleetName, destInstance, err)
+		return err
+	}
+
+	destWorkspaceDir := filepath.Join(state.WorkspacesDir(), fleetName, destInstance, fleetName)
+	if err := os.MkdirAll(filepath.Dir(destWorkspaceDir), 0755); err != nil {
+		err = fmt.Errorf("mkdir dest workspace parent: %w", err)
+		setFailed(fleetName, destInstance, err)
+		return err
+	}
+
+	// Copy the source workspace tree. `cp -a` preserves permissions,
+	// timestamps, and symlinks — important for git's working tree
+	// metadata and any tooling that inspects mtimes.
+	if err := copyWorkspaceTree(src.WorkspaceDir, destWorkspaceDir); err != nil {
+		setFailed(fleetName, destInstance, err)
+		return err
+	}
+
+	resolvedMounts, err := resolveCustomMounts(instanceBackend, fleetName)
+	if err != nil {
+		setFailed(fleetName, destInstance, err)
+		return err
+	}
+
+	result, err := instanceBackend.Clone(src.ContainerID, destWorkspaceDir, resolvedMounts.Mounts)
+	if err != nil {
+		setFailed(fleetName, destInstance, err)
+		return err
+	}
+
+	// Materialise post-clone symlinks the same way Up does so agent
+	// state mounts (e.g. ~/.claude.json) are re-linked inside the clone.
+	// Non-fatal: surface as a warning if it fails.
+	if err := applyMountSymlinks(instanceBackend, destWorkspaceDir, resolvedMounts.Symlinks); err != nil {
+		state.WriteWarn(fleetName, destInstance, fmt.Sprintf("setting up agentic mount symlinks: %v", err))
+	}
+
+	st, err = state.Load()
+	if err != nil {
+		return err
+	}
+	if f, ok := st.Fleets[fleetName]; ok {
+		if instance, err := f.GetInstance(destInstance); err == nil {
+			instance.ContainerID = result.ContainerID
+			instance.Status = fleet.StatusRunning
+			instance.Error = ""
+		}
+	}
+	return state.Save(st)
+}
+
+// copyWorkspaceTree runs `cp -a <src>/. <dest>/` so the contents of src
+// land directly inside dest (mirroring rsync's trailing-slash idiom).
+// The trailing `/.` is the portable way to ask cp to copy contents
+// rather than the directory itself.
+func copyWorkspaceTree(src, dest string) error {
+	if src == "" {
+		return fmt.Errorf("source workspace dir is empty")
+	}
+	if _, err := os.Stat(src); err != nil {
+		return fmt.Errorf("source workspace dir %s: %w", src, err)
+	}
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return fmt.Errorf("mkdir dest workspace dir: %w", err)
+	}
+
+	cmd := exec.Command("cp", "-a", src+"/.", dest+"/")
+	var buf bytes.Buffer
+	cmd.Stdout = io.MultiWriter(os.Stdout, &buf)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &buf)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("cp -a %s -> %s: %w\n%s", src, dest, err, buf.String())
+	}
+	return nil
+}

--- a/internal/fleet/instance_status.go
+++ b/internal/fleet/instance_status.go
@@ -5,6 +5,7 @@ type InstanceStatus string
 
 const (
 	StatusCreating InstanceStatus = "creating"
+	StatusCloning  InstanceStatus = "cloning"
 	StatusRunning  InstanceStatus = "running"
 	StatusStopped  InstanceStatus = "stopped"
 	StatusFailed   InstanceStatus = "failed"

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -156,7 +156,7 @@ func newModel() model {
 	if m.st != nil {
 		for fleetName, f := range m.st.Fleets {
 			for _, instance := range f.Instances {
-				if instance.Status == fleet.StatusCreating {
+				if instance.Status == fleet.StatusCreating || instance.Status == fleet.StatusCloning {
 					m.creating[fleetName+"/"+instance.Name] = true
 				}
 			}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -305,3 +305,34 @@ func createInstanceCmd(fleetName, instanceName, remoteURL, branch string, backen
 		return instanceSpawnedMsg{fleetName, instanceName}
 	}
 }
+
+// cloneInstanceCmd spawns the hidden _clone-instance subcommand as a
+// detached child to clone an instance asynchronously. The destination
+// instance record must already exist in state with StatusCloning so
+// the TUI can render progress while the docker commit + run runs.
+func cloneInstanceCmd(fleetName, srcInstance, destInstance string) tea.Cmd {
+	return func() tea.Msg {
+		self, err := os.Executable()
+		if err != nil {
+			return instanceCreateErrMsg{fleetName, destInstance, fmt.Errorf("os.Executable: %w", err)}
+		}
+
+		args := []string{"_clone-instance", fleetName, srcInstance, destInstance}
+		cmd := exec.Command(self, args...)
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+		logDir := filepath.Join(state.FleetDir(), "logs")
+		_ = os.MkdirAll(logDir, 0755)
+		logFile, err := os.Create(filepath.Join(logDir, fleetName+"-"+destInstance+".log"))
+		if err == nil {
+			cmd.Stdout = logFile
+			cmd.Stderr = logFile
+		}
+
+		if err := cmd.Start(); err != nil {
+			return instanceCreateErrMsg{fleetName, destInstance, fmt.Errorf("spawn: %w", err)}
+		}
+
+		return instanceSpawnedMsg{fleetName, destInstance}
+	}
+}

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -1478,6 +1478,103 @@ func (fleetPage *fleetPage) saveCreateSession(m *model) tea.Cmd {
 	return createSessionCmd(instanceBackend, instance.WorkspaceDir, ref, fullName)
 }
 
+// updateCloneInstance handles the single-text-input dialog that asks
+// the user for a destination instance name when cloning. dialogFleet
+// and dialogInst hold the source instance's identifiers.
+func (fleetPage *fleetPage) updateCloneInstance(m *model, msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if fleetPage.dialogFieldActive {
+			switch msg.String() {
+			case "enter":
+				return fleetPage.saveCloneInstance(m)
+			case "esc":
+				fleetPage.deactivateTextInput()
+				return nil
+			case "ctrl+c":
+				return fleetPage.cancelTextDialog(m)
+			}
+			var cmd tea.Cmd
+			fleetPage.textInput, cmd = fleetPage.textInput.Update(msg)
+			return cmd
+		}
+
+		switch msg.String() {
+		case "enter", " ":
+			return fleetPage.activateTextInput()
+		case "esc", "q", "Q", "ctrl+c":
+			return fleetPage.cancelTextDialog(m)
+		}
+		if isDialogTextKey(msg) {
+			return fleetPage.activateTextInputWithMsg(msg)
+		}
+	}
+
+	return nil
+}
+
+// saveCloneInstance validates the destination name, pre-creates the
+// destination instance record with StatusCloning so the TUI can render
+// progress, and spawns the detached _clone-instance subprocess.
+func (fleetPage *fleetPage) saveCloneInstance(m *model) tea.Cmd {
+	destName := strings.TrimSpace(fleetPage.textInput.Value())
+	if destName == "" {
+		m.message = "Name cannot be empty"
+		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
+		return nil
+	}
+
+	fleetName := fleetPage.dialogFleet
+	srcName := fleetPage.dialogInst
+
+	f, ok := m.st.Fleets[fleetName]
+	if !ok {
+		m.message = fmt.Sprintf("Fleet %s not found", fleetName)
+		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
+		return nil
+	}
+	src, err := f.GetInstance(srcName)
+	if err != nil {
+		m.message = fmt.Sprintf("Source instance %s/%s not found", fleetName, srcName)
+		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
+		return nil
+	}
+	if _, err := f.GetInstance(destName); err == nil {
+		m.message = fmt.Sprintf("Instance %s/%s already exists", fleetName, destName)
+		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
+		return nil
+	}
+
+	wsDir := filepath.Join(state.WorkspacesDir(), fleetName, destName, fleetName)
+	instance := &fleet.Instance{
+		Name:         destName,
+		DisplayName:  destName,
+		Config:       src.Config,
+		WorkspaceDir: wsDir,
+		CreatedAt:    time.Now(),
+		Status:       fleet.StatusCloning,
+		Backend:      src.Backend,
+		Tag:          src.Tag,
+		Color:        src.Color,
+		Branch:       src.Branch,
+	}
+	_ = f.AddInstance(instance)
+	_ = state.Save(m.st)
+
+	key := fleetName + "/" + destName
+	m.creating[key] = true
+	fleetPage.buildRows(m)
+	fleetPage.mode = viewNormal
+	fleetPage.blurDialogFields()
+	m.message = fmt.Sprintf("Cloning %s/%s -> %s...", fleetName, srcName, destName)
+
+	return cloneInstanceCmd(fleetName, srcName, destName)
+}
+
 // updateRenameSession handles the dialog for renaming a tmux session.
 func (fleetPage *fleetPage) updateRenameSession(m *model, msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {

--- a/internal/tui/keybindings.go
+++ b/internal/tui/keybindings.go
@@ -40,6 +40,7 @@ func keybindingsData() []keybindingGroup {
 				{"t", "Tag instance"},
 				{"f", "Port forward"},
 				{"c", "Open VS Code"},
+				{"C", "Clone instance"},
 				{"o", "Open external terminal"},
 				{"l", "View logs"},
 				{"r", "Refresh / rename session"},

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -229,6 +229,8 @@ func (fleetPage *fleetPage) Update(m *model, msg tea.Msg) tea.Cmd {
 		return fleetPage.updateCreateSession(m, msg)
 	case viewRenameSession:
 		return fleetPage.updateRenameSession(m, msg)
+	case viewCloneInstance:
+		return fleetPage.updateCloneInstance(m, msg)
 	default:
 		return fleetPage.updateNormal(m, msg)
 	}
@@ -644,6 +646,28 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 				}
 			}
 
+		case "C":
+			_, instance := fleetPage.selectedInstance(m)
+			if instance == nil {
+				m.message = "Select an instance"
+				break
+			}
+			if !m.instanceBackend(instance).SupportsClone() {
+				m.message = fmt.Sprintf("Clone not supported by %s backend", instance.Backend)
+				break
+			}
+			if instance.ContainerID == "" {
+				m.message = "Instance has not finished provisioning; nothing to clone yet"
+				break
+			}
+			fleetPage.mode = viewCloneInstance
+			fleetPage.dialogFleet = fleetPage.currentFleetName()
+			fleetPage.dialogInst = instance.Name
+			fleetPage.textInput.SetValue("")
+			fleetPage.textInput.Placeholder = "destination-name"
+			fleetPage.textInput.CharLimit = 64
+			return fleetPage.activateTextInput()
+
 		case "b":
 			_, instance := fleetPage.selectedInstance(m)
 			if instance == nil {
@@ -872,7 +896,7 @@ func (fleetPage *fleetPage) contextualHelpKeys(m *model) []string {
 				keys = append(keys,
 					"space: show sessions", "enter: open shell", "e: edit",
 					"s: stop", "a: new session", "d: delete", "t: tag",
-					"f: port-forward", "b: browser", "c: code", "o: terminal", "l: logs",
+					"f: port-forward", "b: browser", "c: code", "C: clone", "o: terminal", "l: logs",
 					"r: refresh", "q: quit",
 				)
 			case r.instance.Status == fleet.StatusStopped:
@@ -1512,6 +1536,20 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			dialogLabel.Render("Name:    "),
 			fleetPage.textInput.View(),
 			dialogHint.Render(fleetPage.textDialogHint("Create (empty for auto-name)")),
+		)
+		b.WriteString(dialogBox.Render(dialog))
+		b.WriteString("\n")
+
+	case viewCloneInstance:
+		b.WriteString("\n")
+		dialog := fmt.Sprintf(
+			"%s\n\n%s %s\n%s %s\n\n%s",
+			dialogTitle.Render("Clone instance"),
+			dialogLabel.Render("Source:     "),
+			fleetExpandedStyle.Render(fleetPage.dialogFleet+"/"+fleetPage.dialogInst),
+			dialogLabel.Render("Destination:"),
+			fleetPage.textInput.View(),
+			dialogHint.Render(fleetPage.textDialogHint("Clone")),
 		)
 		b.WriteString(dialogBox.Render(dialog))
 		b.WriteString("\n")

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -42,6 +42,8 @@ func renderStatus(s fleet.InstanceStatus) string {
 		return statusStoppedStyle.Render("stopped")
 	case fleet.StatusCreating:
 		return statusCreatingStyle.Render("creating")
+	case fleet.StatusCloning:
+		return statusCreatingStyle.Render("cloning")
 	case fleet.StatusStopping:
 		return statusCreatingStyle.Render("stopping")
 	case fleet.StatusStarting:
@@ -59,7 +61,7 @@ func renderStatus(s fleet.InstanceStatus) string {
 // background operation (shown with a spinner on the instance row).
 func isTransitional(s fleet.InstanceStatus) bool {
 	switch s {
-	case fleet.StatusCreating, fleet.StatusStopping, fleet.StatusStarting, fleet.StatusDeleting:
+	case fleet.StatusCreating, fleet.StatusCloning, fleet.StatusStopping, fleet.StatusStarting, fleet.StatusDeleting:
 		return true
 	}
 	return false

--- a/internal/tui/view_mode.go
+++ b/internal/tui/view_mode.go
@@ -14,6 +14,7 @@ const (
 	viewConfirmDelete
 	viewConfirmDeleteFleetWarn
 	viewAddInstance
+	viewCloneInstance
 	viewAddFleet
 	viewAddFleetInspecting
 	viewAddFleetNoDevcontainer


### PR DESCRIPTION
## Summary

Closes #29.

- Adds `Clone` and `SupportsClone` to the `Backend` interface so callers can offer a clone action only on backends that support it.
- Devcontainer: implements clone via `docker commit` of the source container into a private image, then `docker run` a new container from it. Manually-installed software inside the source (e.g. `apt install python3`) is preserved in the clone, which was the explicit ask in the issue.
- Coder / Codespaces: report `SupportsClone == false` and return an error from `Clone`. Their snapshot/clone primitives are managed remotely (templates / GitHub) and out of scope here.
- Both `devcontainer.local_folder` and `devcontainer.config_file` labels are rebased onto the destination workspace path. Without rewriting `config_file`, the devcontainer CLI's container lookup filters on the inherited (source) path and `devcontainer exec` reports "Cannot find Dev Container".
- New `StatusCloning` lifecycle state with a "cloning" badge and spinner in the TUI.
- CLI: `fleet clone <source> <destination>` with `--repo` flag. Hidden `_clone-instance` subcommand for TUI async dispatch, mirroring `_create-instance`.
- TUI: `C` keybinding (lowercase `c` is already "open VS Code") opens a single-input dialog asking for the destination name. Added to the bottom help line and the `?` keybindings overlay.
- `Down` `docker rmi`s the committed image when the container carries a `fleet.clone.image` label, so cloned-instance teardown doesn't leak intermediate images.
- HostConfig flags (`Privileged`, `CapAdd`, `SecurityOpt`, `Devices`, `ExtraHosts`, non-default `NetworkMode`) are inherited from the source so dev environments with extra privileges (docker-in-docker, ptrace, etc.) still work in the clone. Port bindings are deliberately dropped to avoid collisions when source and clone are both running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)