### PR TITLE
feature/browser-initial-url Open browser to devcontainer-configured initialUrl

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
   "privileged": true,
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
-  "postStartCommand": "bash ${containerWorkspaceFolder}/.devcontainer/setup.sh"
+  "postStartCommand": "bash ${containerWorkspaceFolder}/.devcontainer/setup.sh",
   // Configure tool-specific properties.
   // "customizations": {},
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,33 @@ echo 'export FLEET_DEVCONTAINER_UPDATE_REMOTE_USER_UID=never' >> ~/.bashrc
 See [Windows WSL notes](docs/windows-wsl-notes.md) for a full health check and
 disposable smoke-test workflow.
 
+## Devcontainer Customizations
+
+Fleet reads project-level settings from a `customizations.fleet` block in a
+repo's `devcontainer.json`. This follows the standard devcontainer pattern
+where each tool owns a namespaced sub-object under `customizations` (VS Code
+uses `vscode`, GitHub uses `codespaces`, and so on) — Fleet reads `fleet` and
+ignores the rest.
+
+```jsonc
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "customizations": {
+    "fleet": {
+      "browser": {
+        "initialUrl": "http://localhost:3000"
+      }
+    }
+  }
+}
+```
+
+### `browser.initialUrl`
+
+The address the built-in browser (`b` in the TUI) opens to instead of
+`about:blank`. Handy for jumping straight to a dev server or app running
+inside the instance.
+
 ## Devcontainer BuildKit
 
 Fleet uses the devcontainer CLI's default BuildKit behavior unless explicitly

--- a/internal/backend/devcontainer/customizations.go
+++ b/internal/backend/devcontainer/customizations.go
@@ -1,0 +1,92 @@
+package devcontainer
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// ===========================================
+// Customization types
+// ===========================================
+//
+// These types model fleet-man's slice of a devcontainer.json. The
+// devcontainer spec lets each tool carve out a namespaced sub-object
+// under the top-level "customizations" key (VS Code uses "vscode",
+// GitHub uses "codespaces", Coder uses "coder", and so on); fleet-man
+// reads its own "fleet" namespace and ignores every other tool's block.
+//
+//	{
+//	  "customizations": {
+//	    "fleet": {
+//	      "browser": { "initialUrl": "http://localhost:3000" }
+//	    }
+//	  }
+//	}
+//
+// The whole "fleet" block is decoded into FleetCustomizations rather
+// than reaching in for individual keys, so adding a new project-level
+// setting is just a new field here — no new parsing code, and the
+// on-disk schema and in-memory shape stay in lockstep.
+
+// Customizations mirrors the top-level "customizations" object in a
+// devcontainer.json. Only the "fleet" namespace is modelled; sibling
+// tool namespaces are left unparsed.
+type Customizations struct {
+	Fleet FleetCustomizations `json:"fleet"`
+}
+
+// FleetCustomizations is fleet-man's namespace inside a devcontainer.json
+// "customizations" block — the single typed home for every project-level
+// setting fleet-man understands. New settings are added as new fields.
+type FleetCustomizations struct {
+	// Browser configures the built-in browser launch feature.
+	Browser BrowserCustomizations `json:"browser"`
+}
+
+// BrowserCustomizations configures fleet-man's built-in browser launch.
+type BrowserCustomizations struct {
+	// InitialURL is the address the browser opens to instead of
+	// about:blank. An empty value means "use fleet-man's default".
+	InitialURL string `json:"initialUrl"`
+}
+
+// ===========================================
+// Loading
+// ===========================================
+
+// devcontainerConfig is the narrow view of a devcontainer.json that
+// fleet-man decodes. Only the customizations block is modelled; every
+// other top-level field is intentionally ignored so unrelated schema
+// changes can never break this parse.
+type devcontainerConfig struct {
+	Customizations Customizations `json:"customizations"`
+}
+
+// LoadFleetCustomizations reads the devcontainer.json under workspaceDir
+// and returns fleet-man's "customizations.fleet" block.
+//
+// A missing devcontainer.json, an absent customizations/fleet block, or
+// any unset individual field all surface as the zero value rather than
+// an error: callers treat the result as "defaults" and only override
+// behaviour where a field is explicitly set. A genuine read or JSON
+// parse failure is returned so callers can decide whether to surface or
+// ignore it.
+func LoadFleetCustomizations(workspaceDir string) (FleetCustomizations, error) {
+	_, raw, err := findDevcontainerJSON(workspaceDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return FleetCustomizations{}, nil
+		}
+		return FleetCustomizations{}, err
+	}
+
+	// devcontainer.json is JSONC (comments, trailing commas); reuse the
+	// same strict-JSON conversion the mount-conflict logic relies on.
+	var cfg devcontainerConfig
+	if err := json.Unmarshal(toStrictJSON(raw), &cfg); err != nil {
+		return FleetCustomizations{}, fmt.Errorf("parse devcontainer.json customizations: %w", err)
+	}
+	return cfg.Customizations.Fleet, nil
+}

