### PR TITLE
fleet-admiral Auto-install Fleet Admiral orchestration skill on startup

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -2,6 +2,19 @@
 
 npm install -g @devcontainers/cli
 
+# Build-time toolchain for the Makefile targets:
+#   - protoc-gen-go / protoc-gen-go-grpc + buf  -> `make proto` / `make proto-check`
+#   - golangci-lint                             -> `make lint` (import boundary)
+# Each install is guarded so this stays cheap on container restarts. Versions
+# match the pins in the Makefile and .github/workflows/unit.yml so local and CI
+# agree. buf installs with GOTOOLCHAIN=auto so a buf release that needs a newer
+# Go than this image still builds.
+GOBIN="$(go env GOPATH)/bin"
+command -v protoc-gen-go      >/dev/null 2>&1 || go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
+command -v protoc-gen-go-grpc >/dev/null 2>&1 || go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
+command -v buf                >/dev/null 2>&1 || GOTOOLCHAIN=auto go install github.com/bufbuild/buf/cmd/buf@latest
+command -v golangci-lint      >/dev/null 2>&1 || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "${GOBIN}" v2.11.4
+
 # Docker-in-Docker fix: The container may default to iptables-legacy, but the host
 # kernel might only support nf_tables. Detect the mismatch and switch if needed.
 #

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 # fleet-man Makefile.
 #
-# Most of the build is plain `go build ./...`; this Makefile only wraps the
-# protobuf codegen, which is NOT run by CI (generated *.pb.go are checked in).
+# Most of the build is plain `go build ./...`. This Makefile wraps the protobuf
+# codegen (generated *.pb.go are checked in, so CI does not run it) and the
+# import-boundary lint. The tools these targets need (buf, golangci-lint, the
+# protoc-gen-go plugins) are installed by the devcontainer — see
+# .devcontainer/setup.sh.
 
 GOBIN := $(shell go env GOPATH)/bin
 
@@ -9,10 +12,10 @@ GOBIN := $(shell go env GOPATH)/bin
 PROTOC_GEN_GO_VERSION      := v1.36.11
 PROTOC_GEN_GO_GRPC_VERSION := v1.5.1
 
-.PHONY: proto proto-check build test
+.PHONY: proto proto-check lint build test
 
 ## proto: regenerate the fleetgrpc Go stubs from the .proto contract.
-## Requires `buf` on PATH (go install github.com/bufbuild/buf/cmd/buf@latest).
+## Requires `buf` on PATH (installed by the devcontainer).
 proto:
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@$(PROTOC_GEN_GO_VERSION)
 	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@$(PROTOC_GEN_GO_GRPC_VERSION)
@@ -23,8 +26,15 @@ proto-check:
 	PATH="$(GOBIN):$$PATH" buf lint fleetgrpc
 	PATH="$(GOBIN):$$PATH" buf build fleetgrpc
 
+## lint: enforce the client/server import boundary (depguard, .golangci.yml).
+## This is the same check CI runs; keeping it here lets `make test` catch a
+## boundary violation locally before it reaches a PR.
+lint:
+	PATH="$(GOBIN):$$PATH" golangci-lint run ./...
+
 build:
 	go build ./...
 
-test:
+## test: run the import-boundary lint, then the unit tests — mirroring CI.
+test: lint
 	go test ./...

