### PR TITLE
test(integration): cover fleet launch + control-socket mount (#73)

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -15,6 +15,8 @@ integration/
 │       └── devcontainer.json
 ├── fixture-no-devcontainer/    # repo template deliberately missing a devcontainer
 │                               # config, used by new-fleet check-flow tests
+├── fixture-launch/             # devcontainer with a customizations.fleet.fleetLaunch
+│                               # block (Links + Apps), used by the launch tests
 └── tests/
     ├── 010_up_and_ls.sh        # CLI — up + ls
     ├── 020_exec.sh             # CLI — exec

--- a/integration/common.sh
+++ b/integration/common.sh
@@ -30,6 +30,12 @@ FIXTURE_SRC="${INTEGRATION_DIR}/fixture"
 # into it via setup_agent_test instead of setup_test.
 FIXTURE_AGENT_SRC="${INTEGRATION_DIR}/fixture-agent"
 
+# Alternate fixture whose devcontainer.json carries a populated
+# customizations.fleet.fleetLaunch block (Links + Apps). Tests that
+# exercise `fleet launch` opt into it via setup_launch_test so the
+# in-instance launcher has something to list / resolve.
+FIXTURE_LAUNCH_SRC="${INTEGRATION_DIR}/fixture-launch"
+
 # Test scratch dir created fresh per test.
 TEST_SCRATCH_DIR="${TEST_SCRATCH_DIR:-/tmp/fleet-man-itest}"
 
@@ -204,6 +210,14 @@ setup_test() {
 # they need.
 setup_agent_test() {
   FIXTURE_SRC="${FIXTURE_AGENT_SRC}" setup_test
+}
+
+# setup_launch_test prepares a clean environment whose fixture
+# devcontainer.json declares a customizations.fleet.fleetLaunch block,
+# so the in-instance `fleet launch` subcommands have Links and Apps to
+# list / resolve. Identical to setup_test but uses the launch fixture.
+setup_launch_test() {
+  FIXTURE_SRC="${FIXTURE_LAUNCH_SRC}" setup_test
 }
 
 # seed_fleet_settings writes ~/.fleet/state.json with a fleet record

--- a/integration/fixture-launch/.devcontainer/devcontainer.json
+++ b/integration/fixture-launch/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "fleet-man integration launch fixture",
+  "image": "mcr.microsoft.com/devcontainers/base:debian-12",
+  "customizations": {
+    "fleet": {
+      "fleetLaunch": {
+        "sites": [
+          {
+            "title": "Grafana",
+            "subTitle": "Metrics dashboards",
+            "url": "http://localhost:3000"
+          },
+          {
+            "title": "Project Docs",
+            "url": "https://example.com/docs"
+          }
+        ],
+        "apps": [
+          {
+            "title": "Webapp",
+            "command": "true",
+            "port": 8080
+          }
+        ]
+      }
+    }
+  }
+}

--- a/integration/tests/500_launch_list.sh
+++ b/integration/tests/500_launch_list.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Description: `fleet launch list` inside an instance prints the configured fleetLaunch Links and Apps.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+# Uses the launch fixture, whose devcontainer.json declares a
+# customizations.fleet.fleetLaunch block with two Links (Grafana,
+# Project Docs) and one App (Webapp on :8080).
+setup_launch_test
+
+info "fleet up alpha (launch fixture)"
+fleet_up alpha
+
+# `fleet launch` is meant to be run INSIDE an instance: the host stages
+# the fleet binary at /usr/bin/fleet, and `launch list` auto-detects the
+# workspace devcontainer.json (devcontainer exec lands in the workspace
+# folder). No host control socket is needed for the list form.
+info "fleet exec alpha -- fleet launch list"
+list_out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- fleet launch list)
+info "launch list output:"
+printf '%s\n' "${list_out}"
+
+# Section headers.
+assert_contains "${list_out}" "Links:" "missing Links section header"
+assert_contains "${list_out}" "Apps:"  "missing Apps section header"
+
+# Link entries render as "<title> — <url>".
+assert_contains "${list_out}" "Grafana — http://localhost:3000" \
+  "Grafana link not listed"
+assert_contains "${list_out}" "Project Docs — https://example.com/docs" \
+  "Project Docs link not listed"
+
+# App entries render as "<title> — http://localhost:<port>".
+assert_contains "${list_out}" "Webapp — http://localhost:8080" \
+  "Webapp app not listed"
+
+# Neither section should report itself empty.
+assert_not_contains "${list_out}" "(none)" \
+  "a section was unexpectedly empty"
+
+pass "launch list"

