### PR TITLE
launch-redux Stage fleet binary + rc into devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,84 +21,84 @@
   "customizations": {
     "fleet": {
       "browser": {
-        "initialUrl": "https://example.com",
-        "landingPage": {
-          "sites": [
-            {
-              "title": "Cats",
-              "subTitle": "Do you like cats?",
-              "url": "https://cats.com",
-              "healthCheck": "https://cats.com/",
-              "icon": "https://cataas.com/cat"
-            },
-            {
-              "title": "GitHub",
-              "subTitle": "Where the code lives",
-              "url": "https://github.com",
-              "healthCheck": "https://github.com/",
-              "icon": "https://github.githubassets.com/favicons/favicon.svg"
-            },
-            {
-              "title": "Hacker News",
-              "subTitle": "Tech news & discussion",
-              "url": "https://news.ycombinator.com",
-              "healthCheck": "https://news.ycombinator.com/"
-            },
-            {
-              "title": "Wikipedia",
-              "subTitle": "The free encyclopedia",
-              "url": "https://www.wikipedia.org",
-              "icon": "https://www.wikipedia.org/static/apple-touch/wikipedia.png"
-            },
-            {
-              "title": "Go",
-              "subTitle": "Build simple, reliable software",
-              "url": "https://go.dev",
-              "healthCheck": "https://go.dev/",
-              "icon": "https://go.dev/images/go-logo-blue.svg"
-            },
-            {
-              "title": "MDN",
-              "subTitle": "Web docs",
-              "url": "https://developer.mozilla.org"
-            },
-            {
-              "title": "Stack Overflow",
-              "subTitle": "Q&A for developers",
-              "url": "https://stackoverflow.com",
-              "healthCheck": "https://stackoverflow.com/",
-              "icon": "https://cdn.sstatic.net/Sites/stackoverflow/Img/apple-touch-icon.png"
-            },
-            {
-              "title": "Reddit",
-              "url": "https://www.reddit.com"
-            },
-            {
-              "title": "Example",
-              "subTitle": "The canonical example domain",
-              "url": "https://example.com",
-              "healthCheck": "https://example.com/"
-            },
-            {
-              "title": "httpbin",
-              "subTitle": "HTTP request & response service",
-              "url": "https://httpbin.org",
-              "healthCheck": "https://httpbin.org/status/200"
-            }
-          ],
-          "apps": [
-            {
-              "title": "Docker",
-              "command": "docker run -d --name fleet-dozzle -p 16768:8080 -v /var/run/docker.sock:/var/run/docker.sock amir20/dozzle:latest",
-              "port": 16768
-            },
-            {
-              "title": "Grafana",
-              "command": "docker run -d --name fleet-lgtm -e GF_SECURITY_ALLOW_EMBEDDING=true -p 3000:3000 -p 4317:4317 -p 4318:4318 grafana/otel-lgtm",
-              "port": 3000
-            }
-          ]
-        }
+        "initialUrl": "https://example.com"
+      },
+      "fleetLaunch": {
+        "sites": [
+          {
+            "title": "Cats",
+            "subTitle": "Do you like cats?",
+            "url": "https://cats.com",
+            "healthCheck": "https://cats.com/",
+            "icon": "https://cataas.com/cat"
+          },
+          {
+            "title": "GitHub",
+            "subTitle": "Where the code lives",
+            "url": "https://github.com",
+            "healthCheck": "https://github.com/",
+            "icon": "https://github.githubassets.com/favicons/favicon.svg"
+          },
+          {
+            "title": "Hacker News",
+            "subTitle": "Tech news & discussion",
+            "url": "https://news.ycombinator.com",
+            "healthCheck": "https://news.ycombinator.com/"
+          },
+          {
+            "title": "Wikipedia",
+            "subTitle": "The free encyclopedia",
+            "url": "https://www.wikipedia.org",
+            "icon": "https://www.wikipedia.org/static/apple-touch/wikipedia.png"
+          },
+          {
+            "title": "Go",
+            "subTitle": "Build simple, reliable software",
+            "url": "https://go.dev",
+            "healthCheck": "https://go.dev/",
+            "icon": "https://go.dev/images/go-logo-blue.svg"
+          },
+          {
+            "title": "MDN",
+            "subTitle": "Web docs",
+            "url": "https://developer.mozilla.org"
+          },
+          {
+            "title": "Stack Overflow",
+            "subTitle": "Q&A for developers",
+            "url": "https://stackoverflow.com",
+            "healthCheck": "https://stackoverflow.com/",
+            "icon": "https://cdn.sstatic.net/Sites/stackoverflow/Img/apple-touch-icon.png"
+          },
+          {
+            "title": "Reddit",
+            "url": "https://www.reddit.com"
+          },
+          {
+            "title": "Example",
+            "subTitle": "The canonical example domain",
+            "url": "https://example.com",
+            "healthCheck": "https://example.com/"
+          },
+          {
+            "title": "httpbin",
+            "subTitle": "HTTP request & response service",
+            "url": "https://httpbin.org",
+            "healthCheck": "https://httpbin.org/status/200"
+          }
+        ],
+        "apps": [
+          {
+            "title": "Docker",
+            "command": "docker run -d --name fleet-dozzle -p 16768:8080 -v /var/run/docker.sock:/var/run/docker.sock amir20/dozzle:latest",
+            "port": 16768
+          },
+          {
+            "title": "Grafana",
+            "command": "docker run -d --name fleet-lgtm -e GF_SECURITY_ALLOW_EMBEDDING=true -p 3000:3000 -p 4317:4317 -p 4318:4318 grafana/otel-lgtm",
+            "port": 3000
+          }
+        ]
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -134,24 +134,24 @@ ignores the rest.
   "customizations": {
     "fleet": {
       "browser": {
-        "initialUrl": "http://localhost:3000",
-        "landingPage": {
-          "sites": [
-            {
-              "title": "API",
-              "subTitle": "REST backend",
-              "url": "http://localhost:3000",
-              "healthCheck": "http://localhost:3000/healthz"
-            }
-          ],
-          "apps": [
-            {
-              "title": "Logs",
-              "command": "docker run -d -p 16768:8080 -v /var/run/docker.sock:/var/run/docker.sock amir20/dozzle:latest",
-              "port": 16768
-            }
-          ]
-        }
+        "initialUrl": "http://localhost:3000"
+      },
+      "fleetLaunch": {
+        "sites": [
+          {
+            "title": "API",
+            "subTitle": "REST backend",
+            "url": "http://localhost:3000",
+            "healthCheck": "http://localhost:3000/healthz"
+          }
+        ],
+        "apps": [
+          {
+            "title": "Logs",
+            "command": "docker run -d -p 16768:8080 -v /var/run/docker.sock:/var/run/docker.sock amir20/dozzle:latest",
+            "port": 16768
+          }
+        ]
       }
     }
   }
@@ -164,7 +164,7 @@ The address the built-in browser (`b` in the TUI) opens to instead of
 `about:blank`. Handy for jumping straight to a dev server or app running
 inside the instance.
 
-### `browser.landingPage.sites`
+### `fleetLaunch.sites`
 
 A directory of links to the dev services running inside the instance. Each
 entry has:
@@ -179,10 +179,10 @@ entry has:
   reachable; a healthy service shows a green heart, an unreachable one a red
   skull, and hovering reveals the HTTP status (optional).
 
-### `browser.landingPage.apps`
+### `fleetLaunch.apps`
 
-Embedded apps shown as extra tabs on the landing page, alongside the Links
-tab. Each app gets its own tab; opening it starts the app inside the
+Embedded apps shown as extra tabs on the Fleet Launch page, alongside the
+Links tab. Each app gets its own tab; opening it starts the app inside the
 instance and embeds it in an iframe. This is how you surface a web UI that
 lives in the instance — a log viewer, a database console, a build
 dashboard — without leaving Fleet Launch. Each entry has:
@@ -216,14 +216,14 @@ For example, to replace Fleet's former built-in Dozzle log viewer:
 ]
 ```
 
-### Precedence: `initialUrl` vs. the landing page
+### Precedence: `initialUrl` vs. Fleet Launch
 
-When a devcontainer.json sets **both** `initialUrl` and a landing page (any
-`landingPage.sites` or `landingPage.apps`), the per-fleet **Prefer Fleet
-Launch** setting decides which the browser opens to:
+When a devcontainer.json sets **both** `initialUrl` and a Fleet Launch
+block (any `fleetLaunch.sites` or `fleetLaunch.apps`), the per-fleet
+**Prefer Fleet Launch** setting decides which the browser opens to:
 
 - off — `initialUrl` wins.
-- on — the Fleet Launch landing page wins.
+- on — the Fleet Launch page wins.
 
 The **first** time you open the browser on a fleet whose workspace has both
 configured, the TUI prompts you to choose, and saves your answer as the

--- a/internal/backend/devcontainer/customizations.go
+++ b/internal/backend/devcontainer/customizations.go
@@ -43,6 +43,12 @@ type Customizations struct {
 type FleetCustomizations struct {
 	// Browser configures the built-in browser launch feature.
 	Browser BrowserCustomizations `json:"browser"`
+
+	// FleetLaunch configures fleet-man's built-in Fleet Launch page —
+	// a directory of links and embedded apps for the dev services
+	// running inside the instance. Sits at the same level as Browser
+	// because it is its own feature; the browser merely opens to it.
+	FleetLaunch FleetLaunchCustomizations `json:"fleetLaunch"`
 }
 
 // BrowserCustomizations configures fleet-man's built-in browser launch.
@@ -50,36 +56,32 @@ type BrowserCustomizations struct {
 	// InitialURL is the address the browser opens to instead of
 	// about:blank. An empty value means "use fleet-man's default".
 	InitialURL string `json:"initialUrl"`
-
-	// LandingPage configures fleet-man's built-in landing page — a
-	// directory of links to the dev services running inside the
-	// instance.
-	LandingPage LandingPageCustomizations `json:"landingPage"`
 }
 
-// LandingPageCustomizations configures fleet-man's built-in browser
-// landing page.
-type LandingPageCustomizations struct {
-	// Sites is the list of links shown on the landing page's Links tab. An
-	// empty list means "no link entries configured".
-	Sites []LandingPageSite `json:"sites"`
-	// Apps is the list of embedded apps shown on the landing page. Each app
-	// becomes its own tab; opening the tab runs the app's command and
-	// iframes its localhost port. An empty list means "no app tabs".
-	Apps []LandingPageApp `json:"apps"`
+// FleetLaunchCustomizations configures fleet-man's built-in Fleet
+// Launch page.
+type FleetLaunchCustomizations struct {
+	// Sites is the list of links shown on the Fleet Launch page's Links
+	// tab. An empty list means "no link entries configured".
+	Sites []FleetLaunchSite `json:"sites"`
+	// Apps is the list of embedded apps shown on the Fleet Launch page.
+	// Each app becomes its own tab; opening the tab runs the app's
+	// command and iframes its localhost port. An empty list means "no
+	// app tabs".
+	Apps []FleetLaunchApp `json:"apps"`
 }
 
-// Configured reports whether the landing page has anything to show — at
+// Configured reports whether Fleet Launch has anything to show — at
 // least one site link or one app tab. The browser launch logic uses this
 // to decide whether the Fleet Launch page is a valid target.
-func (lp LandingPageCustomizations) Configured() bool {
-	return len(lp.Sites) > 0 || len(lp.Apps) > 0
+func (fl FleetLaunchCustomizations) Configured() bool {
+	return len(fl.Sites) > 0 || len(fl.Apps) > 0
 }
 
-// LandingPageApp is a single embedded app shown as a tab on the landing
-// page. Opening the tab starts the app (if its port isn't already
+// FleetLaunchApp is a single embedded app shown as a tab on the Fleet
+// Launch page. Opening the tab starts the app (if its port isn't already
 // answering) and iframes http://localhost:<port>.
-type LandingPageApp struct {
+type FleetLaunchApp struct {
 	// Title is the label shown on the app's tab.
 	Title string `json:"title"`
 	// Command is a bash command that starts the app. It is run the first
@@ -92,8 +94,8 @@ type LandingPageApp struct {
 	Port int `json:"port"`
 }
 
-// LandingPageSite is a single entry on the browser landing page.
-type LandingPageSite struct {
+// FleetLaunchSite is a single entry on the Fleet Launch page.
+type FleetLaunchSite struct {
 	// Title is the primary label shown for the link.
 	Title string `json:"title"`
 	// Icon is an optional image shown before the title. Its value is used

--- a/internal/backend/devcontainer/customizations_test.go
+++ b/internal/backend/devcontainer/customizations_test.go
@@ -54,29 +54,27 @@ func TestLoadFleetCustomizationsInitialURL(t *testing.T) {
 	}
 }
 
-// TestLoadFleetCustomizationsLandingPageSites verifies the landingPage
-// sites list is read out of the customizations.fleet.browser block,
-// including the subTitle and healthCheck fields.
-func TestLoadFleetCustomizationsLandingPageSites(t *testing.T) {
+// TestLoadFleetCustomizationsFleetLaunchSites verifies the fleetLaunch
+// sites list is read out of the customizations.fleet block, including
+// the subTitle and healthCheck fields.
+func TestLoadFleetCustomizationsFleetLaunchSites(t *testing.T) {
 	dir := t.TempDir()
 	writeDevcontainer(t, dir, `{
 		"customizations": {
 			"fleet": {
-				"browser": {
-					"landingPage": {
-						"sites": [
-							{
-								"title": "API",
-								"subTitle": "REST backend",
-								"url": "http://localhost:3000",
-								"healthCheck": "http://localhost:3000/healthz"
-							},
-							{
-								"title": "Docs",
-								"url": "http://localhost:8080"
-							}
-						]
-					}
+				"fleetLaunch": {
+					"sites": [
+						{
+							"title": "API",
+							"subTitle": "REST backend",
+							"url": "http://localhost:3000",
+							"healthCheck": "http://localhost:3000/healthz"
+						},
+						{
+							"title": "Docs",
+							"url": "http://localhost:8080"
+						}
+					]
 				}
 			}
 		}
@@ -87,7 +85,7 @@ func TestLoadFleetCustomizationsLandingPageSites(t *testing.T) {
 		t.Fatalf("LoadFleetCustomizations = %v, want nil", err)
 	}
 
-	sites := fc.Browser.LandingPage.Sites
+	sites := fc.FleetLaunch.Sites
 	if got, want := len(sites), 2; got != want {
 		t.Fatalf("len(Sites) = %d, want %d", got, want)
 	}
@@ -112,28 +110,26 @@ func TestLoadFleetCustomizationsLandingPageSites(t *testing.T) {
 	}
 }
 
-// TestLoadFleetCustomizationsLandingPageApps verifies the landingPage apps
-// list is read out of the customizations.fleet.browser block, including
-// the command and port fields, and that Configured reflects an apps-only
-// config.
-func TestLoadFleetCustomizationsLandingPageApps(t *testing.T) {
+// TestLoadFleetCustomizationsFleetLaunchApps verifies the fleetLaunch
+// apps list is read out of the customizations.fleet block, including
+// the command and port fields, and that Configured reflects an
+// apps-only config.
+func TestLoadFleetCustomizationsFleetLaunchApps(t *testing.T) {
 	dir := t.TempDir()
 	writeDevcontainer(t, dir, `{
 		"customizations": {
 			"fleet": {
-				"browser": {
-					"landingPage": {
-						"apps": [
-							{
-								"title": "Logs",
-								"command": "docker run -d -p 16768:8080 amir20/dozzle:latest",
-								"port": 16768
-							},
-							{
-								"title": "Already up"
-							}
-						]
-					}
+				"fleetLaunch": {
+					"apps": [
+						{
+							"title": "Logs",
+							"command": "docker run -d -p 16768:8080 amir20/dozzle:latest",
+							"port": 16768
+						},
+						{
+							"title": "Already up"
+						}
+					]
 				}
 			}
 		}
@@ -144,7 +140,7 @@ func TestLoadFleetCustomizationsLandingPageApps(t *testing.T) {
 		t.Fatalf("LoadFleetCustomizations = %v, want nil", err)
 	}
 
-	apps := fc.Browser.LandingPage.Apps
+	apps := fc.FleetLaunch.Apps
 	if got, want := len(apps), 2; got != want {
 		t.Fatalf("len(Apps) = %d, want %d", got, want)
 	}
@@ -165,15 +161,15 @@ func TestLoadFleetCustomizationsLandingPageApps(t *testing.T) {
 		t.Errorf("Apps[1] optional fields = %q/%d, want empty/0", second.Command, second.Port)
 	}
 
-	// A landing page with only apps (no sites) is still configured.
-	if !fc.Browser.LandingPage.Configured() {
-		t.Error("Configured() = false for an apps-only landing page, want true")
+	// A Fleet Launch with only apps (no sites) is still configured.
+	if !fc.FleetLaunch.Configured() {
+		t.Error("Configured() = false for an apps-only Fleet Launch, want true")
 	}
 }
 
-// TestLoadFleetCustomizationsNoLandingPageIsZero verifies a browser block
-// without a landingPage yields an empty sites list rather than an error.
-func TestLoadFleetCustomizationsNoLandingPageIsZero(t *testing.T) {
+// TestLoadFleetCustomizationsNoFleetLaunchIsZero verifies a fleet block
+// without a fleetLaunch yields an empty sites list rather than an error.
+func TestLoadFleetCustomizationsNoFleetLaunchIsZero(t *testing.T) {
 	dir := t.TempDir()
 	writeDevcontainer(t, dir, `{
 		"customizations": {
@@ -185,7 +181,7 @@ func TestLoadFleetCustomizationsNoLandingPageIsZero(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadFleetCustomizations = %v, want nil", err)
 	}
-	if got := len(fc.Browser.LandingPage.Sites); got != 0 {
+	if got := len(fc.FleetLaunch.Sites); got != 0 {
 		t.Errorf("len(Sites) = %d, want 0", got)
 	}
 }

--- a/internal/cli/landing_page.go
+++ b/internal/cli/landing_page.go
@@ -12,7 +12,7 @@ import (
 // browser landing page (see internal/landingpage and the browser launch
 // flow). It is hidden from --help because running it on the host is
 // meaningless — it reads the local devcontainer.json's
-// customizations.fleet.browser.landingPage block and serves it.
+// customizations.fleet.fleetLaunch block and serves it.
 func newLandingPageCmd() *cobra.Command {
 	var port int
 	var workspace string

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -53,6 +53,7 @@ func NewRootCmd() *cobra.Command {
 		newExecInSessionCmd(),
 		newReadSessionCmd(),
 		newLandingPageCmd(),
+		newVersionCmd(),
 	)
 
 	return root

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/version"
+	"github.com/spf13/cobra"
+)
+
+// newVersionCmd creates the `fleet version` command. It prints the
+// compiled-in version string on its own line — empty for dev builds where
+// version.Version was never set via the release-time ldflag.
+//
+// The output shape is load-bearing: fleet-man's TUI launches the landing
+// page by injecting its own binary into an instance, and uses this
+// command to compare the in-container binary's version against the host's
+// so it can refresh a stale copy. The contract there is:
+//
+//   - non-zero exit  → pre-version binary that doesn't know this command.
+//   - empty stdout   → dev build (no version baked in).
+//   - non-empty line → that version.
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the fleet binary version",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Fprintln(cmd.OutOrStdout(), version.Version)
+			return nil
+		},
+	}
+}

--- a/internal/create/clone.go
+++ b/internal/create/clone.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetlaunch"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 )
 
@@ -92,6 +93,14 @@ func RunClone(fleetName, srcInstance, destInstance string, verbose bool) error {
 	if err != nil {
 		setFailed(fleetName, destInstance, err)
 		return err
+	}
+
+	// Stage the fleet-launch binary into the clone the same way Up does
+	// for fresh instances — the source's copy doesn't carry over because
+	// /tmp isn't in the committed image layer. Non-fatal for the same
+	// reason as in Run.
+	if _, err := fleetlaunch.EnsureFresh(instanceBackend, destWorkspaceDir, nil); err != nil {
+		state.WriteWarn(fleetName, destInstance, fmt.Sprintf("stage fleet-launch: %v", err))
 	}
 
 	// Materialise post-clone symlinks the same way Up does so agent

--- a/internal/create/clone.go
+++ b/internal/create/clone.go
@@ -95,12 +95,17 @@ func RunClone(fleetName, srcInstance, destInstance string, verbose bool) error {
 		return err
 	}
 
-	// Stage the fleet-launch binary into the clone the same way Up does
-	// for fresh instances — the source's copy doesn't carry over because
-	// /tmp isn't in the committed image layer. Non-fatal for the same
-	// reason as in Run.
+	// Re-stage the fleet-launch binary and rc in the clone. /usr/bin/fleet
+	// and ~/.fleet/fleet.rc both ride along in the docker commit, so the clone
+	// inherits whatever the source had — which may be stale if the host
+	// has been updated since the source was staged. EnsureFresh skips
+	// when the binary already matches; EnsureFleetRC always rewrites,
+	// which is cheap (small file, one exec). Non-fatal like in Run.
 	if _, err := fleetlaunch.EnsureFresh(instanceBackend, destWorkspaceDir, nil); err != nil {
 		state.WriteWarn(fleetName, destInstance, fmt.Sprintf("stage fleet-launch: %v", err))
+	}
+	if err := fleetlaunch.EnsureFleetRC(instanceBackend, destWorkspaceDir, homeDirForFleet(fleetName)); err != nil {
+		state.WriteWarn(fleetName, destInstance, fmt.Sprintf("stage fleet.rc: %v", err))
 	}
 
 	// Materialise post-clone symlinks the same way Up does so agent

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -16,6 +16,7 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/dotfiles"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetlaunch"
 	mountresolver "github.com/BenjaminBenetti/fleet-man/internal/mounts/resolver"
 	"github.com/BenjaminBenetti/fleet-man/internal/startup"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
@@ -83,6 +84,15 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backen
 	if err != nil {
 		setFailed(fleetName, instanceName, err)
 		return err
+	}
+
+	// Stage the fleet-launch binary into the container so its
+	// in-container subcommands (landing-page server, etc.) are ready
+	// without waiting for the first browser open. Non-fatal: the
+	// browser-open path stages on demand too, so a failure here just
+	// defers the work, it doesn't break the instance.
+	if _, err := fleetlaunch.EnsureFresh(instanceBackend, wsDir, nil); err != nil {
+		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("stage fleet-launch: %v", err))
 	}
 
 	// Materialise the post-Up symlinks for any single-file mounts.

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -95,6 +95,14 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backen
 		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("stage fleet-launch: %v", err))
 	}
 
+	// Stage fleet.rc into the container user's home so interactive
+	// shells can source fleet-aware aliases. Respects the fleet's
+	// HomeDir setting; empty falls back to fleetlaunch.DefaultHomeDir.
+	// Non-fatal for the same reason as the binary stage.
+	if err := fleetlaunch.EnsureFleetRC(instanceBackend, wsDir, homeDirForFleet(fleetName)); err != nil {
+		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("stage fleet.rc: %v", err))
+	}
+
 	// Materialise the post-Up symlinks for any single-file mounts.
 	// Failure is non-fatal — the instance is still usable; the agent
 	// will just have to log in fresh — so we surface the error as a
@@ -370,6 +378,24 @@ func repoFromRemoteURL(remoteURL string) string {
 	}
 
 	return remoteURL
+}
+
+// homeDirForFleet looks up the named fleet's persisted HomeDir
+// setting, returning empty when state can't be loaded or the fleet
+// isn't recorded yet. Callers pass the result straight to
+// fleetlaunch.EnsureFleetRC, which substitutes its DefaultHomeDir
+// when given empty — so missing state silently falls back rather
+// than failing the stage.
+func homeDirForFleet(fleetName string) string {
+	st, err := state.Load()
+	if err != nil {
+		return ""
+	}
+	f, ok := st.Fleets[fleetName]
+	if !ok {
+		return ""
+	}
+	return f.Settings.HomeDir
 }
 
 func setFailed(fleetName, instanceName string, origErr error) {

--- a/internal/fleet/fleet_settings.go
+++ b/internal/fleet/fleet_settings.go
@@ -42,8 +42,8 @@ type FleetSettings struct {
 
 	// PreferFleetLaunch controls which page the built-in browser opens to
 	// when a workspace's devcontainer.json configures BOTH a
-	// customizations.fleet.browser.initialUrl AND a landingPage.sites
-	// list. When only one of the two is configured, it has no effect.
+	// customizations.fleet.browser.initialUrl AND a fleetLaunch block.
+	// When only one of the two is configured, it has no effect.
 	//
 	// It is a pointer so "never set" (nil) is distinct from an explicit
 	// false: the first time the browser is opened on a fleet whose

--- a/internal/fleetlaunch/fleet.rc
+++ b/internal/fleetlaunch/fleet.rc
@@ -1,0 +1,12 @@
+# fleet.rc
+#
+# Sourced automatically from ~/.bashrc inside fleet-managed
+# devcontainers. Exposes convenience aliases for the in-container
+# `fleet` binary.
+#
+# fleet-man rewrites this file every time it stages the fleet binary
+# into the container, so the rc and the binary stay in lockstep. Don't
+# edit this file directly — your changes will be overwritten on the
+# next instance start.
+
+# (Aliases for fleet subcommands will be added here in a future change.)

--- a/internal/fleetlaunch/fleetlaunch.go
+++ b/internal/fleetlaunch/fleetlaunch.go
@@ -1,0 +1,156 @@
+// Package fleetlaunch manages the fleet-launch binary inside a
+// devcontainer — the fleet executable that the host stages into an
+// instance so its in-container subcommands (the landing-page server
+// today, more to come) can be invoked there.
+//
+// The host stages the binary at two points: on instance start (so it's
+// ready by the time anything reaches for it) and on browser open (so a
+// long-lived workspace picks up host-side fleet updates). Both flow
+// through EnsureFresh, which only writes when the remote copy is
+// missing or stale — meaning the second call is cheap and idempotent.
+package fleetlaunch
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+	"github.com/BenjaminBenetti/fleet-man/internal/version"
+)
+
+// RemotePath is the absolute path inside the container where the host
+// stages the fleet binary. /usr/bin so it's on $PATH — anything inside
+// the container (interactive shells, build scripts, future helpers
+// invoked from agents) can run `fleet …` without knowing where the
+// binary lives. Fixed because each container hosts exactly one
+// install. remoteDir is the parent directory; the copy script probes
+// it for writability to decide whether to use sudo.
+const (
+	RemotePath = "/usr/bin/fleet"
+	remoteDir  = "/usr/bin"
+)
+
+// EnsureFresh stages the host's fleet binary at RemotePath when the
+// remote copy is absent, predates the version subcommand, is a dev
+// build, or has a different version than the host. A host that is
+// itself a dev build always re-stages, so host-side iteration
+// propagates into long-lived workspaces. Returns whether the binary
+// was actually copied.
+//
+// beforeRefresh, if non-nil, runs immediately before the overwrite when
+// EnsureFresh decides to refresh — callers use it to stop any
+// in-container process that has the old binary mmap'd, so the new code
+// reliably takes effect on the next start. It is NOT called when the
+// binary is already up to date, so passing a hook that always kills a
+// service won't churn services unnecessarily.
+func EnsureFresh(b backend.Backend, workspaceDir string, beforeRefresh func() error) (bool, error) {
+	refresh, err := needsRefresh(b, workspaceDir)
+	if err != nil {
+		return false, err
+	}
+	if !refresh {
+		return false, nil
+	}
+	if beforeRefresh != nil {
+		if err := beforeRefresh(); err != nil {
+			return false, err
+		}
+	}
+	if err := copyBinary(b, workspaceDir); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// needsRefresh reports whether the binary at RemotePath should be
+// replaced with the host's. It runs the remote binary's `version`
+// subcommand and classifies the outcome into four states — absent,
+// pre-version-command (old binary that doesn't know the subcommand),
+// dev build (no version baked in), or a real version string — then
+// compares that against the host:
+//
+//   - host is a dev build           → always refresh (so host-side
+//     iteration propagates into long-lived workspaces).
+//   - remote isn't a real version   → refresh (absent / old / dev).
+//   - remote version != host version → refresh.
+//   - otherwise                     → leave it alone.
+//
+// The four states are signalled by stdout markers from a single shell
+// snippet so the whole probe is one exec call.
+func needsRefresh(b backend.Backend, workspaceDir string) (bool, error) {
+	if version.Version == "" {
+		return true, nil
+	}
+
+	probe := fmt.Sprintf(`
+if [ ! -x %s ]; then
+  echo ABSENT
+elif ! out="$(%s version 2>/dev/null)"; then
+  echo NO_VERSION_CMD
+else
+  ver="$(printf '%%s' "$out" | tr -d '[:space:]')"
+  if [ -z "$ver" ]; then
+    echo DEV
+  else
+    echo "VERSION $ver"
+  fi
+fi`, RemotePath, RemotePath)
+
+	out, err := b.ExecCommand(workspaceDir, []string{"sh", "-c", probe}).CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("probe remote binary: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+
+	line := strings.TrimSpace(string(out))
+	switch {
+	case line == "ABSENT", line == "NO_VERSION_CMD", line == "DEV":
+		return true, nil
+	case strings.HasPrefix(line, "VERSION "):
+		return strings.TrimPrefix(line, "VERSION ") != version.Version, nil
+	default:
+		// Unexpected output — be conservative and replace the binary so
+		// we converge on a known-good state.
+		return true, nil
+	}
+}
+
+// copyBinary streams the running fleet binary into the container at
+// RemotePath. It unlinks the old file first rather than truncating it:
+// a process the caller has just signalled may still have the old
+// binary mmap'd, and overwriting a mapped executable surfaces as
+// ETXTBSY. Unlink-then-create allocates a fresh inode so the running
+// process keeps its old copy and the new file is written cleanly.
+//
+// /usr/bin is typically not writable by a devcontainer's default user,
+// so the script probes the directory once and either writes directly or
+// re-runs through `sudo -n` (passwordless, matching the pattern used by
+// privoxy and tmux installers elsewhere). The branch is decided BEFORE
+// stdin is consumed so the binary bytes flow down exactly one of the
+// two paths — important because a pipe can only be read once.
+func copyBinary(b backend.Backend, workspaceDir string) error {
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate fleet binary: %w", err)
+	}
+	bin, err := os.Open(self)
+	if err != nil {
+		return fmt.Errorf("open fleet binary: %w", err)
+	}
+	defer bin.Close()
+
+	script := fmt.Sprintf(`
+write='rm -f %s && cat > %s && chmod +x %s'
+if [ -w %s ]; then
+  sh -c "$write"
+else
+  sudo -n sh -c "$write"
+fi`, RemotePath, RemotePath, RemotePath, remoteDir)
+
+	cmd := b.ExecCommand(workspaceDir, []string{"sh", "-c", script})
+	cmd.Stdin = bin
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("copy fleet binary: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/fleetlaunch/fleetrc.go
+++ b/internal/fleetlaunch/fleetrc.go
@@ -1,0 +1,85 @@
+package fleetlaunch
+
+import (
+	_ "embed"
+	"fmt"
+	"strings"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// DefaultHomeDir is the in-container home directory used when a fleet
+// has no HomeDir setting persisted. Matches the user created by
+// Microsoft's standard devcontainer base images and mirrors the same
+// default used by the mount resolver, so an unconfigured fleet's rc
+// lands in the same place its mounts use.
+const DefaultHomeDir = "/home/vscode"
+
+// rcSubdir is the home-relative directory that holds the in-container
+// fleet rc. Namespaced under ~/.fleet/ to match every other in-container
+// fleet path (~/.fleet/startup, ~/.fleet/workspaces, …).
+const rcSubdir = ".fleet"
+
+// rcFilename is the basename of the rc file written into rcSubdir.
+const rcFilename = "fleet.rc"
+
+// bashrcMarker is the fixed substring grep'd against ~/.bashrc to
+// detect a prior wire-in of the source block. Specific enough to never
+// collide; checking just for the path means a hand-edited dupe gets
+// detected and skipped too.
+const bashrcMarker = ".fleet/fleet.rc"
+
+//go:embed fleet.rc
+var fleetRCContent string
+
+// EnsureFleetRC writes the embedded fleet.rc into the container at
+// <homeDir>/.fleet/fleet.rc and ensures the user's ~/.bashrc sources
+// it on shell startup. homeDir is the absolute path of the in-container
+// home (from FleetSettings.HomeDir); an empty string falls back to
+// DefaultHomeDir.
+//
+// Both steps are idempotent:
+//   - the rc itself is overwritten on every call. The content ships
+//     with the fleet binary, so the latest rc reaches the container
+//     alongside every binary refresh; the payload is small enough that
+//     skipping a diff check costs nothing.
+//   - the .bashrc source block is appended only when the marker isn't
+//     already present, so re-stages don't accumulate duplicates.
+//
+// All paths live in the user's home, so no sudo is needed.
+func EnsureFleetRC(b backend.Backend, workspaceDir, homeDir string) error {
+	if homeDir == "" {
+		homeDir = DefaultHomeDir
+	}
+	rcDir := homeDir + "/" + rcSubdir
+	target := rcDir + "/" + rcFilename
+	bashrc := homeDir + "/.bashrc"
+
+	// 1. Write the rc. mkdir -p is idempotent; cat streams the embedded
+	// content over stdin so the body never has to be shell-quoted into
+	// the script literal.
+	write := fmt.Sprintf(`mkdir -p %s && cat > %s`, rcDir, target)
+	cmd := b.ExecCommand(workspaceDir, []string{"sh", "-c", write})
+	cmd.Stdin = strings.NewReader(fleetRCContent)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("write fleet.rc: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+
+	// 2. Wire the rc into .bashrc — touch first so a missing file
+	// doesn't break grep, then append the source block only when the
+	// marker substring is absent. The heredoc is quoted ('EOF') so the
+	// '~' is written literally and expanded by bash at .bashrc read
+	// time, not by the staging shell now.
+	wire := fmt.Sprintf(`touch %s
+if ! grep -qF '%s' %s; then
+  cat >> %s <<'EOF'
+
+# Added by fleet-man — source the fleet rc when present.
+[ -f ~/%s/%s ] && . ~/%s/%s
+EOF
+fi`, bashrc, bashrcMarker, bashrc, bashrc, rcSubdir, rcFilename, rcSubdir, rcFilename)
+	if out, err := b.ExecCommand(workspaceDir, []string{"sh", "-c", wire}).CombinedOutput(); err != nil {
+		return fmt.Errorf("wire fleet.rc into .bashrc: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/instanceops/lifecycle.go
+++ b/internal/instanceops/lifecycle.go
@@ -19,17 +19,23 @@ var newClient = func(backendType fleet.BackendType) containerController {
 }
 
 // postStartHook runs after a successful container Start to set up
-// in-container scaffolding — today, staging the fleet-launch binary so
-// later in-container subcommands have something to invoke. Failures are
-// surfaced as warnings rather than failing the start; the browser-open
-// path stages on demand as a backstop.
+// in-container scaffolding: the fleet-launch binary so later
+// subcommands have something to invoke, and the fleet.rc so
+// interactive shells can source fleet-aware aliases. homeDir is the
+// fleet's persisted HomeDir setting (empty falls back to
+// fleetlaunch.DefaultHomeDir). Failures on either step are surfaced
+// as warnings rather than failing the start; the browser-open path
+// stages the binary on demand as a backstop.
 //
 // It is a package-level var so tests can replace it with a no-op
 // (a real call would need a host backend + a real container).
-var postStartHook = func(fleetName string, instance *fleet.Instance) {
+var postStartHook = func(fleetName string, instance *fleet.Instance, homeDir string) {
 	b := backendutil.NewForInstance(instance, false)
 	if _, err := fleetlaunch.EnsureFresh(b, instance.WorkspaceDir, nil); err != nil {
 		state.WriteWarn(fleetName, instance.Name, fmt.Sprintf("stage fleet-launch: %v", err))
+	}
+	if err := fleetlaunch.EnsureFleetRC(b, instance.WorkspaceDir, homeDir); err != nil {
+		state.WriteWarn(fleetName, instance.Name, fmt.Sprintf("stage fleet.rc: %v", err))
 	}
 }
 
@@ -107,7 +113,13 @@ func transitionLoadedInstance(st *state.State, instance *fleet.Instance, fleetNa
 		if err := instanceBackend.Start(instance.ContainerID); err != nil {
 			return nil, fmt.Errorf("start instance %s/%s: %w", fleetName, instanceName, err)
 		}
-		postStartHook(fleetName, instance)
+		// Resolve the fleet's persisted container-home for the hook; empty
+		// is fine — fleetlaunch substitutes its own default.
+		var homeDir string
+		if f, ok := st.Fleets[fleetName]; ok {
+			homeDir = f.Settings.HomeDir
+		}
+		postStartHook(fleetName, instance, homeDir)
 	default:
 		return nil, fmt.Errorf("unsupported target status %q", targetStatus)
 	}

--- a/internal/instanceops/lifecycle.go
+++ b/internal/instanceops/lifecycle.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetlaunch"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 )
 
@@ -15,6 +16,21 @@ type containerController interface {
 
 var newClient = func(backendType fleet.BackendType) containerController {
 	return backendutil.New(backendType, false)
+}
+
+// postStartHook runs after a successful container Start to set up
+// in-container scaffolding — today, staging the fleet-launch binary so
+// later in-container subcommands have something to invoke. Failures are
+// surfaced as warnings rather than failing the start; the browser-open
+// path stages on demand as a backstop.
+//
+// It is a package-level var so tests can replace it with a no-op
+// (a real call would need a host backend + a real container).
+var postStartHook = func(fleetName string, instance *fleet.Instance) {
+	b := backendutil.NewForInstance(instance, false)
+	if _, err := fleetlaunch.EnsureFresh(b, instance.WorkspaceDir, nil); err != nil {
+		state.WriteWarn(fleetName, instance.Name, fmt.Sprintf("stage fleet-launch: %v", err))
+	}
 }
 
 type Result struct {
@@ -91,6 +107,7 @@ func transitionLoadedInstance(st *state.State, instance *fleet.Instance, fleetNa
 		if err := instanceBackend.Start(instance.ContainerID); err != nil {
 			return nil, fmt.Errorf("start instance %s/%s: %w", fleetName, instanceName, err)
 		}
+		postStartHook(fleetName, instance)
 	default:
 		return nil, fmt.Errorf("unsupported target status %q", targetStatus)
 	}

--- a/internal/instanceops/lifecycle_test.go
+++ b/internal/instanceops/lifecycle_test.go
@@ -142,7 +142,7 @@ func stubLifecycleClient(client containerController) func() {
 	prevClient := newClient
 	prevHook := postStartHook
 	newClient = func(backendType fleet.BackendType) containerController { return client }
-	postStartHook = func(string, *fleet.Instance) {}
+	postStartHook = func(string, *fleet.Instance, string) {}
 	return func() {
 		newClient = prevClient
 		postStartHook = prevHook

--- a/internal/instanceops/lifecycle_test.go
+++ b/internal/instanceops/lifecycle_test.go
@@ -132,11 +132,20 @@ func TestStartInstanceNoOpsWhenAlreadyRunning(t *testing.T) {
 	}
 }
 
+// stubLifecycleClient swaps the package-level client + post-start hook
+// for test doubles. Both are reset together because every transition
+// test goes through the same path: build a client, call Start/Stop, run
+// the post-start hook. Letting the real hook run would have it reach
+// for a host backend and a real container, neither of which exists in
+// these tests.
 func stubLifecycleClient(client containerController) func() {
-	prev := newClient
+	prevClient := newClient
+	prevHook := postStartHook
 	newClient = func(backendType fleet.BackendType) containerController { return client }
+	postStartHook = func(string, *fleet.Instance) {}
 	return func() {
-		newClient = prev
+		newClient = prevClient
+		postStartHook = prevHook
 	}
 }
 

--- a/internal/landingpage/server.go
+++ b/internal/landingpage/server.go
@@ -1,10 +1,10 @@
-// Package landingpage serves fleet-man's built-in browser landing page —
+// Package landingpage serves fleet-man's built-in Fleet Launch page —
 // a directory of links to the dev services running inside an instance.
 //
-// The page is configured by the customizations.fleet.browser.landingPage
-// block in a repo's devcontainer.json. fleet-man injects its own binary
-// into the instance and runs it as `fleet landing-page`; that process
-// serves this page on a fixed port, and the built-in browser opens to it.
+// The page is configured by the customizations.fleet.fleetLaunch block
+// in a repo's devcontainer.json. fleet-man injects its own binary into
+// the instance and runs it as `fleet landing-page`; that process serves
+// this page on a fixed port, and the built-in browser opens to it.
 package landingpage
 
 import (
@@ -92,8 +92,8 @@ func Run(cfg Config) error {
 	router.SetHTMLTemplate(tmpl)
 
 	srv := &server{
-		sites:  fc.Browser.LandingPage.Sites,
-		apps:   fc.Browser.LandingPage.Apps,
+		sites:  fc.FleetLaunch.Sites,
+		apps:   fc.FleetLaunch.Apps,
 		client: &http.Client{Timeout: healthTimeout},
 	}
 	srv.routes(router, assets)
@@ -104,8 +104,8 @@ func Run(cfg Config) error {
 
 // server holds the request-handling state for the landing page.
 type server struct {
-	sites  []devcontainer.LandingPageSite
-	apps   []devcontainer.LandingPageApp
+	sites  []devcontainer.FleetLaunchSite
+	apps   []devcontainer.FleetLaunchApp
 	client *http.Client
 }
 
@@ -220,7 +220,7 @@ func (s *server) handleApp(c *gin.Context) {
 // `docker run -d`). Readiness is determined by polling the port, not by
 // the command's exit, so a server that never binds the port surfaces as a
 // "did not become reachable" error from handleApp rather than a hang.
-func ensureAppRunning(app devcontainer.LandingPageApp, url string) error {
+func ensureAppRunning(app devcontainer.FleetLaunchApp, url string) error {
 	if reachable(url) {
 		return nil // already running
 	}

--- a/internal/tui/browser.go
+++ b/internal/tui/browser.go
@@ -13,6 +13,7 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 	"github.com/BenjaminBenetti/fleet-man/internal/backend/devcontainer"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetlaunch"
 	"github.com/BenjaminBenetti/fleet-man/internal/landingpage"
 	"github.com/BenjaminBenetti/fleet-man/internal/portforward"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
@@ -31,12 +32,14 @@ const browserProxyPort = 58888
 // an initialUrl (see customizations.fleet.browser.initialUrl).
 const defaultBrowserURL = "about:blank"
 
-// landingPageRemotePath is where fleet-man's own binary is copied inside
-// the container to serve the browser landing page, and landingPagePidPath
-// tracks the running server's PID for idempotent (re)starts.
+// landingPagePidPath and landingPageLogPath track the in-container
+// landing-page server fleet-launch hosts. They are namespaced under
+// fleet-launch so future in-container services (each fronted by its
+// own subcommand of the staged binary) can claim their own /tmp paths
+// without colliding. The binary itself lives at fleetlaunch.RemotePath.
 const (
-	landingPageRemotePath = "/tmp/fleet-landing-page"
-	landingPagePidPath    = "/tmp/fleet-landing-page.pid"
+	landingPagePidPath = "/tmp/fleet-launch-landingpage.pid"
+	landingPageLogPath = "/tmp/fleet-launch-landingpage.log"
 )
 
 // ===========================================
@@ -325,60 +328,103 @@ func ensureProxyRunning(instanceBackend backend.Backend, workspaceDir string) er
 	return nil
 }
 
-// ensureLandingPageRunning injects fleet-man's own binary into the
-// container and starts it as `fleet landing-page` on the landing page
-// port. The browser then opens to it through the same privoxy proxy used
-// for all container traffic.
+// ensureLandingPageRunning makes sure the in-container fleet-launch
+// binary is up to date and the landing-page server it hosts is alive.
+// The browser then opens to it through the same privoxy proxy used for
+// all container traffic.
 //
-// It is idempotent: when a landing page process is already running
-// (tracked via pidfile) it returns without re-copying the binary, which
-// also avoids the ETXTBSY that would result from overwriting the running
-// executable. fleet-man only ever serves one landing page per container,
-// so the fixed /tmp paths are safe.
+// Staging the binary is delegated to fleetlaunch.EnsureFresh, which
+// handles the version check + copy. The landing-page-specific pieces —
+// is the server alive, kill the running server before a refresh so the
+// new code actually takes effect, start a fresh server — live here
+// because they are scoped to this particular in-container service. The
+// fleet-launch binary may host more services later; each will own its
+// own pidfile under the /tmp/fleet-launch-* namespace.
 func ensureLandingPageRunning(instanceBackend backend.Backend, workspaceDir string) error {
-	// Already running? Leave it be.
-	check := fmt.Sprintf(`[ -f %s ] && kill -0 "$(cat %s)" 2>/dev/null && echo RUNNING || echo STOPPED`,
-		landingPagePidPath, landingPagePidPath)
-	out, err := instanceBackend.ExecCommand(workspaceDir, []string{"sh", "-c", check}).CombinedOutput()
+	running, err := landingPageProcessAlive(instanceBackend, workspaceDir)
 	if err != nil {
-		return fmt.Errorf("check status: %w (%s)", err, strings.TrimSpace(string(out)))
+		return err
 	}
-	if strings.Contains(string(out), "RUNNING") {
+
+	// Refresh the staged binary if needed. If the landing-page server is
+	// up when we decide to refresh, stop it first — a running process
+	// keeps its old executable mmap'd and otherwise wouldn't pick up the
+	// new code on the next start.
+	refreshed, err := fleetlaunch.EnsureFresh(instanceBackend, workspaceDir, func() error {
+		if !running {
+			return nil
+		}
+		if err := stopLandingPage(instanceBackend, workspaceDir); err != nil {
+			return err
+		}
+		running = false
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if running && !refreshed {
 		return nil
 	}
 
-	// Stream this fleet binary into the container over stdin. devcontainer
-	// exec allocates no TTY, so the bytes pass through unmangled.
-	self, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("locate fleet binary: %w", err)
-	}
-	bin, err := os.Open(self)
-	if err != nil {
-		return fmt.Errorf("open fleet binary: %w", err)
-	}
-	defer bin.Close()
-
-	copyScript := fmt.Sprintf(`cat > %s && chmod +x %s`, landingPageRemotePath, landingPageRemotePath)
-	copyCmd := instanceBackend.ExecCommand(workspaceDir, []string{"sh", "-c", copyScript})
-	copyCmd.Stdin = bin
-	if out, err := copyCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("copy fleet binary: %w (%s)", err, strings.TrimSpace(string(out)))
-	}
-
-	// Start it detached on the landing page port. nohup + redirected stdio
-	// lets the server outlive this exec session; the workspace defaults to
-	// the exec's working dir (the container's workspace folder), so the
-	// server reads the same devcontainer.json fleet just loaded.
-	startScript := fmt.Sprintf(
-		`nohup %s landing-page --port %d --workspace . >/tmp/fleet-landing-page.log 2>&1 & echo $! > %s`,
-		landingPageRemotePath, landingpage.DefaultPort, landingPagePidPath)
-	if out, err := instanceBackend.ExecCommand(workspaceDir, []string{"sh", "-c", startScript}).CombinedOutput(); err != nil {
-		return fmt.Errorf("start server: %w (%s)", err, strings.TrimSpace(string(out)))
+	if err := startLandingPage(instanceBackend, workspaceDir); err != nil {
+		return err
 	}
 
 	// Give the server a moment to bind before the browser hits it.
 	time.Sleep(500 * time.Millisecond)
+	return nil
+}
+
+// landingPageProcessAlive reports whether the in-container landing-page
+// server is still serving — i.e. the pidfile exists and the PID it names
+// is alive. A missing pidfile or a stale one (process gone) both read as
+// "not running".
+func landingPageProcessAlive(instanceBackend backend.Backend, workspaceDir string) (bool, error) {
+	check := fmt.Sprintf(`[ -f %s ] && kill -0 "$(cat %s)" 2>/dev/null && echo RUNNING || echo STOPPED`,
+		landingPagePidPath, landingPagePidPath)
+	out, err := instanceBackend.ExecCommand(workspaceDir, []string{"sh", "-c", check}).CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("check status: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	return strings.Contains(string(out), "RUNNING"), nil
+}
+
+// stopLandingPage signals the in-container landing-page server to exit
+// and clears its pidfile. It waits briefly for the process to actually
+// die so the follow-up start isn't racing the dying server for the port.
+// Missing pidfile or already-dead process are both fine — the goal state
+// is "no server running", not "we killed something".
+func stopLandingPage(instanceBackend backend.Backend, workspaceDir string) error {
+	script := fmt.Sprintf(`
+pid="$(cat %s 2>/dev/null)"
+if [ -n "$pid" ]; then
+  kill "$pid" 2>/dev/null || true
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    kill -0 "$pid" 2>/dev/null || break
+    sleep 0.1
+  done
+fi
+rm -f %s`, landingPagePidPath, landingPagePidPath)
+	if out, err := instanceBackend.ExecCommand(workspaceDir, []string{"sh", "-c", script}).CombinedOutput(); err != nil {
+		return fmt.Errorf("stop landing page: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// startLandingPage launches the in-container fleet binary as the
+// landing-page server, detached so it outlives this exec session. The
+// workspace flag defaults to "." — the exec runs in the container's
+// workspace folder, so the server reads the same devcontainer.json this
+// process just resolved.
+func startLandingPage(instanceBackend backend.Backend, workspaceDir string) error {
+	startScript := fmt.Sprintf(
+		`nohup %s landing-page --port %d --workspace . >%s 2>&1 & echo $! > %s`,
+		fleetlaunch.RemotePath, landingpage.DefaultPort, landingPageLogPath, landingPagePidPath)
+	if out, err := instanceBackend.ExecCommand(workspaceDir, []string{"sh", "-c", startScript}).CombinedOutput(); err != nil {
+		return fmt.Errorf("start server: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
 	return nil
 }
 

--- a/internal/tui/browser.go
+++ b/internal/tui/browser.go
@@ -164,8 +164,8 @@ func openBrowserProxyCmd(
 
 		// 4. Resolve the page the browser opens to from the workspace's
 		//    devcontainer.json fleet customization. Two pages can be
-		//    configured — browser.initialUrl and the landingPage.sites
-		//    list — and precedence between them is:
+		//    configured — browser.initialUrl and the fleetLaunch block
+		//    (sites/apps) — and precedence between them is:
 		//      - only one configured: use that one.
 		//      - both configured: the fleet's PreferFleetLaunch setting
 		//        decides — false (default) opens initialUrl, true opens
@@ -178,7 +178,7 @@ func openBrowserProxyCmd(
 		initialURL := defaultBrowserURL
 		if fc, err := devcontainer.LoadFleetCustomizations(workspaceDir); err == nil {
 			hasURL := fc.Browser.InitialURL != ""
-			hasLanding := fc.Browser.LandingPage.Configured()
+			hasLanding := fc.FleetLaunch.Configured()
 			useLanding := shouldUseLandingPage(hasURL, hasLanding, preferFleetLaunch)
 
 			switch {
@@ -257,7 +257,7 @@ func bothBrowserTargets(workspaceDir string) (initialURL string, both bool) {
 		return "", false
 	}
 	initialURL = fc.Browser.InitialURL
-	return initialURL, initialURL != "" && fc.Browser.LandingPage.Configured()
+	return initialURL, initialURL != "" && fc.FleetLaunch.Configured()
 }
 
 // shouldUseLandingPage decides whether the browser should open the Fleet

--- a/internal/tui/browser_test.go
+++ b/internal/tui/browser_test.go
@@ -25,10 +25,10 @@ func writeWorkspaceDevcontainer(t *testing.T, dir, contents string) {
 }
 
 const bothTargetsDevcontainer = `{
-  "customizations": { "fleet": { "browser": {
-    "initialUrl": "https://example.com",
-    "landingPage": { "sites": [ { "title": "API", "url": "http://localhost:3000" } ] }
-  } } }
+  "customizations": { "fleet": {
+    "browser": { "initialUrl": "https://example.com" },
+    "fleetLaunch": { "sites": [ { "title": "API", "url": "http://localhost:3000" } ] }
+  } }
 }`
 
 // TestBothBrowserTargets verifies detection of "both initialUrl and a
@@ -51,7 +51,7 @@ func TestBothBrowserTargets(t *testing.T) {
 	})
 	t.Run("only landing", func(t *testing.T) {
 		dir := t.TempDir()
-		writeWorkspaceDevcontainer(t, dir, `{"customizations":{"fleet":{"browser":{"landingPage":{"sites":[{"title":"A","url":"u"}]}}}}}`)
+		writeWorkspaceDevcontainer(t, dir, `{"customizations":{"fleet":{"fleetLaunch":{"sites":[{"title":"A","url":"u"}]}}}}`)
 		if _, both := bothBrowserTargets(dir); both {
 			t.Fatalf("both = true, want false (only landing)")
 		}


### PR DESCRIPTION
## Summary

- Adds `internal/fleetlaunch`, which owns the in-container fleet binary. `EnsureFresh` probes the remote `fleet version`, decides whether to refresh (absent / pre-version / dev / mismatched tag / host-is-dev), and copies the host binary in via stdin. `/usr/bin/fleet` is the destination so it's on `$PATH`; the copy script probes `/usr/bin` writability and falls through to `sudo -n` for non-root devcontainer users.
- Adds a `fleet version` CLI subcommand whose output drives the staleness check. Empty stdout = dev build (always refresh); non-empty = the ldflag-injected release tag; non-zero exit = pre-version binary that doesn't know the command.
- Stages the binary on every transition into Running — `create.Run`, `create.RunClone`, and `instanceops.postStartHook` — plus on browser open as a backstop. When a stale binary is detected while the landing-page server is alive, the server is stopped first via SIGTERM-with-bounded-wait, the file is unlink-then-created (sidesteps ETXTBSY), and a fresh server is started.
- Renames the `customizations.fleet.browser.landingPage` config block to top-level `customizations.fleet.fleetLaunch`. The Fleet Launch page is its own feature; the browser merely opens to it, so the relationship is cleaner with `fleetLaunch` alongside `browser` rather than nested inside it. Go types renamed in step (`LandingPageCustomizations` → `FleetLaunchCustomizations`, etc.). Internal implementation names (`internal/landingpage` package, `fleet landing-page` subcommand, `ensureLandingPageRunning`) are left alone — they describe the literal HTML page being served, not the config block.
- Ships an embedded `fleet.rc` and stages it at `~/.fleet/fleet.rc`, matching the existing `~/.fleet/` convention used by `startup/`, `workspaces/`, `scripts/`, etc. Idempotently appends a source block to `~/.bashrc` (grep-then-append by path marker) so interactive shells pick it up automatically. The rc body is just a header today — convenience aliases for fleet subcommands will land here in a follow-up.
- `HomeDir` respects `FleetSettings.HomeDir` at every call site, with `/home/vscode` as the default (mirrors the mount resolver's fallback so the rc lands in the same home the mounts use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)