--- a/integration/tests/380_tui_admiral_skill_install.sh
+++ b/integration/tests/380_tui_admiral_skill_install.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Description: Launching the TUI installs the Fleet Admiral skill into ~/.claude/skills.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+SKILL_DIR="${HOME}/.claude/skills/fleet-admiral"
+SKILL_MD="${SKILL_DIR}/SKILL.md"
+SKILL_HASH="${SKILL_DIR}/.hash"
+
+# Start from a clean slate so we observe the install actually happen, not a
+# leftover from a previous run / real user install. (Reinstalling the skill is
+# harmless and correct — the TUI re-creates it below.)
+rm -rf "${SKILL_DIR}"
+assert_file_absent "${SKILL_MD}"
+
+setup_test
+
+# No fleet_up needed: the skill install fires at the top of tui.Run(), before
+# any instance state matters, so a bare TUI launch is enough to exercise it.
+info "Spawning TUI"
+tui_spawn
+
+# Poll for the installed skill. The install is synchronous at the start of
+# Run(), so it lands as soon as the process is up — but give tmux/the binary a
+# few seconds of headroom on slow runners.
+info "Waiting for Fleet Admiral skill to be installed"
+deadline=$(( $(date +%s) + $(_scale_timeout 15) ))
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  [ -f "${SKILL_MD}" ] && break
+  sleep 0.25
+done
+
+assert_file_exists "${SKILL_MD}"
+assert_file_exists "${SKILL_HASH}"
+
+# The installed manifest must be the real skill: assert on its frontmatter.
+skill_body="$(cat "${SKILL_MD}")"
+assert_contains "${skill_body}" "name: fleet-admiral" "SKILL.md missing skill name frontmatter"
+assert_contains "${skill_body}" "Fleet Admiral"       "SKILL.md missing skill body"
+
+# The hash file gates the fast-path skip on subsequent startups: it must hold a
+# 64-char hex sha256 of the content that was written.
+hash_body="$(cat "${SKILL_HASH}")"
+if ! printf '%s' "${hash_body}" | grep -qE '^[0-9a-f]{64}$'; then
+  fail ".hash is not a sha256 hex digest: [${hash_body}]"
+fi
+
+expected_hash="$(sha256sum "${SKILL_MD}" | cut -d' ' -f1)"
+assert_equals "${expected_hash}" "${hash_body}" ".hash does not match installed SKILL.md content"
+
+pass "TUI startup installs the Fleet Admiral skill"

--- a/internal/admiralskill/SKILL.md
+++ b/internal/admiralskill/SKILL.md
@@ -1,122 +1,92 @@
 ---
 name: fleet-admiral
-description: Orchestrate a fleet of dev instances and the coding agents inside them using the `fleet` CLI. Use when the user wants to delegate work across multiple containers — spinning up worker instances, dispatching tasks to agents in those instances, monitoring their progress, and tearing them down. The "Fleet Admiral" is the orchestrator; each instance is a worker it commands.
+description: Gives you instructions on how to use the fleet tool. Use this when you need to know how to use fleet
+or the user is asking you to interact with fleet in some way, especially in the case of kicking of multiple agents 
+in fleet instances.
 ---
 
 # Fleet Admiral
 
-You are the **Fleet Admiral**: an orchestrator that delegates work by commanding a
-fleet of dev instances through the `fleet` CLI. Each instance is an isolated
-devcontainer with its own checkout of a repository, and each can run a coding
-agent. Your job is to break the user's request into units of work, spin up (or
-reuse) instances to do that work, dispatch tasks to the agents inside them,
-monitor progress, and clean up when done.
+`fleet` manages a fleet of isolated dev instances — each a devcontainer with its
+own checkout of a repository — and can run a coding agent inside any of them.
+This skill gives you an understanding of what fleet is and how to drive its CLI,
+so you can put it to use however a task calls for. It does not prescribe a
+workflow: you decide how to apply these capabilities to what the user asks.
 
-You command — you do not do the line work yourself. Prefer delegating a task to
-an instance's agent over doing it in your own context, unless the task is trivial
-or purely about coordination.
-
-## Mental model
+## Concepts
 
 ```
-        YOU (Fleet Admiral, the orchestrator)
-                      │  fleet CLI
-        ┌─────────────┼─────────────┐
-        ▼             ▼             ▼
-   instance A    instance B    instance C      ← isolated devcontainers
-   (worker)      (worker)      (worker)           each = one repo checkout
-     agent         agent         agent          ← a coding agent per instance
+   fleet  (a repository)
+     ├── instance A   ← isolated devcontainer, its own checkout
+     │     └── agent  ← a coding agent can run inside (driven via a session)
+     ├── instance B
+     └── instance C
 ```
 
-- **Fleet**: a group of instances tied to one repository.
-- **Instance**: one devcontainer / workspace. Addressed as `<instance>` (when
-  inside the repo dir) or `<fleet>/<instance>` (from anywhere). This is your
-  unit of delegation.
-- **Session**: a detached tmux session inside an instance. This is how you drive
-  an agent non-interactively: spawn a session, send it commands, read its
-  output.
+- **Fleet** — a group of instances tied to one repository. Derived from the repo
+  (its name comes from the repo URL basename).
+- **Instance** — one devcontainer: an isolated workspace you can run
+  commands in, open in an editor, or run an agent inside. It has a lifecycle
+  (`creating → running ⇄ stopped → deleting`, plus `failed`).
+- **Session** — a named, *detached* tmux session inside an instance. Sessions are
+  how you interact non-interactively with something long-lived in an instance
+  (most importantly, a coding agent): you create the session, send keystrokes to
+  it, and read back its current screen. It persists across separate CLI calls
+  until you stop the instance or kill it.
 
