### PR TITLE
feat(tui): show release notes dialog after upgrade

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -16,6 +16,12 @@ var mu sync.Mutex
 type State struct {
 	Fleets       map[string]*fleet.Fleet `json:"fleets"`
 	GroupLayouts map[string]GroupLayout  `json:"groupLayouts,omitempty"`
+	// LastSeenVersion is the fleet version whose release notes the user
+	// has already been shown. When it differs from the compiled-in
+	// version (e.g. after an upgrade) the TUI surfaces that version's
+	// GitHub release notes once, then records the version here so the
+	// dialog isn't shown again.
+	LastSeenVersion string `json:"lastSeenVersion,omitempty"`
 }
 
 // FleetDir returns the base directory for fleet state.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -78,6 +78,12 @@ type model struct {
 	// Update check
 	updateAvailable string // non-empty = new version tag from GitHub
 
+	// Release notes overlay: shown once after an upgrade. When
+	// releaseNotesVersion is non-empty the dialog is active and swallows
+	// all key input until dismissed. See releasenotes.go.
+	releaseNotesVersion string
+	releaseNotesBody    string
+
 	// Pending exec after quit: after a successful update the TUI
 	// quits, then Run() replaces the current process with the new
 	// fleet binary via syscall.Exec so the new fleet is NOT nested
