### PR TITLE
feat/fleet-launch-tui Fleet Launch TUI + host control socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ fleet exec agent-1 bash
 # Open VS Code on an instance
 fleet code agent-1
 
+# Launch the in-instance link/app grid (run inside an instance)
+fleet launch
+
 # View logs
 fleet logs agent-1
 
@@ -230,6 +233,57 @@ configured, the TUI prompts you to choose, and saves your answer as the
 fleet's Prefer Fleet Launch setting. You can change it later by editing the
 fleet (`e` in the TUI). When only one of the two is configured, that one is
 used and the setting has no effect.
+
+## Fleet Launch (in-instance TUI)
+
+`fleet launch` is a small terminal UI you run **inside an instance** (over
+`fleet exec`, in a `fleet code` terminal, or any shell in the container). It
+reads the workspace's `customizations.fleet.fleetLaunch` block — the same
+`sites` and `apps` described above — and lays them out as a navigable grid of
+squares: a "Links" section for `fleetLaunch.sites` and an "Apps" section for
+`fleetLaunch.apps`.
+
+```bash
+# auto-detect .devcontainer/devcontainer.json (or ./devcontainer.json) in cwd
+fleet launch
+
+# or point it at an explicit devcontainer.json
+fleet launch --config ./path/to/devcontainer.json
+
+# print the configured links and apps (and the names you can launch), then exit
+fleet launch list
+
+# open a link or app directly by name (a unique prefix is enough), as if clicked
+fleet launch graf
+```
+
+In the grid, navigate with the arrow keys or `hjkl`, or click a square with the
+mouse; `enter` or a click activates the selected square, and `q`/`esc`/`ctrl+c`
+quits. Activating a **link** opens the host browser to its `url`; activating
+an **app** first starts the app's `command` on its `port` inside the instance
+(only if the port isn't already answering), waits for it to come up, then
+opens the host browser to `http://localhost:<port>`.
+
+`fleet launch list` prints the configured Links and Apps with their targets and
+exits — handy for discovering the names. `fleet launch <name>` performs that
+same link/app activation headlessly, without opening the grid. The name is
+matched case-insensitively against the titles: an exact title wins, otherwise a
+unique prefix is enough (so `fleet launch graf` opens "Grafana"). If a prefix
+matches more than one, the candidates are listed so you can type more.
+
+The browser lives on the **host** (it is proxied into the container by
+privoxy), so the in-instance TUI can't open it directly. Instead it drives the
+host browser over a **control socket** — a unix domain socket the host `fleet`
+TUI creates per instance and bind-mounts into the instance (the same mechanism
+as mounting `docker.sock`). The running host `fleet` TUI listens on that socket
+and opens or navigates the browser when `fleet launch` sends it a request. If
+the host `fleet` TUI isn't running, `fleet launch` still renders the grid so
+you can browse the configured options, but shows a status line noting that
+opening won't work until a host connection exists.
+
+Only instances **created or cloned after** this feature was added get the
+control-socket mount; pre-existing instances need to be recreated for
+in-instance launch to drive the host browser.
 
 ## Devcontainer BuildKit
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
+	github.com/charmbracelet/x/term v0.2.2
 	github.com/gin-gonic/gin v1.12.0
+	github.com/muesli/termenv v0.16.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/sys v0.41.0
 )
@@ -20,7 +22,6 @@ require (
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
-	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
@@ -45,7 +46,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect

--- a/internal/appstart/appstart.go
+++ b/internal/appstart/appstart.go
@@ -1,0 +1,112 @@
+// Package appstart provides the shared "ensure a local app is running on a
+// port" logic used to bring a dev service up on demand from inside an
+// instance.
+//
+// The behaviour was first written for the landing page's app tabs (start the
+// app's command if its port isn't already answering, then hold until it comes
+// up) and is reused by the `fleet launch` TUI, so it lives here as a small
+// reusable package rather than being duplicated. Readiness is always
+// determined by polling the port — never by a command's exit — because the
+// commands are long-running servers that are started detached and not waited
+// on.
+package appstart
+
+import (
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// reachTimeout caps a single readiness probe so a slow or hung service can't
+// stall the poll.
+const reachTimeout = time.Second
+
+// startDeadline bounds how long EnsureRunningOnPort waits for a freshly
+// started command to bind its port before giving up. It is deliberately
+// generous: the command often returns well before the service it launches is
+// actually listening (e.g. `docker run -d` exits as soon as the container is
+// created, but the server inside takes seconds to boot — longer still on a
+// first run that has to pull the image, or for a heavier app like Grafana).
+// A short window made activations spuriously fail with "did not become
+// reachable" even though a moment later the port was up. The wait is cheap to
+// extend because it ends the instant the port answers (see pollInterval) and
+// runs on a background command, so the UI stays responsive throughout.
+const startDeadline = 60 * time.Second
+
+// pollInterval is the gap between readiness probes while waiting for a port to
+// come up. Short so a quick-binding app opens with little perceptible lag — the
+// wait returns on the first successful probe, not after a fixed delay.
+const pollInterval = 250 * time.Millisecond
+
+// Reachable reports whether url answers an HTTP request within a short timeout
+// (one second). Any response — even an error status — counts as reachable: it
+// means the app's own server is up and listening, which is all the caller
+// needs to know before pointing a browser at it.
+func Reachable(url string) bool {
+	client := &http.Client{Timeout: reachTimeout}
+	resp, err := client.Get(url)
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return true
+}
+
+// WaitForReachable polls url until it answers or timeout elapses, reporting
+// whether it came up. Used to hold a request open until an app's HTTP server
+// is listening, since a server can take a moment to bind its port after its
+// command is launched.
+func WaitForReachable(url string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if Reachable(url) {
+			return true
+		}
+		time.Sleep(pollInterval)
+	}
+	return false
+}
+
+// LocalURL returns the conventional http://localhost:<port> address for a
+// service listening on port. Centralised so every caller forms the URL the
+// same way.
+func LocalURL(port int) string {
+	return fmt.Sprintf("http://localhost:%d", port)
+}
+
+// EnsureRunningOnPort makes sure something is answering on port, starting
+// command first if needed, then blocks until the port is reachable or the
+// startDeadline passes — retrying every pollInterval so a service that isn't up
+// the instant its command exits is still caught once it finishes booting.
+//
+// It is idempotent: if the port is already answering it returns nil
+// immediately and leaves whatever is running untouched (so a repeated activate
+// or relaunch never double-starts the app). An empty command means "the app is
+// already running; just wait for / confirm its port" — nothing is started and
+// readiness is decided purely by the poll.
+//
+// command, when run, is executed via `bash -c`, started detached, and NOT
+// waited on: it is expected to be a long-running server (or to detach itself,
+// e.g. `docker run -d`). Because readiness is determined by polling the port
+// rather than by the command's exit, a command that never binds the port
+// surfaces here as a "did not become reachable" error rather than a hang.
+func EnsureRunningOnPort(command string, port int) error {
+	url := LocalURL(port)
+	if Reachable(url) {
+		return nil // already serving; leave it alone
+	}
+
+	if strings.TrimSpace(command) != "" {
+		cmd := exec.Command("bash", "-c", command)
+		if err := cmd.Start(); err != nil {
+			return fmt.Errorf("start command: %w", err)
+		}
+	}
+
+	if !WaitForReachable(url, startDeadline) {
+		return fmt.Errorf("did not become reachable on port %d within %s", port, startDeadline)
+	}
+	return nil
+}

--- a/internal/appstart/appstart_test.go
+++ b/internal/appstart/appstart_test.go
@@ -1,0 +1,87 @@
+package appstart
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestReachable verifies Reachable is true against a live server (even one
+// returning an error status) and false against a stopped one.
+func TestReachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// A 500 is still "reachable": the server answered.
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	if !Reachable(srv.URL) {
+		t.Errorf("Reachable(%q) = false, want true for a live server", srv.URL)
+	}
+
+	srv.Close()
+	if Reachable(srv.URL) {
+		t.Errorf("Reachable(%q) = true after close, want false", srv.URL)
+	}
+}
+
+// TestWaitForReachable verifies WaitForReachable returns true for a live
+// server and false (after the timeout) for an address with nothing listening.
+func TestWaitForReachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if !WaitForReachable(srv.URL, time.Second) {
+		t.Errorf("WaitForReachable(live) = false, want true")
+	}
+
+	// A port nothing listens on must time out to false. Use a short timeout so
+	// the test stays fast.
+	if WaitForReachable("http://127.0.0.1:0", 400*time.Millisecond) {
+		t.Errorf("WaitForReachable(dead) = true, want false")
+	}
+}
+
+// TestLocalURL verifies the conventional localhost URL formatting.
+func TestLocalURL(t *testing.T) {
+	cases := []struct {
+		port int
+		want string
+	}{
+		{3000, "http://localhost:3000"},
+		{16767, "http://localhost:16767"},
+	}
+	for _, tc := range cases {
+		if got := LocalURL(tc.port); got != tc.want {
+			t.Errorf("LocalURL(%d) = %q, want %q", tc.port, got, tc.want)
+		}
+	}
+}
+
+// TestEnsureRunningOnPortAlreadyUp verifies an empty command against an
+// already-listening port returns nil immediately without starting anything.
+func TestEnsureRunningOnPortAlreadyUp(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	port := serverPort(t, srv)
+	if err := EnsureRunningOnPort("", port); err != nil {
+		t.Errorf("EnsureRunningOnPort(\"\", %d) = %v, want nil for an already-up port", port, err)
+	}
+}
+
+// serverPort extracts the numeric port an httptest.Server listens on.
+func serverPort(t *testing.T, srv *httptest.Server) int {
+	t.Helper()
+	// httptest binds 127.0.0.1:<port>; pull the port from the TCPAddr.
+	if ta, ok := srv.Listener.Addr().(*net.TCPAddr); ok {
+		return ta.Port
+	}
+	t.Fatalf("could not determine server port from %v", srv.Listener.Addr())
+	return 0
+}

--- a/internal/backend/devcontainer/customizations.go
+++ b/internal/backend/devcontainer/customizations.go
@@ -149,3 +149,31 @@ func LoadFleetCustomizations(workspaceDir string) (FleetCustomizations, error) {
 	}
 	return cfg.Customizations.Fleet, nil
 }
+
+// LoadFleetCustomizationsFromFile reads fleet-man's "customizations.fleet"
+// block from an explicit devcontainer.json at path, for callers handed a
+// concrete file (e.g. `fleet launch --config ./path/to/devcontainer.json`)
+// rather than a workspace directory to search.
+//
+// Unlike LoadFleetCustomizations, a missing file IS an error here: the path
+// was named explicitly, so its absence is a mistake the caller wants to hear
+// about rather than silently treat as "defaults". An absent customizations or
+// fleet block still surfaces as the zero value — only unset fields, not a
+// missing file, mean "use defaults". The file is parsed through the same
+// JSONC-tolerant toStrictJSON conversion as the workspace loader, so comments
+// and trailing commas are accepted.
+func LoadFleetCustomizationsFromFile(path string) (FleetCustomizations, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return FleetCustomizations{}, err
+	}
+
+	// devcontainer.json is JSONC (comments, trailing commas); reuse the
+	// same strict-JSON conversion the workspace loader and mount-conflict
+	// logic rely on.
+	var cfg devcontainerConfig
+	if err := json.Unmarshal(toStrictJSON(raw), &cfg); err != nil {
+		return FleetCustomizations{}, fmt.Errorf("parse devcontainer.json customizations: %w", err)
+	}
+	return cfg.Customizations.Fleet, nil
+}

--- a/internal/backend/devcontainer/customizations_test.go
+++ b/internal/backend/devcontainer/customizations_test.go
@@ -241,3 +241,57 @@ func TestLoadFleetCustomizationsMalformedErrors(t *testing.T) {
 		t.Fatal("LoadFleetCustomizations on malformed JSON = nil, want error")
 	}
 }
+
+// TestLoadFleetCustomizationsFromFile verifies the explicit-path loader
+// parses a JSONC devcontainer.json (comments + trailing commas) with a
+// fleetLaunch block of both sites and apps.
+func TestLoadFleetCustomizationsFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "devcontainer.json")
+	contents := `{
+		// explicit-path config
+		"image": "ubuntu",
+		"customizations": {
+			"fleet": {
+				"fleetLaunch": {
+					"sites": [
+						{ "title": "API", "url": "http://localhost:3000" },
+					],
+					"apps": [
+						{ "title": "Web", "command": "npm start", "port": 5173 },
+					],
+				},
+			},
+		},
+	}`
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write devcontainer.json: %v", err)
+	}
+
+	fc, err := LoadFleetCustomizationsFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadFleetCustomizationsFromFile = %v, want nil", err)
+	}
+	if got := len(fc.FleetLaunch.Sites); got != 1 {
+		t.Fatalf("len(Sites) = %d, want 1", got)
+	}
+	if got := fc.FleetLaunch.Sites[0].URL; got != "http://localhost:3000" {
+		t.Errorf("Sites[0].URL = %q, want http://localhost:3000", got)
+	}
+	if got := len(fc.FleetLaunch.Apps); got != 1 {
+		t.Fatalf("len(Apps) = %d, want 1", got)
+	}
+	if got := fc.FleetLaunch.Apps[0].Port; got != 5173 {
+		t.Errorf("Apps[0].Port = %d, want 5173", got)
+	}
+}
+
+// TestLoadFleetCustomizationsFromFileMissing verifies a missing explicit
+// path is an error (unlike the workspace loader, which treats absence as
+// "use defaults").
+func TestLoadFleetCustomizationsFromFileMissing(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.json")
+	if _, err := LoadFleetCustomizationsFromFile(missing); err == nil {
+		t.Fatal("LoadFleetCustomizationsFromFile on missing file = nil, want error")
+	}
+}

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"github.com/BenjaminBenetti/fleet-man/internal/launchtui"
+	"github.com/spf13/cobra"
+)
+
+// newLaunchCmd creates the user-facing `fleet launch` command.
+//
+// Unlike most fleet commands it is meant to be run INSIDE an instance: it reads
+// the workspace's customizations.fleet.fleetLaunch block (or an explicit
+// --config devcontainer.json). Activating a link or app drives the HOST browser
+// — fleet bind-mounts a control socket into the instance, and the in-instance
+// launcher sends "open this URL" messages to the host fleet TUI over it (see
+// internal/control and internal/launchtui).
+//
+// Three forms:
+//   - `fleet launch`        opens the interactive grid TUI.
+//   - `fleet launch list`   prints the configured links and apps, then exits.
+//   - `fleet launch <name>` opens that link or app directly, as if clicked.
+func newLaunchCmd() *cobra.Command {
+	var configPath string
+
+	cmd := &cobra.Command{
+		Use:   "launch [name|list]",
+		Short: "Open the in-instance Fleet Launch grid (or list/launch its links and apps)",
+		Long: "Open a terminal UI, inside an instance, that lists the links and apps " +
+			"configured in customizations.fleet.fleetLaunch and drives the host browser " +
+			"to them over the control socket fleet mounts into the instance.\n\n" +
+			"With no argument it opens the interactive grid. `fleet launch list` prints the " +
+			"configured links and apps and exits. `fleet launch <name>` opens the named link " +
+			"or app directly, as if it were clicked in the grid.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg := launchtui.Config{ConfigPath: configPath}
+			switch {
+			case len(args) == 0:
+				return launchtui.Run(cfg)
+			case args[0] == "list":
+				return launchtui.List(cfg, cmd.OutOrStdout())
+			default:
+				return launchtui.LaunchByName(cfg, args[0], cmd.ErrOrStderr())
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&configPath, "config", "", "devcontainer.json to read (default: auto-detect in the current directory)")
+
+	return cmd
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -53,6 +53,7 @@ func NewRootCmd() *cobra.Command {
 		newExecInSessionCmd(),
 		newReadSessionCmd(),
 		newLandingPageCmd(),
+		newLaunchCmd(),
 		newVersionCmd(),
 	)
 

--- a/internal/control/client.go
+++ b/internal/control/client.go
@@ -1,0 +1,87 @@
+package control
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+// writeTimeout bounds a single Send's write to the control socket. It is
+// defense-in-depth: a host that has stopped reading (e.g. its TUI is hung)
+// lets the kernel send buffer fill, after which an unbounded write would block
+// the caller — potentially the in-instance UI thread — indefinitely. With a
+// deadline a stuck host instead surfaces as a timeout error the caller can
+// report, rather than a permanent freeze. It is generous enough that a merely
+// busy host won't trip it.
+const writeTimeout = 5 * time.Second
+
+// Client is the instance-side end of the control channel. It holds a single
+// connection to the host's listening socket and writes newline-delimited
+// Envelopes. One Client is intended to live for the lifetime of an
+// in-container process (e.g. the `fleet launch` TUI); each Send writes one
+// JSON line the host's Server decodes and dispatches.
+type Client struct {
+	conn net.Conn
+	// mu serialises writes so concurrent Send calls can't interleave bytes on
+	// the wire and corrupt the newline-delimited framing.
+	mu  sync.Mutex
+	enc *json.Encoder
+}
+
+// Dial connects to the control socket at socketPath (normally
+// ContainerSocketPath inside an instance). A failure means the host isn't
+// listening — there is no socket, or no Server has been started for this
+// instance — and the caller should treat it as "host not available" and run
+// in a degraded mode (e.g. still render its UI but disable host-driven
+// actions) rather than aborting.
+func Dial(socketPath string) (*Client, error) {
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("dial control socket %s: %w", socketPath, err)
+	}
+	// json.Encoder writes each value followed by a newline, which is exactly
+	// the newline-delimited framing the Server reads with a json.Decoder.
+	return &Client{conn: conn, enc: json.NewEncoder(conn)}, nil
+}
+
+// Send marshals payload, wraps it in an Envelope{Type: typ}, and writes it as
+// one JSON line. payload may be nil for a type-only message. Safe for
+// concurrent use: a mutex serialises the underlying write so two goroutines
+// can't interleave bytes mid-line.
+func (c *Client) Send(typ string, payload any) error {
+	var raw json.RawMessage
+	if payload != nil {
+		b, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("marshal control payload: %w", err)
+		}
+		raw = b
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Bound the write so a host that has stopped reading can't block the caller
+	// indefinitely once the kernel send buffer fills. A best-effort deadline:
+	// connections that don't support one simply ignore the error here.
+	_ = c.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
+	if err := c.enc.Encode(Envelope{Type: typ, Payload: raw}); err != nil {
+		return fmt.Errorf("send control envelope: %w", err)
+	}
+	return nil
+}
+
+// OpenBrowser is a typed convenience over Send for TypeOpenBrowser: it asks
+// the host to open (or navigate) its browser to url.
+func (c *Client) OpenBrowser(url string) error {
+	return c.Send(TypeOpenBrowser, OpenBrowserPayload{URL: url})
+}
+
+// Close closes the underlying connection. It is safe to call once; further
+// Sends will fail.
+func (c *Client) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.conn.Close()
+}