--- a/integration/tests/510_launch_by_name.sh
+++ b/integration/tests/510_launch_by_name.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Description: `fleet launch <name>` resolves names (unknown vs unique prefix)
+# and reports a missing host control socket instead of crashing.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+# Launch fixture: Links "Grafana" + "Project Docs", App "Webapp".
+setup_launch_test
+
+info "fleet up alpha (launch fixture)"
+fleet_up alpha
+
+# 1. An unknown name fails fast at resolution — before any host dial —
+#    and points the user at `fleet launch list`.
+info "fleet exec alpha -- fleet launch nope-not-a-thing (expect resolve error)"
+set +e
+unknown_out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" \
+  -- fleet launch nope-not-a-thing 2>&1)
+unknown_rc=$?
+set -e
+info "output: ${unknown_out}"
+[ "${unknown_rc}" -ne 0 ] || fail "unknown name unexpectedly succeeded"
+assert_contains "${unknown_out}" "no link or app matching" \
+  "unknown name did not produce the expected resolve error"
+
+# 2. A unique case-insensitive prefix ("graf" -> "Grafana") resolves, then
+#    tries to drive the host browser over the control socket. No host fleet
+#    TUI runs in CI, so the socket file never appears in the mounted control
+#    dir and the dial fails with a clear "not connected to host fleet"
+#    message — proving the resolve + socket-dial path ran end to end.
+info "fleet exec alpha -- fleet launch graf (expect not-connected error)"
+set +e
+prefix_out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" \
+  -- fleet launch graf 2>&1)
+prefix_rc=$?
+set -e
+info "output: ${prefix_out}"
+[ "${prefix_rc}" -ne 0 ] || fail "launch graf unexpectedly succeeded without a host TUI"
+assert_contains "${prefix_out}" "not connected to host fleet" \
+  "prefix match did not reach the host-socket dial"
+# It must NOT be a resolution failure — the prefix is unambiguous.
+assert_not_contains "${prefix_out}" "no link or app matching" \
+  "unique prefix 'graf' failed to resolve to Grafana"
+
+pass "launch by name"

--- a/integration/tests/520_control_mount.sh
+++ b/integration/tests/520_control_mount.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Description: creating an instance bind-mounts the per-instance control dir
+# into the container at /fleet-mounts/control (host <-> instance IPC channel).
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+# The default fixture is enough — the control mount is wired by create,
+# independent of any fleetLaunch config.
+setup_test
+
+info "fleet up alpha"
+fleet_up alpha
+
+# Host side: create wires state.ControlDir(fleet, instance) as a bind mount.
+# That host dir lives under the instance's workspace tree and must exist
+# after up (the host fleet TUI later drops the socket file into it).
+host_control_dir="${HOME}/.fleet/workspaces/${FIXTURE_REPO_NAME}/alpha/.control"
+info "asserting host control dir exists: ${host_control_dir}"
+assert_file_exists "${host_control_dir}"
+[ -d "${host_control_dir}" ] || fail "host control path is not a directory: ${host_control_dir}"
+
+# Container side: the dir is mounted at the well-known container path
+# (control.ContainerMountDir = /fleet-mounts/control) that the in-instance
+# launcher dials. The socket file itself is created later by the host TUI,
+# so we assert only the mount directory here.
+info "asserting /fleet-mounts/control is a directory inside the container"
+"${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- test -d /fleet-mounts/control \
+  || fail "/fleet-mounts/control is missing or not a directory inside the instance"
+
+info "asserting /fleet-mounts/control is a real bind mount"
+mountinfo=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- cat /proc/self/mountinfo)
+assert_contains "${mountinfo}" " /fleet-mounts/control " \
+  "/fleet-mounts/control is not a mount point"
+
+# Cross-boundary check: a file the host writes into the control dir is
+# visible inside the container through the bind mount (the mechanism the
+# real socket relies on).
+info "asserting a host-written file in the control dir appears in the container"
+probe="host-probe-$$"
+: > "${host_control_dir}/${probe}"
+container_ls=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- ls /fleet-mounts/control)
+assert_contains "${container_ls}" "${probe}" \
+  "host-written control file did not appear inside the container"
+
+pass "control mount applied"


### PR DESCRIPTION
## Summary

PR #73 ("Fleet Launch TUI + host control socket") shipped thorough **unit** tests but no **integration** coverage for the new end-to-end behavior. This PR adds that — three tests driving the real `fleet` binary against a real devcontainer, plus a dedicated fixture.

## New integration tests

- **`500_launch_list.sh`** — `fleet launch list` inside an instance reads the workspace `devcontainer.json`'s `customizations.fleet.fleetLaunch` block (staged binary + auto-detected config) and prints the configured Links and Apps.
- **`510_launch_by_name.sh`** — `fleet launch <name>` resolution: an unknown name fails fast with a helpful "no link or app matching" error, and a unique case-insensitive prefix (`graf` → Grafana) resolves through to the host-socket dial, which reports "not connected to host fleet" (no host TUI runs in CI).
- **`520_control_mount.sh`** — `fleet up` bind-mounts the per-instance control dir into the container at `/fleet-mounts/control`, the host-side `.control` dir exists, and a host-written file in that dir is visible inside the instance.

## Supporting changes

- `integration/fixture-launch/` — devcontainer whose `fleetLaunch` block declares two Links (Grafana, Project Docs) and one App (Webapp:8080).
- `setup_launch_test` helper in `common.sh`, mirroring the existing `setup_agent_test` pattern.
- README layout note for the new fixture.

The fixture reuses the same `debian-12` base image `run.sh` already pre-pulls, so no driver changes were needed.

## Testing

All three tests pass locally against real Docker + the devcontainer CLI. The change is scoped entirely to `integration/` — no production code touched. This PR exists primarily to run the suite through the CI integration pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)