@@ -522,6 +528,7 @@ func (m model) Init() tea.Cmd {
 		m.sessionDiscoveryLoop(),
 		layoutTickCmd(),
 		checkUpdateCmd(),
+		checkReleaseNotesCmd(m.lastSeenVersion()),
 		forceRepaintCmd(),
 		// Probe live state right away so a fleet started after a long
 		// idle (e.g. overnight) reflects containers that stopped while
@@ -614,6 +621,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.agentSpinner, agentSpinCmd = m.agentSpinner.Update(msg)
 	spinCmd := tea.Batch(statusSpinCmd, agentSpinCmd)
 
+	// 2.5 Release notes overlay — while shown it swallows all key input:
+	// any key dismisses it (and persists the version) and is NOT
+	// forwarded to the active page, so e.g. 'q' won't quit the app.
+	if m.releaseNotesShowing() {
+		if _, ok := msg.(tea.KeyMsg); ok {
+			m.dismissReleaseNotes()
+			return m, spinCmd
+		}
+	}
+
 	// 3. Shared-only messages — return early
 	switch msg := msg.(type) {
 	case statsMsg:
@@ -629,6 +646,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case updateCheckMsg:
 		if msg.latestVersion != "" {
 			m.updateAvailable = msg.latestVersion
+		}
+		return m, spinCmd
+
+	case releaseNotesMsg:
+		// Only surface the overlay when there's an actual body to show;
+		// an empty message means dev build, already seen, or fetch error.
+		if msg.version != "" && strings.TrimSpace(msg.body) != "" {
+			m.releaseNotesVersion = msg.version
+			m.releaseNotesBody = msg.body
 		}
 		return m, spinCmd
 
@@ -1000,6 +1026,10 @@ func (m model) View() string {
 	// accompanying WindowSizeMsg invalidates the full line cache,
 	// forcing the last line — and thus this escape — to be rewritten
 	// inside the same atomic buffer flush as the rest of the redraw.
+	// Release notes overlay takes over the whole screen, centered.
+	if m.releaseNotesShowing() {
+		return m.viewReleaseNotes() + "\x1b[0J"
+	}
 	return m.currentPage.View(&m) + "\x1b[0J"
 }
 

--- a/internal/tui/releasenotes.go
+++ b/internal/tui/releasenotes.go
@@ -1,0 +1,138 @@
+package tui
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+	"github.com/BenjaminBenetti/fleet-man/internal/version"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// releaseNotesMsg carries the GitHub release notes for the currently
+// running version, fetched on startup when the user has upgraded. An
+// empty version means "nothing to show" (dev build, already seen,
+// network error, or no release body) and is silently ignored.
+type releaseNotesMsg struct {
+	version string // tag of the running version, e.g. "v1.2.3"
+	body    string // release description (markdown) from GitHub
+}
+
+// checkReleaseNotesCmd fetches the GitHub release notes for the compiled-in
+// version when it differs from the last version the user has seen. It is a
+// no-op for dev builds (no version) and when the user has already seen the
+// current version's notes — in both cases it returns an empty message.
+func checkReleaseNotesCmd(lastSeen string) tea.Cmd {
+	return func() tea.Msg {
+		current := version.Version
+		if current == "" {
+			// Dev build — no release to describe.
+			return releaseNotesMsg{}
+		}
+		if current == lastSeen {
+			// User has already seen this version's notes.
+			return releaseNotesMsg{}
+		}
+
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, err := client.Get("https://api.github.com/repos/BenjaminBenetti/fleet-man/releases/tags/" + current)
+		if err != nil {
+			return releaseNotesMsg{}
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return releaseNotesMsg{}
+		}
+
+		var release struct {
+			Body string `json:"body"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+			return releaseNotesMsg{}
+		}
+
+		return releaseNotesMsg{version: current, body: release.Body}
+	}
+}
+
+// releaseNotesShowing reports whether the release notes overlay is active.
+func (m *model) releaseNotesShowing() bool {
+	return m.releaseNotesVersion != ""
+}
+
+// lastSeenVersion returns the version whose release notes the user has
+// already seen, or "" if state is unavailable.
+func (m *model) lastSeenVersion() string {
+	if m.st == nil {
+		return ""
+	}
+	return m.st.LastSeenVersion
+}
+
+// dismissReleaseNotes closes the release notes overlay and persists the
+// version so the dialog won't be shown again on subsequent startups.
+func (m *model) dismissReleaseNotes() {
+	if m.st != nil {
+		m.st.LastSeenVersion = m.releaseNotesVersion
+		_ = state.Save(m.st)
+	}
+	m.releaseNotesVersion = ""
+	m.releaseNotesBody = ""
+}
+
+// viewReleaseNotes renders the release notes dialog centered in the
+// terminal. The body is GitHub-flavoured markdown shown as-is (wrapped to
+// the dialog width); long notes are truncated to fit the terminal height.
+func (m model) viewReleaseNotes() string {
+	// Size the box to the terminal, within sensible bounds.
+	boxWidth := 72
+	if m.width > 0 && boxWidth > m.width-4 {
+		boxWidth = m.width - 4
+	}
+	boxWidth = max(boxWidth, 20)
+
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("170")).
+		Padding(1, 2).
+		Width(boxWidth)
+
+	// Inner content width = box width minus border (2) and padding (2*2).
+	contentWidth := max(boxWidth-6, 1)
+
+	title := dialogTitle.Render("✨ Fleet updated to " + m.releaseNotesVersion)
+
+	body := strings.TrimSpace(m.releaseNotesBody)
+	bodyStyle := dialogLabel.Width(contentWidth)
+
+	// Cap the rendered body so the dialog never exceeds the terminal
+	// height. Reserve rows for the border (2), padding (2), title (2),
+	// hint (2) and a little breathing room.
+	rendered := bodyStyle.Render(body)
+	if m.height > 0 {
+		maxBodyLines := max(m.height-10, 3)
+		lines := strings.Split(rendered, "\n")
+		if len(lines) > maxBodyLines {
+			lines = append(lines[:maxBodyLines], dialogHint.Render("… (truncated)"))
+			rendered = strings.Join(lines, "\n")
+		}
+	}
+
+	hint := dialogHint.Render("Press any key to dismiss")
+
+	content := title + "\n\n" + rendered + "\n" + hint
+
+	width, height := m.width, m.height
+	if width <= 0 {
+		width = boxWidth + 4
+	}
+	if height <= 0 {
+		height = lipgloss.Height(box.Render(content))
+	}
+
+	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, box.Render(content))
+}


### PR DESCRIPTION
## What

After a version upgrade, fleet now shows the current version's GitHub release notes once, in a dialog centered in the terminal.

## How it works

- **State tracking:** new `lastSeenVersion` field in `state.json` records which version's notes the user has already seen.
- **Trigger:** on startup, if `lastSeenVersion` differs from the compiled-in `version.Version`, the release description for that tag is fetched from the GitHub API (`/releases/tags/{version}`) and shown in a centered overlay.
- **Dismiss:** any key closes the dialog and persists the version, so it won't appear again. While shown, the overlay swallows all key input (e.g. `q` dismisses rather than quitting the app).

No-ops (silent, mirroring the existing update-check flow):
- Dev builds (no `-ldflags` version)
- Versions already seen
- Network / HTTP / decode errors
- Releases with an empty body

Long notes are wrapped to the dialog width and truncated to fit the terminal height.

## Files

- `internal/state/state.go` — add `LastSeenVersion` to `State`
- `internal/tui/releasenotes.go` — fetch command, dismiss, and centered view (new)
- `internal/tui/app.go` — model fields, `Init` hook, key swallow + message handling, View overlay

## Testing

Built with `-ldflags "-X .../version.Version=v0.27.0"` against an isolated `HOME`:
- Dialog appears centered on first launch
- Any key dismisses; `lastSeenVersion` written to `state.json`
- Re-launch shows no dialog
- `go build ./...` and `go test ./internal/state ./internal/tui` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)