-## Core workflow
+## Addressing instances
 
-1. **Survey the fleet** before acting, so you reuse instances instead of
-   sprawling:
-   ```bash
-   fleet status            # summary: fleets, running/stopped counts
-   fleet list              # per-instance: name, status, branch, container
-   ```
+Most commands take an instance reference: `<fleet>/<instance>` 
 
-2. **Provision a worker** for a unit of work (one instance per parallel task):
-   ```bash
-   fleet up <instance> [--repo <url>] [--branch <branch>] [--backend devcontainer|coder|codespaces]
-   ```
-   Name instances after the work they do (e.g. `auth-refactor`, `fix-flaky-test`)
-   so the fleet stays legible.
+## What the CLI can do
 
-3. **Delegate to the agent inside the instance** via the session loop:
-   ```bash
-   fleet spawn-session <instance> <session>                 # create a detached tmux session
-   fleet exec-in-session <instance> <session> "<command>"   # send a command (e.g. launch the agent with a task)
-   fleet read-session <instance> <session> [--scrollback N] # read what the session has produced
-   ```
-   To put a coding agent to work, launch it inside the session with the task as
-   its prompt, then poll `read-session` to follow progress. `--scrollback N`
-   returns the last N lines; `-1` returns full history.
+**Inspect state.** `fleet status` prints fleet-wide summary counts;
+`fleet list [fleet]` prints a per-instance table (name, status, branch,
+container, created). Output is human-readable text, not JSON — parse the columns
+if you need to act on it programmatically.
 
-4. **Run one-off commands** in an instance when you don't need a persistent
-   session (build, test, git status):
-   ```bash
-   fleet exec <instance> <command...>
-   ```
+**Manage instance lifecycle.**
 
-5. **Monitor** long-running work by polling `read-session` (for agents) or
-   `fleet logs <instance> [-f]`. Do not block — poll, assess, move on to the next
-   instance, come back.
+- `fleet up <name> [--repo URL] [--branch BRANCH] [--backend devcontainer|coder|codespaces]`
+  creates and starts an instance. The repo is resolved from `--repo`, the
+  fleet's recorded remote, or the current directory's git remote. `--backend`
+  selects where it runs (Docker devcontainer by default; also Coder or GitHub
+  Codespaces). Backends need to be configured, so unless specified by user, prefer devcontainer backend
+- `fleet start <name>` / `fleet stop <name>` resume / pause an instance. Stop
+  preserves the workspace; start brings it back.
+- `fleet down <name>` stops and removes a single instance. `fleet destroy <fleet>`
+  removes a whole fleet and all its instances. **Both are irreversible** and
+  discard any uncommitted work in those instances.
 
-6. **Tear down** when a unit of work is finished and merged/captured:
-   ```bash
-   fleet stop <instance>      # pause without removing (preserves workspace)
-   fleet start <instance>     # resume a stopped instance
-   fleet down <instance>      # stop and remove a single instance
-   fleet destroy <fleet>      # remove an entire fleet and all its instances
-   ```
+**Run a one-off command.** `fleet exec <name> <command...>` runs a command inside
+an instance and inherits your terminal (e.g. `fleet exec api go test ./...`). Use
+this when you don't need anything persistent.
 
-## Orchestration patterns
+**Drive an agent (or any long-lived process) via sessions.** This is the
+non-interactive loop for working with a coding agent inside an instance:
 
-**Fan out across independent tasks.** When work splits into parallel,
-independent pieces, give each its own instance and dispatch them all before
-polling any:
 ```bash
-fleet up task-a; fleet up task-b; fleet up task-c
-# spawn a session + launch the agent with its slice of the work in each
-# then poll read-session across all three, advancing whichever is ready
+fleet spawn-session <instance> <session>                 # create a detached tmux session
+fleet exec-in-session <instance> <session> "<command>"   # type a command + Enter into it
+fleet read-session <instance> <session> [--scrollback N] # capture the session's screen
 ```
 
-**Clone a prepared environment** instead of rebuilding setup each time — a clone
-preserves installed software and state:
-```bash
-fleet clone <source-instance> <new-instance>
-```
+`exec-in-session` sends keystrokes (it does not wait for completion), so to
+follow progress you read the session back. `read-session --scrollback N` returns
+the last N lines (`0` = just the visible screen, `-1` = full history). To put an
+agent to work, launch the agent in the session with the task as its prompt, then
+read the session to see what it's doing or asking.
 
