### PR TITLE
feat/recurring-update-check Re-check for updates every 10 minutes

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -555,6 +555,7 @@ func (m model) Init() tea.Cmd {
 		m.sessionDiscoveryLoop(),
 		layoutTickCmd(),
 		checkUpdateCmd(),
+		updateCheckPollCmd(),
 		checkReleaseNotesCmd(m.lastSeenVersion()),
 		forceRepaintCmd(),
 		// Probe live state right away so a fleet started after a long
@@ -679,6 +680,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.updateAvailable = msg.latestVersion
 		}
 		return m, spinCmd
+
+	case updateCheckTickMsg:
+		// Re-check for updates and re-arm the periodic tick so users who
+		// leave fleet open get notified about releases published mid-session.
+		return m, tea.Batch(spinCmd, checkUpdateCmd(), updateCheckPollCmd())
 
 	case releaseNotesMsg:
 		// Only surface the overlay when there's an actual body to show;

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -11,10 +11,19 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+// updateCheckInterval controls how often the TUI re-checks GitHub for a
+// newer release while running. Many users leave fleet open indefinitely,
+// so a one-shot check at startup would never surface updates for them.
+const updateCheckInterval = 10 * time.Minute
+
 // updateCheckMsg is sent when the background update check completes.
 type updateCheckMsg struct {
 	latestVersion string // empty if no update or error
 }
+
+// updateCheckTickMsg fires every updateCheckInterval and triggers another
+// background update check.
+type updateCheckTickMsg struct{}
 
 // updateInstalledMsg is sent after the install script finishes.
 //
@@ -67,6 +76,13 @@ func checkUpdateCmd() tea.Cmd {
 
 		return updateCheckMsg{}
 	}
+}
+
+// updateCheckPollCmd schedules the next periodic update check.
+func updateCheckPollCmd() tea.Cmd {
+	return tea.Tick(updateCheckInterval, func(time.Time) tea.Msg {
+		return updateCheckTickMsg{}
+	})
 }
 
 // performUpdateCmd runs the install script via tea.ExecProcess and, on


### PR DESCRIPTION
## Summary

- The update check previously ran **only once at TUI startup**, so users who leave fleet open indefinitely (a common workflow) never saw notifications for releases published mid-session.
- Added a recurring `tea.Tick` timer (`updateCheckInterval = 10m`) that fires another background update check and re-arms itself, following the existing `liveStatusPollCmd` polling pattern.
- The startup one-shot check is preserved, so the first check still happens immediately.
- Mid-session checks reuse the existing `checkUpdateCmd` / `updateCheckMsg` path, which already no-ops gracefully on dev builds and network/API errors and simply retries on the next tick. No changes needed to the settings/fleet page notification rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)