### PR TITLE
feat/fleet-event-log Add ~/.fleet/fleet.log event log with timing & session tracing

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -52,18 +52,21 @@ type Backend interface {
 	// Stdin, stdout, and stderr are connected to the caller's terminal.
 	Exec(workspaceDir string, command []string) error
 
-	// ExecCommand returns an unstarted *exec.Cmd for running a command
-	// inside a workspace. The caller controls stdio and lifecycle. It
-	// writes a "container exec" entry to the event log (~/.fleet/fleet.log)
-	// so container commands are traceable by default; use it for everything
-	// except hot polling loops.
-	ExecCommand(workspaceDir string, command []string) *exec.Cmd
+	// ExecCommand returns an unstarted *Cmd for running a command inside a
+	// workspace. The caller controls stdio and lifecycle. Because *Cmd
+	// shadows the run methods, it writes a single timed "container exec"
+	// entry to the event log (~/.fleet/fleet.log) when the caller runs it via
+	// Run/Output/CombinedOutput. Use it for everything except hot polling
+	// loops. Callers needing the raw *exec.Cmd reach it via the returned
+	// value's embedded .Cmd field (which forgoes the log entry).
+	ExecCommand(workspaceDir string, command []string) *Cmd
 
-	// ExecCommandQuiet is ExecCommand without the event-log entry. Use it
-	// from high-frequency polling and probe loops (e.g. the periodic tmux
-	// session discovery) where logging every command would flood the event
-	// log. Behaviour is otherwise identical to ExecCommand.
-	ExecCommandQuiet(workspaceDir string, command []string) *exec.Cmd
+	// ExecCommandQuiet is ExecCommand without any event-log entries (its
+	// *Cmd carries no completion callback). Use it from high-frequency
+	// polling and probe loops (e.g. the periodic tmux session discovery)
+	// where logging every command would flood the event log. Behaviour is
+	// otherwise identical to ExecCommand.
+	ExecCommandQuiet(workspaceDir string, command []string) *Cmd
 
 	// Stats returns CPU and memory usage for the given container IDs.
 	Stats(containerIDs []string) (map[string]*ContainerStats, error)

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -53,8 +53,17 @@ type Backend interface {
 	Exec(workspaceDir string, command []string) error
 
 	// ExecCommand returns an unstarted *exec.Cmd for running a command
-	// inside a workspace. The caller controls stdio and lifecycle.
+	// inside a workspace. The caller controls stdio and lifecycle. It
+	// writes a "container exec" entry to the event log (~/.fleet/fleet.log)
+	// so container commands are traceable by default; use it for everything
+	// except hot polling loops.
 	ExecCommand(workspaceDir string, command []string) *exec.Cmd
+
+	// ExecCommandQuiet is ExecCommand without the event-log entry. Use it
+	// from high-frequency polling and probe loops (e.g. the periodic tmux
+	// session discovery) where logging every command would flood the event
+	// log. Behaviour is otherwise identical to ExecCommand.
+	ExecCommandQuiet(workspaceDir string, command []string) *exec.Cmd
 
 	// Stats returns CPU and memory usage for the given container IDs.
 	Stats(containerIDs []string) (map[string]*ContainerStats, error)

--- a/internal/backend/cmd.go
+++ b/internal/backend/cmd.go
@@ -1,0 +1,65 @@
+package backend
+
+import (
+	"os/exec"
+	"time"
+)
+
+// Cmd wraps an *exec.Cmd built by a Backend's ExecCommand so the command's
+// completion can be observed even though the caller — not the backend — runs
+// it. exec.Cmd offers no completion hook (a context only interrupts the
+// process; there is no "on exit" callback), so we embed *exec.Cmd and shadow
+// the three run-to-completion methods (Run, Output, CombinedOutput), invoking
+// an onDone callback the backend registered. The embedded *exec.Cmd is
+// promoted, so callers still set Stdin/Stdout/Stderr, read Args, etc. exactly
+// as they would on a plain *exec.Cmd.
+//
+// Callers that need the raw *exec.Cmd — e.g. to hand to tea.ExecProcess, which
+// requires that concrete type — reach it through the embedded field: cmd.Cmd.
+type Cmd struct {
+	*exec.Cmd
+	// onDone, if non-nil, is called with the run duration and result after
+	// Run/Output/CombinedOutput finish. ExecCommand sets it to log a single
+	// timed "container exec" event; ExecCommandQuiet leaves it nil so polling
+	// loops stay silent.
+	onDone func(time.Duration, error)
+}
+
+// NewCmd wraps raw with an optional completion callback. A nil onDone makes
+// the run methods behave exactly like the underlying *exec.Cmd.
+func NewCmd(raw *exec.Cmd, onDone func(time.Duration, error)) *Cmd {
+	return &Cmd{Cmd: raw, onDone: onDone}
+}
+
+// Run shadows exec.Cmd.Run, timing the call and firing onDone on completion.
+func (c *Cmd) Run() error {
+	start := time.Now()
+	err := c.Cmd.Run()
+	c.fireDone(start, err)
+	return err
+}
+
+// Output shadows exec.Cmd.Output. exec.Cmd.Output internally calls the
+// embedded Run via static dispatch (not this wrapper's Run), so onDone fires
+// exactly once per call.
+func (c *Cmd) Output() ([]byte, error) {
+	start := time.Now()
+	out, err := c.Cmd.Output()
+	c.fireDone(start, err)
+	return out, err
+}
+
+// CombinedOutput shadows exec.Cmd.CombinedOutput, with the same single-fire
+// guarantee as Output.
+func (c *Cmd) CombinedOutput() ([]byte, error) {
+	start := time.Now()
+	out, err := c.Cmd.CombinedOutput()
+	c.fireDone(start, err)
+	return out, err
+}
+
+func (c *Cmd) fireDone(start time.Time, err error) {
+	if c.onDone != nil {
+		c.onDone(time.Since(start), err)
+	}
+}

--- a/internal/backend/coder/coder_backend.go
+++ b/internal/backend/coder/coder_backend.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 )
 
 // CoderBackend implements backend.Backend using the Coder CLI.
@@ -150,6 +151,7 @@ func (coderBackend *CoderBackend) Start(containerID string) error {
 
 // Exec runs an interactive command inside a Coder workspace via SSH.
 func (coderBackend *CoderBackend) Exec(workspaceDir string, command []string) error {
+	flog.ContainerExec("coder", workspaceDir, command)
 	name := coderWorkspaceName(workspaceDir)
 	target := coderBackend.resolveSSHTarget(name)
 	args := sshArgs(target, command)
@@ -161,8 +163,15 @@ func (coderBackend *CoderBackend) Exec(workspaceDir string, command []string) er
 }
 
 // ExecCommand returns an unstarted *exec.Cmd for running a command
-// inside a Coder workspace via SSH.
+// inside a Coder workspace via SSH, logging the command to the event
+// log. Hot polling loops should use ExecCommandQuiet instead.
 func (coderBackend *CoderBackend) ExecCommand(workspaceDir string, command []string) *exec.Cmd {
+	flog.ContainerExec("coder", workspaceDir, command)
+	return coderBackend.ExecCommandQuiet(workspaceDir, command)
+}
+
+// ExecCommandQuiet is ExecCommand without the event-log entry.
+func (coderBackend *CoderBackend) ExecCommandQuiet(workspaceDir string, command []string) *exec.Cmd {
 	name := coderWorkspaceName(workspaceDir)
 	target := coderBackend.resolveSSHTarget(name)
 	args := sshArgs(target, command)

--- a/internal/backend/coder/coder_backend.go
+++ b/internal/backend/coder/coder_backend.go
@@ -149,29 +149,37 @@ func (coderBackend *CoderBackend) Start(containerID string) error {
 	return nil
 }
 
-// Exec runs an interactive command inside a Coder workspace via SSH.
+// Exec runs an interactive command inside a Coder workspace via SSH, logging
+// a single timed "container exec" event when it completes.
 func (coderBackend *CoderBackend) Exec(workspaceDir string, command []string) error {
-	flog.ContainerExec("coder", workspaceDir, command)
-	name := coderWorkspaceName(workspaceDir)
-	target := coderBackend.resolveSSHTarget(name)
-	args := sshArgs(target, command)
-	cmd := exec.Command("coder", args...)
+	cmd := coderBackend.rawExec(workspaceDir, command)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	start := time.Now()
+	err := cmd.Run()
+	flog.ContainerExec("coder", workspaceDir, command, time.Since(start), err)
+	return err
 }
 
-// ExecCommand returns an unstarted *exec.Cmd for running a command
-// inside a Coder workspace via SSH, logging the command to the event
-// log. Hot polling loops should use ExecCommandQuiet instead.
-func (coderBackend *CoderBackend) ExecCommand(workspaceDir string, command []string) *exec.Cmd {
-	flog.ContainerExec("coder", workspaceDir, command)
-	return coderBackend.ExecCommandQuiet(workspaceDir, command)
+// ExecCommand returns an unstarted *backend.Cmd for running a command inside
+// a Coder workspace via SSH. Because *Cmd shadows the run methods, it logs a
+// single timed "container exec" event when the caller runs it via
+// Run/Output/CombinedOutput. Hot polling loops should use ExecCommandQuiet.
+func (coderBackend *CoderBackend) ExecCommand(workspaceDir string, command []string) *backend.Cmd {
+	return backend.NewCmd(coderBackend.rawExec(workspaceDir, command), func(d time.Duration, err error) {
+		flog.ContainerExec("coder", workspaceDir, command, d, err)
+	})
 }
 
-// ExecCommandQuiet is ExecCommand without the event-log entry.
-func (coderBackend *CoderBackend) ExecCommandQuiet(workspaceDir string, command []string) *exec.Cmd {
+// ExecCommandQuiet is ExecCommand without any event-log entries.
+func (coderBackend *CoderBackend) ExecCommandQuiet(workspaceDir string, command []string) *backend.Cmd {
+	return backend.NewCmd(coderBackend.rawExec(workspaceDir, command), nil)
+}
+
+// rawExec builds the underlying `coder ssh` *exec.Cmd shared by ExecCommand
+// and ExecCommandQuiet.
+func (coderBackend *CoderBackend) rawExec(workspaceDir string, command []string) *exec.Cmd {
 	name := coderWorkspaceName(workspaceDir)
 	target := coderBackend.resolveSSHTarget(name)
 	args := sshArgs(target, command)

--- a/internal/backend/codespaces/codespaces_backend.go
+++ b/internal/backend/codespaces/codespaces_backend.go
@@ -175,27 +175,37 @@ func (codespacesBackend *CodespacesBackend) Start(containerID string) error {
 // Execution
 // ===========================================
 
-// Exec runs an interactive command inside a codespace via SSH.
+// Exec runs an interactive command inside a codespace via SSH, logging a
+// single timed "container exec" event when it completes.
 func (codespacesBackend *CodespacesBackend) Exec(workspaceDir string, command []string) error {
-	flog.ContainerExec("codespaces", workspaceDir, command)
-	name := codespacesBackend.resolveCodespaceName(workspaceDir)
-	cmd := codespacesBackend.sshCommand(name, command, true)
+	cmd := codespacesBackend.rawExec(workspaceDir, command)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	start := time.Now()
+	err := cmd.Run()
+	flog.ContainerExec("codespaces", workspaceDir, command, time.Since(start), err)
+	return err
 }
 
-// ExecCommand returns an unstarted *exec.Cmd for running a command
-// inside a codespace via SSH, logging the command to the event log.
-// Hot polling loops should use ExecCommandQuiet instead.
-func (codespacesBackend *CodespacesBackend) ExecCommand(workspaceDir string, command []string) *exec.Cmd {
-	flog.ContainerExec("codespaces", workspaceDir, command)
-	return codespacesBackend.ExecCommandQuiet(workspaceDir, command)
+// ExecCommand returns an unstarted *backend.Cmd for running a command inside
+// a codespace via SSH. Because *Cmd shadows the run methods, it logs a single
+// timed "container exec" event when the caller runs it via
+// Run/Output/CombinedOutput. Hot polling loops should use ExecCommandQuiet.
+func (codespacesBackend *CodespacesBackend) ExecCommand(workspaceDir string, command []string) *backend.Cmd {
+	return backend.NewCmd(codespacesBackend.rawExec(workspaceDir, command), func(d time.Duration, err error) {
+		flog.ContainerExec("codespaces", workspaceDir, command, d, err)
+	})
 }
 
-// ExecCommandQuiet is ExecCommand without the event-log entry.
-func (codespacesBackend *CodespacesBackend) ExecCommandQuiet(workspaceDir string, command []string) *exec.Cmd {
+// ExecCommandQuiet is ExecCommand without any event-log entries.
+func (codespacesBackend *CodespacesBackend) ExecCommandQuiet(workspaceDir string, command []string) *backend.Cmd {
+	return backend.NewCmd(codespacesBackend.rawExec(workspaceDir, command), nil)
+}
+
+// rawExec builds the underlying `gh codespace ssh` *exec.Cmd shared by
+// ExecCommand and ExecCommandQuiet.
+func (codespacesBackend *CodespacesBackend) rawExec(workspaceDir string, command []string) *exec.Cmd {
 	name := codespacesBackend.resolveCodespaceName(workspaceDir)
 	return codespacesBackend.sshCommand(name, command, true)
 }

--- a/internal/backend/codespaces/codespaces_backend.go
+++ b/internal/backend/codespaces/codespaces_backend.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 )
 
 // ===========================================
@@ -176,6 +177,7 @@ func (codespacesBackend *CodespacesBackend) Start(containerID string) error {
 
 // Exec runs an interactive command inside a codespace via SSH.
 func (codespacesBackend *CodespacesBackend) Exec(workspaceDir string, command []string) error {
+	flog.ContainerExec("codespaces", workspaceDir, command)
 	name := codespacesBackend.resolveCodespaceName(workspaceDir)
 	cmd := codespacesBackend.sshCommand(name, command, true)
 	cmd.Stdin = os.Stdin
@@ -185,8 +187,15 @@ func (codespacesBackend *CodespacesBackend) Exec(workspaceDir string, command []
 }
 
 // ExecCommand returns an unstarted *exec.Cmd for running a command
-// inside a codespace via SSH.
+// inside a codespace via SSH, logging the command to the event log.
+// Hot polling loops should use ExecCommandQuiet instead.
 func (codespacesBackend *CodespacesBackend) ExecCommand(workspaceDir string, command []string) *exec.Cmd {
+	flog.ContainerExec("codespaces", workspaceDir, command)
+	return codespacesBackend.ExecCommandQuiet(workspaceDir, command)
+}
+
+// ExecCommandQuiet is ExecCommand without the event-log entry.
+func (codespacesBackend *CodespacesBackend) ExecCommandQuiet(workspaceDir string, command []string) *exec.Cmd {
 	name := codespacesBackend.resolveCodespaceName(workspaceDir)
 	return codespacesBackend.sshCommand(name, command, true)
 }

--- a/internal/backend/devcontainer/devcontainer_backend.go
+++ b/internal/backend/devcontainer/devcontainer_backend.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 	"github.com/BenjaminBenetti/fleet-man/internal/flog"
@@ -169,27 +170,37 @@ func devcontainerEnv(base []string) ([]string, error) {
 	}
 }
 
-// Exec runs `devcontainer exec` in the given workspace folder.
+// Exec runs `devcontainer exec` in the given workspace folder, logging a
+// single timed "container exec" event when it completes.
 func (devcontainerBackend *DevcontainerBackend) Exec(workspaceDir string, command []string) error {
-	flog.ContainerExec("devcontainer", workspaceDir, command)
-	args := execArgs(workspaceDir, command)
-	cmd := exec.Command("devcontainer", args...)
+	cmd := devcontainerBackend.rawExec(workspaceDir, command)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	start := time.Now()
+	err := cmd.Run()
+	flog.ContainerExec("devcontainer", workspaceDir, command, time.Since(start), err)
+	return err
 }
 
-// ExecCommand returns an unstarted *exec.Cmd for running a command
-// inside a workspace via `devcontainer exec`, logging the command to the
-// event log. Hot polling loops should use ExecCommandQuiet instead.
-func (devcontainerBackend *DevcontainerBackend) ExecCommand(workspaceDir string, command []string) *exec.Cmd {
-	flog.ContainerExec("devcontainer", workspaceDir, command)
-	return devcontainerBackend.ExecCommandQuiet(workspaceDir, command)
+// ExecCommand returns an unstarted *backend.Cmd for running a command inside
+// a workspace via `devcontainer exec`. Because *Cmd shadows the run methods,
+// it logs a single timed "container exec" event when the caller runs it via
+// Run/Output/CombinedOutput. Hot polling loops should use ExecCommandQuiet.
+func (devcontainerBackend *DevcontainerBackend) ExecCommand(workspaceDir string, command []string) *backend.Cmd {
+	return backend.NewCmd(devcontainerBackend.rawExec(workspaceDir, command), func(d time.Duration, err error) {
+		flog.ContainerExec("devcontainer", workspaceDir, command, d, err)
+	})
 }
 
-// ExecCommandQuiet is ExecCommand without the event-log entry.
-func (devcontainerBackend *DevcontainerBackend) ExecCommandQuiet(workspaceDir string, command []string) *exec.Cmd {
+// ExecCommandQuiet is ExecCommand without any event-log entries.
+func (devcontainerBackend *DevcontainerBackend) ExecCommandQuiet(workspaceDir string, command []string) *backend.Cmd {
+	return backend.NewCmd(devcontainerBackend.rawExec(workspaceDir, command), nil)
+}
+
+// rawExec builds the underlying `devcontainer exec` *exec.Cmd shared by
+// ExecCommand and ExecCommandQuiet.
+func (devcontainerBackend *DevcontainerBackend) rawExec(workspaceDir string, command []string) *exec.Cmd {
 	args := execArgs(workspaceDir, command)
 	return exec.Command("devcontainer", args...)
 }

--- a/internal/backend/devcontainer/devcontainer_backend.go
+++ b/internal/backend/devcontainer/devcontainer_backend.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 )
 
 // DevcontainerBackend implements backend.Backend using the devcontainer
@@ -170,6 +171,7 @@ func devcontainerEnv(base []string) ([]string, error) {
 
 // Exec runs `devcontainer exec` in the given workspace folder.
 func (devcontainerBackend *DevcontainerBackend) Exec(workspaceDir string, command []string) error {
+	flog.ContainerExec("devcontainer", workspaceDir, command)
 	args := execArgs(workspaceDir, command)
 	cmd := exec.Command("devcontainer", args...)
 	cmd.Stdin = os.Stdin
@@ -179,8 +181,15 @@ func (devcontainerBackend *DevcontainerBackend) Exec(workspaceDir string, comman
 }
 
 // ExecCommand returns an unstarted *exec.Cmd for running a command
-// inside a workspace via `devcontainer exec`.
+// inside a workspace via `devcontainer exec`, logging the command to the
+// event log. Hot polling loops should use ExecCommandQuiet instead.
 func (devcontainerBackend *DevcontainerBackend) ExecCommand(workspaceDir string, command []string) *exec.Cmd {
+	flog.ContainerExec("devcontainer", workspaceDir, command)
+	return devcontainerBackend.ExecCommandQuiet(workspaceDir, command)
+}
+
+// ExecCommandQuiet is ExecCommand without the event-log entry.
+func (devcontainerBackend *DevcontainerBackend) ExecCommandQuiet(workspaceDir string, command []string) *exec.Cmd {
 	args := execArgs(workspaceDir, command)
 	return exec.Command("devcontainer", args...)
 }

--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/flog"
@@ -28,6 +29,7 @@ func newDestroyCmd() *cobra.Command {
 				return fmt.Errorf("fleet %q not found", fleetName)
 			}
 
+			start := time.Now()
 			for _, instance := range f.Instances {
 				fmt.Printf("Stopping %s/%s...\n", fleetName, instance.Name)
 				instanceBackend := backendutil.New(instance.Backend, false)
@@ -47,7 +49,7 @@ func newDestroyCmd() *cobra.Command {
 				return err
 			}
 
-			flog.Info("fleet destroyed", "fleet", fleetName, "instances", len(f.Instances))
+			flog.Info("fleet destroyed", "fleet", fleetName, "instances", len(f.Instances), "ms", flog.MillisSince(start))
 			fmt.Printf("Fleet %s destroyed (%d instances removed).\n", fleetName, len(f.Instances))
 			return nil
 		},

--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	"github.com/spf13/cobra"
 )
@@ -46,6 +47,7 @@ func newDestroyCmd() *cobra.Command {
 				return err
 			}
 
+			flog.Info("fleet destroyed", "fleet", fleetName, "instances", len(f.Instances))
 			fmt.Printf("Fleet %s destroyed (%d instances removed).\n", fleetName, len(f.Instances))
 			return nil
 		},

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	"github.com/spf13/cobra"
 )
@@ -43,6 +44,7 @@ func newDownCmd() *cobra.Command {
 				return err
 			}
 
+			flog.Info("instance deleted", "fleet", target.Fleet, "instance", target.Instance)
 			fmt.Printf("Instance %s/%s removed.\n", target.Fleet, target.Instance)
 			return nil
 		},

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/flog"
@@ -21,6 +22,7 @@ func newDownCmd() *cobra.Command {
 				return err
 			}
 
+			start := time.Now()
 			// Stop the container
 			fmt.Printf("Stopping %s/%s...\n", target.Fleet, target.Instance)
 			instanceBackend := backendutil.New(instance.Backend, false)
@@ -44,7 +46,7 @@ func newDownCmd() *cobra.Command {
 				return err
 			}
 
-			flog.Info("instance deleted", "fleet", target.Fleet, "instance", target.Instance)
+			flog.Info("instance deleted", "fleet", target.Fleet, "instance", target.Instance, "ms", flog.MillisSince(start))
 			fmt.Printf("Instance %s/%s removed.\n", target.Fleet, target.Instance)
 			return nil
 		},

--- a/internal/cli/exec_in_session.go
+++ b/internal/cli/exec_in_session.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/dotfiles"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
@@ -45,11 +46,12 @@ Examples:
 				fmt.Sprintf(`tmux send-keys -t %s %s Enter`, dotfiles.ShQuote(sessionName), dotfiles.ShQuote(command)),
 			})
 
+			start := time.Now()
 			if err := execCmd.Run(); err != nil {
 				return fmt.Errorf("failed to execute command in session %q: %w", sessionName, err)
 			}
 
-			flog.Info("session exec", "instance", args[0], "session", sessionName, "cmd", command)
+			flog.Info("session exec", "instance", args[0], "session", sessionName, "cmd", command, "ms", flog.MillisSince(start))
 			fmt.Printf("Executed command in session %q of instance %s\n", sessionName, args[0])
 			return nil
 		},

--- a/internal/cli/exec_in_session.go
+++ b/internal/cli/exec_in_session.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/BenjaminBenetti/fleet-man/internal/dotfiles"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/spf13/cobra"
 )
 
@@ -48,6 +49,7 @@ Examples:
 				return fmt.Errorf("failed to execute command in session %q: %w", sessionName, err)
 			}
 
+			flog.Info("session exec", "instance", args[0], "session", sessionName, "cmd", command)
 			fmt.Printf("Executed command in session %q of instance %s\n", sessionName, args[0])
 			return nil
 		},

--- a/internal/cli/read_session.go
+++ b/internal/cli/read_session.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/dotfiles"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/spf13/cobra"
 )
 