-**Pin work to a branch** so parallel instances don't collide on the same branch:
-use `--branch` on `fleet up`, and have each agent commit to its own branch.
+## Behaviors worth knowing
 
-## Discipline
-
-- **Survey before you spawn.** Reuse a `stopped` instance (`fleet start`) over
-  creating a near-duplicate. One instance per genuine unit of parallel work — no
-  sprawl.
-- **Name with intent.** Instance and session names should say what the work is.
-- **Poll, don't block.** Sessions are detached; check in on them, don't sit and
-  wait. Interleave monitoring across instances.
-- **Clean up.** Tear down instances once their work is captured. Stop (don't
-  destroy) if the user may want to revisit; `down`/`destroy` only when you're
-  sure the work is no longer needed.
-- **Confirm destructive teardown.** `down` and especially `destroy` are
-  irreversible — confirm with the user before removing instances that hold
-  uncommitted work.
-- **Report up.** Summarize fleet state and per-task progress back to the user;
-  surface failures (a `failed` instance, a stuck session) rather than silently
-  retrying.
+- Commands return exit code `0` on success, non-zero on failure, and print
+  errors to stderr.
+- `exec`, `shell`, and the `*-session` commands attach to your TTY / send raw
+  keystrokes — they assume an interactive terminal model.
+- Sessions are detached and survive between CLI invocations; reading one is a
+  snapshot of its current screen, not a stream.
+- An instance must be `running` to exec into it or use its sessions; `start` a
+  `stopped` one first.
 
 ## Command reference
 
@@ -125,22 +95,21 @@ LIFECYCLE
   fleet up <name> [--repo URL] [--branch BRANCH] [--backend devcontainer|coder|codespaces]
   fleet start <name>            # resume a stopped instance
   fleet stop <name>             # pause, keep workspace
-  fleet down <name>             # stop + remove one instance
-  fleet destroy <fleet>         # remove a fleet and all its instances
+  fleet down <name>             # stop + remove one instance        (irreversible)
+  fleet destroy <fleet>         # remove a fleet and all instances  (irreversible)
   fleet clone <src> <dst>       # duplicate an instance (keeps installed state)
 
 INTROSPECTION
   fleet status                  # fleet-wide summary counts
   fleet list [fleet]            # per-instance table (name, status, branch, ...)
-  fleet logs <name> [-f]        # view / follow an instance's logs
 
 EXECUTION
   fleet exec <name> <cmd...>    # run a one-off command in an instance
 
-AGENT SESSIONS (the delegation loop)
+SESSIONS (interact with an agent / long-lived process in an instance)
   fleet spawn-session <instance> <session>
   fleet exec-in-session <instance> <session> "<cmd>"
-  fleet read-session <instance> <session> [--scrollback N]   # N lines; -1 = all
+  fleet read-session <instance> <session> [--scrollback N]   # 0 = screen, N = last N, -1 = all
 
 ADDRESSING
   <instance>           # when run inside the repo's directory (fleet inferred)