--- a/internal/backend/devcontainer/customizations_test.go
+++ b/internal/backend/devcontainer/customizations_test.go
@@ -1,0 +1,111 @@
+package devcontainer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeDevcontainer drops contents into <dir>/.devcontainer/devcontainer.json
+// and fails the test if anything along the way errors.
+func writeDevcontainer(t *testing.T, dir, contents string) {
+	t.Helper()
+	configDir := filepath.Join(dir, ".devcontainer")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir .devcontainer: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "devcontainer.json"), []byte(contents), 0o644); err != nil {
+		t.Fatalf("write devcontainer.json: %v", err)
+	}
+}
+
+// TestLoadFleetCustomizationsMissingConfigIsZero verifies that a
+// workspace without a devcontainer.json yields the zero value and no
+// error, so callers can safely treat the result as "use defaults".
+func TestLoadFleetCustomizationsMissingConfigIsZero(t *testing.T) {
+	fc, err := LoadFleetCustomizations(t.TempDir())
+	if err != nil {
+		t.Fatalf("LoadFleetCustomizations on missing config = %v, want nil", err)
+	}
+	if fc.Browser.InitialURL != "" {
+		t.Errorf("InitialURL = %q, want empty", fc.Browser.InitialURL)
+	}
+}
+
+// TestLoadFleetCustomizationsInitialURL verifies the initialUrl is read
+// out of the customizations.fleet.browser block.
+func TestLoadFleetCustomizationsInitialURL(t *testing.T) {
+	dir := t.TempDir()
+	writeDevcontainer(t, dir, `{
+		"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+		"customizations": {
+			"fleet": {
+				"browser": { "initialUrl": "http://localhost:3000" }
+			}
+		}
+	}`)
+
+	fc, err := LoadFleetCustomizations(dir)
+	if err != nil {
+		t.Fatalf("LoadFleetCustomizations = %v, want nil", err)
+	}
+	if got, want := fc.Browser.InitialURL, "http://localhost:3000"; got != want {
+		t.Errorf("InitialURL = %q, want %q", got, want)
+	}
+}
+
+// TestLoadFleetCustomizationsJSONC verifies the loader tolerates the
+// comments and trailing commas allowed in devcontainer.json (JSONC) and
+// ignores sibling tool namespaces under customizations.
+func TestLoadFleetCustomizationsJSONC(t *testing.T) {
+	dir := t.TempDir()
+	writeDevcontainer(t, dir, `{
+		// project dev container
+		"image": "ubuntu",
+		"customizations": {
+			"vscode": { "extensions": ["golang.go"] },
+			"fleet": {
+				"browser": {
+					"initialUrl": "https://example.test/app", // landing page
+				},
+			},
+		},
+	}`)
+
+	fc, err := LoadFleetCustomizations(dir)
+	if err != nil {
+		t.Fatalf("LoadFleetCustomizations = %v, want nil", err)
+	}
+	if got, want := fc.Browser.InitialURL, "https://example.test/app"; got != want {
+		t.Errorf("InitialURL = %q, want %q", got, want)
+	}
+}
+
+// TestLoadFleetCustomizationsNoFleetBlock verifies that a devcontainer
+// with customizations but no fleet namespace yields the zero value.
+func TestLoadFleetCustomizationsNoFleetBlock(t *testing.T) {
+	dir := t.TempDir()
+	writeDevcontainer(t, dir, `{
+		"customizations": { "coder": { "ignore": true } }
+	}`)
+
+	fc, err := LoadFleetCustomizations(dir)
+	if err != nil {
+		t.Fatalf("LoadFleetCustomizations = %v, want nil", err)
+	}
+	if fc.Browser.InitialURL != "" {
+		t.Errorf("InitialURL = %q, want empty", fc.Browser.InitialURL)
+	}
+}
+
+// TestLoadFleetCustomizationsMalformedErrors verifies that genuinely
+// invalid JSON surfaces as an error (callers may still choose to ignore
+// it and fall back to defaults).
+func TestLoadFleetCustomizationsMalformedErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeDevcontainer(t, dir, `{ "customizations": { "fleet": { `)
+
+	if _, err := LoadFleetCustomizations(dir); err == nil {
+		t.Fatal("LoadFleetCustomizations on malformed JSON = nil, want error")
+	}
+}

