### PR TITLE
fix(tui): indent sessions under instances for clearer hierarchy

### DIFF
--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -1034,18 +1034,18 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 				label = fmt.Sprintf("%s %s", icon, r.sessionName)
 			}
 			if isSelected {
-				listContent.WriteString(fmt.Sprintf("%s      %s", cursor, selectedStyle.Render(label)))
+				listContent.WriteString(fmt.Sprintf("%s        %s", cursor, selectedStyle.Render(label)))
 			} else {
-				listContent.WriteString(fmt.Sprintf("%s      %s", cursor, style.Render(label)))
+				listContent.WriteString(fmt.Sprintf("%s        %s", cursor, style.Render(label)))
 			}
 			listContent.WriteString("\n")
 
 		} else if r.kind == rowNewSession {
 			label := "+ new session"
 			if isSelected {
-				listContent.WriteString(fmt.Sprintf("%s      %s", cursor, selectedStyle.Render(label)))
+				listContent.WriteString(fmt.Sprintf("%s        %s", cursor, selectedStyle.Render(label)))
 			} else {
-				listContent.WriteString(fmt.Sprintf("%s      %s", cursor, newSessionStyle.Render(label)))
+				listContent.WriteString(fmt.Sprintf("%s        %s", cursor, newSessionStyle.Render(label)))
 			}
 			listContent.WriteString("\n")
 


### PR DESCRIPTION
## Summary
- Users reported difficulty distinguishing tmux session rows from instance rows on the main TUI page — they previously aligned at the same column.
- Push session and new-session rows two columns past the instance name so the parent/child relationship reads at a glance.

## Test plan
- [ ] Open the TUI with at least one running instance that has multiple sessions; expand the instance and confirm session rows are visibly indented past the instance name.
- [ ] Confirm the `+ new session` row is indented to match session rows.
- [ ] Cursor highlight and selection still render correctly on session rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)