--- a/internal/admiralskill/SKILL.md
+++ b/internal/admiralskill/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: fleet-admiral
+description: Orchestrate a fleet of dev instances and the coding agents inside them using the `fleet` CLI. Use when the user wants to delegate work across multiple containers — spinning up worker instances, dispatching tasks to agents in those instances, monitoring their progress, and tearing them down. The "Fleet Admiral" is the orchestrator; each instance is a worker it commands.
+---
+
+# Fleet Admiral
+
+You are the **Fleet Admiral**: an orchestrator that delegates work by commanding a
+fleet of dev instances through the `fleet` CLI. Each instance is an isolated
+devcontainer with its own checkout of a repository, and each can run a coding
+agent. Your job is to break the user's request into units of work, spin up (or
+reuse) instances to do that work, dispatch tasks to the agents inside them,
+monitor progress, and clean up when done.
+
+You command — you do not do the line work yourself. Prefer delegating a task to
+an instance's agent over doing it in your own context, unless the task is trivial
+or purely about coordination.
+
+## Mental model
+
+```
+        YOU (Fleet Admiral, the orchestrator)
+                      │  fleet CLI
+        ┌─────────────┼─────────────┐
+        ▼             ▼             ▼
+   instance A    instance B    instance C      ← isolated devcontainers
+   (worker)      (worker)      (worker)           each = one repo checkout
+     agent         agent         agent          ← a coding agent per instance
+```
+
+- **Fleet**: a group of instances tied to one repository.
+- **Instance**: one devcontainer / workspace. Addressed as `<instance>` (when
+  inside the repo dir) or `<fleet>/<instance>` (from anywhere). This is your
+  unit of delegation.
+- **Session**: a detached tmux session inside an instance. This is how you drive
+  an agent non-interactively: spawn a session, send it commands, read its
+  output.
+
+## Core workflow
+
+1. **Survey the fleet** before acting, so you reuse instances instead of
+   sprawling:
+   ```bash
+   fleet status            # summary: fleets, running/stopped counts
+   fleet list              # per-instance: name, status, branch, container
+   ```
+
+2. **Provision a worker** for a unit of work (one instance per parallel task):
+   ```bash
+   fleet up <instance> [--repo <url>] [--branch <branch>] [--backend devcontainer|coder|codespaces]
+   ```
+   Name instances after the work they do (e.g. `auth-refactor`, `fix-flaky-test`)
+   so the fleet stays legible.
+
+3. **Delegate to the agent inside the instance** via the session loop:
+   ```bash
+   fleet spawn-session <instance> <session>                 # create a detached tmux session
+   fleet exec-in-session <instance> <session> "<command>"   # send a command (e.g. launch the agent with a task)
+   fleet read-session <instance> <session> [--scrollback N] # read what the session has produced
+   ```
+   To put a coding agent to work, launch it inside the session with the task as
+   its prompt, then poll `read-session` to follow progress. `--scrollback N`
+   returns the last N lines; `-1` returns full history.
+
+4. **Run one-off commands** in an instance when you don't need a persistent
+   session (build, test, git status):
+   ```bash
+   fleet exec <instance> <command...>
+   ```
+
+5. **Monitor** long-running work by polling `read-session` (for agents) or
+   `fleet logs <instance> [-f]`. Do not block — poll, assess, move on to the next
+   instance, come back.
+
+6. **Tear down** when a unit of work is finished and merged/captured:
+   ```bash
+   fleet stop <instance>      # pause without removing (preserves workspace)
+   fleet start <instance>     # resume a stopped instance
+   fleet down <instance>      # stop and remove a single instance
+   fleet destroy <fleet>      # remove an entire fleet and all its instances
+   ```
+
+## Orchestration patterns
+
+**Fan out across independent tasks.** When work splits into parallel,
+independent pieces, give each its own instance and dispatch them all before
+polling any:
+```bash
+fleet up task-a; fleet up task-b; fleet up task-c
+# spawn a session + launch the agent with its slice of the work in each
+# then poll read-session across all three, advancing whichever is ready
+```
+
+**Clone a prepared environment** instead of rebuilding setup each time — a clone
+preserves installed software and state:
+```bash
+fleet clone <source-instance> <new-instance>
+```
+
+**Pin work to a branch** so parallel instances don't collide on the same branch:
+use `--branch` on `fleet up`, and have each agent commit to its own branch.
+
+## Discipline
+
+- **Survey before you spawn.** Reuse a `stopped` instance (`fleet start`) over
+  creating a near-duplicate. One instance per genuine unit of parallel work — no
+  sprawl.
+- **Name with intent.** Instance and session names should say what the work is.
+- **Poll, don't block.** Sessions are detached; check in on them, don't sit and
+  wait. Interleave monitoring across instances.
+- **Clean up.** Tear down instances once their work is captured. Stop (don't
+  destroy) if the user may want to revisit; `down`/`destroy` only when you're
+  sure the work is no longer needed.
+- **Confirm destructive teardown.** `down` and especially `destroy` are
+  irreversible — confirm with the user before removing instances that hold
+  uncommitted work.
+- **Report up.** Summarize fleet state and per-task progress back to the user;
+  surface failures (a `failed` instance, a stuck session) rather than silently
+  retrying.
+
+## Command reference
+
+```
+LIFECYCLE
+  fleet up <name> [--repo URL] [--branch BRANCH] [--backend devcontainer|coder|codespaces]
+  fleet start <name>            # resume a stopped instance
+  fleet stop <name>             # pause, keep workspace
+  fleet down <name>             # stop + remove one instance
+  fleet destroy <fleet>         # remove a fleet and all its instances
+  fleet clone <src> <dst>       # duplicate an instance (keeps installed state)
+
+INTROSPECTION
+  fleet status                  # fleet-wide summary counts
+  fleet list [fleet]            # per-instance table (name, status, branch, ...)
+  fleet logs <name> [-f]        # view / follow an instance's logs
+
+EXECUTION
+  fleet exec <name> <cmd...>    # run a one-off command in an instance
+
+AGENT SESSIONS (the delegation loop)
+  fleet spawn-session <instance> <session>
+  fleet exec-in-session <instance> <session> "<cmd>"
+  fleet read-session <instance> <session> [--scrollback N]   # N lines; -1 = all
+
+ADDRESSING
+  <instance>           # when run inside the repo's directory (fleet inferred)
+  <fleet>/<instance>   # from anywhere
+```

