### PR TITLE
ci(release): support vX.Y.Z-beta tags (publish, but not Latest)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,12 @@ name: Release
 on:
   push:
     tags:
+      # Stable release, e.g. v1.2.3 — published and marked "Latest".
       - "v[0-9]+.[0-9]+.[0-9]+"
+      # Beta release, e.g. v1.2.3-beta — published the same way but NOT marked
+      # "Latest" (so `install.sh`, which hits /releases/latest, keeps the stable
+      # line), and the public landing page is not redeployed to the beta version.
+      - "v[0-9]+.[0-9]+.[0-9]+-beta"
 
 permissions:
   contents: write
@@ -39,13 +44,26 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # A -beta tag publishes a normal release but marks it as a pre-release
+          # and NOT "Latest", so the default install (install.sh -> /releases/latest,
+          # which excludes pre-releases) keeps getting the stable line. A stable
+          # tag is unchanged: gh's default "Latest" handling applies.
+          extra_args=""
+          case "${GITHUB_REF_NAME}" in
+            *-beta) extra_args="--prerelease --latest=false" ;;
+          esac
+
           gh release create "${GITHUB_REF_NAME}" \
             --title "Fleet ${GITHUB_REF_NAME}" \
             --generate-notes \
+            ${extra_args} \
             dist/*
 
   pages:
     needs: release
+    # Beta releases must not become the public-facing version: skip the landing
+    # page redeploy so the site keeps advertising the latest stable.
+    if: ${{ !endsWith(github.ref_name, '-beta') }}
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## What

The release workflow now accepts a `vX.Y.Z-beta` tag in addition to `vX.Y.Z`.

A `-beta` tag does everything a stable tag does (build the linux amd64/arm64
binaries + checksums, create the GitHub release with generated notes), with two
differences so it is **not** the version users get by default:

- The GitHub release is created with `--prerelease --latest=false`, so it is
  **not marked "Latest"**.
- The **`pages` job is skipped**, so the public landing page keeps advertising
  the latest stable rather than the beta.

Stable (`vX.Y.Z`) behavior is **unchanged**.

## Why it works

`install.sh` resolves the default version from
`api.github.com/repos/<repo>/releases/latest`, which returns the "Latest"
release and **excludes pre-releases**. So a beta never reaches the default
`curl | sh` install. Beta testers opt in explicitly:

```bash
curl -sL .../install.sh | sh -s -- --version v1.2.3-beta
```

## Decision to confirm

You asked specifically for "not the latest GitHub release." I also **skipped the
`pages` deploy for betas** — otherwise a beta tag would republish the public
landing page showing `vX.Y.Z-beta` as the version, which reads as "this is the
current release." If you'd rather betas still deploy the landing page, drop the
`if:` on the `pages` job and I'll adjust.

## Tag syntax

GitHub Actions tag filters treat `+` as a quantifier and `.` as literal, so the
existing `v[0-9]+.[0-9]+.[0-9]+` does not match `...-beta`; the new
`v[0-9]+.[0-9]+.[0-9]+-beta` pattern catches betas exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)