### PR TITLE
feat(landingpage): simplify wordmark to just "fleet"

### DIFF
--- a/internal/landingpage/templates/index.html
+++ b/internal/landingpage/templates/index.html
@@ -15,24 +15,11 @@
        at the far left and the tab bar's underline runs out to the right
        edge. Only the main content below stays in the centered column. -->
   <header class="mb-5 flex items-end gap-8 px-4">
-    <div class="flex items-start gap-4" role="img" aria-label="fleet - launch">
+    <div role="img" aria-label="fleet">
       <pre class="banner">  __ _         _
  / _| |___ ___| |_
 |  _| / -_) -_)  _|
 |_| |_\___\___|\__|</pre>
-      <!-- The blank line below is load-bearing: it gives the dash its top
-           row so it sits centred against the 4-line words. It must be a
-           real empty line, NOT a trailing space (linters strip that, and
-           the browser then eats the leading newline and the dash rides
-           one row too high). -->
-      <pre class="banner" aria-hidden="true">
-
- ___
-|___|</pre>
-      <pre class="banner"> _                   _
-| |__ _ _  _ _ _  __| |_
-| / _` | || | ' \/ _| ' \
-|_\__,_|\_,_|_||_\__|_||_|</pre>
     </div>
 
     <nav class="tabs">


### PR DESCRIPTION
## What

Trims the Fleet Launch landing-page wordmark from **"fleet - launch"** down to just **"fleet"** — simpler and more consistent. Drops the ASCII-art dash separator and the "launch" block, removes the now-unneeded alignment comment, and updates the image `aria-label` to match.

## Why

The two-word wordmark read as wordy; a single "fleet" is cleaner.

## Test plan

- [x] `go build ./...`
- [x] Template render check: index.html now has exactly one `.banner` block, `aria-label="fleet"`, and no leftover dash art

🤖 Generated with [Claude Code](https://claude.com/claude-code)