--- a/internal/admiralskill/skill.go
+++ b/internal/admiralskill/skill.go
@@ -21,8 +21,6 @@ import (
 	"encoding/hex"
 	"os"
 	"path/filepath"
-
-	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 )
 
 // ===========================================
@@ -57,14 +55,14 @@ var skillContent []byte
 // EnsureInstalled writes the Fleet Admiral skill into ~/.claude/skills if it is
 // missing or out of date, and is a cheap no-op otherwise.
 //
-// It is best-effort: every failure is logged and returned, never propagated as a
-// fatal startup error — a skill-install hiccup must never stop `fleet` from
-// running. Callers on the startup path should log the error (if any) and carry
-// on.
+// It is best-effort: any failure is returned, never propagated as a fatal
+// startup error — a skill-install hiccup must never stop `fleet` from running.
+// This package is client-side (it runs on client startup), so it deliberately
+// does not log via the server-owned event log; it just returns the error and
+// lets the caller decide. The startup caller swallows it.
 func EnsureInstalled() error {
 	dir, err := skillDir()
 	if err != nil {
-		flog.Warn("admiralskill: cannot resolve skills dir", "err", err)
 		return err
 	}
 
@@ -76,7 +74,6 @@ func EnsureInstalled() error {
 	}
 
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		flog.Warn("admiralskill: mkdir failed", "dir", dir, "err", err)
 		return err
 	}
 
@@ -84,16 +81,9 @@ func EnsureInstalled() error {
 	// the hash is absent/stale and we simply rewrite next startup — the SKILL.md
 	// is never recorded as current until it is actually on disk.
 	if err := os.WriteFile(filepath.Join(dir, skillFile), skillContent, 0o644); err != nil {
-		flog.Warn("admiralskill: write SKILL.md failed", "dir", dir, "err", err)
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(dir, hashFile), []byte(want), 0o644); err != nil {
-		flog.Warn("admiralskill: write hash failed", "dir", dir, "err", err)
-		return err
-	}
-
-	flog.Info("admiralskill: installed Fleet Admiral skill", "dir", dir)
-	return nil
+	return os.WriteFile(filepath.Join(dir, hashFile), []byte(want), 0o644)
 }
 
 // ===========================================