--- a/internal/control/control.go
+++ b/internal/control/control.go
@@ -1,0 +1,71 @@
+// Package control is a generic host↔instance IPC channel built on a unix
+// domain socket that fleet bind-mounts into an instance.
+//
+// The split is deliberate: fleet's browser lives on the host, while features
+// like the `fleet launch` TUI run inside an instance. Those in-container
+// processes can't drive the host browser directly, so they speak to the host
+// over this socket. The host runs a Server (the listener that owns the socket
+// file); the instance connects as a Client and writes messages.
+//
+// The wire format is newline-delimited JSON — one Envelope per line. The
+// Envelope is a thin, type-discriminated container: a Type string plus an
+// opaque JSON Payload that only the handler registered for that Type knows
+// how to decode. New features add a new Type constant and a new payload
+// struct without touching the transport, so the channel stays generic.
+//
+// A unix socket created by the host inside a bind-mounted directory is
+// reachable from inside the container (same kernel, shared mount) — the same
+// mechanism fleet already relies on to share docker.sock. The socket basename
+// (SocketName) MUST be identical on both ends because the host derives the
+// host-side absolute path while the instance uses the container-side mount
+// path, and both must resolve to the same file through the bind mount.
+package control
+
+import "encoding/json"
+
+// Path constants for the container side of the channel. The host side derives
+// its own absolute path via internal/state; both ends resolve to the SAME
+// file through the bind mount, so the socket basename (SocketName) MUST be
+// identical on both ends.
+const (
+	// ContainerMountDir is the directory the host control directory is
+	// bind-mounted to inside the instance.
+	ContainerMountDir = "/fleet-mounts/control"
+	// SocketName is the socket file's basename. It is shared by the host and
+	// the container ends so both resolve to the same file through the mount.
+	SocketName = "fleet.sock"
+	// ContainerSocketPath is the absolute path the instance dials: the mount
+	// directory joined with the shared socket basename.
+	ContainerSocketPath = ContainerMountDir + "/" + SocketName
+)
+
+// Message type identifiers. Each value names a distinct kind of Envelope; the
+// handler switches on it to pick the matching payload struct. New features add
+// a new constant here alongside a new payload type.
+const (
+	// TypeOpenBrowser asks the host to open (or navigate) its browser to a
+	// URL. Its payload is OpenBrowserPayload.
+	TypeOpenBrowser = "browser.open"
+)
+
+// Envelope is the generic wire message: a type discriminator plus an opaque
+// JSON payload. The transport carries the Envelope verbatim; the handler
+// registered for env.Type decodes env.Payload into the matching payload
+// struct. Keeping the payload as json.RawMessage means the transport never
+// needs to know about individual message shapes.
+type Envelope struct {
+	// Type names the kind of message — one of the Type* constants. The
+	// handler switches on it to choose how to decode Payload.
+	Type string `json:"type"`
+	// Payload is the message body, left undecoded by the transport. It is
+	// omitted from the wire when empty so type-only messages stay compact.
+	Payload json.RawMessage `json:"payload,omitempty"`
+}
+
+// OpenBrowserPayload is the body of a TypeOpenBrowser Envelope: the address
+// the host browser should open or navigate to.
+type OpenBrowserPayload struct {
+	// URL is the address to open. The host opens its proxied browser to this
+	// URL (or forwards it as a new tab to an already-running browser).
+	URL string `json:"url"`
+}

--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -1,0 +1,281 @@
+package control
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// collector is a concurrency-safe sink for envelopes received by a Server's
+// handler. The handler may run on multiple goroutines, so every access is
+// guarded; wait blocks until at least n envelopes have arrived (or the test
+// times out), avoiding flaky sleeps.
+type collector struct {
+	mu   sync.Mutex
+	got  []Envelope
+	cond *sync.Cond
+}
+
+func newCollector() *collector {
+	c := &collector{}
+	c.cond = sync.NewCond(&c.mu)
+	return c
+}
+
+func (c *collector) handle(env Envelope) {
+	c.mu.Lock()
+	c.got = append(c.got, env)
+	c.cond.Broadcast()
+	c.mu.Unlock()
+}
+
+// wait blocks until at least n envelopes have been received or the deadline
+// passes, returning a copy of what arrived.
+func (c *collector) wait(t *testing.T, n int, timeout time.Duration) []Envelope {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for len(c.got) < n {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		// sync.Cond has no timed wait; arm a timer that wakes the wait so we
+		// re-check the deadline rather than blocking forever on a missed
+		// broadcast.
+		timer := time.AfterFunc(remaining, func() {
+			c.mu.Lock()
+			c.cond.Broadcast()
+			c.mu.Unlock()
+		})
+		c.cond.Wait()
+		timer.Stop()
+	}
+	out := make([]Envelope, len(c.got))
+	copy(out, c.got)
+	return out
+}
+
+// tempSocket returns a socket path inside a fresh temp dir.
+func tempSocket(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), SocketName)
+}
+
+// TestRoundTripOpenBrowser dials a listening Server, sends an OpenBrowser
+// message, and asserts the handler receives the correct Type and a payload
+// that decodes back to the original URL.
+func TestRoundTripOpenBrowser(t *testing.T) {
+	c := newCollector()
+	srv, err := Listen(tempSocket(t), c.handle)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer srv.Close()
+
+	cli, err := Dial(srv.socketPath)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer cli.Close()
+
+	const want = "http://localhost:3000"
+	if err := cli.OpenBrowser(want); err != nil {
+		t.Fatalf("OpenBrowser: %v", err)
+	}
+
+	got := c.wait(t, 1, 2*time.Second)
+	if len(got) != 1 {
+		t.Fatalf("received %d envelopes, want 1", len(got))
+	}
+	if got[0].Type != TypeOpenBrowser {
+		t.Errorf("Type = %q, want %q", got[0].Type, TypeOpenBrowser)
+	}
+	var p OpenBrowserPayload
+	if err := json.Unmarshal(got[0].Payload, &p); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if p.URL != want {
+		t.Errorf("URL = %q, want %q", p.URL, want)
+	}
+}
+
+// TestMultipleMessagesOneConnection verifies several Envelopes sent over a
+// single connection are each decoded and dispatched in order.
+func TestMultipleMessagesOneConnection(t *testing.T) {
+	c := newCollector()
+	srv, err := Listen(tempSocket(t), c.handle)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer srv.Close()
+
+	cli, err := Dial(srv.socketPath)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer cli.Close()
+
+	urls := []string{"http://a", "http://b", "http://c"}
+	for _, u := range urls {
+		if err := cli.OpenBrowser(u); err != nil {
+			t.Fatalf("OpenBrowser(%q): %v", u, err)
+		}
+	}
+
+	got := c.wait(t, len(urls), 2*time.Second)
+	if len(got) != len(urls) {
+		t.Fatalf("received %d envelopes, want %d", len(got), len(urls))
+	}
+	for i, env := range got {
+		var p OpenBrowserPayload
+		if err := json.Unmarshal(env.Payload, &p); err != nil {
+			t.Fatalf("decode payload %d: %v", i, err)
+		}
+		if p.URL != urls[i] {
+			t.Errorf("envelope %d URL = %q, want %q", i, p.URL, urls[i])
+		}
+	}
+}
+
+// TestConcurrentClientsNoCrossTalk proves that two independently-dialled
+// clients sending at the same time do NOT corrupt or interleave each other's
+// messages. Each Dial is a distinct stream connection that the Server reads
+// with its own json.Decoder, so bytes from one client can never bleed into
+// another's frame. If they could, the JSON would desync and either fail to
+// decode or yield a URL that matches neither client's prefix — both of which
+// this test would catch. (Multiple clients are the realistic case: two
+// `fleet launch` processes running in the same instance at once.)
+func TestConcurrentClientsNoCrossTalk(t *testing.T) {
+	c := newCollector()
+	srv, err := Listen(tempSocket(t), c.handle)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer srv.Close()
+
+	const perClient = 50
+	// Two clients send concurrently, each tagging every URL with its own
+	// prefix so a crossed byte stream would surface as a decode error or a
+	// mismatched prefix.
+	prefixes := []string{"http://client-A/", "http://client-B/"}
+	var wg sync.WaitGroup
+	for _, prefix := range prefixes {
+		wg.Add(1)
+		go func(prefix string) {
+			defer wg.Done()
+			cli, err := Dial(srv.socketPath)
+			if err != nil {
+				t.Errorf("Dial(%s): %v", prefix, err)
+				return
+			}
+			defer cli.Close()
+			for i := 0; i < perClient; i++ {
+				if err := cli.OpenBrowser(prefix + strconv.Itoa(i)); err != nil {
+					t.Errorf("OpenBrowser(%s%d): %v", prefix, i, err)
+					return
+				}
+			}
+		}(prefix)
+	}
+	wg.Wait()
+
+	got := c.wait(t, len(prefixes)*perClient, 5*time.Second)
+	if len(got) != len(prefixes)*perClient {
+		t.Fatalf("received %d envelopes, want %d", len(got), len(prefixes)*perClient)
+	}
+
+	// Every envelope must decode cleanly and carry exactly one client's prefix
+	// with a parseable index — no garbled frames, no lost or duplicated sends.
+	counts := map[string]int{}
+	for i, env := range got {
+		if env.Type != TypeOpenBrowser {
+			t.Fatalf("envelope %d Type = %q, want %q", i, env.Type, TypeOpenBrowser)
+		}
+		var p OpenBrowserPayload
+		if err := json.Unmarshal(env.Payload, &p); err != nil {
+			t.Fatalf("envelope %d failed to decode (stream cross-talk?): %v", i, err)
+		}
+		matched := false
+		for _, prefix := range prefixes {
+			if suffix, ok := strings.CutPrefix(p.URL, prefix); ok {
+				if _, err := strconv.Atoi(suffix); err != nil {
+					t.Fatalf("envelope %d URL %q has non-numeric suffix (corruption?)", i, p.URL)
+				}
+				counts[prefix]++
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			t.Fatalf("envelope %d URL %q matches no client prefix (cross-talk?)", i, p.URL)
+		}
+	}
+	for _, prefix := range prefixes {
+		if counts[prefix] != perClient {
+			t.Errorf("client %q delivered %d messages, want %d", prefix, counts[prefix], perClient)
+		}
+	}
+}
+
+// TestListenReplacesStaleSocket verifies Listen succeeds even when a leftover
+// file already exists at the socket path (e.g. from a crashed prior run): the
+// stale file is removed before listening.
+func TestListenReplacesStaleSocket(t *testing.T) {
+	path := tempSocket(t)
+	if err := os.WriteFile(path, []byte("stale"), 0o666); err != nil {
+		t.Fatalf("write stale file: %v", err)
+	}
+
+	srv, err := Listen(path, func(Envelope) {})
+	if err != nil {
+		t.Fatalf("Listen over stale file: %v", err)
+	}
+	defer srv.Close()
+
+	// And the listener is genuinely usable.
+	cli, err := Dial(path)
+	if err != nil {
+		t.Fatalf("Dial after stale replacement: %v", err)
+	}
+	cli.Close()
+}
+
+// TestCloseRemovesSocketFile verifies Close deletes the socket file it
+// created, leaving the path clean for the next Listen.
+func TestCloseRemovesSocketFile(t *testing.T) {
+	path := tempSocket(t)
+	srv, err := Listen(path, func(Envelope) {})
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("socket file missing while listening: %v", err)
+	}
+
+	if err := srv.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("socket file still present after Close (stat err = %v), want not-exist", err)
+	}
+
+	// A second Close is a no-op.
+	if err := srv.Close(); err != nil {
+		t.Errorf("second Close = %v, want nil", err)
+	}
+}
+
+// TestDialNoServerErrors verifies Dial against a path with no listener returns
+// an error the caller can treat as "host not available".
+func TestDialNoServerErrors(t *testing.T) {
+	if _, err := Dial(tempSocket(t)); err == nil {
+		t.Fatal("Dial with no server = nil error, want error")
+	}
+}

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -1,0 +1,180 @@
+package control
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Server is the host-side listener. It owns a unix socket file, accepts
+// connections from in-container Clients, and invokes a handler for every
+// Envelope received on any connection. One Server runs per instance the host
+// wants to receive messages from; the host typically keeps a registry of them
+// keyed by instance.
+//
+// Listen starts the accept loop in a background goroutine and returns once the
+// socket is listening, so serving continues without blocking the caller.
+type Server struct {
+	ln         net.Listener
+	socketPath string
+	handler    func(Envelope)
+
+	// mu guards conns and closed so Close can race safely against the accept
+	// loop and per-connection goroutines.
+	mu     sync.Mutex
+	conns  map[net.Conn]struct{}
+	closed bool
+	// wg tracks the accept loop and per-connection goroutines so Close can
+	// wait for them to unwind before removing the socket file.
+	wg sync.WaitGroup
+}
+
+// Listen creates and serves the control socket at socketPath. It prepares the
+// parent directory and a clean socket file, listens, relaxes the socket's
+// permissions, and starts accepting in the background; it returns as soon as
+// the socket is listening.
+//
+// handler is invoked for every decoded Envelope and MAY be called from
+// multiple goroutines concurrently (one per open connection), so it must be
+// safe for concurrent use.
+//
+// Setup mirrors fleet's existing bind-mount conventions:
+//   - The parent directory is created 0777 because the socket is bind-mounted
+//     into a container whose user may have a different UID from the host user
+//     running fleet (the same rationale as the mount resolver's ensureHostDir).
+//   - Any stale socket file from a prior run is removed first, since
+//     net.Listen("unix", …) fails if the path already exists.
+//   - After listening, the socket is chmod'd 0666 so the container user can
+//     connect through the mount (the ensureHostFile rationale).
+func Listen(socketPath string, handler func(Envelope)) (*Server, error) {
+	// 0777 parent + remove-stale: the directory is bind-mounted cross-UID and
+	// a leftover socket file from a crashed prior run would otherwise make
+	// net.Listen fail with "address already in use".
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0777); err != nil {
+		return nil, fmt.Errorf("create control dir: %w", err)
+	}
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("remove stale control socket: %w", err)
+	}
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("listen on control socket %s: %w", socketPath, err)
+	}
+
+	// 0666 so a container user with a different UID than the host user can
+	// connect to the socket through the bind mount.
+	if err := os.Chmod(socketPath, 0666); err != nil {
+		ln.Close()
+		os.Remove(socketPath)
+		return nil, fmt.Errorf("chmod control socket: %w", err)
+	}
+
+	s := &Server{
+		ln:         ln,
+		socketPath: socketPath,
+		handler:    handler,
+		conns:      make(map[net.Conn]struct{}),
+	}
+
+	s.wg.Add(1)
+	go s.acceptLoop()
+	return s, nil
+}
+
+// acceptLoop accepts connections until the listener is closed. After Close,
+// Accept returns an error; the loop checks the closed flag and exits cleanly
+// rather than log-spamming on the expected shutdown error.
+func (s *Server) acceptLoop() {
+	defer s.wg.Done()
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			s.mu.Lock()
+			closed := s.closed
+			s.mu.Unlock()
+			if closed {
+				return // expected: Close shut the listener down
+			}
+			// A transient accept error on a live listener is rare; keep the
+			// loop alive rather than tearing the whole Server down for it.
+			continue
+		}
+
+		s.mu.Lock()
+		if s.closed {
+			// Raced with Close after Accept returned the connection.
+			s.mu.Unlock()
+			conn.Close()
+			return
+		}
+		s.conns[conn] = struct{}{}
+		s.wg.Add(1)
+		s.mu.Unlock()
+
+		go s.serveConn(conn)
+	}
+}
+
+// serveConn reads successive Envelopes from one connection until EOF or a
+// decode error, dispatching each to the handler. A decode error closes that
+// connection (the framing is desynchronised once a line is unparseable, so the
+// safe move is to drop it rather than guess where the next message starts).
+func (s *Server) serveConn(conn net.Conn) {
+	defer s.wg.Done()
+	defer s.dropConn(conn)
+
+	dec := json.NewDecoder(conn)
+	for {
+		var env Envelope
+		if err := dec.Decode(&env); err != nil {
+			return // EOF or undecodable: close this connection
+		}
+		s.handler(env)
+	}
+}
+
+// dropConn closes a connection and removes it from the tracked set. Safe to
+// call once per connection; Close also closes tracked connections, so this is
+// idempotent against that race via the map delete.
+func (s *Server) dropConn(conn net.Conn) {
+	s.mu.Lock()
+	delete(s.conns, conn) // no-op if Close already removed it
+	s.mu.Unlock()
+	conn.Close()
+}
+
+// Close stops accepting new connections, closes every open connection, waits
+// for the background goroutines to unwind, and removes the socket file. It is
+// safe to call once; a second call is a no-op.
+func (s *Server) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	conns := make([]net.Conn, 0, len(s.conns))
+	for c := range s.conns {
+		conns = append(conns, c)
+	}
+	s.mu.Unlock()
+
+	// Close the listener first so acceptLoop exits, then close in-flight
+	// connections so their serveConn goroutines hit EOF and return.
+	err := s.ln.Close()
+	for _, c := range conns {
+		c.Close()
+	}
+	s.wg.Wait()
+
+	// Remove the socket file we created so the next Listen on the same path
+	// starts clean even if it doesn't run the stale-file removal.
+	if rmErr := os.Remove(s.socketPath); rmErr != nil && !os.IsNotExist(rmErr) && err == nil {
+		err = fmt.Errorf("remove control socket: %w", rmErr)
+	}
+	return err
+}

--- a/internal/create/clone.go
+++ b/internal/create/clone.go
@@ -89,6 +89,21 @@ func RunClone(fleetName, srcInstance, destInstance string, verbose bool) error {
 		return err
 	}
 