@@ -54,16 +57,21 @@ Examples:
 			// Stream tmux's capture directly to our stdout so the caller
 			// (typically an AI agent) sees the raw pane contents with no
 			// wrapping noise from this process.
-			captureCmd := sessionExecCommand(instance, []string{
+			readCmd := []string{
 				"sh", "-c",
 				fmt.Sprintf(`tmux capture-pane -p %s-t %s`, startFlag, dotfiles.ShQuote(sessionName)),
-			})
+			}
+			captureCmd := sessionExecCommand(instance, readCmd)
 			captureCmd.Stdout = readSessionStdout
 			captureCmd.Stderr = readSessionStderr
 
-			if err := captureCmd.Run(); err != nil {
+			start := time.Now()
+			err = captureCmd.Run()
+			if err != nil {
+				flog.Error("session read failed", "instance", args[0], "session", sessionName, "cmd", strings.Join(readCmd, " "), "ms", flog.MillisSince(start), "err", err)
 				return fmt.Errorf("failed to read session %q: %w", sessionName, err)
 			}
+			flog.Info("session read", "instance", args[0], "session", sessionName, "cmd", strings.Join(readCmd, " "), "ms", flog.MillisSince(start))
 
 			return nil
 		},

--- a/internal/cli/session_exec.go
+++ b/internal/cli/session_exec.go
@@ -12,5 +12,11 @@ import (
 // Tests override this so commands run against a private tmux server on the
 // host instead of being shelled into a real container.
 var sessionExecCommand = func(instance *fleet.Instance, args []string) *exec.Cmd {
-	return backendutil.NewForInstance(instance, false).ExecCommand(instance.WorkspaceDir, args)
+	// Unwrapping to the raw *exec.Cmd via .Cmd bypasses the wrapper's single
+	// timed "container exec" log. That is intentional: spawn-session and
+	// exec-in-session log their own timed events ("session created" /
+	// "session exec" with ms), so a generic "container exec" would
+	// double-count the same work; read-session is a plain screen read. The
+	// test seam also returns a plain *exec.Cmd, so this layer matches it.
+	return backendutil.NewForInstance(instance, false).ExecCommand(instance.WorkspaceDir, args).Cmd
 }

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -5,8 +5,14 @@ import (
 	"encoding/hex"
 	"os"
 	"os/exec"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	"github.com/BenjaminBenetti/fleet-man/internal/tui"
 	"github.com/spf13/cobra"
@@ -26,7 +32,7 @@ By default, creates a new session group. Use --group to add a pane to an
 existing group, or --session to reconnect to a specific named session.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, _, _, instance, err := resolveInstance(args[0], "")
+			target, _, _, instance, err := resolveInstance(args[0], "")
 			if err != nil {
 				return err
 			}
@@ -69,12 +75,36 @@ existing group, or --session to reconnect to a specific named session.`,
 			cols, rows := termSize()
 
 			shellCmd := tui.ShellCommandForSession(config, sessionName, cols, rows, nested)
+			start := time.Now()
+			// Log the full in-container command (tmux attach + the SSH-agent
+			// socket fix, etc.) at start, and the close with how long the
+			// session ran. We log here and run the raw .Cmd (rather than the
+			// *Cmd wrapper) so there is exactly one open/close pair.
+			flog.Info("session opened", "fleet", target.Fleet, "instance", instance.Name, "session", sessionName, "mode", "shell", "cmd", strings.Join(shellCmd, " "))
+			logClose := sync.OnceFunc(func() {
+				flog.Info("session closed", "fleet", target.Fleet, "instance", instance.Name, "session", sessionName, "mode", "shell", "ms", flog.MillisSince(start))
+			})
+			// fleet shell is interactive and is SIGHUP'd (not gracefully
+			// returned) when its tmux pane is closed/killed, which would
+			// otherwise lose the close timing. Catch the signal, log the
+			// close, and exit. sync.OnceFunc keeps it to a single entry
+			// whether we exit via signal or a normal return.
+			sigCh := make(chan os.Signal, 1)
+			signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGTERM)
+			go func() {
+				<-sigCh
+				logClose()
+				os.Exit(0)
+			}()
+
 			instanceBackend := backendutil.NewForInstance(instance, false)
-			execCmd := instanceBackend.ExecCommand(instance.WorkspaceDir, shellCmd)
+			execCmd := instanceBackend.ExecCommand(instance.WorkspaceDir, shellCmd).Cmd
 			execCmd.Stdin = os.Stdin
 			execCmd.Stdout = os.Stdout
 			execCmd.Stderr = os.Stderr
-			return execCmd.Run()
+			err = execCmd.Run()
+			logClose()
+			return err
 		},
 	}
 

--- a/internal/cli/spawn_session.go
+++ b/internal/cli/spawn_session.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/BenjaminBenetti/fleet-man/internal/dotfiles"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/spf13/cobra"
 )
 
@@ -40,9 +41,11 @@ Examples:
 			})
 
 			if err := createCmd.Run(); err != nil {
+				flog.Error("session create failed", "instance", args[0], "session", sessionName, "err", err)
 				return fmt.Errorf("failed to create session %q: %w", sessionName, err)
 			}
 
+			flog.Info("session created", "instance", args[0], "session", sessionName)
 			fmt.Printf("Created tmux session %q in instance %s\n", sessionName, args[0])
 			return nil
 		},

--- a/internal/cli/spawn_session.go
+++ b/internal/cli/spawn_session.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/dotfiles"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
@@ -40,12 +41,13 @@ Examples:
 				dotfiles.TmuxEnsureInstalled + fmt.Sprintf(`tmux new-session -d -s %s`, dotfiles.ShQuote(sessionName)),
 			})
 
+			start := time.Now()
 			if err := createCmd.Run(); err != nil {
-				flog.Error("session create failed", "instance", args[0], "session", sessionName, "err", err)
+				flog.Error("session create failed", "instance", args[0], "session", sessionName, "ms", flog.MillisSince(start), "err", err)
 				return fmt.Errorf("failed to create session %q: %w", sessionName, err)
 			}
 
-			flog.Info("session created", "instance", args[0], "session", sessionName)
+			flog.Info("session created", "instance", args[0], "session", sessionName, "ms", flog.MillisSince(start))
 			fmt.Printf("Created tmux session %q in instance %s\n", sessionName, args[0])
 			return nil
 		},

--- a/internal/create/clone.go
+++ b/internal/create/clone.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetlaunch"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 )
 
@@ -38,6 +39,7 @@ import (
 // carries their effects. Running them again would diverge the clone
 // from the source.
 func RunClone(fleetName, srcInstance, destInstance string, verbose bool) error {
+	flog.Info("instance clone started", "fleet", fleetName, "src", srcInstance, "instance", destInstance)
 	st, err := state.Load()
 	if err != nil {
 		setFailed(fleetName, destInstance, err)
@@ -129,7 +131,11 @@ func RunClone(fleetName, srcInstance, destInstance string, verbose bool) error {
 		state.WriteWarn(fleetName, destInstance, fmt.Sprintf("setting up agentic mount symlinks: %v", err))
 	}
 
-	return markInstanceRunning(fleetName, destInstance, result.ContainerID)
+	if err := markInstanceRunning(fleetName, destInstance, result.ContainerID); err != nil {
+		return err
+	}
+	flog.Info("instance cloned", "fleet", fleetName, "src", srcInstance, "instance", destInstance, "container", result.ContainerID)
+	return nil
 }
 
 // copyWorkspaceTree runs `cp -a <src>/. <dest>/` so the contents of src

--- a/internal/create/clone.go
+++ b/internal/create/clone.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetlaunch"
@@ -38,8 +39,16 @@ import (
 // scripts: the source already executed those, and the committed image
 // carries their effects. Running them again would diverge the clone
 // from the source.
-func RunClone(fleetName, srcInstance, destInstance string, verbose bool) error {
+func RunClone(fleetName, srcInstance, destInstance string, verbose bool) (err error) {
+	start := time.Now()
 	flog.Info("instance clone started", "fleet", fleetName, "src", srcInstance, "instance", destInstance)
+	// Failure outcome (with elapsed time) is logged from one place; setFailed
+	// only annotates state. Success is logged inline at the end.
+	defer func() {
+		if err != nil {
+			flog.Error("instance clone failed", "fleet", fleetName, "src", srcInstance, "instance", destInstance, "ms", flog.MillisSince(start), "err", err)
+		}
+	}()
 	st, err := state.Load()
 	if err != nil {
 		setFailed(fleetName, destInstance, err)
@@ -134,7 +143,7 @@ func RunClone(fleetName, srcInstance, destInstance string, verbose bool) error {
 	if err := markInstanceRunning(fleetName, destInstance, result.ContainerID); err != nil {
 		return err
 	}
-	flog.Info("instance cloned", "fleet", fleetName, "src", srcInstance, "instance", destInstance, "container", result.ContainerID)
+	flog.Info("instance cloned", "fleet", fleetName, "src", srcInstance, "instance", destInstance, "container", result.ContainerID, "ms", flog.MillisSince(start))
 	return nil
 }
 

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/agentdetect"
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
@@ -28,8 +29,18 @@ import (
 // When branch is non-empty, the devcontainer clone uses `git clone
 // --branch <branch>` so the instance is provisioned against that ref
 // rather than the repository's default branch.
-func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backendType fleet.BackendType) error {
+func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backendType fleet.BackendType) (err error) {
+	start := time.Now()
 	flog.Info("instance create started", "fleet", fleetName, "instance", instanceName, "backend", backendType, "branch", branch, "remote", remoteURL)
+	// Log the failure outcome (with elapsed time) from one place: every error
+	// return below flows through the named err, and setFailed only annotates
+	// state. The success outcome is logged inline at the end where the
+	// container ID is in scope.
+	defer func() {
+		if err != nil {
+			flog.Error("instance create failed", "fleet", fleetName, "instance", instanceName, "backend", backendType, "ms", flog.MillisSince(start), "err", err)
+		}
+	}()
 	if err := fleet.ValidateBackendType(backendType); err != nil {
 		setFailed(fleetName, instanceName, err)
 		return err
@@ -167,6 +178,6 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backen
 	if err := markInstanceRunning(fleetName, instanceName, result.ContainerID); err != nil {
 		return err
 	}
-	flog.Info("instance created", "fleet", fleetName, "instance", instanceName, "backend", backendType, "container", result.ContainerID)
+	flog.Info("instance created", "fleet", fleetName, "instance", instanceName, "backend", backendType, "container", result.ContainerID, "ms", flog.MillisSince(start))
 	return nil
 }

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -15,6 +15,7 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/dotfiles"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetlaunch"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 )
 
@@ -28,6 +29,7 @@ import (
 // --branch <branch>` so the instance is provisioned against that ref
 // rather than the repository's default branch.
 func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backendType fleet.BackendType) error {
+	flog.Info("instance create started", "fleet", fleetName, "instance", instanceName, "backend", backendType, "branch", branch, "remote", remoteURL)
 	if err := fleet.ValidateBackendType(backendType); err != nil {
 		setFailed(fleetName, instanceName, err)
 		return err
@@ -162,5 +164,9 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backen
 	}
 
 	// Success: update state (instance is running even if dotfiles failed)
-	return markInstanceRunning(fleetName, instanceName, result.ContainerID)
+	if err := markInstanceRunning(fleetName, instanceName, result.ContainerID); err != nil {
+		return err
+	}
+	flog.Info("instance created", "fleet", fleetName, "instance", instanceName, "backend", backendType, "container", result.ContainerID)
+	return nil
 }

--- a/internal/create/set_failed.go
+++ b/internal/create/set_failed.go
@@ -2,6 +2,7 @@ package create
 
 import (
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 )
 
@@ -11,6 +12,7 @@ import (
 // already decided to bail, so it must not mask the original error with a
 // secondary one.
 func setFailed(fleetName, instanceName string, origErr error) {
+	flog.Error("instance provisioning failed", "fleet", fleetName, "instance", instanceName, "err", origErr)
 	st, err := state.Load()
 	if err != nil {
 		return

--- a/internal/create/set_failed.go
+++ b/internal/create/set_failed.go
@@ -2,7 +2,6 @@ package create
 
 import (
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
-	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 )
 
@@ -10,9 +9,9 @@ import (
 // message on it, persisting the change. State load/save errors are swallowed:
 // it is a best-effort failure annotation invoked from error paths that have
 // already decided to bail, so it must not mask the original error with a
-// secondary one.
+// secondary one. The failure itself (with timing) is logged by the caller
+// (Run / RunClone), so setFailed does not log.
 func setFailed(fleetName, instanceName string, origErr error) {
-	flog.Error("instance provisioning failed", "fleet", fleetName, "instance", instanceName, "err", origErr)
 	st, err := state.Load()
 	if err != nil {
 		return

--- a/internal/flog/flog.go
+++ b/internal/flog/flog.go
@@ -1,0 +1,115 @@
+// Package flog is fleet-man's application-wide event log.
+//
+// Major lifecycle actions across the codebase — fleet and instance
+// create/destroy, instance start/stop/clone, session create/kill/rename,
+// port-forwards, browser opens, TUI start/stop — and every command run
+// against a container write structured records here so the whole system's
+// behavior can be traced from one place: ~/.fleet/fleet.log.
+//
+// This is deliberately distinct from the per-instance creation logs under
+// ~/.fleet/logs/<fleet>-<instance>.log, which capture a single instance's
+// provisioning output. fleet.log is the cross-cutting, append-only trail of
+// what the fleet host process(es) did and when.
+//
+// fleet runs as several cooperating processes — the long-lived TUI, the
+// detached _create-instance / _clone-instance children, and one-shot CLI
+// commands — and they all append to the same file, so records from every
+// process interleave. The file is opened with O_APPEND and each slog record
+// is written in a single Write call, so individual log lines never tear
+// across processes; each record carries the pid so one process's actions can
+// be followed through the interleaving.
+//
+// Logging is best-effort: if the log file cannot be opened the logger
+// discards everything rather than failing the action being logged, mirroring
+// the swallow-and-continue policy used elsewhere (e.g. state.WriteWarn).
+package flog
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+const logFileName = "fleet.log"
+
+var (
+	initOnce sync.Once
+	logger   *slog.Logger
+)
+
+// Path returns the absolute path of the event log file (~/.fleet/fleet.log).
+//
+// The ~/.fleet base is intentionally recomputed here rather than imported
+// from internal/state: state — and most of the tree — imports flog, so
+// importing state back would create a cycle. The path is trivial and stable,
+// so this small duplication is worth keeping flog dependency-free and
+// importable from anywhere, including state itself.
+func Path() string {
+	return filepath.Join(os.Getenv("HOME"), ".fleet", logFileName)
+}
+
+// L returns the shared logger, initializing it on first use. It always
+// returns a usable *slog.Logger: if the log file cannot be opened the logger
+// writes to io.Discard so callers never have to nil-check or handle errors.
+func L() *slog.Logger {
+	initOnce.Do(initLogger)
+	return logger
+}
+
+func initLogger() {
+	var w io.Writer = io.Discard
+
+	path := Path()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err == nil {
+		// O_APPEND so concurrent fleet processes interleave cleanly; each
+		// slog record is one Write, which the OS appends atomically.
+		if f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644); err == nil {
+			w = f
+		}
+	}
+
+	handler := slog.NewTextHandler(w, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			// Render the top-level timestamp as a compact local time
+			// ("2006-01-02 15:04:05.000") instead of slog's default
+			// RFC3339-with-nanos, which is noisier to scan by eye.
+			if len(groups) == 0 && a.Key == slog.TimeKey {
+				a.Value = slog.StringValue(a.Value.Time().Format("2006-01-02 15:04:05.000"))
+			}
+			return a
+		},
+	})
+
+	logger = slog.New(handler).With("pid", os.Getpid())
+}
+
+// Info, Warn, and Error append a structured event to the log. The variadic
+// args are slog-style alternating key/value pairs:
+//
+//	flog.Info("instance created", "fleet", fleetName, "instance", name)
+//	flog.Error("instance provisioning failed", "fleet", f, "instance", i, "err", err)
+//
+// Keep keys consistent across call sites so the log stays greppable. The
+// conventional keys are: fleet, instance, session, backend, container,
+// branch, remote, from, to, port, and err.
+func Info(msg string, args ...any)  { L().Info(msg, args...) }
+func Warn(msg string, args ...any)  { L().Warn(msg, args...) }
+func Error(msg string, args ...any) { L().Error(msg, args...) }
+
+// ContainerExec records a command being run against a container's workspace.
+// Backends call it from their Exec/ExecCommand implementations so that every
+// command fleet runs inside a container is traced by default — useful for
+// following what a workflow (instance creation, dotfiles install, session
+// spawn, …) is actually doing.
+//
+// High-frequency polling and probe loops (periodic tmux session discovery,
+// etc.) deliberately route through the backend's ExecCommandQuiet variant,
+// which skips this call, so the log stays a readable trace instead of being
+// flooded by per-tick reads.
+func ContainerExec(backend, workspaceDir string, command []string) {
+	Info("container exec", "backend", backend, "workspace", workspaceDir, "cmd", strings.Join(command, " "))
+}

--- a/internal/flog/flog.go
+++ b/internal/flog/flog.go
@@ -31,6 +31,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 )
 
 const logFileName = "fleet.log"
@@ -95,21 +96,40 @@ func initLogger() {
 //
 // Keep keys consistent across call sites so the log stays greppable. The
 // conventional keys are: fleet, instance, session, backend, container,
-// branch, remote, from, to, port, and err.
+// branch, remote, from, to, port, ms, and err.
 func Info(msg string, args ...any)  { L().Info(msg, args...) }
 func Warn(msg string, args ...any)  { L().Warn(msg, args...) }
 func Error(msg string, args ...any) { L().Error(msg, args...) }
 
-// ContainerExec records a command being run against a container's workspace.
-// Backends call it from their Exec/ExecCommand implementations so that every
-// command fleet runs inside a container is traced by default — useful for
-// following what a workflow (instance creation, dotfiles install, session
-// spawn, …) is actually doing.
+// MillisSince returns the whole milliseconds elapsed since start. Use it for
+// the "ms" attribute on completion events so durations are logged as a plain
+// integer count of milliseconds:
 //
-// High-frequency polling and probe loops (periodic tmux session discovery,
-// etc.) deliberately route through the backend's ExecCommandQuiet variant,
-// which skips this call, so the log stays a readable trace instead of being
-// flooded by per-tick reads.
-func ContainerExec(backend, workspaceDir string, command []string) {
-	Info("container exec", "backend", backend, "workspace", workspaceDir, "cmd", strings.Join(command, " "))
+//	start := time.Now()
+//	... do the work ...
+//	flog.Info("instance created", "fleet", f, "instance", i, "ms", flog.MillisSince(start))
+//
+// Only attach "ms" to events that mark the END of work that takes a
+// measurable amount of time (provisioning, container start/stop, deletes,
+// session/exec round-trips). Instant actions and "…started" markers should
+// be left without it.
+func MillisSince(start time.Time) int64 {
+	return time.Since(start).Milliseconds()
+}
+
+// ContainerExec records a command run against a container's workspace, with
+// how long it took (ms) and whether it errored. Each container command is
+// logged exactly once — when it finishes — so there is no separate "issued"
+// event. Backends wire it up as the completion callback on the *Cmd returned
+// by ExecCommand (so the duration is measured around the caller's own
+// Run/Output/CombinedOutput) and call it directly from the synchronous Exec.
+//
+// High-frequency polling and probe loops route through ExecCommandQuiet, whose
+// *Cmd carries no callback, so they log nothing and never flood the trace.
+func ContainerExec(backend, workspaceDir string, command []string, d time.Duration, err error) {
+	if err != nil {
+		Error("container exec", "backend", backend, "workspace", workspaceDir, "cmd", strings.Join(command, " "), "ms", d.Milliseconds(), "err", err)
+		return
+	}
+	Info("container exec", "backend", backend, "workspace", workspaceDir, "cmd", strings.Join(command, " "), "ms", d.Milliseconds())
 }

--- a/internal/instanceops/lifecycle.go
+++ b/internal/instanceops/lifecycle.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 )
 
@@ -101,6 +102,7 @@ func transitionLoadedInstance(st *state.State, instance *fleet.Instance, fleetNa
 
 	result.Status = instance.Status
 	result.Changed = true
+	flog.Info("instance status changed", "fleet", fleetName, "instance", instanceName, "from", result.PreviousStatus, "to", targetStatus)
 	return result, nil
 }
 

--- a/internal/instanceops/lifecycle.go
+++ b/internal/instanceops/lifecycle.go
@@ -2,6 +2,7 @@ package instanceops
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/flog"
@@ -65,6 +66,7 @@ func transitionLoadedInstance(st *state.State, instance *fleet.Instance, fleetNa
 
 	instanceBackend := newClient(instance.Backend)
 
+	start := time.Now()
 	switch targetStatus {
 	case fleet.StatusStopped:
 		if instance.Status != fleet.StatusRunning && instance.Status != fleet.StatusStopping {
@@ -102,7 +104,7 @@ func transitionLoadedInstance(st *state.State, instance *fleet.Instance, fleetNa
 
 	result.Status = instance.Status
 	result.Changed = true
-	flog.Info("instance status changed", "fleet", fleetName, "instance", instanceName, "from", result.PreviousStatus, "to", targetStatus)
+	flog.Info("instance status changed", "fleet", fleetName, "instance", instanceName, "from", result.PreviousStatus, "to", targetStatus, "ms", flog.MillisSince(start))
 	return result, nil
 }
 

--- a/internal/portforward/manager.go
+++ b/internal/portforward/manager.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net"
 	"sync"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 )
 
 // Manager tracks active port forward processes per instance.
@@ -32,7 +34,11 @@ func (m *Manager) Add(key string, localPort, remotePort int, factory CmdFactory,
 		}
 	}
 
-	return m.addForwardLocked(key, localPort, remotePort, factory, containerID, resolve, false)
+	if err := m.addForwardLocked(key, localPort, remotePort, factory, containerID, resolve, false); err != nil {
+		return err
+	}
+	flog.Info("port-forward started", "key", key, "localPort", localPort, "remotePort", remotePort)
+	return nil
 }
 
 // addForwardLocked starts a forward on localPort and records it under
@@ -107,6 +113,7 @@ func (m *Manager) AddBrowserProxy(key string, remotePort int, factory CmdFactory
 	if err := m.addForwardLocked(key, localPort, remotePort, factory, containerID, resolve, true); err != nil {
 		return 0, err
 	}
+	flog.Info("browser proxy started", "key", key, "localPort", localPort, "remotePort", remotePort)
 	return localPort, nil
 }
 
@@ -120,6 +127,7 @@ func (m *Manager) Remove(key string, localPort int) error {
 		if fwd.LocalPort == localPort {
 			stopForward(fwd)
 			m.forwards[key] = append(fwds[:i], fwds[i+1:]...)
+			flog.Info("port-forward stopped", "key", key, "localPort", localPort)
 			return nil
 		}
 	}
@@ -130,6 +138,10 @@ func (m *Manager) Remove(key string, localPort int) error {
 func (m *Manager) RemoveAll(key string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if n := len(m.forwards[key]); n > 0 {
+		flog.Info("port-forwards stopped", "key", key, "count", n)
+	}
 
 	for _, fwd := range m.forwards[key] {
 		stopForward(fwd)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 )
 
 var mu sync.Mutex
@@ -84,6 +85,7 @@ func (s *State) GetOrCreateFleet(name, remote string) *fleet.Fleet {
 		Instances: make([]*fleet.Instance, 0),
 	}
 	s.Fleets[name] = newFleet
+	flog.Info("fleet created", "fleet", name, "remote", remote)
 	return newFleet
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/control"
 	"github.com/BenjaminBenetti/fleet-man/internal/deps"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/portforward"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	"github.com/charmbracelet/bubbles/spinner"
@@ -1100,6 +1101,7 @@ func sortedFleetNames(fleets map[string]*fleet.Fleet) []string {
 
 // Run starts the TUI.
 func Run() error {
+	flog.Info("fleet TUI started")
 	m := newModel()
 
 	// Start clipboard buffer polling when running inside tmux.
@@ -1118,6 +1120,7 @@ func Run() error {
 
 	program := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	finalModel, err := program.Run()
+	flog.Info("fleet TUI stopped")
 
 	if clipCancel != nil {
 		clipCancel()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1101,6 +1101,7 @@ func sortedFleetNames(fleets map[string]*fleet.Fleet) []string {
 
 // Run starts the TUI.
 func Run() error {
+	start := time.Now()
 	flog.Info("fleet TUI started")
 	m := newModel()
 
@@ -1120,7 +1121,7 @@ func Run() error {
 
 	program := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	finalModel, err := program.Run()
-	flog.Info("fleet TUI stopped")
+	flog.Info("fleet TUI stopped", "ms", flog.MillisSince(start))
 
 	if clipCancel != nil {
 		clipCancel()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -876,6 +876,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.message = fmt.Sprintf("failed to do tmux split pane: %v", msg.err)
 		}
 		if msg.paneID != "" {
+			// Log "session opened" only for direct (splitPaneCmd) opens, which
+			// run the command in the pane with no `fleet shell` subprocess.
+			// Group restores (restoreSeq != 0) spawn `fleet shell` per pane,
+			// and that process logs its own open/close — logging here too
+			// would duplicate it. splitOpenedAt/splitViaRestore pair with the
+			// "session closed" log in clearSplit.
+			fleetPage.splitOpenedAt = time.Now()
+			fleetPage.splitViaRestore = msg.restoreSeq != 0
+			if !fleetPage.splitViaRestore {
+				logSessionOpen("split", msg.ref.Fleet, msg.ref.Instance, msg.session, msg.command)
+			}
 			fleetPage.splitPaneID = msg.paneID
 			fleetPage.splitRef = msg.ref
 			fleetPage.splitSession = msg.session

--- a/internal/tui/browser.go
+++ b/internal/tui/browser.go
@@ -15,6 +15,7 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/backend/devcontainer"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetlaunch"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/landingpage"
 	"github.com/BenjaminBenetti/fleet-man/internal/portforward"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
@@ -222,6 +223,7 @@ func openBrowserProxyCmd(
 // the choose-launch dialog (which saves the answer and then launches);
 // otherwise it launches straight away.
 func (fleetPage *fleetPage) beginBrowserOpen(m *model, instance *fleet.Instance, fleetName string) tea.Cmd {
+	flog.Info("browser open requested", "fleet", fleetName, "instance", instance.Name)
 	if f, ok := m.st.Fleets[fleetName]; ok && !f.Settings.PreferFleetLaunchSet() {
 		if _, both := bothBrowserTargets(instance.WorkspaceDir); both {
 			fleetPage.mode = viewChooseBrowserLaunch

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -117,6 +117,7 @@ func toggleInstanceCmd(fleetName, instanceName string) tea.Cmd {
 // deleteInstanceCmd runs instance deletion in the background.
 func deleteInstanceCmd(instanceBackend backend.Backend, fleetName, instanceName, containerID, wsDir string, pf *portforward.Manager) tea.Cmd {
 	return func() tea.Msg {
+		start := time.Now()
 		pf.RemoveAll(fleetName + "/" + instanceName)
 		_ = instanceBackend.Down(containerID)
 		if wsDir != "" {
@@ -129,7 +130,7 @@ func deleteInstanceCmd(instanceBackend backend.Backend, fleetName, instanceName,
 				_ = state.Save(st)
 			}
 		}
-		flog.Info("instance deleted", "fleet", fleetName, "instance", instanceName)
+		flog.Info("instance deleted", "fleet", fleetName, "instance", instanceName, "ms", flog.MillisSince(start))
 		key := fleetName + "/" + instanceName
 		return operationDoneMsg{fleetName, instanceName, fmt.Sprintf("Removed %s", key), nil}
 	}
@@ -153,6 +154,7 @@ func deleteFleetCmd(backends map[fleet.BackendType]backend.Backend, fleetName st
 		targets = append(targets, target{backends[backendType], instance.Name, instance.ContainerID, instance.WorkspaceDir})
 	}
 	return func() tea.Msg {
+		start := time.Now()
 		for _, instanceTarget := range targets {
 			pf.RemoveAll(fleetName + "/" + instanceTarget.name)
 			if instanceTarget.instanceBackend != nil {
@@ -167,7 +169,7 @@ func deleteFleetCmd(backends map[fleet.BackendType]backend.Backend, fleetName st
 			delete(st.Fleets, fleetName)
 			_ = state.Save(st)
 		}
-		flog.Info("fleet destroyed", "fleet", fleetName, "instances", len(targets))
+		flog.Info("fleet destroyed", "fleet", fleetName, "instances", len(targets), "ms", flog.MillisSince(start))
 		return operationDoneMsg{fleetName, "", fmt.Sprintf("Removed fleet %s", fleetName), nil}
 	}
 }

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -13,6 +13,7 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 	coderbackend "github.com/BenjaminBenetti/fleet-man/internal/backend/coder"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/portforward"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 
@@ -128,6 +129,7 @@ func deleteInstanceCmd(instanceBackend backend.Backend, fleetName, instanceName,
 				_ = state.Save(st)
 			}
 		}
+		flog.Info("instance deleted", "fleet", fleetName, "instance", instanceName)
 		key := fleetName + "/" + instanceName
 		return operationDoneMsg{fleetName, instanceName, fmt.Sprintf("Removed %s", key), nil}
 	}
@@ -165,6 +167,7 @@ func deleteFleetCmd(backends map[fleet.BackendType]backend.Backend, fleetName st
 			delete(st.Fleets, fleetName)
 			_ = state.Save(st)
 		}
+		flog.Info("fleet destroyed", "fleet", fleetName, "instances", len(targets))
 		return operationDoneMsg{fleetName, "", fmt.Sprintf("Removed fleet %s", fleetName), nil}
 	}
 }
@@ -301,6 +304,7 @@ func createInstanceCmd(fleetName, instanceName, remoteURL, branch string, backen
 			return instanceCreateErrMsg{fleetName, instanceName, fmt.Errorf("spawn: %w", err)}
 		}
 
+		flog.Info("instance create dispatched", "fleet", fleetName, "instance", instanceName, "backend", backendType, "branch", branch)
 		// Detach: do not call cmd.Wait(). The child runs independently.
 		return instanceSpawnedMsg{fleetName, instanceName}
 	}
@@ -333,6 +337,7 @@ func cloneInstanceCmd(fleetName, srcInstance, destInstance string) tea.Cmd {
 			return instanceCreateErrMsg{fleetName, destInstance, fmt.Errorf("spawn: %w", err)}
 		}
 
+		flog.Info("instance clone dispatched", "fleet", fleetName, "src", srcInstance, "instance", destInstance)
 		return instanceSpawnedMsg{fleetName, destInstance}
 	}
 }

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/agentdetect"
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
@@ -637,7 +638,9 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 				m.message = "Select an instance"
 				break
 			}
-			cmd := m.instanceBackend(instance).ExecCommand(instance.WorkspaceDir, freshShellCommand(m.config))
+			shellCmd := freshShellCommand(m.config)
+			cmd := m.instanceBackend(instance).ExecCommand(instance.WorkspaceDir, shellCmd)
+			logSessionOpen("terminal", fleetPage.currentFleetName(), instance.Name, "", shellCmd)
 			err := openInTerminal(cmd.Args)
 			if err != nil {
 				m.message = fmt.Sprintf("Could not open terminal: %v", err)
@@ -833,21 +836,24 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 			}
 			cols, rows := tmuxWindowSize()
 			cols = cols * 70 / 100
-			cmd := m.instanceBackend(instance).ExecCommand(
-				instance.WorkspaceDir,
-				ShellCommandForSession(m.config, sessionName, cols, rows, true),
-			)
+			shellCmd := ShellCommandForSession(m.config, sessionName, cols, rows, true)
+			cmd := m.instanceBackend(instance).ExecCommand(instance.WorkspaceDir, shellCmd)
+			logSessionOpen("split", r.fleetName, instance.Name, sessionName, shellCmd)
 			return splitPaneCmd(fleetPage.splitPaneID, sessRef, sessionName, groupID, cmd.Cmd)
 		}
-		cmd := m.instanceBackend(instance).ExecCommand(
-			instance.WorkspaceDir,
-			ShellCommandForSession(m.config, sessionName, m.width, m.height, false),
-		)
+		shellCmd := ShellCommandForSession(m.config, sessionName, m.width, m.height, false)
+		cmd := m.instanceBackend(instance).ExecCommand(instance.WorkspaceDir, shellCmd)
 		banner := renderGradient(nameToBanner(instance.GetDisplayName()))
 		banner += "\n  " + dimStyle.Render("ctrl+q/ctrl+o to detach (session persists)")
+		sessFleet, sessInstance := r.fleetName, instance.Name
+		start := time.Now()
+		logSessionOpen("attach", sessFleet, sessInstance, sessionName, shellCmd)
 		return tea.ExecProcess(
 			execWithBannerCmd(banner, cmd.Cmd),
-			func(err error) tea.Msg { return execDoneMsg{err} },
+			func(err error) tea.Msg {
+				logSessionClose(sessFleet, sessInstance, sessionName, start)
+				return execDoneMsg{err}
+			},
 		)
 
 	case rowInstance:
@@ -882,12 +888,19 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 		}
 		m.sessionStore.SetLastActive(instRef, lastSession{sessionName: sessionName})
 
-		cmd := m.instanceBackend(instance).ExecCommand(instance.WorkspaceDir, ShellCommandForSession(m.config, sessionName, m.width, m.height, false))
+		shellCmd := ShellCommandForSession(m.config, sessionName, m.width, m.height, false)
+		cmd := m.instanceBackend(instance).ExecCommand(instance.WorkspaceDir, shellCmd)
 		banner := renderGradient(nameToBanner(instance.GetDisplayName()))
 		banner += "\n  " + dimStyle.Render("ctrl+q/ctrl+o to detach (session persists)")
+		instName := instance.Name
+		start := time.Now()
+		logSessionOpen("attach", instFleetName, instName, sessionName, shellCmd)
 		return tea.ExecProcess(
 			execWithBannerCmd(banner, cmd.Cmd),
-			func(err error) tea.Msg { return execDoneMsg{err} },
+			func(err error) tea.Msg {
+				logSessionClose(instFleetName, instName, sessionName, start)
+				return execDoneMsg{err}
+			},
 		)
 	}
 
@@ -1725,10 +1738,9 @@ func (fleetPage *fleetPage) openInstanceSession(m *model, fleetName string, inst
 		}
 		cols, rows := tmuxWindowSize()
 		cols = cols * 70 / 100
-		cmd := m.instanceBackend(instance).ExecCommand(
-			instance.WorkspaceDir,
-			ShellCommandForSession(m.config, last.sessionName, cols, rows, true),
-		)
+		shellCmd := ShellCommandForSession(m.config, last.sessionName, cols, rows, true)
+		cmd := m.instanceBackend(instance).ExecCommand(instance.WorkspaceDir, shellCmd)
+		logSessionOpen("split", fleetName, instance.Name, last.sessionName, shellCmd)
 		return splitPaneCmd(fleetPage.splitPaneID, ref, last.sessionName, last.groupID, cmd.Cmd)
 	}
 
@@ -1740,10 +1752,9 @@ func (fleetPage *fleetPage) openInstanceSession(m *model, fleetName string, inst
 		}
 		cols, rows := tmuxWindowSize()
 		cols = cols * 70 / 100
-		cmd := m.instanceBackend(instance).ExecCommand(
-			instance.WorkspaceDir,
-			ShellCommandForSession(m.config, rootName, cols, rows, true),
-		)
+		shellCmd := ShellCommandForSession(m.config, rootName, cols, rows, true)
+		cmd := m.instanceBackend(instance).ExecCommand(instance.WorkspaceDir, shellCmd)
+		logSessionOpen("split", fleetName, instance.Name, rootName, shellCmd)
 		return splitPaneCmd(fleetPage.splitPaneID, ref, rootName, g.GroupID, cmd.Cmd)
 	}
 
@@ -1751,10 +1762,9 @@ func (fleetPage *fleetPage) openInstanceSession(m *model, fleetName string, inst
 	sessName := groupSessionName(sanitized, newGroupID)
 	cols, rows := tmuxWindowSize()
 	cols = cols * 70 / 100
-	cmd := m.instanceBackend(instance).ExecCommand(
-		instance.WorkspaceDir,
-		ShellCommandForSession(m.config, sessName, cols, rows, true),
-	)
+	shellCmd := ShellCommandForSession(m.config, sessName, cols, rows, true)
+	cmd := m.instanceBackend(instance).ExecCommand(instance.WorkspaceDir, shellCmd)
+	logSessionOpen("split", fleetName, instance.Name, sessName, shellCmd)
 	return splitPaneCmd(fleetPage.splitPaneID, ref, sessName, newGroupID, cmd.Cmd)
 }
 

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -837,7 +837,7 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 				instance.WorkspaceDir,
 				ShellCommandForSession(m.config, sessionName, cols, rows, true),
 			)
-			return splitPaneCmd(fleetPage.splitPaneID, sessRef, sessionName, groupID, cmd)
+			return splitPaneCmd(fleetPage.splitPaneID, sessRef, sessionName, groupID, cmd.Cmd)
 		}
 		cmd := m.instanceBackend(instance).ExecCommand(
 			instance.WorkspaceDir,
@@ -846,7 +846,7 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 		banner := renderGradient(nameToBanner(instance.GetDisplayName()))
 		banner += "\n  " + dimStyle.Render("ctrl+q/ctrl+o to detach (session persists)")
 		return tea.ExecProcess(
-			execWithBannerCmd(banner, cmd),
+			execWithBannerCmd(banner, cmd.Cmd),
 			func(err error) tea.Msg { return execDoneMsg{err} },
 		)
 
@@ -886,7 +886,7 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 		banner := renderGradient(nameToBanner(instance.GetDisplayName()))
 		banner += "\n  " + dimStyle.Render("ctrl+q/ctrl+o to detach (session persists)")
 		return tea.ExecProcess(
-			execWithBannerCmd(banner, cmd),
+			execWithBannerCmd(banner, cmd.Cmd),
 			func(err error) tea.Msg { return execDoneMsg{err} },
 		)
 	}
@@ -1729,7 +1729,7 @@ func (fleetPage *fleetPage) openInstanceSession(m *model, fleetName string, inst
 			instance.WorkspaceDir,
 			ShellCommandForSession(m.config, last.sessionName, cols, rows, true),
 		)
-		return splitPaneCmd(fleetPage.splitPaneID, ref, last.sessionName, last.groupID, cmd)
+		return splitPaneCmd(fleetPage.splitPaneID, ref, last.sessionName, last.groupID, cmd.Cmd)
 	}
 
 	if groups := m.sessionStore.Groups(ref); len(groups) > 0 {
@@ -1744,7 +1744,7 @@ func (fleetPage *fleetPage) openInstanceSession(m *model, fleetName string, inst
 			instance.WorkspaceDir,
 			ShellCommandForSession(m.config, rootName, cols, rows, true),
 		)
-		return splitPaneCmd(fleetPage.splitPaneID, ref, rootName, g.GroupID, cmd)
+		return splitPaneCmd(fleetPage.splitPaneID, ref, rootName, g.GroupID, cmd.Cmd)
 	}
 
 	newGroupID := randomHex(3)
@@ -1755,7 +1755,7 @@ func (fleetPage *fleetPage) openInstanceSession(m *model, fleetName string, inst
 		instance.WorkspaceDir,
 		ShellCommandForSession(m.config, sessName, cols, rows, true),
 	)
-	return splitPaneCmd(fleetPage.splitPaneID, ref, sessName, newGroupID, cmd)
+	return splitPaneCmd(fleetPage.splitPaneID, ref, sessName, newGroupID, cmd.Cmd)
 }
 
 // cycleSessionGroup moves the visual selection to the next or previous

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -73,9 +73,11 @@ type fleetPage struct {
 	pfCursor      int
 	pfContainerID string
 
-	splitPaneID  string
-	splitRef     InstanceRef // (fleet, instance) of the open split pane; zero when none
-	splitSession string
+	splitPaneID     string
+	splitRef        InstanceRef // (fleet, instance) of the open split pane; zero when none
+	splitSession    string
+	splitOpenedAt   time.Time // when the current split pane was opened; for "session closed" duration
+	splitViaRestore bool      // true when the split was opened via restoreGroupCmd (fleet shell logs its own open/close, so the TUI must not duplicate it)
 
 	activeGroup      ActiveGroup // qualified by splitRef so two groups with the same ID across instances cannot alias
 	savedGroups      map[string]savedGroup
@@ -139,9 +141,19 @@ func (fleetPage *fleetPage) finishGroupRestore(seq int) bool {
 // whenever the split is closed (user toggle, external kill, restore
 // teardown) so a future open starts from a known-empty state.
 func (fleetPage *fleetPage) clearSplit() {
+	// A non-empty paneID means a split was actually open, so this is a real
+	// session close (toggle shut, switched away, deleted, or the pane was
+	// closed externally) — log it with how long it was open. Skip it for
+	// restore-backed splits: their `fleet shell` panes log their own close,
+	// so logging here would duplicate it.
+	if fleetPage.splitPaneID != "" && !fleetPage.splitViaRestore {
+		logSessionClose(fleetPage.splitRef.Fleet, fleetPage.splitRef.Instance, fleetPage.splitSession, fleetPage.splitOpenedAt)
+	}
 	fleetPage.splitPaneID = ""
 	fleetPage.splitRef = InstanceRef{}
 	fleetPage.splitSession = ""
+	fleetPage.splitOpenedAt = time.Time{}
+	fleetPage.splitViaRestore = false
 	fleetPage.activeGroup = ActiveGroup{}
 	fleetPage.restoringGroupID = ""
 }
@@ -640,7 +652,7 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			}
 			shellCmd := freshShellCommand(m.config)
 			cmd := m.instanceBackend(instance).ExecCommand(instance.WorkspaceDir, shellCmd)
-			logSessionOpen("terminal", fleetPage.currentFleetName(), instance.Name, "", shellCmd)
+			logSessionOpen("terminal", fleetPage.currentFleetName(), instance.Name, "", strings.Join(shellCmd, " "))
 			err := openInTerminal(cmd.Args)
 			if err != nil {
 				m.message = fmt.Sprintf("Could not open terminal: %v", err)
@@ -838,7 +850,8 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 			cols = cols * 70 / 100
 			shellCmd := ShellCommandForSession(m.config, sessionName, cols, rows, true)
 			cmd := m.instanceBackend(instance).ExecCommand(instance.WorkspaceDir, shellCmd)
-			logSessionOpen("split", r.fleetName, instance.Name, sessionName, shellCmd)
+			// The "session opened" event for split panes is logged centrally
+			// in the splitPaneMsg handler (covers grouped + ungrouped opens).
 			return splitPaneCmd(fleetPage.splitPaneID, sessRef, sessionName, groupID, cmd.Cmd)
 		}
 		shellCmd := ShellCommandForSession(m.config, sessionName, m.width, m.height, false)
@@ -847,7 +860,7 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 		banner += "\n  " + dimStyle.Render("ctrl+q/ctrl+o to detach (session persists)")
 		sessFleet, sessInstance := r.fleetName, instance.Name
 		start := time.Now()
-		logSessionOpen("attach", sessFleet, sessInstance, sessionName, shellCmd)
+		logSessionOpen("attach", sessFleet, sessInstance, sessionName, strings.Join(shellCmd, " "))
 		return tea.ExecProcess(
 			execWithBannerCmd(banner, cmd.Cmd),
 			func(err error) tea.Msg {
@@ -894,7 +907,7 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 		banner += "\n  " + dimStyle.Render("ctrl+q/ctrl+o to detach (session persists)")
 		instName := instance.Name
 		start := time.Now()
-		logSessionOpen("attach", instFleetName, instName, sessionName, shellCmd)
+		logSessionOpen("attach", instFleetName, instName, sessionName, strings.Join(shellCmd, " "))
 		return tea.ExecProcess(
 			execWithBannerCmd(banner, cmd.Cmd),
 			func(err error) tea.Msg {
@@ -1740,7 +1753,6 @@ func (fleetPage *fleetPage) openInstanceSession(m *model, fleetName string, inst
 		cols = cols * 70 / 100
 		shellCmd := ShellCommandForSession(m.config, last.sessionName, cols, rows, true)
 		cmd := m.instanceBackend(instance).ExecCommand(instance.WorkspaceDir, shellCmd)
-		logSessionOpen("split", fleetName, instance.Name, last.sessionName, shellCmd)
 		return splitPaneCmd(fleetPage.splitPaneID, ref, last.sessionName, last.groupID, cmd.Cmd)
 	}
 
@@ -1754,7 +1766,6 @@ func (fleetPage *fleetPage) openInstanceSession(m *model, fleetName string, inst
 		cols = cols * 70 / 100
 		shellCmd := ShellCommandForSession(m.config, rootName, cols, rows, true)
 		cmd := m.instanceBackend(instance).ExecCommand(instance.WorkspaceDir, shellCmd)
-		logSessionOpen("split", fleetName, instance.Name, rootName, shellCmd)
 		return splitPaneCmd(fleetPage.splitPaneID, ref, rootName, g.GroupID, cmd.Cmd)
 	}
 
@@ -1764,7 +1775,6 @@ func (fleetPage *fleetPage) openInstanceSession(m *model, fleetName string, inst
 	cols = cols * 70 / 100
 	shellCmd := ShellCommandForSession(m.config, sessName, cols, rows, true)
 	cmd := m.instanceBackend(instance).ExecCommand(instance.WorkspaceDir, shellCmd)
-	logSessionOpen("split", fleetName, instance.Name, sessName, shellCmd)
 	return splitPaneCmd(fleetPage.splitPaneID, ref, sessName, newGroupID, cmd.Cmd)
 }
 

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -126,7 +127,7 @@ func sessionDiscoveryCmd(
 			wg.Add(1)
 			go func(instanceBackend backend.Backend, wsDir string, ref InstanceRef) {
 				defer wg.Done()
-				cmd := instanceBackend.ExecCommand(wsDir, []string{
+				cmd := instanceBackend.ExecCommandQuiet(wsDir, []string{
 					"sh", "-c",
 					`tmux list-sessions -F "#{session_name}:#{session_windows}:#{session_attached}" 2>/dev/null`,
 				})
@@ -161,7 +162,7 @@ func ensureSessionsLoaded(m *model, instanceBackend backend.Backend, workspaceDi
 	if m.sessionStore.HasDiscovery(ref) {
 		return
 	}
-	cmd := instanceBackend.ExecCommand(workspaceDir, []string{
+	cmd := instanceBackend.ExecCommandQuiet(workspaceDir, []string{
 		"sh", "-c",
 		`tmux list-sessions -F "#{session_name}:#{session_windows}:#{session_attached}" 2>/dev/null`,
 	})
@@ -177,7 +178,7 @@ func ensureSessionsLoaded(m *model, instanceBackend backend.Backend, workspaceDi
 // inside the container and parses the output into tmuxSession structs.
 func listSessionsCmd(instanceBackend backend.Backend, workspaceDir string, ref InstanceRef) tea.Cmd {
 	return func() tea.Msg {
-		cmd := instanceBackend.ExecCommand(workspaceDir, []string{
+		cmd := instanceBackend.ExecCommandQuiet(workspaceDir, []string{
 			"sh", "-c",
 			`tmux list-sessions -F "#{session_name}:#{session_windows}:#{session_attached}" 2>/dev/null`,
 		})
@@ -199,8 +200,10 @@ func createSessionCmd(instanceBackend backend.Backend, workspaceDir string, ref 
 			tmuxEnsureInstalled + fmt.Sprintf(`tmux new-session -d -s %s 2>/dev/null`, shQuote(sessionName)),
 		})
 		if err := cmd.Run(); err != nil {
+			flog.Error("session create failed", "fleet", ref.Fleet, "instance", ref.Instance, "session", sessionName, "err", err)
 			return sessionCreatedMsg{ref: ref, err: err}
 		}
+		flog.Info("session created", "fleet", ref.Fleet, "instance", ref.Instance, "session", sessionName)
 		return sessionCreatedMsg{ref: ref}
 	}
 }
@@ -216,6 +219,7 @@ func renameSessionCmd(instanceBackend backend.Backend, workspaceDir string, ref 
 		if err := cmd.Run(); err != nil {
 			return sessionRenamedMsg{ref: ref, oldName: oldName, newName: newName, err: err}
 		}
+		flog.Info("session renamed", "fleet", ref.Fleet, "instance", ref.Instance, "from", oldName, "to", newName)
 		return sessionRenamedMsg{ref: ref, oldName: oldName, newName: newName}
 	}
 }
@@ -229,7 +233,7 @@ func renameGroupCmd(instanceBackend backend.Backend, workspaceDir string, ref In
 
 	return func() tea.Msg {
 		// List all sessions in the container.
-		listCmd := instanceBackend.ExecCommand(workspaceDir, []string{
+		listCmd := instanceBackend.ExecCommandQuiet(workspaceDir, []string{
 			"sh", "-c",
 			`tmux list-sessions -F "#{session_name}" 2>/dev/null`,
 		})
@@ -258,6 +262,7 @@ func renameGroupCmd(instanceBackend backend.Backend, workspaceDir string, ref In
 		if lastErr != nil {
 			return sessionRenamedMsg{ref: ref, oldName: oldPrefix, newName: newPrefix, err: lastErr}
 		}
+		flog.Info("session group renamed", "fleet", ref.Fleet, "instance", ref.Instance, "from", oldPrefix, "to", newPrefix)
 		return sessionRenamedMsg{ref: ref, oldName: oldPrefix, newName: newPrefix}
 	}
 }
@@ -272,6 +277,7 @@ func deleteSessionCmd(instanceBackend backend.Backend, workspaceDir string, ref 
 		if err := cmd.Run(); err != nil {
 			return sessionDeletedMsg{ref: ref, sessionName: sessionName, err: err}
 		}
+		flog.Info("session killed", "fleet", ref.Fleet, "instance", ref.Instance, "session", sessionName)
 		return sessionDeletedMsg{ref: ref, sessionName: sessionName}
 	}
 }
@@ -283,7 +289,7 @@ func deleteGroupSessionsCmd(instanceBackend backend.Backend, workspaceDir string
 
 	return func() tea.Msg {
 		// List all sessions in the container.
-		listCmd := instanceBackend.ExecCommand(workspaceDir, []string{
+		listCmd := instanceBackend.ExecCommandQuiet(workspaceDir, []string{
 			"sh", "-c",
 			`tmux list-sessions -F "#{session_name}" 2>/dev/null`,
 		})
@@ -310,6 +316,7 @@ func deleteGroupSessionsCmd(instanceBackend backend.Backend, workspaceDir string
 		if lastErr != nil {
 			return sessionDeletedMsg{ref: ref, sessionName: prefix, groupID: groupID, err: lastErr}
 		}
+		flog.Info("session group killed", "fleet", ref.Fleet, "instance", ref.Instance, "group", groupID)
 		return sessionDeletedMsg{ref: ref, sessionName: prefix, groupID: groupID}
 	}
 }

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -199,11 +199,12 @@ func createSessionCmd(instanceBackend backend.Backend, workspaceDir string, ref 
 			"sh", "-c",
 			tmuxEnsureInstalled + fmt.Sprintf(`tmux new-session -d -s %s 2>/dev/null`, shQuote(sessionName)),
 		})
+		start := time.Now()
 		if err := cmd.Run(); err != nil {
-			flog.Error("session create failed", "fleet", ref.Fleet, "instance", ref.Instance, "session", sessionName, "err", err)
+			flog.Error("session create failed", "fleet", ref.Fleet, "instance", ref.Instance, "session", sessionName, "ms", flog.MillisSince(start), "err", err)
 			return sessionCreatedMsg{ref: ref, err: err}
 		}
-		flog.Info("session created", "fleet", ref.Fleet, "instance", ref.Instance, "session", sessionName)
+		flog.Info("session created", "fleet", ref.Fleet, "instance", ref.Instance, "session", sessionName, "ms", flog.MillisSince(start))
 		return sessionCreatedMsg{ref: ref}
 	}
 }
@@ -216,10 +217,11 @@ func renameSessionCmd(instanceBackend backend.Backend, workspaceDir string, ref 
 			"sh", "-c",
 			fmt.Sprintf(`tmux rename-session -t %s %s 2>/dev/null`, shQuote(oldName), shQuote(newName)),
 		})
+		start := time.Now()
 		if err := cmd.Run(); err != nil {
 			return sessionRenamedMsg{ref: ref, oldName: oldName, newName: newName, err: err}
 		}
-		flog.Info("session renamed", "fleet", ref.Fleet, "instance", ref.Instance, "from", oldName, "to", newName)
+		flog.Info("session renamed", "fleet", ref.Fleet, "instance", ref.Instance, "from", oldName, "to", newName, "ms", flog.MillisSince(start))
 		return sessionRenamedMsg{ref: ref, oldName: oldName, newName: newName}
 	}
 }
@@ -232,6 +234,7 @@ func renameGroupCmd(instanceBackend backend.Backend, workspaceDir string, ref In
 	newPrefix := sanitizedInstance + groupSep + newGroupID
 
 	return func() tea.Msg {
+		start := time.Now()
 		// List all sessions in the container.
 		listCmd := instanceBackend.ExecCommandQuiet(workspaceDir, []string{
 			"sh", "-c",
@@ -262,7 +265,7 @@ func renameGroupCmd(instanceBackend backend.Backend, workspaceDir string, ref In
 		if lastErr != nil {
 			return sessionRenamedMsg{ref: ref, oldName: oldPrefix, newName: newPrefix, err: lastErr}
 		}
-		flog.Info("session group renamed", "fleet", ref.Fleet, "instance", ref.Instance, "from", oldPrefix, "to", newPrefix)
+		flog.Info("session group renamed", "fleet", ref.Fleet, "instance", ref.Instance, "from", oldPrefix, "to", newPrefix, "ms", flog.MillisSince(start))
 		return sessionRenamedMsg{ref: ref, oldName: oldPrefix, newName: newPrefix}
 	}
 }
@@ -274,10 +277,11 @@ func deleteSessionCmd(instanceBackend backend.Backend, workspaceDir string, ref 
 			"sh", "-c",
 			fmt.Sprintf(`tmux kill-session -t %s 2>/dev/null`, shQuote(sessionName)),
 		})
+		start := time.Now()
 		if err := cmd.Run(); err != nil {
 			return sessionDeletedMsg{ref: ref, sessionName: sessionName, err: err}
 		}
-		flog.Info("session killed", "fleet", ref.Fleet, "instance", ref.Instance, "session", sessionName)
+		flog.Info("session killed", "fleet", ref.Fleet, "instance", ref.Instance, "session", sessionName, "ms", flog.MillisSince(start))
 		return sessionDeletedMsg{ref: ref, sessionName: sessionName}
 	}
 }
@@ -288,6 +292,7 @@ func deleteGroupSessionsCmd(instanceBackend backend.Backend, workspaceDir string
 	prefix := sanitizedInstance + groupSep + groupID
 
 	return func() tea.Msg {
+		start := time.Now()
 		// List all sessions in the container.
 		listCmd := instanceBackend.ExecCommandQuiet(workspaceDir, []string{
 			"sh", "-c",
@@ -316,7 +321,7 @@ func deleteGroupSessionsCmd(instanceBackend backend.Backend, workspaceDir string
 		if lastErr != nil {
 			return sessionDeletedMsg{ref: ref, sessionName: prefix, groupID: groupID, err: lastErr}
 		}
-		flog.Info("session group killed", "fleet", ref.Fleet, "instance", ref.Instance, "group", groupID)
+		flog.Info("session group killed", "fleet", ref.Fleet, "instance", ref.Instance, "group", groupID, "ms", flog.MillisSince(start))
 		return sessionDeletedMsg{ref: ref, sessionName: prefix, groupID: groupID}
 	}
 }

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -209,6 +209,26 @@ func createSessionCmd(instanceBackend backend.Backend, workspaceDir string, ref 
 	}
 }
 
+// logSessionOpen records a TUI session being opened, including the raw shell
+// command run inside the container and how it is surfaced: "attach" (suspends
+// the TUI, runs in the foreground), "split" (a tmux split pane), or "terminal"
+// (a separate terminal emulator). These paths run the command outside the
+// backend.Cmd wrapper, so they are instrumented here by hand. Only "attach"
+// has a matching close event (logSessionClose) and therefore a duration; split
+// panes and external terminals detach and keep running, so they are logged
+// without one. The command is the inner command (what runs in the container),
+// not the backend's exec wrapper.
+func logSessionOpen(mode, fleetName, instanceName, sessionName string, command []string) {
+	flog.Info("session opened", "fleet", fleetName, "instance", instanceName, "session", sessionName, "mode", mode, "cmd", strings.Join(command, " "))
+}
+
+// logSessionClose records a foreground session attach ending, with how long it
+// was attached. Called from the tea.ExecProcess completion callback, which
+// fires when the user detaches or the shell exits.
+func logSessionClose(fleetName, instanceName, sessionName string, start time.Time) {
+	flog.Info("session closed", "fleet", fleetName, "instance", instanceName, "session", sessionName, "ms", flog.MillisSince(start))
+}
+
 // renameSessionCmd execs `tmux rename-session -t <old> <new>` inside
 // the container.
 func renameSessionCmd(instanceBackend backend.Backend, workspaceDir string, ref InstanceRef, oldName, newName string) tea.Cmd {

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -218,8 +218,8 @@ func createSessionCmd(instanceBackend backend.Backend, workspaceDir string, ref 
 // panes and external terminals detach and keep running, so they are logged
 // without one. The command is the inner command (what runs in the container),
 // not the backend's exec wrapper.
-func logSessionOpen(mode, fleetName, instanceName, sessionName string, command []string) {
-	flog.Info("session opened", "fleet", fleetName, "instance", instanceName, "session", sessionName, "mode", mode, "cmd", strings.Join(command, " "))
+func logSessionOpen(mode, fleetName, instanceName, sessionName, command string) {
+	flog.Info("session opened", "fleet", fleetName, "instance", instanceName, "session", sessionName, "mode", mode, "cmd", command)
 }
 
 // logSessionClose records a foreground session attach ending, with how long it

--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -20,6 +20,7 @@ type splitPaneMsg struct {
 	ref        InstanceRef // instance occupying the pane
 	session    string      // tmux session name in the pane
 	groupID    string      // session group ID (for group management)
+	command    string      // command(s) launched in the pane(s); for the event log
 	restoreSeq int         // async restore token; zero means not a group restore
 	err        error
 }
@@ -59,6 +60,7 @@ func quoteArgs(args []string) string {
 func splitPaneCmd(existingPaneID string, ref InstanceRef, sessionName string, groupID string, cmd *exec.Cmd) tea.Cmd {
 	// Snapshot the args — we must not capture the *exec.Cmd across goroutines.
 	args := cmd.Args
+	cmdStr := strings.Join(args, " ")
 
 	return func() tea.Msg {
 		// Wrap the command so that on non-zero exit the pane stays open
@@ -76,7 +78,7 @@ func splitPaneCmd(existingPaneID string, ref InstanceRef, sessionName string, gr
 			if exec.Command("tmux", respawnArgs...).Run() == nil {
 				tagPaneTitle(existingPaneID, sessionName)
 				_ = exec.Command("tmux", "select-pane", "-t", existingPaneID).Run()
-				return splitPaneMsg{paneID: existingPaneID, ref: ref, session: sessionName, groupID: groupID}
+				return splitPaneMsg{paneID: existingPaneID, ref: ref, session: sessionName, groupID: groupID, command: cmdStr}
 			}
 			// Pane is gone — fall through to create a fresh split.
 		}
@@ -103,7 +105,7 @@ func splitPaneCmd(existingPaneID string, ref InstanceRef, sessionName string, gr
 		paneID := strings.TrimSpace(string(out))
 		tagPaneTitle(paneID, sessionName)
 		_ = exec.Command("tmux", "select-pane", "-t", paneID).Run()
-		return splitPaneMsg{paneID: paneID, ref: ref, session: sessionName, groupID: groupID}
+		return splitPaneMsg{paneID: paneID, ref: ref, session: sessionName, groupID: groupID, command: cmdStr}
 	}
 }
 
@@ -535,6 +537,7 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 		// `fleet shell` child got far enough to call `tmux select-pane
 		// -T`. The pre-tag closes the race deterministically.
 		paneSlots := listPaneSlots()
+		var ranCmds []string
 		for i, sessName := range sessions {
 			if i >= len(paneSlots) {
 				break
@@ -542,6 +545,7 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 			paneID := paneSlots[i]
 			tagPaneTitle(paneID, sessName)
 			shellCmd := fmt.Sprintf("%s shell %s --session %s", self, qualifiedName, sessName)
+			ranCmds = append(ranCmds, shellCmd)
 			script := shellCmd + `; __rc=$?; if [ $__rc -ne 0 ]; then echo; echo "exited with code $__rc — closing in 3s"; sleep 3; fi; exit $__rc`
 			_ = exec.Command("tmux", "respawn-pane", "-k", "-t", paneID, "sh", "-c", script).Run()
 		}
@@ -567,6 +571,7 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 			ref:        InstanceRef{Fleet: fleetName, Instance: instanceName},
 			session:    firstSession,
 			groupID:    groupID,
+			command:    strings.Join(ranCmds, " ; "),
 			restoreSeq: restoreSeq,
 		}
 		if splitErr != nil {

--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -457,7 +457,7 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 		}
 
 		// Query the inner tmux for all sessions in this group.
-		listCmd := instanceBackend.ExecCommand(workspaceDir, []string{
+		listCmd := instanceBackend.ExecCommandQuiet(workspaceDir, []string{
 			"sh", "-c",
 			`tmux list-sessions -F "#{session_name}" 2>/dev/null`,
 		})


### PR DESCRIPTION
## Summary

- Adds **`internal/flog`** — a cross-cutting, append-only event log at `~/.fleet/fleet.log` (stdlib `log/slog`, every line tagged with `pid`, best-effort so it never fails the action it's logging). Opened in append mode so the TUI, the detached `_create-instance`/`_clone-instance` children, and one-shot CLI commands all interleave cleanly. Distinct from the per-instance provisioning logs under `~/.fleet/logs/`. It recomputes the `~/.fleet` path itself rather than importing `internal/state`, avoiding an import cycle (since `state` logs too).
- Instruments the **major lifecycle actions**: fleet create/destroy, instance create/clone/delete, start↔stop transitions, provisioning failures; session create/exec/kill/rename; port-forward start/stop; browser opens; TUI start/stop.
- Adds **`ms` timing** to the events that represent measurable work (instance create/clone, start/stop, delete/destroy, session ops, TUI uptime) via `flog.MillisSince`; instant actions and "…started" markers are left untimed.
- Logs **every command run against a container** as a single timed `container exec` event. `backend.Cmd` embeds `*exec.Cmd` and shadows `Run`/`Output`/`CombinedOutput` to fire a completion callback (duration measured around the caller's own run); `ExecCommandQuiet` carries no callback so high-frequency polling/probe loops (tmux session discovery, etc.) stay silent.
- Traces **TUI session open/close** — including the full `tmux new-session` attach command (with the SSH-agent socket fix). `fleet shell` logs the command on open and the elapsed time on close, catching `SIGHUP` so the close is still recorded when its pane is killed rather than exited. Restore-backed split panes are logged once (by their `fleet shell` panes) while direct panes are logged by the TUI, so there are no duplicate entries.

### Notes / trade-offs
- Session and `fleet shell` durations measure the command's wall-clock lifetime — for an interactive session that's "how long it was open", since `exec tmux …` doesn't return until the session ends.
- Logging is intentionally a readable trace of state-changing actions; per-tick telemetry (stats, screen capture, agent-tool probes, status) routes through dedicated backend methods / `ExecCommandQuiet` and is not logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