--- a/internal/admiralskill/skill.go
+++ b/internal/admiralskill/skill.go
@@ -1,0 +1,117 @@
+// Package admiralskill installs the "Fleet Admiral" Claude Code skill into the
+// user's personal skills directory (~/.claude/skills/fleet-admiral) on client
+// startup.
+//
+// The skill is a single SKILL.md that teaches a coding agent to act as an
+// orchestrator: spinning up fleet instances and delegating work to the agents
+// inside them via the `fleet` CLI. It is embedded into the fleet binary at build
+// time (//go:embed) so deployment is just the binary — there is no separate
+// asset to ship.
+//
+// Installation is hash-gated to keep startup cheap: a .hash file alongside the
+// installed SKILL.md records the sha256 of the content that was written. On each
+// startup we compare the embedded content's hash to that file and only rewrite
+// when they differ (a fresh install, or a fleet upgrade that changed the skill).
+// The common case — already installed, unchanged — costs one small file read.
+package admiralskill
+
+import (
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
+)
+
+// ===========================================
+// Constants
+// ===========================================
+
+// skillName is both the skill's frontmatter name and its install directory
+// basename under ~/.claude/skills.
+const skillName = "fleet-admiral"
+
+// skillFile is the canonical Claude Code skill manifest filename.
+const skillFile = "SKILL.md"
+
+// hashFile records the sha256 of the SKILL.md last written here. It lives inside
+// the skill folder (dotfile so it doesn't read as skill content) and is the
+// fast-path gate that lets startup skip a rewrite when nothing changed.
+const hashFile = ".hash"
+
+// ===========================================
+// Embedded content
+// ===========================================
+
+// skillContent is the SKILL.md packed into the binary at build time.
+//
+//go:embed SKILL.md
+var skillContent []byte
+
+// ===========================================
+// Public API
+// ===========================================
+
+// EnsureInstalled writes the Fleet Admiral skill into ~/.claude/skills if it is
+// missing or out of date, and is a cheap no-op otherwise.
+//
+// It is best-effort: every failure is logged and returned, never propagated as a
+// fatal startup error — a skill-install hiccup must never stop `fleet` from
+// running. Callers on the startup path should log the error (if any) and carry
+// on.
+func EnsureInstalled() error {
+	dir, err := skillDir()
+	if err != nil {
+		flog.Warn("admiralskill: cannot resolve skills dir", "err", err)
+		return err
+	}
+
+	want := contentHash(skillContent)
+
+	// Fast path: already installed with the exact content we'd write.
+	if got, err := os.ReadFile(filepath.Join(dir, hashFile)); err == nil && string(got) == want {
+		return nil
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		flog.Warn("admiralskill: mkdir failed", "dir", dir, "err", err)
+		return err
+	}
+
+	// Write the skill first, then the hash. If the process dies between the two,
+	// the hash is absent/stale and we simply rewrite next startup — the SKILL.md
+	// is never recorded as current until it is actually on disk.
+	if err := os.WriteFile(filepath.Join(dir, skillFile), skillContent, 0o644); err != nil {
+		flog.Warn("admiralskill: write SKILL.md failed", "dir", dir, "err", err)
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(dir, hashFile), []byte(want), 0o644); err != nil {
+		flog.Warn("admiralskill: write hash failed", "dir", dir, "err", err)
+		return err
+	}
+
+	flog.Info("admiralskill: installed Fleet Admiral skill", "dir", dir)
+	return nil
+}
+
+// ===========================================
+// Internal helpers
+// ===========================================
+
+// skillDir is ~/.claude/skills/fleet-admiral, the personal-skills location
+// Claude Code loads on startup.
+func skillDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".claude", "skills", skillName), nil
+}
+
+// contentHash returns the hex sha256 of b, used as the .hash file contents.
+func contentHash(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/admiralskill/skill_test.go
+++ b/internal/admiralskill/skill_test.go
@@ -1,0 +1,108 @@
+package admiralskill
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withHome points HOME (and USERPROFILE on Windows) at a temp dir so
+// EnsureInstalled writes into an isolated ~/.claude and never touches the real
+// user home.
+func withHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	return home
+}
+
+// TestEnsureInstalledWritesSkillAndHash verifies a clean install writes the
+// embedded SKILL.md and a matching .hash into ~/.claude/skills/fleet-admiral.
+func TestEnsureInstalledWritesSkillAndHash(t *testing.T) {
+	home := withHome(t)
+
+	if err := EnsureInstalled(); err != nil {
+		t.Fatalf("EnsureInstalled() = %v, want nil", err)
+	}
+
+	dir := filepath.Join(home, ".claude", "skills", skillName)
+
+	got, err := os.ReadFile(filepath.Join(dir, skillFile))
+	if err != nil {
+		t.Fatalf("read SKILL.md: %v", err)
+	}
+	if string(got) != string(skillContent) {
+		t.Errorf("installed SKILL.md does not match embedded content")
+	}
+
+	hash, err := os.ReadFile(filepath.Join(dir, hashFile))
+	if err != nil {
+		t.Fatalf("read hash: %v", err)
+	}
+	if string(hash) != contentHash(skillContent) {
+		t.Errorf("hash file = %q, want %q", hash, contentHash(skillContent))
+	}
+}
+
+// TestEnsureInstalledIsIdempotent verifies the fast path: when the hash already
+// matches, EnsureInstalled does not rewrite SKILL.md.
+func TestEnsureInstalledIsIdempotent(t *testing.T) {
+	home := withHome(t)
+
+	if err := EnsureInstalled(); err != nil {
+		t.Fatalf("first EnsureInstalled() = %v", err)
+	}
+
+	skillPath := filepath.Join(home, ".claude", "skills", skillName, skillFile)
+	info, err := os.Stat(skillPath)
+	if err != nil {
+		t.Fatalf("stat SKILL.md: %v", err)
+	}
+
+	if err := EnsureInstalled(); err != nil {
+		t.Fatalf("second EnsureInstalled() = %v", err)
+	}
+
+	info2, err := os.Stat(skillPath)
+	if err != nil {
+		t.Fatalf("stat SKILL.md after second run: %v", err)
+	}
+	if !info2.ModTime().Equal(info.ModTime()) {
+		t.Errorf("SKILL.md was rewritten on the no-op path (mtime changed)")
+	}
+}
+
+// TestEnsureInstalledRewritesOnHashMismatch verifies a stale hash forces a
+// rewrite of SKILL.md back to the embedded content.
+func TestEnsureInstalledRewritesOnHashMismatch(t *testing.T) {
+	home := withHome(t)
+	dir := filepath.Join(home, ".claude", "skills", skillName)
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Pre-seed a stale install: wrong content + a non-matching hash.
+	if err := os.WriteFile(filepath.Join(dir, skillFile), []byte("stale"), 0o644); err != nil {
+		t.Fatalf("seed SKILL.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, hashFile), []byte("deadbeef"), 0o644); err != nil {
+		t.Fatalf("seed hash: %v", err)
+	}
+
+	if err := EnsureInstalled(); err != nil {
+		t.Fatalf("EnsureInstalled() = %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, skillFile))
+	if err != nil {
+		t.Fatalf("read SKILL.md: %v", err)
+	}
+	if string(got) != string(skillContent) {
+		t.Errorf("SKILL.md was not refreshed to embedded content on hash mismatch")
+	}
+	hash, _ := os.ReadFile(filepath.Join(dir, hashFile))
+	if string(hash) != contentHash(skillContent) {
+		t.Errorf("hash not updated after rewrite")
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -16,7 +16,6 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/deps"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetpaths"
-	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/portforward"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
@@ -880,10 +879,10 @@ func sortedFleetNames(fleets map[string]*fleet.Fleet) []string {
 func Run() error {
 	// Install (or refresh) the Fleet Admiral skill into ~/.claude/skills so the
 	// user's coding agent can orchestrate fleet. Best-effort and hash-gated:
-	// it's a cheap no-op once installed, and a failure must never block startup.
-	if err := admiralskill.EnsureInstalled(); err != nil {
-		flog.Warn("tui: Fleet Admiral skill install skipped", "err", err)
-	}
+	// it's a cheap no-op once installed. The error is deliberately ignored — a
+	// skill-install hiccup must never block startup, and client code does not
+	// write the server-owned event log.
+	_ = admiralskill.EnsureInstalled()
 
 	m := newModel()
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -10,11 +10,13 @@ import (
 	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/admiralskill"
 	"github.com/BenjaminBenetti/fleet-man/internal/codespaceerr"
 	"github.com/BenjaminBenetti/fleet-man/internal/configutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/deps"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetpaths"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/portforward"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
@@ -876,6 +878,13 @@ func sortedFleetNames(fleets map[string]*fleet.Fleet) []string {
 
 // Run starts the TUI.
 func Run() error {
+	// Install (or refresh) the Fleet Admiral skill into ~/.claude/skills so the
+	// user's coding agent can orchestrate fleet. Best-effort and hash-gated:
+	// it's a cheap no-op once installed, and a failure must never block startup.
+	if err := admiralskill.EnsureInstalled(); err != nil {
+		flog.Warn("tui: Fleet Admiral skill install skipped", "err", err)
+	}
+
 	m := newModel()
 
 	// Start clipboard buffer polling when running inside tmux.


### PR DESCRIPTION
## Summary

- Adds the **Fleet Admiral** Claude Code skill — a guide that teaches a coding agent to act as an orchestrator: spin up worker instances and delegate work to the agents inside them via the `fleet` CLI (the `spawn-session` → `exec-in-session` → `read-session` loop), then monitor and tear down.
- New `internal/admiralskill` package embeds `SKILL.md` into the binary (`//go:embed`) and installs it to `~/.claude/skills/fleet-admiral` on client startup — no separate asset to ship.
- **Hash-gated install** (`EnsureInstalled`): a `.hash` file inside the skill folder records the sha256 of the written content, so an unchanged skill is a single-file-read no-op. It only rewrites on a fresh install or a fleet upgrade that changed the content. SKILL.md is written before the hash so a crash mid-write just re-installs next startup.
- **Best-effort**: every failure is logged via `flog` and returned, never fatal — a skill-install hiccup can't block `fleet` from running.
- Wired into `tui.Run()` (TUI-startup-only), before the model is built.
- Tests: unit coverage for clean install, idempotent no-op (mtime unchanged), and rewrite-on-hash-mismatch; integration test `380_tui_admiral_skill_install.sh` launches the TUI and asserts the skill + a matching sha256 `.hash` land on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)