+	// Bind-mount the per-instance control directory into the clone, the same
+	// way Run does, so the host fleet TUI can drive the in-instance
+	// `fleet launch` browser control over a unix socket. Guard with
+	// SupportsCustomMounts (only devcontainer-style backends honor mounts)
+	// and treat a host-directory failure as non-fatal — surface a warning
+	// and keep going rather than aborting the clone.
+	if instanceBackend.SupportsCustomMounts() {
+		mount, err := controlMount(fleetName, destInstance)
+		if err != nil {
+			state.WriteWarn(fleetName, destInstance, fmt.Sprintf("control mount: %v", err))
+		} else {
+			resolvedMounts.Mounts = append(resolvedMounts.Mounts, mount)
+		}
+	}
+
 	result, err := instanceBackend.Clone(src.ContainerID, destWorkspaceDir, resolvedMounts.Mounts)
 	if err != nil {
 		setFailed(fleetName, destInstance, err)

--- a/internal/create/control_mount.go
+++ b/internal/create/control_mount.go
@@ -1,0 +1,39 @@
+package create
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+	"github.com/BenjaminBenetti/fleet-man/internal/control"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// controlMount ensures the per-instance host control directory exists and
+// returns the bind mount that exposes it inside the instance at
+// control.ContainerMountDir.
+//
+// The host directory is state.ControlDir(fleetName, instanceName) — a
+// per-instance directory under the instance's workspace tree. It is created
+// with 0777 permissions for the same cross-UID reason as the agentic mount
+// resolver: the process inside the container that connects to the control
+// socket may run as a different user than the host fleet that creates the
+// socket, so the shared directory must be traversable by both. The control
+// socket itself does not exist yet at create/clone time — the host fleet TUI
+// later creates it inside this directory, and the instance sees it through the
+// bind mount (same kernel, shared mount, exactly like docker.sock).
+//
+// Returning the mount (rather than appending it directly) keeps this helper
+// pure and testable: it only touches the host directory and reports what mount
+// the backend should honor, leaving the caller to decide whether the backend
+// supports custom mounts at all.
+func controlMount(fleetName, instanceName string) (backend.Mount, error) {
+	dir := state.ControlDir(fleetName, instanceName)
+	if err := os.MkdirAll(dir, 0777); err != nil {
+		return backend.Mount{}, fmt.Errorf("create control dir %s: %w", dir, err)
+	}
+	return backend.Mount{
+		LocalPath:     dir,
+		ContainerPath: control.ContainerMountDir,
+	}, nil
+}

--- a/internal/create/control_mount_test.go
+++ b/internal/create/control_mount_test.go
@@ -1,0 +1,64 @@
+package create
+
+import (
+	"os"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/control"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// TestControlMount verifies that controlMount returns a bind mount pointing at
+// the per-instance control directory inside the container at the well-known
+// control.ContainerMountDir, that its host LocalPath matches
+// state.ControlDir, and that the host directory is created as a side effect.
+//
+// Each case runs against a temp HOME (via t.Setenv) so state.ControlDir
+// resolves into an isolated tree that the test owns and the testing harness
+// cleans up.
+func TestControlMount(t *testing.T) {
+	tests := []struct {
+		name     string
+		fleet    string
+		instance string
+	}{
+		{
+			name:     "simple names",
+			fleet:    "myfleet",
+			instance: "alpha",
+		},
+		{
+			name:     "hyphenated names",
+			fleet:    "my-fleet",
+			instance: "instance-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+
+			mount, err := controlMount(tt.fleet, tt.instance)
+			if err != nil {
+				t.Fatalf("controlMount(%q, %q) returned error: %v", tt.fleet, tt.instance, err)
+			}
+
+			if mount.ContainerPath != control.ContainerMountDir {
+				t.Errorf("ContainerPath = %q, want %q", mount.ContainerPath, control.ContainerMountDir)
+			}
+
+			wantLocal := state.ControlDir(tt.fleet, tt.instance)
+			if mount.LocalPath != wantLocal {
+				t.Errorf("LocalPath = %q, want %q", mount.LocalPath, wantLocal)
+			}
+
+			info, err := os.Stat(wantLocal)
+			if err != nil {
+				t.Fatalf("host control dir %q not created: %v", wantLocal, err)
+			}
+			if !info.IsDir() {
+				t.Errorf("host control path %q is not a directory", wantLocal)
+			}
+		})
+	}
+}

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -80,6 +80,23 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backen
 		return err
 	}
 
+	// Bind-mount the per-instance control directory so the host fleet TUI
+	// can create a unix socket the in-instance `fleet launch` connects to.
+	// Only devcontainer-style backends honor custom mounts; cloud-managed
+	// backends ignore them, so we skip the host-side prep for those. A
+	// failure to create the host directory is non-fatal — the instance is
+	// still usable, it just won't have in-instance control until recreated —
+	// so we surface it as a warning and continue, matching the surrounding
+	// best-effort pattern.
+	if instanceBackend.SupportsCustomMounts() {
+		mount, err := controlMount(fleetName, instanceName)
+		if err != nil {
+			state.WriteWarn(fleetName, instanceName, fmt.Sprintf("control mount: %v", err))
+		} else {
+			resolvedMounts.Mounts = append(resolvedMounts.Mounts, mount)
+		}
+	}
+
 	result, err := instanceBackend.Up(wsDir, resolvedMounts.Mounts)
 	if err != nil {
 		setFailed(fleetName, instanceName, err)

--- a/internal/fleetlaunch/fleet.rc
+++ b/internal/fleetlaunch/fleet.rc
@@ -9,4 +9,7 @@
 # edit this file directly — your changes will be overwritten on the
 # next instance start.
 
-# (Aliases for fleet subcommands will be added here in a future change.)
+# fl — shorthand for Fleet Launch. With no argument it opens the interactive
+# grid of this instance's configured links and apps; `fl list` prints them; and
+# `fl <name>` launches one directly by (a unique prefix of) its name.
+alias fl='fleet launch'

--- a/internal/landingpage/server.go
+++ b/internal/landingpage/server.go
@@ -13,11 +13,10 @@ import (
 	"html/template"
 	"io/fs"
 	"net/http"
-	"os/exec"
 	"strconv"
-	"strings"
 	"time"
 
+	"github.com/BenjaminBenetti/fleet-man/internal/appstart"
 	"github.com/BenjaminBenetti/fleet-man/internal/backend/devcontainer"
 	"github.com/gin-gonic/gin"
 )
@@ -192,72 +191,14 @@ func (s *server) handleApp(c *gin.Context) {
 		return
 	}
 	app := s.apps[i]
-	url := fmt.Sprintf("http://localhost:%d", app.Port)
 
-	if err := ensureAppRunning(app, url); err != nil {
+	// EnsureRunningOnPort starts the command if the port isn't already
+	// answering and holds until it comes up, so the browser's first paint
+	// isn't a connection-refused page. A start failure or a port that never
+	// binds both surface as a single error rendered into the fragment.
+	if err := appstart.EnsureRunningOnPort(app.Command, app.Port); err != nil {
 		c.HTML(http.StatusOK, "app.html", gin.H{"Title": app.Title, "Err": err.Error()})
 		return
 	}
-	// Hold the request open until the app is actually answering, so the
-	// browser's first paint isn't a connection-refused page.
-	if !waitForReachable(url) {
-		c.HTML(http.StatusOK, "app.html", gin.H{
-			"Title": app.Title,
-			"Err":   fmt.Sprintf("did not become reachable on port %d", app.Port),
-		})
-		return
-	}
-	c.HTML(http.StatusOK, "app.html", gin.H{"Title": app.Title, "URL": url})
-}
-
-// ensureAppRunning starts the app's command unless its port is already
-// answering. It is idempotent: an app already serving on its port is left
-// alone (so a second tab open or a browser relaunch doesn't double-start
-// it), and an app with no command relies entirely on the port poll.
-//
-// The command is started in the background and not waited on — it is
-// expected to be a long-running server (or to detach itself, e.g.
-// `docker run -d`). Readiness is determined by polling the port, not by
-// the command's exit, so a server that never binds the port surfaces as a
-// "did not become reachable" error from handleApp rather than a hang.
-func ensureAppRunning(app devcontainer.FleetLaunchApp, url string) error {
-	if reachable(url) {
-		return nil // already running
-	}
-	if strings.TrimSpace(app.Command) == "" {
-		return nil // nothing to start; rely on the port poll
-	}
-	cmd := exec.Command("bash", "-c", app.Command)
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("start command: %w", err)
-	}
-	return nil
-}
-
-// reachable reports whether url answers an HTTP request within a short
-// timeout. Any response (even an error status) counts as reachable — the
-// app's own server is up.
-func reachable(url string) bool {
-	client := &http.Client{Timeout: time.Second}
-	resp, err := client.Get(url)
-	if err != nil {
-		return false
-	}
-	resp.Body.Close()
-	return true
-}
-
-// waitForReachable polls url until it answers or a deadline passes,
-// reporting whether it came up. Used to hold an app-tab request open until
-// the app's HTTP server is listening (it can take a moment to start after
-// its command is launched).
-func waitForReachable(url string) bool {
-	deadline := time.Now().Add(15 * time.Second)
-	for time.Now().Before(deadline) {
-		if reachable(url) {
-			return true
-		}
-		time.Sleep(300 * time.Millisecond)
-	}
-	return false
+	c.HTML(http.StatusOK, "app.html", gin.H{"Title": app.Title, "URL": appstart.LocalURL(app.Port)})
 }

--- a/internal/launchtui/headless.go
+++ b/internal/launchtui/headless.go
@@ -1,0 +1,171 @@
+package launchtui
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/appstart"
+	"github.com/BenjaminBenetti/fleet-man/internal/control"
+)
+
+// ===========================================
+// Headless entry points
+// ===========================================
+//
+// Besides the interactive grid (Run), `fleet launch` supports two non-TUI
+// modes that share the same configuration loading and activation logic:
+//
+//   - List writes the configured links and apps (so a user — or a script — can
+//     see what names are available) and exits.
+//   - LaunchByName opens a single named link or app exactly as clicking it in
+//     the grid would, then exits.
+
+// List writes the configured links and apps to w, grouped into a "Links"
+// section and an "Apps" section, each entry showing the title used to launch it
+// and its target. It needs no host connection. Backs `fleet launch list`.
+func List(cfg Config, w io.Writer) error {
+	fl, err := loadCustomizations(cfg.ConfigPath)
+	if err != nil {
+		return err
+	}
+	items := buildItems(fl)
+	links := items[:linkCount(items)]
+	apps := items[linkCount(items):]
+
+	fmt.Fprintln(w, "Links:")
+	writeItemList(w, links)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Apps:")
+	writeItemList(w, apps)
+	return nil
+}
+
+// writeItemList writes one indented line per item ("  <title> — <target>"), or
+// a single "(none)" line when the section is empty.
+func writeItemList(w io.Writer, items []item) {
+	if len(items) == 0 {
+		fmt.Fprintln(w, "  (none)")
+		return
+	}
+	for _, it := range items {
+		fmt.Fprintf(w, "  %s — %s\n", itemTitle(it), itemTarget(it))
+	}
+}
+
+// itemTarget describes where an item points, for the listing: a link's URL, or
+// an app's localhost:<port>.
+func itemTarget(it item) string {
+	if it.kind == kindLink {
+		return it.url
+	}
+	return appstart.LocalURL(it.port)
+}
+
+// LaunchByName opens the link or app matching name exactly as activating it in
+// the grid would: a link opens its URL on the host browser; an app is started
+// on its port (if not already up) and then opened. Backs `fleet launch <name>`.
+//
+// name is matched case-insensitively against item titles (see resolveItem): a
+// unique prefix is enough, so a few leading characters usually suffice. An
+// ambiguous prefix lists the candidates so the user can type more; an unknown
+// name points at `fleet launch list`.
+//
+// out receives human feedback: a spinner while an app boots (on a terminal) and
+// an "Opened <name>" confirmation on success. Pass a CLI's stderr; a nil writer
+// is treated as no output.
+//
+// It dials the host control socket directly (there is no UI to fall back to), so
+// a missing host connection is a hard error rather than the grid's degraded
+// mode.
+func LaunchByName(cfg Config, name string, out io.Writer) error {
+	if out == nil {
+		out = io.Discard
+	}
+
+	fl, err := loadCustomizations(cfg.ConfigPath)
+	if err != nil {
+		return err
+	}
+	items := buildItems(fl)
+	idx, matches := resolveItem(items, name)
+	if idx < 0 {
+		if len(matches) == 0 {
+			return fmt.Errorf("no link or app matching %q (run `fleet launch list` to see the options)", name)
+		}
+		return fmt.Errorf("%q matches multiple options: %s — type more of the name to pick one",
+			name, strings.Join(matches, ", "))
+	}
+
+	socketPath := cfg.SocketPath
+	if socketPath == "" {
+		socketPath = control.ContainerSocketPath
+	}
+	client, err := control.Dial(socketPath)
+	if err != nil {
+		return fmt.Errorf("not connected to host fleet — is the host `fleet` TUI running? (%w)", err)
+	}
+	defer client.Close()
+
+	it := items[idx]
+	if it.kind == kindApp {
+		// Starting an app can block (the command runs, then we wait for its port
+		// to answer), so show a spinner for feedback while it boots.
+		stop := startSpinner(out, fmt.Sprintf("Starting %s…", itemTitle(it)))
+		err := openApp(client, it)
+		stop()
+		if err != nil {
+			return err
+		}
+	} else if err := openLink(client, it); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Opened %s\n", itemTitle(it))
+	return nil
+}
+
+// resolveItem matches name against item titles, case-insensitively, to support
+// launching by a leading fragment of a name:
+//
+//   - An exact title match always wins (so "Logs" picks "Logs" even when
+//     "LogsViewer" also exists).
+//   - Otherwise a unique prefix match is used (so "graf" picks "Grafana").
+//
+// It returns the resolved index and a nil match list on success. When the name
+// resolves to no item it returns (-1, nil); when it is ambiguous it returns
+// (-1, titles) listing every candidate so the caller can ask the user to type
+// more. The candidate titles are returned in item (links-then-apps) order.
+func resolveItem(items []item, name string) (int, []string) {
+	nameLower := strings.ToLower(name)
+
+	var exact, prefix []int
+	for i, it := range items {
+		title := strings.ToLower(itemTitle(it))
+		switch {
+		case title == nameLower:
+			exact = append(exact, i)
+		case strings.HasPrefix(title, nameLower):
+			prefix = append(prefix, i)
+		}
+	}
+
+	// A single exact match wins outright, regardless of how many other titles
+	// merely start with the same characters.
+	if len(exact) == 1 {
+		return exact[0], nil
+	}
+
+	// Otherwise the candidates are the exact matches (rare duplicate titles)
+	// plus the prefix matches; the switch above keeps the two sets disjoint.
+	candidates := append(append([]int{}, exact...), prefix...)
+	if len(candidates) == 1 {
+		return candidates[0], nil
+	}
+
+	titles := make([]string, len(candidates))
+	for i, c := range candidates {
+		titles[i] = itemTitle(items[c])
+	}
+	return -1, titles
+}