--- a/internal/tui/browser.go
+++ b/internal/tui/browser.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+	"github.com/BenjaminBenetti/fleet-man/internal/backend/devcontainer"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/portforward"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
@@ -23,6 +24,11 @@ import (
 
 // browserProxyPort is the port privoxy listens on inside the container.
 const browserProxyPort = 58888
+
+// defaultBrowserURL is the page the browser opens to when a fleet
+// customization in the workspace's devcontainer.json does not specify
+// an initialUrl (see customizations.fleet.browser.initialUrl).
+const defaultBrowserURL = "about:blank"
 
 // ===========================================
 // Messages
@@ -143,8 +149,15 @@ func openBrowserProxyCmd(
 			return browserProxyMsg{instanceKey: instanceKey, err: err}
 		}
 
-		// 4. Launch the browser.
-		if err := launchBrowser(localPort, dataDir); err != nil {
+		// 4. Launch the browser, honoring any initialUrl declared in the
+		//    workspace's devcontainer.json fleet customization. A missing
+		//    or malformed config falls back to the default page rather
+		//    than blocking the launch.
+		initialURL := defaultBrowserURL
+		if fc, err := devcontainer.LoadFleetCustomizations(workspaceDir); err == nil && fc.Browser.InitialURL != "" {
+			initialURL = fc.Browser.InitialURL
+		}
+		if err := launchBrowser(localPort, dataDir, initialURL); err != nil {
 			return browserProxyMsg{instanceKey: instanceKey, err: fmt.Errorf("launch browser: %w", err)}
 		}
 
@@ -212,7 +225,11 @@ func ensureProxyRunning(instanceBackend backend.Backend, workspaceDir string) er
 // traffic routed through the proxy on localPort. The user data directory
 // is supplied by the caller so the layout (per-fleet vs per-instance) is
 // owned by configuration, not by this function.
-func launchBrowser(localPort int, dataDir string) error {
+//
+// initialURL is the page the browser opens to. Callers resolve it from
+// the workspace's devcontainer.json fleet customization, falling back to
+// defaultBrowserURL when none is configured.
+func launchBrowser(localPort int, dataDir, initialURL string) error {
 	proxyArg := fmt.Sprintf("--proxy-server=http://localhost:%d", localPort)
 
 	// Chrome won't start if the data dir doesn't exist on first launch
@@ -242,7 +259,7 @@ func launchBrowser(localPort int, dataDir string) error {
 				"--user-data-dir="+dataDir,
 				"--no-first-run",
 				"--no-default-browser-check",
-				"about:blank",
+				initialURL,
 			)
 			return cmd.Start()
 		}


### PR DESCRIPTION
## Summary

- Adds a `customizations.fleet` namespace to `devcontainer.json`, giving projects a typed, expandable place to configure fleet-man. The first setting, `browser.initialUrl`, makes the built-in browser (`b` in the TUI) open to a configured address instead of `about:blank`.
- New `Customizations` / `FleetCustomizations` / `BrowserCustomizations` structs in the `devcontainer` package. The whole `fleet` block is decoded into typed structs (rather than reaching for individual keys), so future settings are just new fields — schema and in-memory shape stay in lockstep.
- `LoadFleetCustomizations` reads the **managed instance's** workspace `devcontainer.json`, reusing the existing JSONC stripper. Missing config or absent fields return the zero value (callers use defaults); only genuine parse failures are surfaced.
- `launchBrowser` now takes the resolved URL; `openBrowserProxyCmd` loads it live at launch time and falls back to `about:blank` on missing/malformed config, so a broken `devcontainer.json` never blocks the browser.
- Fixes a missing comma in this repo's own `devcontainer.json`.
- Documents the `customizations.fleet.browser.initialUrl` block in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)