### PR TITLE
fix(fleetclient): versioned client reclaims a local dev/old server; compare on semver core

### DIFF
--- a/internal/fleetclient/version_check.go
+++ b/internal/fleetclient/version_check.go
@@ -13,51 +13,76 @@ import (
 )
 
 // reconcileServer enforces the version/freshness policy against the server we
-// just connected to, returning whether it relaunched the server (so the caller
-// can re-settle its connection onto the new process).
-//
-//   - DEV client (no compiled-in version): version strings can't tell us whether
-//     a PRE-EXISTING server runs the freshly-built code, so we fall back to the
-//     binary's mtime: if this executable is newer than the server's start time,
-//     the server is stale and we replace it. This makes local dev fool-proof —
-//     every rebuild's first command transparently gets a fresh server — WITHOUT
-//     thrashing (an unchanged binary, or a server we just spawned, is left
-//     alone, so repeated/concurrent commands don't restart needlessly). A remote
-//     server can't be relaunched.
-//   - VERSIONED client: same version is fine; a strictly-newer client relaunches
-//     a too-old LOCAL server; an older client (or any remote mismatch) errors.
+// just connected to, returning whether it relaunched it (so the caller can
+// re-settle its connection onto the new process). The decision is delegated to
+// the pure, table-tested decideReconcile; this only performs the chosen action.
 func reconcileServer(ctx context.Context, ep Endpoint, svc fleetgrpc.FleetServiceClient, reply *fleetgrpc.HelloReply, spawned bool) (restarted bool, err error) {
 	cv := version.Version
 	sv := reply.GetServerVersion()
+	// Binary-mtime staleness only matters for a dev client; skip the stat otherwise.
+	stale := cv == "" && serverIsStale(reply)
 
-	if cv == "" { // dev client: use binary freshness instead of version strings
-		// A server we just spawned is, by definition, the current binary.
-		if spawned || !ep.IsLocal() {
-			return false, nil
-		}
-		if !serverIsStale(reply) {
-			return false, nil
-		}
+	switch action, decErr := decideReconcile(cv, sv, ep.IsLocal(), spawned, stale); action {
+	case actionRestart:
 		if err := restartServer(ctx, ep, svc); err != nil {
 			return false, err
 		}
 		return true, nil
+	case actionError:
+		return false, decErr
+	default:
+		return false, nil
+	}
+}
+
+// reconcileAction is the pure policy decision computed by decideReconcile.
+type reconcileAction int
+
+const (
+	actionNone    reconcileAction = iota // the running server is acceptable as-is
+	actionRestart                        // a LOCAL server must be drained + relaunched
+	actionError                          // incompatible; cannot reconcile
+)
+
+// decideReconcile is the version/freshness policy expressed as a pure function,
+// so every case is unit-testable without spawning a process. cv is this client's
+// compiled-in version ("" = a dev build); sv is the server's reported version
+// ("" = a dev build); isLocal = the server runs on this host; spawned = WE just
+// started it; stale = (dev client only) this binary postdates the server's start.
+//
+//   - DEV client: ignore versions entirely — restart a local, pre-existing
+//     server only when this freshly-built binary postdates it. This holds even
+//     against a VERSIONED server, since one machine both tests dev builds and
+//     runs the release, so build-time is the only reliable signal.
+//   - VERSIONED client: a server reporting NO version is a dev build — replace it
+//     locally, error on a remote one. The same numeric core is fine (a
+//     pre-release counts as its release; see versionCore). A strictly-older local
+//     server is replaced; a newer one (or any remote version mismatch) errors.
+func decideReconcile(cv, sv string, isLocal, spawned, stale bool) (reconcileAction, error) {
+	if cv == "" { // dev client
+		if spawned || !isLocal || !stale {
+			return actionNone, nil
+		}
+		return actionRestart, nil
 	}
 
 	// Versioned client.
-	if sv == "" || cv == sv {
-		return false, nil
+	if sv == "" { // server is a dev build (or pre-version)
+		if !isLocal {
+			return actionError, fmt.Errorf("fleet server is a dev build but client is %s — restart the server", cv)
+		}
+		return actionRestart, nil
 	}
-	if !ep.IsLocal() {
-		return false, fmt.Errorf("fleet server is %s but client is %s — upgrade your client", sv, cv)
+	if versionCore(cv) == versionCore(sv) {
+		return actionNone, nil
+	}
+	if !isLocal {
+		return actionError, fmt.Errorf("fleet server is %s but client is %s — upgrade your client", sv, cv)
 	}
 	if versionLess(sv, cv) { // server older than this client
-		if err := restartServer(ctx, ep, svc); err != nil {
-			return false, err
-		}
-		return true, nil
+		return actionRestart, nil
 	}
-	return false, fmt.Errorf("fleet server is newer (%s) than this client (%s) — upgrade your client", sv, cv)
+	return actionError, fmt.Errorf("fleet server is newer (%s) than this client (%s) — upgrade your client", sv, cv)
 }
 
 // serverIsStale reports whether the running server predates this client binary —
@@ -124,12 +149,25 @@ func restartReason() string {
 
 func strptr(s string) *string { return &s }
 
-// versionLess reports whether version a is strictly older than b. Both are
-// dotted numeric versions with an optional leading 'v' (e.g. v1.2.3). A
-// non-numeric component falls back to a string compare for that position.
+// versionCore strips an optional leading 'v' and any pre-release/build suffix
+// (everything from the first '-'), leaving the dotted numeric core: so
+// "v1.2.3-beta" and "v1.2.3" both yield "1.2.3". This keeps a pre-release from
+// being treated as a different — or "newer" — version than its release.
+func versionCore(v string) string {
+	v = strings.TrimPrefix(v, "v")
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		v = v[:i]
+	}
+	return v
+}
+
+// versionLess reports whether version a is strictly older than b, comparing only
+// their numeric cores — pre-release/build suffixes are ignored (see versionCore),
+// so v1.2.3-beta and v1.2.3 are NOT ordered relative to each other. A non-numeric
+// component falls back to a string compare for that position.
 func versionLess(a, b string) bool {
-	as := strings.Split(strings.TrimPrefix(a, "v"), ".")
-	bs := strings.Split(strings.TrimPrefix(b, "v"), ".")
+	as := strings.Split(versionCore(a), ".")
+	bs := strings.Split(versionCore(b), ".")
 	for i := 0; i < len(as) || i < len(bs); i++ {
 		var ai, bi string
 		if i < len(as) {

--- a/internal/fleetclient/version_check_test.go
+++ b/internal/fleetclient/version_check_test.go
@@ -1,0 +1,100 @@
+package fleetclient
+
+import "testing"
+
+// TestDecideReconcile encodes the full version/freshness policy table. Each row
+// is (client version, server version, isLocal, spawned, stale) -> action.
+func TestDecideReconcile(t *testing.T) {
+	const (
+		dev  = "" // a dev build reports no version
+		beta = "v1.0.0-beta"
+		v100 = "v1.0.0"
+		v101 = "v1.0.1"
+	)
+	cases := []struct {
+		name                   string
+		cv, sv                 string
+		isLocal, spawned, stale bool
+		want                   reconcileAction
+	}{
+		// --- DEV client: versions ignored, decided by binary freshness ---
+		{"dev: just spawned", dev, dev, true, true, true, actionNone},
+		{"dev: remote", dev, dev, false, false, true, actionNone},
+		{"dev: local, not stale", dev, dev, true, false, false, actionNone},
+		{"dev: local, stale", dev, dev, true, false, true, actionRestart},
+		// A dev client restarts even a VERSIONED server when its binary is newer
+		// (one machine both tests dev builds and runs the release).
+		{"dev: local, stale, versioned server", dev, v100, true, false, true, actionRestart},
+		{"dev: local, not stale, versioned server", dev, v100, true, false, false, actionNone},
+
+		// --- VERSIONED client ---
+		// The fix: a release reclaims a leftover LOCAL dev (no-version) server.
+		{"versioned: dev server, local -> restart", v100, dev, true, false, false, actionRestart},
+		// A remote dev server can't be relaunched -> error.
+		{"versioned: dev server, remote -> error", v100, dev, false, false, false, actionError},
+		// Same numeric core (pre-release counts as its release) -> leave it.
+		{"versioned: same core (stable vs beta) -> none", v100, beta, true, false, false, actionNone},
+		{"versioned: identical -> none", v100, v100, true, false, false, actionNone},
+		{"versioned: beta client vs beta server -> none", beta, beta, true, false, false, actionNone},
+		// Older local server -> replace.
+		{"versioned: older server, local -> restart", v101, v100, true, false, false, actionRestart},
+		{"versioned: older server core via beta -> restart", v101, beta, true, false, false, actionRestart},
+		// Newer server -> client must upgrade (error), never restart.
+		{"versioned: newer server -> error", v100, v101, true, false, false, actionError},
+		// Any version mismatch on a remote server -> error.
+		{"versioned: older server but remote -> error", v101, v100, false, false, false, actionError},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := decideReconcile(tc.cv, tc.sv, tc.isLocal, tc.spawned, tc.stale)
+			if got != tc.want {
+				t.Fatalf("decideReconcile(%q,%q,local=%v,spawned=%v,stale=%v) action = %v, want %v",
+					tc.cv, tc.sv, tc.isLocal, tc.spawned, tc.stale, got, tc.want)
+			}
+			if (err != nil) != (tc.want == actionError) {
+				t.Fatalf("error presence = %v (err=%v), want error==%v", err != nil, err, tc.want == actionError)
+			}
+		})
+	}
+}
+
+func TestVersionCore(t *testing.T) {
+	cases := map[string]string{
+		"v1.2.3":        "1.2.3",
+		"1.2.3":         "1.2.3",
+		"v1.2.3-beta":   "1.2.3",
+		"v1.0.0-rc.1":   "1.0.0",
+		"v1.0.0-beta-2": "1.0.0", // trims at the FIRST '-'
+		"":              "",
+	}
+	for in, want := range cases {
+		if got := versionCore(in); got != want {
+			t.Errorf("versionCore(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestVersionLess(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"v1.0.0", "v1.0.1", true},
+		{"v1.0.1", "v1.0.0", false},
+		{"v1.0.0", "v1.0.0", false},
+		{"v1.2.0", "v1.10.0", true}, // numeric, not lexical: 2 < 10
+		{"v2.0.0", "v1.9.9", false},
+		// Pre-release suffixes are ignored: same core is never "less".
+		{"v1.0.0-beta", "v1.0.0", false},
+		{"v1.0.0", "v1.0.0-beta", false},
+		// Core ordering still applies across a pre-release.
+		{"v1.0.0-beta", "v1.0.1", true},
+		{"v1.0.1", "v1.0.0-beta", false},
+	}
+	for _, tc := range cases {
+		if got := versionLess(tc.a, tc.b); got != tc.want {
+			t.Errorf("versionLess(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What & why

Found while installing `v1.0.0-beta` over a still-running dev-built daemon: the new release *client* connected but **kept using the old dev *server*** (same PID, running out of the dev folder). Two reconcile-policy fixes:

1. **A versioned client now reclaims a local dev/no-version server.** Previously the versioned-client branch short-circuited on `sv == ""` (`if sv == "" || cv == sv { return false }`), so a release never restarted a leftover dev daemon. Now: a server reporting **no version** is treated as a dev build → **restart it locally**, **error on a remote one** (can't relaunch a remote process).

2. **Version comparison ignores the pre-release/build suffix and compares the numeric core.** `versionCore` strips everything from the first `-`, so `v1.2.3-beta` and `v1.2.3` share core `1.2.3`. Without this, a future stable `v1.0.0` client meeting the running `v1.0.0-beta` server would wrongly hit the *"server is newer"* error instead of treating them as the same release — a real footgun for this very beta.

The **dev-client path is unchanged**: ignore versions entirely, restart a local pre-existing server only when this freshly-built binary postdates it (even against a versioned server — one machine both tests dev builds and runs the release).

## The policy table (now enforced)

**Dev client** — decided by binary mtime vs server `started_at`, server version ignored:

| Condition | Action |
|---|---|
| just spawned / remote / not stale | none |
| local & this binary newer than server start | **restart** |

**Versioned client:**

| Server reports | Local? | Action |
|---|---|---|
| no version (dev) | local | **restart** ⬅️ the fix |
| no version (dev) | remote | error |
| same core (incl. `-beta` of same version) | either | none |
| older core | local | **restart** |
| older core | remote | error |
| newer core | either | error ("upgrade your client") |

## How it's verified

The decision is extracted into a pure `decideReconcile(cv, sv, isLocal, spawned, stale)` so it's unit-testable without spawning processes. `version_check_test.go` covers every row above plus `versionCore`/`versionLess` (incl. the `-beta` ordering). `go build/vet/test ./...` + `golangci-lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)