--- a/internal/launchtui/headless_test.go
+++ b/internal/launchtui/headless_test.go
@@ -1,0 +1,287 @@
+package launchtui
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/control"
+)
+
+// writeSampleConfig writes a devcontainer.json with a fleetLaunch block (two
+// links, two apps) to a temp file and returns its path.
+func writeSampleConfig(t *testing.T) string {
+	t.Helper()
+	const cfg = `{
+  "customizations": {
+    "fleet": {
+      "fleetLaunch": {
+        "sites": [
+          { "title": "API", "url": "http://localhost:3000" },
+          { "title": "Docs", "url": "http://localhost:8080" }
+        ],
+        "apps": [
+          { "title": "Grafana", "port": 3000, "command": "echo grafana" },
+          { "title": "Logs", "port": 16768 }
+        ]
+      }
+    }
+  }
+}`
+	path := filepath.Join(t.TempDir(), "devcontainer.json")
+	if err := os.WriteFile(path, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+// TestResolveItem checks case-insensitive exact and unique-prefix matching,
+// exact-wins-over-prefix, ambiguity, and the not-found case.
+func TestResolveItem(t *testing.T) {
+	// indices: 0 API, 1 Docs, 2 Admin (links), 3 Grafana (app)
+	items, _ := mkItems([]string{"API", "Docs", "Admin"}, []string{"Grafana"})
+
+	resolved := []struct {
+		name string
+		want int
+	}{
+		{"API", 0},  // exact
+		{"api", 0},  // exact, case-insensitive
+		{"docs", 1}, // exact
+		{"graf", 3}, // unique prefix
+		{"d", 1},    // unique prefix (only Docs starts with d)
+	}
+	for _, c := range resolved {
+		if got, m := resolveItem(items, c.name); got != c.want || m != nil {
+			t.Errorf("resolveItem(%q) = (%d, %v), want (%d, nil)", c.name, got, m, c.want)
+		}
+	}
+
+	// Ambiguous prefix: both API and Admin start with "a"; returned in item order.
+	if got, m := resolveItem(items, "a"); got != -1 || len(m) != 2 || m[0] != "API" || m[1] != "Admin" {
+		t.Errorf("resolveItem(%q) = (%d, %v), want (-1, [API Admin])", "a", got, m)
+	}
+
+	// No match.
+	if got, m := resolveItem(items, "zzz"); got != -1 || len(m) != 0 {
+		t.Errorf("resolveItem(%q) = (%d, %v), want (-1, [])", "zzz", got, m)
+	}
+
+	// An exact match wins even when a longer sibling shares the prefix.
+	items2, _ := mkItems([]string{"Log", "Logs"}, nil)
+	if got, m := resolveItem(items2, "log"); got != 0 || m != nil {
+		t.Errorf("resolveItem(%q) = (%d, %v), want (0, nil) — exact should win", "log", got, m)
+	}
+}
+
+// TestList prints both sections with their entries and targets.
+func TestList(t *testing.T) {
+	var buf bytes.Buffer
+	if err := List(Config{ConfigPath: writeSampleConfig(t)}, &buf); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	out := buf.String()
+
+	// Sections present and ordered Links before Apps.
+	li := strings.Index(out, "Links:")
+	ai := strings.Index(out, "Apps:")
+	if li < 0 || ai < 0 || li > ai {
+		t.Fatalf("expected Links: before Apps: in output:\n%s", out)
+	}
+	for _, want := range []string{"API", "http://localhost:3000", "Docs", "Grafana", "Logs", "localhost:16768"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("List output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestListEmptySections shows "(none)" under a section with no entries.
+func TestListEmptySections(t *testing.T) {
+	const cfg = `{"customizations":{"fleet":{"fleetLaunch":{
+      "sites":[{"title":"Only","url":"http://x"}]}}}}`
+	path := filepath.Join(t.TempDir(), "devcontainer.json")
+	if err := os.WriteFile(path, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := List(Config{ConfigPath: path}, &buf); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if !strings.Contains(buf.String(), "(none)") {
+		t.Errorf("expected an empty Apps section to render (none):\n%s", buf.String())
+	}
+}
+
+// TestLaunchByNameLink dials a real control server and asserts launching a link
+// by name sends an open-browser request for that link's URL.
+func TestLaunchByNameLink(t *testing.T) {
+	got := make(chan control.Envelope, 1)
+	sock := filepath.Join(t.TempDir(), control.SocketName)
+	srv, err := control.Listen(sock, func(e control.Envelope) { got <- e })
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer srv.Close()
+
+	cfg := Config{ConfigPath: writeSampleConfig(t), SocketPath: sock}
+	var out bytes.Buffer
+	if err := LaunchByName(cfg, "docs", &out); err != nil { // case-insensitive
+		t.Fatalf("LaunchByName: %v", err)
+	}
+	if !strings.Contains(out.String(), "Opened Docs") {
+		t.Errorf("expected an 'Opened Docs' confirmation, got %q", out.String())
+	}
+
+	select {
+	case e := <-got:
+		if e.Type != control.TypeOpenBrowser {
+			t.Fatalf("envelope type = %q, want %q", e.Type, control.TypeOpenBrowser)
+		}
+		if !strings.Contains(string(e.Payload), "http://localhost:8080") {
+			t.Errorf("payload %q does not carry the Docs URL", string(e.Payload))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the open-browser request")
+	}
+}
+
+// TestLaunchByNamePrefix launches by a unique leading fragment of a name: "ap"
+// resolves to "API" and its URL is sent to the host.
+func TestLaunchByNamePrefix(t *testing.T) {
+	got := make(chan control.Envelope, 1)
+	sock := filepath.Join(t.TempDir(), control.SocketName)
+	srv, err := control.Listen(sock, func(e control.Envelope) { got <- e })
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer srv.Close()
+
+	cfg := Config{ConfigPath: writeSampleConfig(t), SocketPath: sock}
+	if err := LaunchByName(cfg, "ap", io.Discard); err != nil { // unique prefix of "API"
+		t.Fatalf("LaunchByName(prefix): %v", err)
+	}
+	select {
+	case e := <-got:
+		if !strings.Contains(string(e.Payload), "http://localhost:3000") {
+			t.Errorf("payload %q does not carry the API URL", string(e.Payload))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the open-browser request")
+	}
+}
+
+// TestLaunchByNameAmbiguous reports every candidate when a prefix matches more
+// than one item, and does so without needing a host connection.
+func TestLaunchByNameAmbiguous(t *testing.T) {
+	const cfg = `{"customizations":{"fleet":{"fleetLaunch":{"sites":[
+      {"title":"Grafana","url":"http://a"},{"title":"Graphite","url":"http://b"}]}}}}`
+	path := filepath.Join(t.TempDir(), "devcontainer.json")
+	if err := os.WriteFile(path, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := LaunchByName(Config{ConfigPath: path}, "gra", io.Discard)
+	if err == nil {
+		t.Fatal("LaunchByName(ambiguous) = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "Grafana") || !strings.Contains(err.Error(), "Graphite") {
+		t.Errorf("ambiguous error should list both candidates: %v", err)
+	}
+}
+
+// TestLaunchByNameNotFound returns a helpful error for an unknown name without
+// needing a host connection.
+func TestLaunchByNameNotFound(t *testing.T) {
+	err := LaunchByName(Config{ConfigPath: writeSampleConfig(t)}, "ghost", io.Discard)
+	if err == nil {
+		t.Fatal("LaunchByName(unknown) = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Errorf("error %q should name the missing item", err)
+	}
+}
+
+// TestLaunchByNameNoHost errors clearly when the control socket can't be dialled
+// (no host listening).
+func TestLaunchByNameNoHost(t *testing.T) {
+	cfg := Config{
+		ConfigPath: writeSampleConfig(t),
+		SocketPath: filepath.Join(t.TempDir(), "absent.sock"),
+	}
+	err := LaunchByName(cfg, "API", io.Discard)
+	if err == nil {
+		t.Fatal("LaunchByName with no host = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "host") {
+		t.Errorf("error %q should mention the missing host", err)
+	}
+}
+
+// TestLaunchByNameAppProgress launches an app whose port is already answering
+// (so the boot wait returns immediately) and asserts the user gets progress
+// feedback: a "Starting <app>…" line and an "Opened <app>" confirmation, and
+// the host receives the localhost URL. The progress writer is a plain buffer
+// (not a TTY), so the spinner degrades to a single static line — keeping the
+// assertion deterministic.
+func TestLaunchByNameAppProgress(t *testing.T) {
+	// A live HTTP server stands in for the already-running app on its port.
+	app := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	defer app.Close()
+	u, err := url.Parse(app.URL)
+	if err != nil {
+		t.Fatalf("parse httptest URL: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+
+	// Control server to receive the open-browser request.
+	gotMsg := make(chan control.Envelope, 1)
+	sock := filepath.Join(t.TempDir(), control.SocketName)
+	srv, err := control.Listen(sock, func(e control.Envelope) { gotMsg <- e })
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer srv.Close()
+
+	// Config: one app, no command (rely on the already-listening port), pointed
+	// at the httptest server's port.
+	cfgJSON := fmt.Sprintf(`{"customizations":{"fleet":{"fleetLaunch":{
+      "apps":[{"title":"Metrics","port":%d}]}}}}`, port)
+	path := filepath.Join(t.TempDir(), "devcontainer.json")
+	if err := os.WriteFile(path, []byte(cfgJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if err := LaunchByName(Config{ConfigPath: path, SocketPath: sock}, "metrics", &out); err != nil {
+		t.Fatalf("LaunchByName(app): %v", err)
+	}
+
+	feedback := out.String()
+	if !strings.Contains(feedback, "Starting Metrics") {
+		t.Errorf("expected a 'Starting Metrics' progress line, got %q", feedback)
+	}
+	if !strings.Contains(feedback, "Opened Metrics") {
+		t.Errorf("expected an 'Opened Metrics' confirmation, got %q", feedback)
+	}
+
+	select {
+	case e := <-gotMsg:
+		want := fmt.Sprintf("http://localhost:%d", port)
+		if !strings.Contains(string(e.Payload), want) {
+			t.Errorf("payload %q does not carry %q", string(e.Payload), want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the open-browser request")
+	}
+}

--- a/internal/launchtui/item.go
+++ b/internal/launchtui/item.go
@@ -1,0 +1,88 @@
+package launchtui
+
+import "github.com/BenjaminBenetti/fleet-man/internal/backend/devcontainer"
+
+// ===========================================
+// Selectable items
+// ===========================================
+//
+// The two configured lists — fleetLaunch.sites (links) and fleetLaunch.apps —
+// are flattened into a single ordered slice of items: every link first, then
+// every app. That flat order is the cursor's index space and the render order,
+// so a single integer addresses both "which square is highlighted" and "which
+// square am I drawing". Each item keeps just enough of its source config to
+// render a square and to activate it (open a URL, or start a command then open
+// localhost:port).
+
+// itemKind distinguishes the two kinds of selectable squares so activation can
+// branch: a link opens a URL directly, an app must be started locally first.
+type itemKind int
+
+const (
+	// kindLink is a fleetLaunch.sites entry: activating it opens site.URL.
+	kindLink itemKind = iota
+	// kindApp is a fleetLaunch.apps entry: activating it ensures the command is
+	// running on its port, then opens http://localhost:<port>.
+	kindApp
+)
+
+// item is one selectable square in the grid. title/subtitle are what the square
+// renders; the activation fields carry whichever target the kind needs (url for
+// a link, command+port for an app). Fields not relevant to the kind are zero.
+type item struct {
+	// kind selects link vs app behaviour on activation.
+	kind itemKind
+	// title is the square's primary label.
+	title string
+	// subtitle is the square's secondary line (a link's subtitle, or an app's
+	// localhost:port hint). May be empty.
+	subtitle string
+	// url is the link target. Set only for kindLink.
+	url string
+	// command is the app's start command. Set only for kindApp; may be empty
+	// when the app is expected to already be running.
+	command string
+	// port is the app's localhost port. Set only for kindApp.
+	port int
+}
+
+// buildItems flattens a FleetCustomizations into the ordered item slice: all
+// link entries (in config order) followed by all app entries (in config
+// order). This ordering is load-bearing — layout() is told the link count and
+// app count and assumes exactly this links-then-apps arrangement, and the
+// cursor indexes into the same slice.
+func buildItems(fl devcontainer.FleetCustomizations) []item {
+	items := make([]item, 0, len(fl.FleetLaunch.Sites)+len(fl.FleetLaunch.Apps))
+	for _, s := range fl.FleetLaunch.Sites {
+		items = append(items, item{
+			kind:     kindLink,
+			title:    s.Title,
+			subtitle: s.SubTitle,
+			url:      s.URL,
+		})
+	}
+	for _, a := range fl.FleetLaunch.Apps {
+		items = append(items, item{
+			kind:     kindApp,
+			title:    a.Title,
+			subtitle: localhostHint(a.Port),
+			command:  a.Command,
+			port:     a.Port,
+		})
+	}
+	return items
+}
+
+// linkCount returns how many leading items are links, which is the boundary
+// layout() needs between its two sections. It counts the contiguous run of
+// kindLink items at the front (buildItems guarantees links precede apps).
+func linkCount(items []item) int {
+	n := 0
+	for _, it := range items {
+		if it.kind != kindLink {
+			break
+		}
+		n++
+	}
+	return n
+}

--- a/internal/launchtui/item_test.go
+++ b/internal/launchtui/item_test.go
@@ -1,0 +1,150 @@
+package launchtui
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend/devcontainer"
+)
+
+// TestBuildItems verifies links are flattened before apps, fields are carried
+// across, and linkCount reports the boundary.
+func TestBuildItems(t *testing.T) {
+	fl := devcontainer.FleetCustomizations{
+		FleetLaunch: devcontainer.FleetLaunchCustomizations{
+			Sites: []devcontainer.FleetLaunchSite{
+				{Title: "Docs", SubTitle: "reference", URL: "https://docs"},
+			},
+			Apps: []devcontainer.FleetLaunchApp{
+				{Title: "Web", Command: "npm start", Port: 3000},
+			},
+		},
+	}
+	items := buildItems(fl)
+	if len(items) != 2 {
+		t.Fatalf("len(items) = %d, want 2", len(items))
+	}
+	if items[0].kind != kindLink || items[0].url != "https://docs" || items[0].subtitle != "reference" {
+		t.Errorf("link item wrong: %+v", items[0])
+	}
+	if items[1].kind != kindApp || items[1].command != "npm start" || items[1].port != 3000 {
+		t.Errorf("app item wrong: %+v", items[1])
+	}
+	if items[1].subtitle != "localhost:3000" {
+		t.Errorf("app subtitle = %q, want localhost:3000", items[1].subtitle)
+	}
+	if got := linkCount(items); got != 1 {
+		t.Errorf("linkCount = %d, want 1", got)
+	}
+}
+
+// fakeClient records OpenBrowser calls and can be made to fail, standing in for
+// a *control.Client in model tests.
+type fakeClient struct {
+	urls []string
+	err  error
+}
+
+func (f *fakeClient) OpenBrowser(url string) error {
+	f.urls = append(f.urls, url)
+	return f.err
+}
+
+// TestActivateLink confirms activating a link sets an "Opening…" status and
+// returns an async command (it must NOT call OpenBrowser inline, so a slow or
+// hung host can't block the UI thread); running that command then sends the
+// link's URL to the client.
+func TestActivateLink(t *testing.T) {
+	items := []item{{kind: kindLink, title: "Docs", url: "https://docs"}}
+	fc := &fakeClient{}
+	m := model{items: items, links: 1, client: fc}
+
+	next, cmd := m.activate(0)
+	nm := next.(model)
+	if cmd == nil {
+		t.Fatalf("expected a tea.Cmd for link activation")
+	}
+	// OpenBrowser must not have been called synchronously on the UI thread.
+	if len(fc.urls) != 0 {
+		t.Errorf("OpenBrowser called inline for link; want async only")
+	}
+	if nm.status == "" {
+		t.Errorf("expected a non-empty status after activating a link")
+	}
+
+	// Running the async command sends the link's URL.
+	msg := cmd()
+	res, ok := msg.(appOpenedMsg)
+	if !ok {
+		t.Fatalf("msg type = %T, want appOpenedMsg", msg)
+	}
+	if res.err != nil {
+		t.Fatalf("err = %v, want nil", res.err)
+	}
+	if len(fc.urls) != 1 || fc.urls[0] != "https://docs" {
+		t.Fatalf("OpenBrowser calls = %v, want [https://docs]", fc.urls)
+	}
+}
+
+// TestActivateDegraded confirms that with no client, activation sets an error
+// status and does not panic.
+func TestActivateDegraded(t *testing.T) {
+	items := []item{{kind: kindLink, title: "Docs", url: "https://docs"}}
+	m := model{items: items, links: 1} // client nil
+
+	next, cmd := m.activate(0)
+	nm := next.(model)
+	if cmd != nil {
+		t.Errorf("expected no command when degraded")
+	}
+	if nm.status == "" {
+		t.Errorf("expected an error status when no client")
+	}
+}
+
+// TestActivateAppReturnsCmd confirms an app activation returns a command (the
+// async start) rather than calling OpenBrowser inline.
+func TestActivateAppReturnsCmd(t *testing.T) {
+	items := []item{{kind: kindApp, title: "Web", command: "true", port: 65535}}
+	fc := &fakeClient{}
+	m := model{items: items, links: 0, client: fc}
+
+	_, cmd := m.activate(0)
+	if cmd == nil {
+		t.Fatalf("expected a tea.Cmd for app activation")
+	}
+	// OpenBrowser must not have been called synchronously.
+	if len(fc.urls) != 0 {
+		t.Errorf("OpenBrowser called inline for app; want async only")
+	}
+}
+
+// TestOpenAppCmdAlreadyUp drives the async app command against a port that is
+// already answering (an httptest server): EnsureRunningOnPort returns nil
+// immediately, so the command should open localhost:<port> on the client and
+// report success with no error. This avoids the 15s start deadline by ensuring
+// the port is already reachable.
+func TestOpenAppCmdAlreadyUp(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	fc := &fakeClient{}
+	it := item{kind: kindApp, title: "Web", command: "", port: port}
+
+	msg := openAppCmd(fc, it)()
+	res, ok := msg.(appOpenedMsg)
+	if !ok {
+		t.Fatalf("msg type = %T, want appOpenedMsg", msg)
+	}
+	if res.err != nil {
+		t.Fatalf("err = %v, want nil for an already-up port", res.err)
+	}
+	wantURL := "http://localhost:" + strconv.Itoa(port)
+	if len(fc.urls) != 1 || fc.urls[0] != wantURL {
+		t.Errorf("OpenBrowser calls = %v, want [%s]", fc.urls, wantURL)
+	}
+}

--- a/internal/launchtui/launchtui.go
+++ b/internal/launchtui/launchtui.go
@@ -1,0 +1,525 @@
+// Package launchtui is the in-instance Fleet Launch terminal UI run by
+// `fleet launch`. It reads the workspace's customizations.fleet.fleetLaunch
+// block and presents the configured Links (fleetLaunch.sites) and Apps
+// (fleetLaunch.apps) as a flex grid of squares that wraps to the terminal
+// width. Arrow keys and hjkl move a cursor; enter or a mouse click activates a
+// square.
+//
+// The browser the TUI drives lives on the host (it is proxied into the
+// container by privoxy), so the TUI cannot open it directly. Instead it dials
+// the control socket fleet bind-mounts into the instance (internal/control)
+// and asks the host fleet TUI to open or navigate the browser:
+//
+//   - activating a Link sends the link's URL straight to the host;
+//   - activating an App first ensures the app's command is running on its port
+//     locally (internal/appstart), waits for the port, then sends
+//     http://localhost:<port> to the host.
+//
+// If the control socket cannot be dialled (the host fleet TUI isn't running)
+// the program still renders so the user can browse the configured options; it
+// shows a persistent status line and refuses to "open" anything until a host
+// connection exists.
+package launchtui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/appstart"
+	"github.com/BenjaminBenetti/fleet-man/internal/backend/devcontainer"
+	"github.com/BenjaminBenetti/fleet-man/internal/control"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ===========================================
+// Public entry point
+// ===========================================
+
+// Config parameterises Run. The zero value is the normal in-instance case:
+// auto-detect the workspace's devcontainer.json and dial the standard control
+// socket.
+type Config struct {
+	// ConfigPath is the devcontainer.json to read. Empty means auto-detect by
+	// searching the current directory for .devcontainer/devcontainer.json or
+	// ./devcontainer.json (LoadFleetCustomizations(".")). A non-empty path is
+	// read directly (LoadFleetCustomizationsFromFile) and a missing file is an
+	// error.
+	ConfigPath string
+	// SocketPath overrides the control socket the client dials. Empty means the
+	// standard container-side path (control.ContainerSocketPath). Tests set
+	// this to a temp socket.
+	SocketPath string
+}
+
+// Run loads the fleetLaunch configuration, dials the host control socket, and
+// runs the grid TUI until the user quits. It returns nil on a clean quit.
+//
+// Two early exits avoid an empty screen: a configuration that defines neither
+// links nor apps prints a friendly note and returns (nothing to show), and a
+// failed control dial is NOT fatal — the program runs "degraded" (rendering
+// the grid but reporting that opens won't work) so the user can still see what
+// is configured.
+func Run(cfg Config) error {
+	fl, err := loadCustomizations(cfg.ConfigPath)
+	if err != nil {
+		return err
+	}
+	if !fl.FleetLaunch.Configured() {
+		fmt.Println("Fleet Launch has nothing to show: no links (fleetLaunch.sites) or apps (fleetLaunch.apps) are configured in this devcontainer.json.")
+		return nil
+	}
+
+	socketPath := cfg.SocketPath
+	if socketPath == "" {
+		socketPath = control.ContainerSocketPath
+	}
+
+	// A dial failure is expected when the host fleet TUI isn't running; keep
+	// the client nil and run degraded rather than aborting.
+	client, dialErr := control.Dial(socketPath)
+	if client != nil {
+		defer client.Close()
+	}
+
+	m := newModel(buildItems(fl), client, dialErr)
+	prog := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
+	_, runErr := prog.Run()
+	return runErr
+}
+
+// loadCustomizations reads the fleetLaunch configuration from an explicit path
+// when one is given, otherwise auto-detects it from the current directory.
+func loadCustomizations(configPath string) (devcontainer.FleetCustomizations, error) {
+	if configPath != "" {
+		return devcontainer.LoadFleetCustomizationsFromFile(configPath)
+	}
+	return devcontainer.LoadFleetCustomizations(".")
+}
+
+// ===========================================
+// Messages
+// ===========================================
+
+// appOpenedMsg reports the outcome of activating an App square: the result of
+// starting it on its port and asking the host to open localhost:<port>. title
+// is the app's label for the status line; err is non-nil when the app never
+// came up or the host refused the open.
+type appOpenedMsg struct {
+	title string
+	err   error
+}
+
+// ===========================================
+// Model
+// ===========================================
+
+// model is the Bubble Tea model for the launcher grid. It owns the flattened
+// item list, the cursor, the most recent terminal size (for layout), the
+// control client (nil when running degraded), and a single status line.
+type model struct {
+	items   []item
+	links   int
+	cursor  int
+	width   int
+	height  int
+	client  controlClient
+	degrade bool
+	status  string
+}
+
+// controlClient is the slice of *control.Client the model uses. Defining it as
+// an interface keeps the model testable and documents the exact surface the
+// TUI depends on, but in production it is always a *control.Client.
+type controlClient interface {
+	OpenBrowser(url string) error
+}
+
+// newModel builds the initial model from the flattened items and a (possibly
+// nil) control client. dialErr, when non-nil, puts the model into degraded
+// mode with an explanatory status line so the user understands why opening is
+// disabled.
+func newModel(items []item, client *control.Client, dialErr error) model {
+	m := model{
+		items: items,
+		links: linkCount(items),
+	}
+	// A typed-nil *control.Client stored in an interface is NOT == nil, so only
+	// assign the interface when the concrete client is real; otherwise leave
+	// m.client nil and run degraded.
+	if client != nil {
+		m.client = client
+	}
+	if dialErr != nil || client == nil {
+		m.degrade = true
+		m.status = "not connected to host fleet — open will not work (is the host `fleet` TUI running?)"
+	}
+	return m
+}
+
+// Init satisfies tea.Model. The launcher has no startup command; layout and
+// rendering wait for the first WindowSizeMsg.
+func (m model) Init() tea.Cmd {
+	return nil
+}
+
+// Update satisfies tea.Model. It handles the terminal size, keyboard
+// navigation/activation, mouse clicks, and the asynchronous result of starting
+// an app.
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+
+	case tea.MouseMsg:
+		return m.handleMouse(msg)
+
+	case appOpenedMsg:
+		if msg.err != nil {
+			m.status = fmt.Sprintf("Could not open %s: %v", msg.title, msg.err)
+		} else {
+			m.status = fmt.Sprintf("Opening %s…", msg.title)
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+// handleKey applies a keypress: quit keys, the four movement directions (arrows
+// and hjkl), and enter to activate the cursor.
+func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	gl := m.grid()
+	switch msg.String() {
+	case "q", "esc", "ctrl+c":
+		return m, tea.Quit
+	case "left", "h":
+		m.cursor = moveLeft(m.cursor, len(m.items))
+	case "right", "l":
+		m.cursor = moveRight(m.cursor, len(m.items))
+	case "up", "k":
+		m.cursor = moveUp(gl, m.cursor)
+	case "down", "j":
+		m.cursor = moveDown(gl, m.cursor)
+	case "enter":
+		return m.activate(m.cursor)
+	}
+	return m, nil
+}
+
+// handleMouse activates the square under a left-button press. Any other mouse
+// activity (movement, other buttons, releases) is ignored. A click both selects
+// and activates, matching the "click = open" contract.
+func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if msg.Action != tea.MouseActionPress || msg.Button != tea.MouseButtonLeft {
+		return m, nil
+	}
+	idx := m.grid().hitTest(msg.X, msg.Y)
+	if idx < 0 {
+		return m, nil
+	}
+	m.cursor = idx
+	return m.activate(idx)
+}
+
+// activate opens the item at idx. Both links and apps open via an async
+// command so the UI thread never blocks: a link on the socket write to a
+// slow/hung host, an app on its command start and the wait for its port to come
+// up. When no host connection exists, it sets an error status instead of
+// attempting an open.
+func (m model) activate(idx int) (tea.Model, tea.Cmd) {
+	if idx < 0 || idx >= len(m.items) {
+		return m, nil
+	}
+	it := m.items[idx]
+
+	if m.client == nil {
+		m.status = "not connected to host fleet — cannot open (is the host `fleet` TUI running?)"
+		return m, nil
+	}
+
+	switch it.kind {
+	case kindLink:
+		m.status = fmt.Sprintf("Opening %s…", it.title)
+		return m, openLinkCmd(m.client, it)
+	case kindApp:
+		m.status = fmt.Sprintf("Starting %s…", it.title)
+		return m, openAppCmd(m.client, it)
+	}
+	return m, nil
+}
+
+// openLink asks the host to open a link's URL. It is the shared activation used
+// by both the TUI (wrapped in a tea.Cmd) and the headless `fleet launch <name>`
+// path.
+func openLink(client controlClient, it item) error {
+	return client.OpenBrowser(it.url)
+}
+
+// openApp starts an app on its port (only if it isn't already answering) and
+// then asks the host to open http://localhost:<port>. Shared by the TUI and the
+// headless launch path.
+func openApp(client controlClient, it item) error {
+	if err := appstart.EnsureRunningOnPort(it.command, it.port); err != nil {
+		return err
+	}
+	return client.OpenBrowser(appstart.LocalURL(it.port))
+}
+
+// openLinkCmd builds the tea.Cmd that asks the host to open a link's URL. The
+// send runs off the UI thread for the same reason openAppCmd does: control.
+// Client.Send writes to the unix socket, and a hung or slow host that has
+// stopped reading lets the kernel send buffer fill so the write blocks. Doing
+// that on the bubbletea Update goroutine would freeze the whole launcher with
+// no way to recover; the async command reports the result as an appOpenedMsg
+// instead. (Apps already went through openAppCmd; only the link path was
+// synchronous.)
+func openLinkCmd(client controlClient, it item) tea.Cmd {
+	return func() tea.Msg {
+		return appOpenedMsg{title: it.title, err: openLink(client, it)}
+	}
+}
+
+// openAppCmd builds the tea.Cmd that starts an app on its port (only if it
+// isn't already answering) and then asks the host to open localhost:<port>.
+// All blocking work — the command launch and the wait for the port to come up —
+// happens inside the returned function, which Bubble Tea runs on its own
+// goroutine, so the UI stays responsive.
+func openAppCmd(client controlClient, it item) tea.Cmd {
+	return func() tea.Msg {
+		return appOpenedMsg{title: it.title, err: openApp(client, it)}
+	}
+}
+
+// grid resolves the current layout from the latest terminal width and the
+// link/app split. It is recomputed on demand (it is cheap) so navigation and
+// hit-testing always use geometry that matches the most recent render.
+func (m model) grid() gridLayout {
+	return layout(m.width, m.items, m.links)
+}
+
+// ===========================================
+// Rendering
+// ===========================================
+//
+// The stylesheet deliberately mirrors the host TUI's palette (see
+// internal/tui/styles.go) so the launcher feels like part of the same app:
+// colour 170 (magenta/pink) is the primary accent and selection, 39 (cyan) is
+// the section-header/secondary colour, and 241 is the dim help text. Pills are
+// drawn as plain coloured text whose colour alternates by global render index
+// between pink and cyan so adjacent options are easy to tell apart; only the
+// selected pill gets a solid magenta box drawn behind it.
+
+var (
+	// headerStyle renders a section header ("Links" / "Apps") in the secondary
+	// cyan the host TUI uses for fleet/section headers.
+	headerStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("39")).
+			MarginLeft(horizontalMargin)
+
+	// dividerStyle renders the horizontal rule beneath a section header in the
+	// same cyan as the header, separating the label from its pills.
+	dividerStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("39")).
+			MarginLeft(horizontalMargin)
+
+	// statusStyle renders the bottom status line in the host TUI's dim help
+	// colour.
+	statusStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("241")).
+			MarginLeft(horizontalMargin)
+
+	// degradedStyle renders the status line when no host connection exists, in
+	// the host TUI's error red.
+	degradedStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("196")).
+			MarginLeft(horizontalMargin)
+
+	// pillTextEven / pillTextOdd are the two alternating text colours for
+	// unselected pills — the app's two accents, pink and cyan — so neighbouring
+	// options are easy to tell apart with no background fill.
+	pillTextEven = lipgloss.Color("170") // pink
+	pillTextOdd  = lipgloss.Color("39")  // cyan/blue
+
+	// pillSelectedBg / pillSelectedFg style the focused pill as a solid box in
+	// the magenta selection accent the host TUI uses, with dark text so it pops
+	// against the surrounding plain-text pills.
+	pillSelectedBg = lipgloss.Color("170")
+	pillSelectedFg = lipgloss.Color("16")
+)
+
+// View satisfies tea.Model. It renders the two labelled sections of pills and
+// the status/help line. Composition uses lipgloss's ANSI-aware
+// JoinHorizontal/JoinVertical rather than a hand-rolled character grid: the
+// pills are already styled (their background fills carry escape sequences), and
+// only lipgloss's join primitives measure and stack such strings without
+// shredding those sequences.
+//
+// The vertical stack is built to match layout()'s geometry exactly so the
+// mouse handler's hit-testing stays in sync: for each section a one-line label
+// and a one-line divider (headerRows = 2) followed by its wrapped rows of pills
+// (stacked with no gap between rows). Empty sections contribute no pill lines —
+// which is also what layout() assumes when it offsets the Apps section by the
+// (possibly zero) number of Link rows.
+func (m model) View() string {
+	if m.width == 0 {
+		// No size yet (first frame before WindowSizeMsg); render nothing to
+		// avoid a misplaced flash.
+		return ""
+	}
+
+	gl := m.grid()
+	divider := m.divider()
+
+	// "Links" label + divider (headerRows), then its pills.
+	parts := []string{
+		headerStyle.Render("Links"),
+		divider,
+	}
+	if links := m.renderSection(gl, sectionLink); links != "" {
+		parts = append(parts, links)
+	}
+	// "Apps" label + divider (headerRows), then its pills.
+	parts = append(parts, headerStyle.Render("Apps"), divider)
+	if apps := m.renderSection(gl, sectionApp); apps != "" {
+		parts = append(parts, apps)
+	}
+
+	body := lipgloss.JoinVertical(lipgloss.Left, parts...)
+	return body + "\n" + m.footer()
+}
+
+// renderSection renders one section's pills as a left-indented, wrapping grid:
+// each row's pills are joined horizontally (separated by pillGap blank columns)
+// and the rows are stacked with no blank line between them (rowStride = 1), so
+// the output matches layout()'s geometry exactly. Pills are drawn in flattened
+// (global) index order so the alternating fill reads as one continuous pattern
+// across both sections. Returns "" when the section has no items, so View can
+// omit it and keep the vertical geometry aligned with layout().
+func (m model) renderSection(gl gridLayout, sec section) string {
+	// Group this section's item indices by their layout row.
+	byRow := map[int][]int{}
+	maxRow := -1
+	for i, p := range gl.placements {
+		if p.section != sec {
+			continue
+		}
+		byRow[p.row] = append(byRow[p.row], i)
+		if p.row > maxRow {
+			maxRow = p.row
+		}
+	}
+	if maxRow < 0 {
+		return ""
+	}
+
+	gap := strings.Repeat(" ", pillGap)
+	indent := strings.Repeat(" ", horizontalMargin)
+	var lines []string
+	for r := 0; r <= maxRow; r++ {
+		var pills []string
+		for n, i := range byRow[r] {
+			if n > 0 {
+				pills = append(pills, gap)
+			}
+			pills = append(pills, m.renderPill(gl.placements[i], i))
+		}
+		lines = append(lines, indent+lipgloss.JoinHorizontal(lipgloss.Top, pills...))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// divider renders the horizontal rule shown beneath a section header: a run of
+// box-drawing dashes spanning the available content width, in the header's
+// cyan, indented to the same left margin as the labels and pills.
+func (m model) divider() string {
+	w := m.width - 2*horizontalMargin
+	if w < 1 {
+		w = 1
+	}
+	return dividerStyle.Render(strings.Repeat("─", w))
+}
+
+// renderPill styles the i-th item as a compact single-line pill: just its title,
+// no border and no subtitle. Unselected pills are plain coloured text whose
+// colour alternates by global index i (pink/cyan) so neighbouring options
+// differ; the selected pill instead gets a solid magenta box with dark text.
+// Either way the rendered width is the label plus pillPadding on each side
+// (padding is whitespace when unselected, the box's interior when selected) —
+// exactly the width layout() recorded in the placement's rect, so rendering and
+// hit-testing stay in lock-step.
+func (m model) renderPill(p itemPlacement, i int) string {
+	style := lipgloss.NewStyle().Padding(0, pillPadding)
+	switch {
+	case i == m.cursor:
+		style = style.Background(pillSelectedBg).Foreground(pillSelectedFg).Bold(true)
+	case i%2 == 0:
+		style = style.Foreground(pillTextEven)
+	default:
+		style = style.Foreground(pillTextOdd)
+	}
+	return style.Render(p.label)
+}
+
+// footer renders the status line (or the degraded warning) above a one-line key
+// hint.
+func (m model) footer() string {
+	var status string
+	switch {
+	case m.degrade:
+		status = degradedStyle.Render(m.status)
+	case m.status != "":
+		status = statusStyle.Render(m.status)
+	default:
+		status = statusStyle.Render(" ")
+	}
+	help := statusStyle.Render("↑/↓/←/→ or hjkl move · enter/click open · q quit")
+	return status + "\n" + help
+}
+
+// ===========================================
+// Small rendering helpers
+// ===========================================
+
+// itemTitle returns the title to show for an item, falling back to the link URL
+// (or a generic "App" label) when no explicit title was configured.
+func itemTitle(it item) string {
+	if it.title != "" {
+		return it.title
+	}
+	if it.kind == kindLink {
+		return it.url
+	}
+	return "App"
+}
+
+// localhostHint renders an app's "localhost:<port>" subtitle, or empty when the
+// port is unset.
+func localhostHint(port int) string {
+	if port <= 0 {
+		return ""
+	}
+	return "localhost:" + strconv.Itoa(port)
+}
+
+// truncate shortens s to at most max display cells, appending an ellipsis when
+// it had to cut. A non-positive max yields the empty string.
+func truncate(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	if max == 1 {
+		return "…"
+	}
+	return string(r[:max-1]) + "…"
+}

--- a/internal/launchtui/layout.go
+++ b/internal/launchtui/layout.go
@@ -1,0 +1,195 @@
+package launchtui
+
+import "github.com/charmbracelet/lipgloss"
+
+// ===========================================
+// Pure layout geometry
+// ===========================================
+//
+// The grid is laid out by pure functions so the exact same geometry drives both
+// rendering (View) and mouse hit-testing (Update). If View and the mouse handler
+// computed positions independently they would inevitably drift and a click would
+// land on the wrong pill; sharing one gridLayout makes that impossible.
+//
+// Each item renders as a compact single-line "pill": its title text plus a
+// little horizontal padding, on a coloured background — no border, no subtitle.
+// Pills are sized to their content (not a fixed grid cell), so a row packs as
+// many as fit across the available width and then wraps. Coordinates are
+// character cells, origin (0,0) at the top-left of the rendered view; the title
+// and section headers occupy whole rows above the pills and their height is
+// baked into every pill's Y so the mouse handler can map a raw (X,Y) straight to
+// an item.
+
+// section identifies which of the two labelled groups an item belongs to.
+type section int
+
+const (
+	// sectionLink is the "Links" group (configured fleetLaunch.sites).
+	sectionLink section = iota
+	// sectionApp is the "Apps" group (configured fleetLaunch.apps).
+	sectionApp
+)
+
+// Layout sizing constants.
+const (
+	// pillPadding is the horizontal padding inside a pill, on each side of the
+	// title. A pill's rendered width is the title's display width plus twice
+	// this.
+	pillPadding = 1
+	// pillGap is the blank space between two adjacent pills on a row.
+	pillGap = 1
+	// headerRows is the height a section consumes above its pills: the bold
+	// label line plus the horizontal divider line beneath it.
+	headerRows = 2
+	// horizontalMargin is the blank space kept at the left so pills don't butt
+	// against the edge; the column-fit budget reserves it on the right too.
+	horizontalMargin = 2
+)
+
+// rowStride is the vertical distance between the tops of two consecutive pill
+// rows. Pills are a single line and are stacked with no gap between rows, so
+// successive rows are adjacent — keeping the grid as vertically compact as
+// possible.
+const rowStride = 1
+
+// rect is an axis-aligned rectangle in character cells: its top-left corner
+// (X,Y) and its size (W,H). Contains reports whether a point falls inside.
+type rect struct {
+	X, Y, W, H int
+}
+
+// contains reports whether the cell at (px,py) lies within r (inclusive of the
+// top/left edge, exclusive of the bottom/right edge — standard half-open box).
+func (r rect) contains(px, py int) bool {
+	return px >= r.X && px < r.X+r.W && py >= r.Y && py < r.Y+r.H
+}
+
+// itemPlacement is the resolved position of one selectable item: which section
+// it is in, its row/column within that section's wrapped grid, the label its
+// pill shows (already truncated to fit), and the screen-space rectangle of the
+// pill. Row/col are section-relative; the rectangle is absolute (it already
+// accounts for the title and section headers stacked above it).
+type itemPlacement struct {
+	section section
+	row     int
+	col     int
+	label   string
+	rect    rect
+}
+
+// gridLayout is the fully resolved geometry of one render: the placement of
+// every selectable item, indexed by the item's position in the flattened
+// links-then-apps order. View walks placements to draw pills; the mouse handler
+// scans them to map a click to an item index. Both read the same slice, so they
+// can never disagree.
+type gridLayout struct {
+	// placements holds one entry per item, in flattened order (all links, then
+	// all apps). placements[i] is the geometry of item i.
+	placements []itemPlacement
+}
+
+// pillLabel returns the text shown in an item's pill, truncated so the rendered
+// pill (label + padding) never exceeds maxWidth columns. maxWidth is the
+// available content width for a whole row, so an absurdly long title degrades to
+// a truncated single pill rather than overflowing the line.
+func pillLabel(it item, maxWidth int) string {
+	capacity := maxWidth - 2*pillPadding
+	if capacity < 1 {
+		capacity = 1
+	}
+	return truncate(itemTitle(it), capacity)
+}
+
+// pillWidth is the rendered width of a pill showing label: its display width
+// plus the padding on both sides.
+func pillWidth(label string) int {
+	return lipgloss.Width(label) + 2*pillPadding
+}
+
+// layout resolves the geometry for the given items rendered at the given
+// terminal width, where the first `links` items are the Links section and the
+// rest are Apps. Pills flow left to right and wrap when the next one wouldn't
+// fit; the Apps section is stacked below all Link rows plus both headers.
+//
+// Vertical stacking, top to bottom:
+//
+//	"Links" label + divider  (headerRows)
+//	link pills               (linkRows rows, rowStride each)
+//	"Apps" label + divider   (headerRows)
+//	app pills                (appRows rows, rowStride each)
+//
+// The Apps section always sits below the Links section even when one side is
+// empty (an empty section contributes zero pill rows), matching the
+// two-headers-always layout in View.
+func layout(width int, items []item, links int) gridLayout {
+	if links < 0 {
+		links = 0
+	}
+	if links > len(items) {
+		links = len(items)
+	}
+
+	avail := width - 2*horizontalMargin
+	if avail < 1 {
+		avail = 1
+	}
+
+	gl := gridLayout{placements: make([]itemPlacement, 0, len(items))}
+
+	linkTop := headerRows
+	linkPlacements, linkRows := layoutSection(items[:links], sectionLink, avail, linkTop)
+
+	appsTop := linkTop + linkRows*rowStride + headerRows
+	appPlacements, _ := layoutSection(items[links:], sectionApp, avail, appsTop)
+
+	gl.placements = append(gl.placements, linkPlacements...)
+	gl.placements = append(gl.placements, appPlacements...)
+	return gl
+}
+
+// layoutSection lays one section's items into wrapping rows whose first row
+// begins at screen row sectionTop. avail is the usable content width (terminal
+// width minus margins). It returns the placements (in item order) and the number
+// of pill rows the section occupies (zero when it has no items).
+func layoutSection(items []item, sec section, avail, sectionTop int) ([]itemPlacement, int) {
+	placements := make([]itemPlacement, 0, len(items))
+	x, row, col := 0, 0, 0
+	for _, it := range items {
+		label := pillLabel(it, avail)
+		w := pillWidth(label)
+		// Wrap when this pill wouldn't fit on the current row (but never wrap a
+		// row that has no pills yet — a single over-wide pill just gets its own
+		// row, clamped by pillLabel).
+		if col > 0 && x+w > avail {
+			row++
+			col = 0
+			x = 0
+		}
+		placements = append(placements, itemPlacement{
+			section: sec,
+			row:     row,
+			col:     col,
+			label:   label,
+			rect:    rect{X: horizontalMargin + x, Y: sectionTop + row*rowStride, W: w, H: 1},
+		})
+		x += w + pillGap
+		col++
+	}
+	rows := 0
+	if len(placements) > 0 {
+		rows = row + 1
+	}
+	return placements, rows
+}
+
+// hitTest maps a point to the index of the item whose pill contains it, or -1
+// when the point falls on a gap, header, or empty area. The flattened index it
+// returns is directly assignable to the model's cursor.
+func (gl gridLayout) hitTest(px, py int) int {
+	for i, p := range gl.placements {
+		if p.rect.contains(px, py) {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/launchtui/layout_test.go
+++ b/internal/launchtui/layout_test.go
@@ -1,0 +1,133 @@
+package launchtui
+
+import "testing"
+
+// mkItems builds a flattened item slice from link titles followed by app
+// titles, returning it together with the link count the layout/model need.
+func mkItems(linkTitles, appTitles []string) ([]item, int) {
+	var items []item
+	for _, t := range linkTitles {
+		items = append(items, item{kind: kindLink, title: t})
+	}
+	for _, t := range appTitles {
+		items = append(items, item{kind: kindApp, title: t})
+	}
+	return items, len(linkTitles)
+}
+
+// twoColTestWidth is a terminal width chosen so exactly two width-2 titles fit
+// per row: each pill is 4 wide (title 2 + pillPadding on each side), so with
+// avail = width - 2*horizontalMargin = 10, pills 0 and 1 fit (x+w = 9 ≤ 10) and
+// a third would overflow (14 > 10) and wrap.
+const twoColTestWidth = 2*horizontalMargin + 10
+
+// TestLayoutWrapAndSections checks each item's section/row/col assignment for a
+// grid that wraps, the Links-start offset, and the Apps section being stacked
+// below the Links rows plus both headers.
+func TestLayoutWrapAndSections(t *testing.T) {
+	items, links := mkItems([]string{"AA", "BB", "CC"}, []string{"DD", "EE"})
+	gl := layout(twoColTestWidth, items, links)
+
+	if len(gl.placements) != 5 {
+		t.Fatalf("placements = %d, want 5", len(gl.placements))
+	}
+
+	type rc struct {
+		sec      section
+		row, col int
+	}
+	want := []rc{
+		{sectionLink, 0, 0},
+		{sectionLink, 0, 1},
+		{sectionLink, 1, 0}, // wrapped
+		{sectionApp, 0, 0},
+		{sectionApp, 0, 1},
+	}
+	for i, w := range want {
+		p := gl.placements[i]
+		if p.section != w.sec || p.row != w.row || p.col != w.col {
+			t.Errorf("item %d = {sec:%d row:%d col:%d}, want {sec:%d row:%d col:%d}",
+				i, p.section, p.row, p.col, w.sec, w.row, w.col)
+		}
+	}
+
+	// Links start just below the "Links" label + divider (headerRows).
+	if got, want := gl.placements[0].rect.Y, headerRows; got != want {
+		t.Errorf("first link Y = %d, want %d", got, want)
+	}
+
+	// Apps begin below the two Links rows plus the "Apps" label + divider.
+	linkRows := 2
+	wantAppsY := headerRows + linkRows*rowStride + headerRows
+	if got := gl.placements[3].rect.Y; got != wantAppsY {
+		t.Errorf("first app Y = %d, want %d", got, wantAppsY)
+	}
+}
+
+// TestLayoutEmptyLinks verifies the Apps offset is stable when there are no
+// links: the empty Links section contributes zero pill rows, so Apps sit
+// directly below both headers.
+func TestLayoutEmptyLinks(t *testing.T) {
+	items, links := mkItems(nil, []string{"DD", "EE"})
+	gl := layout(twoColTestWidth, items, links)
+
+	if len(gl.placements) != 2 {
+		t.Fatalf("placements = %d, want 2", len(gl.placements))
+	}
+	wantAppsY := headerRows + 0*rowStride + headerRows
+	if got := gl.placements[0].rect.Y; got != wantAppsY {
+		t.Errorf("first app Y with no links = %d, want %d", got, wantAppsY)
+	}
+}
+
+// TestPillWidthFromLabel verifies a pill's recorded width is the label's display
+// width plus padding on both sides, and that an over-wide title is truncated to
+// fit the available width rather than overflowing.
+func TestPillWidthFromLabel(t *testing.T) {
+	items, links := mkItems([]string{"Grafana"}, nil)
+	gl := layout(80, items, links)
+	if got, want := gl.placements[0].rect.W, len("Grafana")+2*pillPadding; got != want {
+		t.Errorf("pill width = %d, want %d", got, want)
+	}
+	if got := gl.placements[0].label; got != "Grafana" {
+		t.Errorf("label = %q, want %q", got, "Grafana")
+	}
+
+	// A title far wider than the terminal is truncated so the pill fits avail.
+	narrow := 2*horizontalMargin + 8 // avail = 8
+	items2, links2 := mkItems([]string{"ThisIsAVeryLongTitle"}, nil)
+	gl2 := layout(narrow, items2, links2)
+	if got := gl2.placements[0].rect.W; got > 8 {
+		t.Errorf("over-wide pill width = %d, want ≤ avail 8", got)
+	}
+}
+
+// TestHitTest maps known points to item indices: the centre of a pill hits it,
+// the title row hits nothing, the pill's own top-left corner hits it, and a
+// point beyond all pills hits nothing.
+func TestHitTest(t *testing.T) {
+	items, links := mkItems([]string{"AA", "BB", "CC"}, []string{"DD", "EE"})
+	gl := layout(twoColTestWidth, items, links)
+
+	// Centre of item 1 (links row 0, col 1).
+	p1 := gl.placements[1].rect
+	if got := gl.hitTest(p1.X+p1.W/2, p1.Y); got != 1 {
+		t.Errorf("hitTest centre of item 1 = %d, want 1", got)
+	}
+
+	// The very top-left cell is the title row — no item there.
+	if got := gl.hitTest(0, 0); got != -1 {
+		t.Errorf("hitTest(0,0) = %d, want -1 (title row)", got)
+	}
+
+	// Top-left corner of item 0's pill should hit item 0.
+	p0 := gl.placements[0].rect
+	if got := gl.hitTest(p0.X, p0.Y); got != 0 {
+		t.Errorf("hitTest top-left of item 0 = %d, want 0", got)
+	}
+
+	// A point far to the right, beyond all pills, hits nothing.
+	if got := gl.hitTest(twoColTestWidth+50, p0.Y); got != -1 {
+		t.Errorf("hitTest off-grid = %d, want -1", got)
+	}
+}

--- a/internal/launchtui/nav.go
+++ b/internal/launchtui/nav.go
@@ -1,0 +1,123 @@
+package launchtui
+
+// ===========================================
+// Pure navigation
+// ===========================================
+//
+// Cursor movement is split out as pure functions over a gridLayout so the
+// keyboard handling in Update stays a thin dispatch and the tricky cases —
+// wrapping rows, a ragged last row, crossing the Links→Apps section boundary —
+// are exercised by table tests without spinning up a live Bubble Tea program.
+//
+// The cursor is an index into the flattened links-then-apps item list. Left and
+// right step through that flat order (so they naturally flow across row and
+// section boundaries). Up and down move by visual geometry: they find the item
+// whose square sits directly above/below the current one, which keeps vertical
+// motion intuitive even when the two sections have different row widths or the
+// last row is ragged.
+
+// moveLeft returns the cursor one item earlier in the flattened order, clamped
+// at the first item. With no items it returns 0.
+func moveLeft(cursor, count int) int {
+	if count == 0 {
+		return 0
+	}
+	if cursor <= 0 {
+		return 0
+	}
+	return cursor - 1
+}
+
+// moveRight returns the cursor one item later in the flattened order, clamped
+// at the last item. With no items it returns 0.
+func moveRight(cursor, count int) int {
+	if count == 0 {
+		return 0
+	}
+	if cursor >= count-1 {
+		return count - 1
+	}
+	return cursor + 1
+}
+
+// moveDown returns the index of the item visually below the cursor. It picks
+// the placement whose pill starts on the next row down and whose horizontal
+// centre is nearest the current pill's centre — so a move from the last
+// (ragged) Links row lands on the closest Apps pill, and a move within a section
+// steps to the pill most directly beneath. When nothing sits below (the cursor
+// is already on the bottom row of the last section) the cursor is returned
+// unchanged.
+func moveDown(gl gridLayout, cursor int) int {
+	return moveVertical(gl, cursor, +1)
+}
+
+// moveUp returns the index of the item visually above the cursor, mirroring
+// moveDown. When nothing sits above (the cursor is on the very top row) the
+// cursor is returned unchanged.
+func moveUp(gl gridLayout, cursor int) int {
+	return moveVertical(gl, cursor, -1)
+}
+
+// moveVertical is the shared engine for moveUp/moveDown. dir is +1 for down and
+// -1 for up. It scans for the candidate row of pills immediately adjacent to the
+// cursor's row (by rectangle Y), then within that row picks the pill whose
+// horizontal centre is closest to the cursor's pill centre. Closeness by pixel
+// centre (rather than column index) is what keeps vertical motion intuitive now
+// that pills are variable width — column 2 of one row need not sit beneath
+// column 2 of the next. Working in Y also handles the gap that section headers
+// insert between the last Links row and the first Apps row.
+func moveVertical(gl gridLayout, cursor, dir int) int {
+	if len(gl.placements) == 0 {
+		return cursor
+	}
+	if cursor < 0 || cursor >= len(gl.placements) {
+		return cursor
+	}
+	cur := gl.placements[cursor]
+	curCenter := cur.rect.X + cur.rect.W/2
+
+	// Find the nearest adjacent row in the travel direction: the smallest Y
+	// strictly greater than the current row (down), or the largest Y strictly
+	// less (up).
+	targetY := -1
+	for _, p := range gl.placements {
+		if dir > 0 {
+			if p.rect.Y > cur.rect.Y && (targetY == -1 || p.rect.Y < targetY) {
+				targetY = p.rect.Y
+			}
+		} else {
+			if p.rect.Y < cur.rect.Y && (targetY == -1 || p.rect.Y > targetY) {
+				targetY = p.rect.Y
+			}
+		}
+	}
+	if targetY == -1 {
+		// No row in that direction; stay put.
+		return cursor
+	}
+
+	// Among items on the target row, choose the one whose horizontal centre is
+	// closest to the current pill's centre. Ties resolve to the earlier
+	// (lower-index) item.
+	best := cursor
+	bestDelta := -1
+	for i, p := range gl.placements {
+		if p.rect.Y != targetY {
+			continue
+		}
+		delta := abs(p.rect.X + p.rect.W/2 - curCenter)
+		if bestDelta == -1 || delta < bestDelta {
+			bestDelta = delta
+			best = i
+		}
+	}
+	return best
+}
+
+// abs returns the absolute value of n.
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}

--- a/internal/launchtui/nav_test.go
+++ b/internal/launchtui/nav_test.go
@@ -1,0 +1,108 @@
+package launchtui
+
+import "testing"
+
+// TestMoveLeftRight covers horizontal stepping through the flattened order,
+// including clamping at both ends and the empty list.
+func TestMoveLeftRight(t *testing.T) {
+	tests := []struct {
+		name          string
+		cursor, count int
+		want          int
+	}{
+		{name: "right from middle", cursor: 2, count: 5, want: 3},
+		{name: "right clamps at end", cursor: 4, count: 5, want: 4},
+		{name: "right on empty", cursor: 0, count: 0, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := moveRight(tt.cursor, tt.count); got != tt.want {
+				t.Errorf("moveRight(%d,%d) = %d, want %d", tt.cursor, tt.count, got, tt.want)
+			}
+		})
+	}
+
+	leftTests := []struct {
+		name          string
+		cursor, count int
+		want          int
+	}{
+		{"left from middle", 2, 5, 1},
+		{"left clamps at 0", 0, 5, 0},
+		{"left on empty", 0, 0, 0},
+	}
+	for _, tt := range leftTests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := moveLeft(tt.cursor, tt.count); got != tt.want {
+				t.Errorf("moveLeft(%d,%d) = %d, want %d", tt.cursor, tt.count, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMoveVertical exercises the geometry-driven up/down motion across the
+// interesting cases: single row, multi-row wrap, crossing the Links→Apps
+// section boundary, and a ragged last row. All titles are width 2 so pills are
+// uniform and two fit per row at twoColTestWidth, which makes the expected
+// landing indices deterministic.
+func TestMoveVertical(t *testing.T) {
+	width := twoColTestWidth
+
+	t.Run("single row has nothing below or above", func(t *testing.T) {
+		items, links := mkItems([]string{"AA", "BB"}, nil) // one row
+		gl := layout(width, items, links)
+		if got := moveDown(gl, 0); got != 0 {
+			t.Errorf("moveDown from single row = %d, want 0 (unchanged)", got)
+		}
+		if got := moveUp(gl, 1); got != 1 {
+			t.Errorf("moveUp from single row = %d, want 1 (unchanged)", got)
+		}
+	})
+
+	t.Run("multi-row wrap moves straight down a column", func(t *testing.T) {
+		items, links := mkItems([]string{"AA", "BB", "CC", "DD"}, nil) // rows {0:[0,1],1:[2,3]}
+		gl := layout(width, items, links)
+		if got := moveDown(gl, 0); got != 2 {
+			t.Errorf("moveDown from 0 = %d, want 2", got)
+		}
+		if got := moveDown(gl, 1); got != 3 {
+			t.Errorf("moveDown from 1 = %d, want 3", got)
+		}
+		if got := moveUp(gl, 3); got != 1 {
+			t.Errorf("moveUp from 3 = %d, want 1", got)
+		}
+	})
+
+	t.Run("crossing section boundary lands on nearest app column", func(t *testing.T) {
+		// 2 links (single row: cols 0,1), 2 apps (single row: cols 0,1).
+		items, links := mkItems([]string{"AA", "BB"}, []string{"DD", "EE"})
+		gl := layout(width, items, links)
+		// Down from link col 1 (index 1) should land on app col 1 (index 3).
+		if got := moveDown(gl, 1); got != 3 {
+			t.Errorf("moveDown across boundary from 1 = %d, want 3", got)
+		}
+		// Down from link col 0 (index 0) lands on app col 0 (index 2).
+		if got := moveDown(gl, 0); got != 2 {
+			t.Errorf("moveDown across boundary from 0 = %d, want 2", got)
+		}
+		// Up from app col 1 (index 3) returns to link col 1 (index 1).
+		if got := moveUp(gl, 3); got != 1 {
+			t.Errorf("moveUp across boundary from 3 = %d, want 1", got)
+		}
+	})
+
+	t.Run("ragged last row clamps to nearest column", func(t *testing.T) {
+		// 3 links: rows {0:[0,1], 1:[2]}. From link index 1 (row0 col1),
+		// moving down should land on the only item in row 1 (index 2, col 0).
+		items, links := mkItems([]string{"AA", "BB", "CC"}, nil)
+		gl := layout(width, items, links)
+		if got := moveDown(gl, 1); got != 2 {
+			t.Errorf("moveDown into ragged row from 1 = %d, want 2", got)
+		}
+		// Up from the lone ragged item (index 2, col 0) returns to col 0 above
+		// (index 0).
+		if got := moveUp(gl, 2); got != 0 {
+			t.Errorf("moveUp out of ragged row from 2 = %d, want 0", got)
+		}
+	})
+}

--- a/internal/launchtui/render_test.go
+++ b/internal/launchtui/render_test.go
@@ -1,0 +1,112 @@
+package launchtui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend/devcontainer"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
+)
+
+// sampleCustomizations is a representative fleetLaunch block: a couple of links
+// and a couple of apps, enough to exercise both sections and a wrapped row.
+func sampleCustomizations() devcontainer.FleetCustomizations {
+	return devcontainer.FleetCustomizations{
+		FleetLaunch: devcontainer.FleetLaunchCustomizations{
+			Sites: []devcontainer.FleetLaunchSite{
+				{Title: "API", SubTitle: "REST backend", URL: "http://localhost:3000"},
+				{Title: "Docs", SubTitle: "handbook", URL: "http://localhost:8080"},
+				{Title: "Mail", URL: "http://localhost:1080"},
+			},
+			Apps: []devcontainer.FleetLaunchApp{
+				{Title: "Grafana", Port: 3000},
+				{Title: "Go", Port: 6060},
+			},
+		},
+	}
+}
+
+// TestViewDoesNotLeakEscapeCodes is the regression guard for the rendering bug
+// where styled squares were composed into a hand-rolled character grid that
+// shredded their ANSI escape sequences, leaking fragments like "8;5;240;48;5;236m"
+// onto the screen as visible text. It forces a colour profile (so lipgloss
+// actually emits escapes even though `go test` has no TTY), renders the view,
+// and asserts that once the *valid* escape sequences are stripped, none of the
+// telltale SGR fragments remain as visible text.
+func TestViewDoesNotLeakEscapeCodes(t *testing.T) {
+	// Force colour output regardless of the test environment's TTY/profile so
+	// the squares carry real escape sequences to (not) leak.
+	lipgloss.SetColorProfile(termenv.ANSI256)
+
+	m := newModel(buildItems(sampleCustomizations()), nil, nil)
+	m.width = 90
+	m.height = 30
+
+	out := m.View()
+
+	// With colour forced on, the output must contain genuine CSI sequences —
+	// otherwise the test isn't actually exercising the styled path.
+	if !strings.Contains(out, "\x1b[") {
+		t.Fatalf("rendered view contains no ANSI escapes; colour profile not applied?\n%q", out)
+	}
+
+	// Stripping the valid escape sequences must remove every SGR code. If any of
+	// these fragments survive as visible text, escapes leaked (the old bug).
+	visible := ansi.Strip(out)
+	for _, leak := range []string{"38;5", "48;5", "5;236", "5;238", "\x1b"} {
+		if strings.Contains(visible, leak) {
+			t.Errorf("escape fragment %q leaked into visible text:\n%s", leak, visible)
+		}
+	}
+
+	// And the visible text must actually contain the section headers and the
+	// item titles (subtitles are intentionally not rendered).
+	for _, want := range []string{"Links", "Apps", "API", "Grafana"} {
+		if !strings.Contains(visible, want) {
+			t.Errorf("visible output is missing %q\nfull visible text:\n%s", want, visible)
+		}
+	}
+
+	// Subtitles must NOT appear — the redesign shows title-only pills.
+	for _, unwanted := range []string{"REST backend", "handbook"} {
+		if strings.Contains(visible, unwanted) {
+			t.Errorf("visible output unexpectedly contains subtitle %q", unwanted)
+		}
+	}
+}
+
+// TestViewGeometryMatchesLayout checks that the rendered rows line up with the
+// geometry the mouse handler hit-tests against: the first link square's border
+// must appear on the row layout() assigns to link 0, indented to its column.
+func TestViewGeometryMatchesLayout(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii) // plain text: easiest to assert positions
+
+	m := newModel(buildItems(sampleCustomizations()), nil, nil)
+	m.width = 90
+	m.height = 30
+
+	lines := strings.Split(m.View(), "\n")
+	gl := m.grid()
+	if len(gl.placements) == 0 {
+		t.Fatal("no placements")
+	}
+
+	// Link 0's pill: its label must appear on the row layout() assigns, indented
+	// to its X plus the pill's left padding.
+	top := gl.placements[0].rect.Y
+	left := gl.placements[0].rect.X
+	label := gl.placements[0].label
+	if top >= len(lines) {
+		t.Fatalf("layout puts link 0 at row %d but only %d rows rendered", top, len(lines))
+	}
+	// Strip escapes before measuring: lipgloss emits zero-width reset sequences
+	// even under the Ascii profile, so the visible column is the rune index in
+	// the stripped row, not the raw string.
+	row := ansi.Strip(lines[top])
+	wantIdx := left + pillPadding
+	if idx := strings.Index(row, label); idx != wantIdx {
+		t.Errorf("link 0 label %q at column %d, layout expected %d\nrow: %q", label, idx, wantIdx, row)
+	}
+}

--- a/internal/launchtui/spinner.go
+++ b/internal/launchtui/spinner.go
@@ -1,0 +1,78 @@
+package launchtui
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/charmbracelet/x/term"
+)
+
+// ===========================================
+// CLI progress spinner
+// ===========================================
+//
+// The headless `fleet launch <name>` path can block for a while when it starts
+// an app (the command runs, then we wait for the port to come up). A small
+// spinner gives the user feedback that something is happening rather than a
+// silent hang. It is deliberately tiny and self-contained — the interactive
+// grid uses Bubble Tea's spinner; this is for plain CLI output.
+
+// spinnerFrames is a smooth braille spinner cycle.
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// spinnerInterval is the repaint cadence.
+const spinnerInterval = 100 * time.Millisecond
+
+// startSpinner gives feedback for a blocking operation labelled msg and returns
+// a stop function to call exactly once when the operation finishes.
+//
+// On a terminal it animates a spinner in front of msg, repainting in place; the
+// stop function halts the animation and clears the line so the caller can print
+// a final result cleanly. When w is not a terminal (a pipe, a redirect, or a
+// test buffer) it prints msg once as a plain line and the stop function is a
+// no-op — so non-interactive output never accumulates carriage-return spam.
+func startSpinner(w io.Writer, msg string) (stop func()) {
+	if !isTerminalWriter(w) {
+		fmt.Fprintln(w, msg)
+		return func() {}
+	}
+
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		ticker := time.NewTicker(spinnerInterval)
+		defer ticker.Stop()
+		i := 0
+		for {
+			// Repaint in place: carriage return, magenta spinner frame (matching
+			// the app's accent), then the message.
+			fmt.Fprintf(w, "\r\x1b[38;5;170m%s\x1b[0m %s", spinnerFrames[i], msg)
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				i = (i + 1) % len(spinnerFrames)
+			}
+		}
+	}()
+
+	return func() {
+		close(done)
+		<-finished
+		// Clear the spinner line: carriage return + erase to end of line.
+		fmt.Fprint(w, "\r\x1b[K")
+	}
+}
+
+// isTerminalWriter reports whether w is an *os.File backed by a terminal, i.e.
+// one we can safely animate on.
+func isTerminalWriter(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(f.Fd())
+}

--- a/internal/state/control_path_test.go
+++ b/internal/state/control_path_test.go
@@ -1,0 +1,45 @@
+package state
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/control"
+)
+
+// TestControlSocketPath verifies the host control-socket path is rooted under
+// the workspaces tree and ends with the per-instance .control dir plus the
+// shared socket basename (so host and container agree on the same file).
+func TestControlSocketPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const (
+		fleetName    = "myfleet"
+		instanceName = "alice"
+	)
+
+	got := ControlSocketPath(fleetName, instanceName)
+
+	// Lives under the workspaces tree so it shares the instance's lifecycle.
+	if !strings.HasPrefix(got, WorkspacesDir()+string(filepath.Separator)) {
+		t.Errorf("ControlSocketPath = %q, want it under WorkspacesDir() %q", got, WorkspacesDir())
+	}
+
+	// Ends with .control/<SocketName>, basename sourced from control.SocketName.
+	wantSuffix := filepath.Join(".control", control.SocketName)
+	if !strings.HasSuffix(got, string(filepath.Separator)+wantSuffix) {
+		t.Errorf("ControlSocketPath = %q, want suffix %q", got, wantSuffix)
+	}
+
+	// The socket sits directly inside ControlDir for the same instance.
+	if dir := ControlDir(fleetName, instanceName); filepath.Dir(got) != dir {
+		t.Errorf("filepath.Dir(socket) = %q, want ControlDir %q", filepath.Dir(got), dir)
+	}
+
+	// And ControlDir is the per-instance .control directory.
+	wantDir := filepath.Join(WorkspacesDir(), fleetName, instanceName, ".control")
+	if dir := ControlDir(fleetName, instanceName); dir != wantDir {
+		t.Errorf("ControlDir = %q, want %q", dir, wantDir)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/BenjaminBenetti/fleet-man/internal/control"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 )
 
@@ -46,6 +47,22 @@ func WorkspacesDir() string {
 // the path manually so all warnings end up in the same well-known place.
 func WarnPath(fleetName, instanceName string) string {
 	return filepath.Join(FleetDir(), "logs", fleetName+"-"+instanceName+".warn")
+}
+
+// ControlDir returns the host directory bind-mounted into an instance to
+// carry the control socket. It is per-instance (not per-fleet) so the host
+// can tell which instance a received message came from, and it lives under
+// the instance's workspace tree so it shares that tree's lifecycle (created
+// when the instance is and cleaned up with it).
+func ControlDir(fleetName, instanceName string) string {
+	return filepath.Join(WorkspacesDir(), fleetName, instanceName, ".control")
+}
+
+// ControlSocketPath returns the host path of an instance's control socket.
+// The basename comes from control.SocketName so the host listener and the
+// in-container client agree on the same file through the bind mount.
+func ControlSocketPath(fleetName, instanceName string) string {
+	return filepath.Join(ControlDir(fleetName, instanceName), control.SocketName)
 }
 
 // WriteWarn writes warning to the instance's WarnPath. Errors are

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -14,6 +15,7 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 	codespacesbackend "github.com/BenjaminBenetti/fleet-man/internal/backend/codespaces"
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
+	"github.com/BenjaminBenetti/fleet-man/internal/control"
 	"github.com/BenjaminBenetti/fleet-man/internal/deps"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/portforward"
@@ -63,6 +65,21 @@ type model struct {
 
 	// Port forwarding
 	portForwards *portforward.Manager // manages active port forward processes
+
+	// activeBrowser records which instance the browser bound to a given
+	// Chrome data dir is currently proxied to: data dir → "<fleet>/<instance>".
+	// A data dir is shared across a fleet's instances (unless
+	// MultipleBrowsersPerFleet), and a Chrome process can only be proxied to one
+	// instance at a time, so a control-socket "open" for a different instance
+	// must switch the browser over rather than forward the URL into the
+	// wrong-proxied existing process. Populated on every successful browser open.
+	activeBrowser map[string]string
+
+	// control owns one control-socket listener per running instance and
+	// funnels received envelopes (e.g. an in-instance `fleet launch` TUI's
+	// "browser.open" requests) into a channel the Update loop drains. Its
+	// listener set is kept in step with the running instances by reload().
+	control *controlRegistry
 
 	// Per-instance session state: discovery, expansion, last-active
 	// session. All three are owned by the SessionStore so every read
@@ -118,6 +135,8 @@ func newModel() model {
 		activity:       NewActivityTracker(),
 		reprovisioning: &sync.Map{},
 		portForwards:   portforward.NewManager(),
+		activeBrowser:  make(map[string]string),
+		control:        newControlRegistry(),
 		sessionStore:   NewSessionStore(),
 		spinner:        spinnerModel,
 		agentSpinner:   agentSpinnerModel,
@@ -195,6 +214,13 @@ func (m *model) reload() {
 	m.st = st
 	m.config = config
 	m.err = nil
+
+	// Keep the control-socket listeners in step with the running set: start
+	// listeners for newly-running instances, drop them for stopped/gone ones.
+	// Idempotent, so funnelling every state refresh through here is cheap.
+	if m.control != nil {
+		m.control.syncRunning(st)
+	}
 
 	// Auto-collapse expanded instances that are no longer running
 	for _, ref := range m.sessionStore.ExpandedRefs() {
@@ -536,6 +562,10 @@ func (m model) Init() tea.Cmd {
 		// periodic tick that follows handles drift during the session.
 		refreshLiveStatusCmd(collectLiveStatusProbes(m.st)),
 		liveStatusPollCmd(),
+		// Drain control-socket events from in-instance senders (the listeners
+		// themselves were started by the reload() inside newModel()). The
+		// model-level Update re-arms this waiter after each event.
+		waitForControlEventCmd(m.control.events),
 		m.currentPage.Init(&m),
 	}
 	if len(m.creating) > 0 {
@@ -742,6 +772,23 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.reload()
 		}
 		return m, spinCmd
+
+	case controlEventMsg:
+		// An in-instance sender (e.g. a `fleet launch` TUI) wrote an Envelope
+		// to that instance's control socket. Dispatch by type, then re-arm the
+		// waiter so the single in-flight command keeps draining the channel.
+		// msg is already the concrete controlEventMsg here (the switch binds
+		// it), so convert it to the underlying controlEvent directly.
+		ev := controlEvent(msg)
+		var cmd tea.Cmd
+		switch ev.env.Type {
+		case control.TypeOpenBrowser:
+			var p control.OpenBrowserPayload
+			if json.Unmarshal(ev.env.Payload, &p) == nil && p.URL != "" {
+				cmd = m.openControlBrowserCmd(ev.instanceKey, p.URL)
+			}
+		}
+		return m, tea.Batch(cmd, waitForControlEventCmd(m.control.events))
 
 	case forceRepaintTickMsg:
 		// Scrub artifacts left by outer-tmux pane resizes without
@@ -1075,6 +1122,11 @@ func Run() error {
 	if clipCancel != nil {
 		clipCancel()
 	}
+
+	// Tear down every control-socket listener so the host releases the socket
+	// files it created. The registry pointer in m is shared with the program's
+	// copy of the model, so this Closes the same servers the loop was draining.
+	m.control.shutdown()
 
 	// If the user just performed a successful auto-update, replace
 	// the current process with the freshly installed binary. Doing

--- a/internal/tui/browser.go
+++ b/internal/tui/browser.go
@@ -125,6 +125,14 @@ var proxySetupScript = privoxyEnsureInstalled +
 //	  | Launch browser with   |
 //	  | --proxy-server flag   |
 //	  +-----------------------+
+//
+// targetURL, when non-empty, overrides the page the browser opens to: it is
+// used verbatim as the initial URL and the config-resolution / landing-page
+// startup block is skipped entirely. This is the path taken by control-socket
+// "browser.open" requests, where the in-instance TUI has already chosen the
+// exact URL (a site link, or http://localhost:<port> for an app). An empty
+// targetURL preserves the original behaviour: resolve the page from the
+// workspace's devcontainer.json fleet customization.
 func openBrowserProxyCmd(
 	pf *portforward.Manager,
 	instanceBackend backend.Backend,
@@ -132,6 +140,7 @@ func openBrowserProxyCmd(
 	instanceKey string,
 	dataDir string,
 	preferFleetLaunch bool,
+	targetURL string,
 ) tea.Cmd {
 	// Capture values for the goroutine.
 	workspaceDir := instance.WorkspaceDir
@@ -175,8 +184,15 @@ func openBrowserProxyCmd(
 		//    binary as the landing-page server in the container. A missing
 		//    or malformed config (load error) falls back to the default
 		//    rather than blocking the launch.
+		//
+		//    When the caller supplied an explicit targetURL (a control-socket
+		//    "browser.open" request), skip all of this: the URL was already
+		//    chosen by the in-instance TUI, so there is no config to resolve
+		//    and no landing page to start.
 		initialURL := defaultBrowserURL
-		if fc, err := devcontainer.LoadFleetCustomizations(workspaceDir); err == nil {
+		if targetURL != "" {
+			initialURL = targetURL
+		} else if fc, err := devcontainer.LoadFleetCustomizations(workspaceDir); err == nil {
 			hasURL := fc.Browser.InitialURL != ""
 			hasLanding := fc.FleetLaunch.Configured()
 			useLanding := shouldUseLandingPage(hasURL, hasLanding, preferFleetLaunch)
@@ -236,7 +252,7 @@ func (fleetPage *fleetPage) startBrowser(m *model, instance *fleet.Instance, fle
 	if _, running := existingBrowserPID(dataDir); running {
 		if !multiplePerFleet && m.config != nil && m.config.BrowserSettings.AutoSwitchEnabled() {
 			m.message = fmt.Sprintf("Switching browser to %s...", instance.GetDisplayName())
-			return switchBrowserCmd(m.portForwards, b, instance, instanceKey, dataDir, preferFleetLaunch)
+			return switchBrowserCmd(m.portForwards, b, instance, instanceKey, dataDir, preferFleetLaunch, "")
 		}
 		fleetPage.mode = viewConfirmBrowserSwitch
 		fleetPage.dialogFleet = fleetName
@@ -244,7 +260,84 @@ func (fleetPage *fleetPage) startBrowser(m *model, instance *fleet.Instance, fle
 		return nil
 	}
 	m.message = fmt.Sprintf("Starting browser proxy for %s...", instance.GetDisplayName())
-	return openBrowserProxyCmd(m.portForwards, b, instance, instanceKey, dataDir, preferFleetLaunch)
+	return openBrowserProxyCmd(m.portForwards, b, instance, instanceKey, dataDir, preferFleetLaunch, "")
+}
+
+// openControlBrowserCmd builds the browser-open command for a control-socket
+// "browser.open" request: resolve the instance from instanceKey, then open the
+// proxied browser at url.
+//
+// The subtlety is which instance the existing browser (if any) is proxied to.
+// A fleet's instances share one Chrome data dir (unless MultipleBrowsersPerFleet),
+// and that one Chrome can only route through a single instance's privoxy proxy
+// at a time. There are three cases for the data dir's live browser:
+//
+//   - none running              → start a fresh proxied browser at url.
+//   - running, this instance    → forward url to it as a new tab (Chrome's
+//     singleton drops the second --proxy-server flag, but the live process
+//     already has the right proxy), which is what a plain openBrowserProxyCmd
+//     does.
+//   - running, OTHER instance   → switch: kill it and relaunch against THIS
+//     instance, then open url. Without this the URL would be forwarded into the
+//     other instance's browser, whose proxy can't reach this instance's
+//     address — the bug this guards against.
+//
+// activeBrowser records who the live browser serves (see model). An unknown
+// owner (empty) is treated as "different" and switches, which is also correct
+// after a host restart: the surviving Chrome's old proxy port is dead, so a
+// fresh relaunch is needed regardless.
+//
+// If the instance can't be found or isn't running, it returns a
+// browserProxyMsg carrying the error, which the existing page_fleet.go handler
+// surfaces as a status message — no special-casing needed at the call site.
+func (m *model) openControlBrowserCmd(instanceKey, url string) tea.Cmd {
+	fleetName, instanceName, ok := splitInstanceKey(instanceKey)
+	if !ok {
+		return func() tea.Msg {
+			return browserProxyMsg{instanceKey: instanceKey, err: fmt.Errorf("malformed instance key %q", instanceKey)}
+		}
+	}
+
+	f, ok := m.st.Fleets[fleetName]
+	if !ok {
+		return func() tea.Msg {
+			return browserProxyMsg{instanceKey: instanceKey, err: fmt.Errorf("fleet %q not found", fleetName)}
+		}
+	}
+	instance, err := f.GetInstance(instanceName)
+	if err != nil {
+		return func() tea.Msg {
+			return browserProxyMsg{instanceKey: instanceKey, err: err}
+		}
+	}
+	if instance.Status != fleet.StatusRunning {
+		return func() tea.Msg {
+			return browserProxyMsg{instanceKey: instanceKey, err: fmt.Errorf("instance %q is not running", instanceKey)}
+		}
+	}
+
+	dataDir := browserDataDir(fleetName, instance.Name, multipleBrowsersPerFleet(m))
+	b := m.instanceBackend(instance)
+
+	// If a browser is already live for this data dir but proxied to a different
+	// instance, switch it over to this one (kill + relaunch) instead of letting
+	// Chrome forward the URL into the wrong-proxied process.
+	_, running := existingBrowserPID(dataDir)
+	if shouldSwitchBrowser(running, m.activeBrowser[dataDir], instanceKey) {
+		return switchBrowserCmd(m.portForwards, b, instance, instanceKey, dataDir, false, url)
+	}
+	return openBrowserProxyCmd(m.portForwards, b, instance, instanceKey, dataDir, false, url)
+}
+
+// shouldSwitchBrowser reports whether a control-socket open for instanceKey must
+// switch the live browser (kill + relaunch) rather than reuse it. That is the
+// case only when a browser is actually running for the data dir AND it is not
+// already proxied to instanceKey — an unknown/empty recorded owner counts as
+// "not this instance" so a browser of uncertain origin (e.g. one that survived
+// a host restart with a now-dead proxy) is relaunched cleanly rather than
+// new-tabbed into.
+func shouldSwitchBrowser(running bool, activeInstanceKey, instanceKey string) bool {
+	return running && activeInstanceKey != instanceKey
 }
 
 // bothBrowserTargets reports whether the workspace's devcontainer.json
@@ -283,8 +376,9 @@ func switchBrowserCmd(
 	instanceKey string,
 	dataDir string,
 	preferFleetLaunch bool,
+	targetURL string,
 ) tea.Cmd {
-	inner := openBrowserProxyCmd(pf, instanceBackend, instance, instanceKey, dataDir, preferFleetLaunch)
+	inner := openBrowserProxyCmd(pf, instanceBackend, instance, instanceKey, dataDir, preferFleetLaunch, targetURL)
 	return func() tea.Msg {
 		if err := killExistingBrowser(dataDir); err != nil {
 			return browserProxyMsg{

--- a/internal/tui/browser_test.go
+++ b/internal/tui/browser_test.go
@@ -185,3 +185,31 @@ func TestShouldUseLandingPage(t *testing.T) {
 		})
 	}
 }
+
+// TestShouldSwitchBrowser documents the control-socket open decision matrix:
+// a switch (kill + relaunch) is required only when a browser is actually
+// running for the data dir and it is not already proxied to the requesting
+// instance — with an unknown owner treated as "not this instance".
+func TestShouldSwitchBrowser(t *testing.T) {
+	cases := []struct {
+		name    string
+		running bool
+		active  string
+		key     string
+		want    bool
+	}{
+		{"none running", false, "", "fleet/b", false},
+		{"none running, stale active", false, "fleet/a", "fleet/b", false},
+		{"running, same instance", true, "fleet/b", "fleet/b", false},
+		{"running, different instance", true, "fleet/a", "fleet/b", true},
+		{"running, unknown owner", true, "", "fleet/b", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldSwitchBrowser(tc.running, tc.active, tc.key); got != tc.want {
+				t.Errorf("shouldSwitchBrowser(running=%v, active=%q, key=%q) = %v, want %v",
+					tc.running, tc.active, tc.key, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tui/control.go
+++ b/internal/tui/control.go
@@ -1,0 +1,181 @@
+package tui
+
+import (
+	"sync"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/control"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// ===========================================
+// Control Registry
+// ===========================================
+
+// controlEvent carries a single Envelope received on an instance's control
+// socket along with the key of the instance it came from. The host TUI keys
+// listeners (and thus events) by "<fleet>/<instance>" so it can resolve the
+// originating instance when it dispatches the message — e.g. to find the
+// backend and browser data dir for a browser.open request.
+type controlEvent struct {
+	// instanceKey is "<fleet>/<instance>" — the same form fleet uses for
+	// browser proxy bookkeeping (see fleetName + "/" + instance.Name).
+	instanceKey string
+	// env is the decoded control Envelope; the consumer switches on env.Type.
+	env control.Envelope
+}
+
+// controlRegistry owns one control.Server per running instance and funnels
+// every received Envelope into a single channel the Bubble Tea loop drains.
+//
+// The host can only receive control messages from instances it is currently
+// listening for, so the registry's job is to keep its set of listeners in
+// lock-step with the set of running instances. reload() drives that via
+// syncRunning on every state refresh; shutdown() tears every listener down
+// when the TUI exits. All three operations are concurrency-safe because the
+// registry is shared between the bubbletea model (passed by value) and the
+// per-server handler goroutines.
+type controlRegistry struct {
+	// mu guards servers so syncRunning and shutdown can run while handler
+	// goroutines are live without racing on the map.
+	mu sync.Mutex
+	// servers maps instanceKey → its running listener. An entry exists exactly
+	// while a listener is open for that instance.
+	servers map[string]*control.Server
+	// events is the single sink every per-instance handler writes to. It is
+	// buffered so a burst of messages (or a slow bubbletea tick) doesn't block
+	// the handler goroutine inside control.Server.
+	events chan controlEvent
+}
+
+// newControlRegistry creates an empty registry with a buffered event channel.
+// The buffer (16) absorbs short bursts of control messages without blocking
+// the server's handler goroutines while the bubbletea loop catches up.
+func newControlRegistry() *controlRegistry {
+	return &controlRegistry{
+		servers: make(map[string]*control.Server),
+		events:  make(chan controlEvent, 16),
+	}
+}
+
+// syncRunning reconciles the registry's listeners against the set of running
+// instances in st. It starts a listener for every running instance that lacks
+// one and Closes (and drops) listeners for instances that are gone or no
+// longer running. It is idempotent and safe to call on every reload — the
+// common case (no change to the running set) does nothing.
+//
+// Starting a listener is best-effort: a Listen failure (e.g. the per-instance
+// control directory could not be created) is swallowed so a single bad
+// instance can't break the registry or the reload that called it. The instance
+// simply won't have host-side control until the next sync succeeds.
+func (r *controlRegistry) syncRunning(st *state.State) {
+	if st == nil {
+		return
+	}
+
+	// Snapshot the desired set: every currently-running instance, keyed the
+	// same way the registry keys its servers.
+	want := make(map[string]struct{})
+	for fleetName, f := range st.Fleets {
+		for _, instance := range f.Instances {
+			if instance.Status == fleet.StatusRunning {
+				want[fleetName+"/"+instance.Name] = struct{}{}
+			}
+		}
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Drop listeners for instances that are gone or no longer running.
+	for key, srv := range r.servers {
+		if _, ok := want[key]; !ok {
+			srv.Close()
+			delete(r.servers, key)
+		}
+	}
+
+	// Start listeners for running instances that lack one.
+	for key := range want {
+		if _, ok := r.servers[key]; ok {
+			continue
+		}
+		fleetName, instanceName, ok := splitInstanceKey(key)
+		if !ok {
+			continue
+		}
+		socketPath := state.ControlSocketPath(fleetName, instanceName)
+		// Capture key for the handler closure so every Envelope is tagged with
+		// the instance it arrived from. The handler may run on multiple
+		// goroutines; sending to a buffered channel is safe for concurrent use.
+		//
+		// The send is NON-BLOCKING (select+default) and that matters for more
+		// than burst tolerance: the handler runs synchronously inside
+		// control.Server.serveConn, whose goroutine is tracked by the server's
+		// WaitGroup, and control.Server.Close waits on that WaitGroup. A blocking
+		// send on a full buffer would wedge serveConn, so any Close of this server
+		// would hang forever on wg.Wait(). That fires at shutdown (the drained-no-
+		// longer Run loop has stopped reading r.events) and, worse, mid-session:
+		// reload → syncRunning → srv.Close runs on the bubbletea Update goroutine,
+		// which is the very goroutine that drains r.events, so a blocked handler
+		// would deadlock the whole UI. Dropping on a full buffer (acceptable for
+		// browser.open bursts) keeps serveConn — and therefore Close — unblockable.
+		srv, err := control.Listen(socketPath, func(env control.Envelope) {
+			select {
+			case r.events <- controlEvent{instanceKey: key, env: env}:
+			default:
+				// Buffer full: drop rather than block the serveConn goroutine
+				// (and any Close waiting on the server's WaitGroup).
+			}
+		})
+		if err != nil {
+			// Best-effort: a listen failure leaves this instance without
+			// host-side control until the next sync. Don't fail the reload.
+			continue
+		}
+		r.servers[key] = srv
+	}
+}
+
+// shutdown closes every listener the registry owns and clears the set. Called
+// once when the TUI exits so the host releases the socket files it created.
+func (r *controlRegistry) shutdown() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for key, srv := range r.servers {
+		srv.Close()
+		delete(r.servers, key)
+	}
+}
+
+// splitInstanceKey splits a "<fleet>/<instance>" key back into its two parts.
+// It returns ok=false for a malformed key (no separator) so callers can skip
+// it rather than listen on a path derived from garbage.
+func splitInstanceKey(key string) (fleetName, instanceName string, ok bool) {
+	for i := 0; i < len(key); i++ {
+		if key[i] == '/' {
+			return key[:i], key[i+1:], true
+		}
+	}
+	return "", "", false
+}
+
+// ===========================================
+// Messages
+// ===========================================
+
+// controlEventMsg delivers a controlEvent into the bubbletea Update loop. The
+// model-level Update switches on the wrapped env.Type to dispatch the message
+// (e.g. TypeOpenBrowser → openControlBrowserCmd) and then re-arms the waiter.
+type controlEventMsg controlEvent
+
+// waitForControlEventCmd returns a tea.Cmd that blocks on the registry's event
+// channel and delivers the next controlEvent as a controlEventMsg. The loop
+// re-issues this command after handling each event, so a single in-flight
+// waiter continuously drains the channel for the life of the program.
+func waitForControlEventCmd(ch <-chan controlEvent) tea.Cmd {
+	return func() tea.Msg {
+		return controlEventMsg(<-ch)
+	}
+}

--- a/internal/tui/control_test.go
+++ b/internal/tui/control_test.go
@@ -1,0 +1,235 @@
+package tui
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/control"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// waitForSocket polls path until it exists or the deadline passes. The control
+// listener creates the socket file synchronously inside Listen, but syncRunning
+// runs it best-effort, so the test waits rather than assuming instantaneous
+// appearance on a loaded machine.
+func waitForSocket(t *testing.T, path string, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// fabricatedRunningState builds a *state.State containing one running instance
+// in one fleet, the minimal shape syncRunning keys its listeners off.
+func fabricatedRunningState(fleetName, instanceName string) *state.State {
+	inst := &fleet.Instance{Name: instanceName, Status: fleet.StatusRunning}
+	f := &fleet.Fleet{Name: fleetName, Instances: []*fleet.Instance{inst}}
+	return &state.State{Fleets: map[string]*fleet.Fleet{fleetName: f}}
+}
+
+// TestSyncRunningRoundTrip verifies the full host-side path: syncRunning starts
+// a listener for a running instance (its socket file appears), an in-instance
+// client.OpenBrowser round-trips an event onto the registry's events channel
+// tagged with the right instance key, and a stopped instance's listener is
+// dropped on the next sync.
+func TestSyncRunningRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const (
+		fleetName    = "alpha"
+		instanceName = "i1"
+	)
+	key := fleetName + "/" + instanceName
+
+	r := newControlRegistry()
+	defer r.shutdown()
+
+	// 1. Start a listener for the running instance.
+	r.syncRunning(fabricatedRunningState(fleetName, instanceName))
+
+	socketPath := state.ControlSocketPath(fleetName, instanceName)
+	if !waitForSocket(t, socketPath, 2*time.Second) {
+		t.Fatalf("control socket %q never appeared after syncRunning", socketPath)
+	}
+	if _, ok := r.servers[key]; !ok {
+		t.Fatalf("registry has no server for running instance %q", key)
+	}
+
+	// 2. Dial as the in-instance client would and send a browser.open.
+	client, err := control.Dial(socketPath)
+	if err != nil {
+		t.Fatalf("Dial(%q): %v", socketPath, err)
+	}
+	defer client.Close()
+
+	const wantURL = "http://localhost:3000"
+	if err := client.OpenBrowser(wantURL); err != nil {
+		t.Fatalf("OpenBrowser: %v", err)
+	}
+
+	// 3. The event arrives on the registry channel, correctly tagged.
+	select {
+	case ev := <-r.events:
+		if ev.instanceKey != key {
+			t.Errorf("event instanceKey = %q, want %q", ev.instanceKey, key)
+		}
+		if ev.env.Type != control.TypeOpenBrowser {
+			t.Errorf("event Type = %q, want %q", ev.env.Type, control.TypeOpenBrowser)
+		}
+		var p control.OpenBrowserPayload
+		if err := json.Unmarshal(ev.env.Payload, &p); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if p.URL != wantURL {
+			t.Errorf("payload URL = %q, want %q", p.URL, wantURL)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for control event on registry channel")
+	}
+
+	// 4. When the instance is no longer running, the next sync drops it.
+	r.syncRunning(&state.State{Fleets: map[string]*fleet.Fleet{}})
+	if _, ok := r.servers[key]; ok {
+		t.Fatalf("registry still has server for stopped instance %q", key)
+	}
+}
+
+// TestShutdownFullBuffer is the regression guard for the blocked-send
+// deadlock: the per-instance handler's send to r.events must be non-blocking.
+// If a client floods more browser.open messages than the events buffer holds
+// while nothing drains the channel, the handler goroutines must drop the
+// overflow rather than block inside control.Server.serveConn — otherwise the
+// server's WaitGroup never unwinds and shutdown() (which calls Server.Close →
+// wg.Wait) hangs forever. The test sends far more than the buffer's capacity
+// with no drainer, then asserts shutdown() returns promptly. (The test name is
+// kept short so the temp-HOME socket path stays under the unix sun_path limit.)
+func TestShutdownFullBuffer(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const (
+		fleetName    = "alpha"
+		instanceName = "i1"
+	)
+
+	r := newControlRegistry()
+
+	r.syncRunning(fabricatedRunningState(fleetName, instanceName))
+	socketPath := state.ControlSocketPath(fleetName, instanceName)
+	if !waitForSocket(t, socketPath, 2*time.Second) {
+		t.Fatalf("control socket %q never appeared after syncRunning", socketPath)
+	}
+
+	client, err := control.Dial(socketPath)
+	if err != nil {
+		t.Fatalf("Dial(%q): %v", socketPath, err)
+	}
+	defer client.Close()
+
+	// Send well beyond the events buffer (16) with nothing draining it, so the
+	// handler hits the full-buffer path repeatedly.
+	for i := 0; i < 256; i++ {
+		if err := client.OpenBrowser("http://localhost:3000"); err != nil {
+			t.Fatalf("OpenBrowser #%d: %v", i, err)
+		}
+	}
+
+	// shutdown must return promptly even though the buffer is full and undrained.
+	done := make(chan struct{})
+	go func() {
+		r.shutdown()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("shutdown() hung with a full, undrained events buffer (blocked-send deadlock)")
+	}
+}
+
+// TestSyncRunningIdempotent verifies repeated syncs against an unchanged
+// running set neither leak nor recreate listeners: the same server pointer is
+// kept across calls.
+func TestSyncRunningIdempotent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const (
+		fleetName    = "alpha"
+		instanceName = "i1"
+	)
+	key := fleetName + "/" + instanceName
+
+	r := newControlRegistry()
+	defer r.shutdown()
+
+	st := fabricatedRunningState(fleetName, instanceName)
+	r.syncRunning(st)
+	first := r.servers[key]
+	if first == nil {
+		t.Fatalf("no server after first sync")
+	}
+
+	r.syncRunning(st)
+	if second := r.servers[key]; second != first {
+		t.Fatalf("second sync replaced the server pointer (%p → %p)", first, second)
+	}
+	if len(r.servers) != 1 {
+		t.Fatalf("server count = %d, want 1", len(r.servers))
+	}
+}
+
+// TestWaitForControlEventCmd verifies the waiter command returns the queued
+// event wrapped as a controlEventMsg.
+func TestWaitForControlEventCmd(t *testing.T) {
+	ch := make(chan controlEvent, 1)
+	want := controlEvent{
+		instanceKey: "alpha/i1",
+		env:         control.Envelope{Type: control.TypeOpenBrowser},
+	}
+	ch <- want
+
+	msg := waitForControlEventCmd(ch)()
+
+	got, ok := msg.(controlEventMsg)
+	if !ok {
+		t.Fatalf("msg type = %T, want controlEventMsg", msg)
+	}
+	if got.instanceKey != want.instanceKey {
+		t.Errorf("instanceKey = %q, want %q", got.instanceKey, want.instanceKey)
+	}
+	if got.env.Type != want.env.Type {
+		t.Errorf("env.Type = %q, want %q", got.env.Type, want.env.Type)
+	}
+}
+
+// TestSplitInstanceKey covers the "<fleet>/<instance>" splitter, including a
+// malformed key with no separator.
+func TestSplitInstanceKey(t *testing.T) {
+	cases := []struct {
+		key          string
+		wantFleet    string
+		wantInstance string
+		wantOK       bool
+	}{
+		{"alpha/i1", "alpha", "i1", true},
+		{"a/b/c", "a", "b/c", true}, // splits on the first separator
+		{"noseparator", "", "", false},
+		{"", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			f, i, ok := splitInstanceKey(tc.key)
+			if f != tc.wantFleet || i != tc.wantInstance || ok != tc.wantOK {
+				t.Errorf("splitInstanceKey(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tc.key, f, i, ok, tc.wantFleet, tc.wantInstance, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -158,7 +158,7 @@ func (fleetPage *fleetPage) updateConfirmBrowserSwitch(m *model, msg tea.Msg) te
 			// clears the flag and the mode.
 			fleetPage.dialogBrowserSwitching = true
 			m.message = ""
-			return switchBrowserCmd(m.portForwards, instanceBackend, instance, instanceKey, dataDir, f.Settings.PreferFleetLaunchEnabled())
+			return switchBrowserCmd(m.portForwards, instanceBackend, instance, instanceKey, dataDir, f.Settings.PreferFleetLaunchEnabled(), "")
 		}
 	}
 	return nil

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -194,6 +194,17 @@ func (fleetPage *fleetPage) Update(m *model, msg tea.Msg) tea.Cmd {
 			m.message = fmt.Sprintf("Browser proxy error: %v", bpm.err)
 		} else {
 			m.message = fmt.Sprintf("Browser opened (proxy on localhost:%d)", bpm.localPort)
+			// Record which instance the browser bound to this data dir now
+			// serves, so a later control-socket open for a different instance
+			// switches the browser over rather than new-tabbing into the wrong
+			// proxy. Recompute the data dir the same way the open path did.
+			if fleetName, instanceName, ok := splitInstanceKey(bpm.instanceKey); ok {
+				dataDir := browserDataDir(fleetName, instanceName, multipleBrowsersPerFleet(m))
+				if m.activeBrowser == nil {
+					m.activeBrowser = make(map[string]string)
+				}
+				m.activeBrowser[dataDir] = bpm.instanceKey
+			}
 		}
 		// Tear down the switching-spinner dialog if it was active.
 		if fleetPage.dialogBrowserSwitching {


### PR DESCRIPTION
## Summary

- **`fleet launch`** — a new in-instance terminal UI listing the `customizations.fleet.fleetLaunch` **Links** (`sites`) and **Apps** as a compact, themed grid of single-line pills. Navigate with arrows/`hjkl` or the mouse; activating a link opens the host browser to it, activating an app starts its command on its port (if needed), waits, then opens it.
- **Generic control channel (`internal/control`)** — newline-delimited-JSON IPC over a per-instance unix socket (`Client`/`Server`), bind-mounted into each instance at create/clone. The in-instance launcher can't reach the host browser directly (it's proxied via privoxy), so it sends `browser.open` messages to the host fleet TUI, which drives the browser. Built to carry future message types, not just browser control.
- **Headless commands** — `fleet launch list` prints the configured links/apps; `fleet launch <name>` opens one directly (case-insensitive, unique-prefix match — e.g. `fleet launch graf`), with a CLI spinner while an app boots. `fl` alias added to `fleet.rc`.
- **Cross-instance browser switch** — opening for an instance while the (per-fleet, shared) browser is proxied to a *different* instance now auto-switches it over, instead of new-tabbing into the wrong-proxied process.
- **`internal/appstart`** — extracted the shared "start app on port and wait" helper (also used by the landing page) and raised the readiness wait to 60s so cold-starting apps (image pulls, slow servers) don't spuriously fail.
- Note: only instances **created/cloned after this change** get the control-socket mount; pre-existing instances need recreation for in-instance launch to drive the host browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)