### PR TITLE
feat(buildkit): per-fleet shared buildkit server

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"bcc7cb75-9720-44f2-867b-e8c15121637b","pid":44318,"procStart":"43977434","acquiredAt":1780631320803}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,8 @@ linters:
               desc: client code must not touch backends directly; use fleetgrpc RPCs/jobs
             - pkg: github.com/BenjaminBenetti/fleet-man/internal/create
               desc: provisioning is a server-side job; call fleetgrpc.CreateInstance
+            - pkg: github.com/BenjaminBenetti/fleet-man/internal/buildkit
+              desc: the shared buildkit server is server-side provisioning; clients only flip FleetSettings.BuildkitServer via fleetgrpc
             - pkg: github.com/BenjaminBenetti/fleet-man/internal/control
               desc: the server owns control sockets; clients receive control events over Watch
             - pkg: github.com/BenjaminBenetti/fleet-man/internal/flog

--- a/fleetgrpc/domain.pb.go
+++ b/fleetgrpc/domain.pb.go
@@ -365,8 +365,15 @@ type FleetSettings struct {
 	GhMount           bool                   `protobuf:"varint,3,opt,name=gh_mount,json=ghMount,proto3" json:"gh_mount,omitempty"`
 	HomeDir           *string                `protobuf:"bytes,4,opt,name=home_dir,json=homeDir,proto3,oneof" json:"home_dir,omitempty"`
 	PreferFleetLaunch *bool                  `protobuf:"varint,5,opt,name=prefer_fleet_launch,json=preferFleetLaunch,proto3,oneof" json:"prefer_fleet_launch,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// buildkit_server enables a shared moby/buildkit container for the fleet
+	// whose unix socket (under ~/.fleet/workspaces/<fleet>/.buildkit/) is
+	// bind-mounted into every instance, giving all instances one shared build
+	// cache. Plain bool (default off): false == "never set" == disabled, like
+	// the *Mount flags. Honored only on backends that SupportsCustomMounts()
+	// (devcontainer); cloud backends silently skip it.
+	BuildkitServer bool `protobuf:"varint,6,opt,name=buildkit_server,json=buildkitServer,proto3" json:"buildkit_server,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *FleetSettings) Reset() {
@@ -430,6 +437,13 @@ func (x *FleetSettings) GetHomeDir() string {
 func (x *FleetSettings) GetPreferFleetLaunch() bool {
 	if x != nil && x.PreferFleetLaunch != nil {
 		return *x.PreferFleetLaunch
+	}
+	return false
+}
+
+func (x *FleetSettings) GetBuildkitServer() bool {
+	if x != nil {
+		return x.BuildkitServer
 	}
 	return false
 }
@@ -677,14 +691,15 @@ const file_domain_proto_rawDesc = "" +
 	"\x06_errorB\x06\n" +
 	"\x04_tagB\b\n" +
 	"\x06_colorB\t\n" +
-	"\a_branchJ\x04\b\x0e\x10\x1f\"\xf1\x01\n" +
+	"\a_branchJ\x04\b\x0e\x10\x1f\"\x9a\x02\n" +
 	"\rFleetSettings\x12*\n" +
 	"\x11claude_code_mount\x18\x01 \x01(\bR\x0fclaudeCodeMount\x12\x1f\n" +
 	"\vcodex_mount\x18\x02 \x01(\bR\n" +
 	"codexMount\x12\x19\n" +
 	"\bgh_mount\x18\x03 \x01(\bR\aghMount\x12\x1e\n" +
 	"\bhome_dir\x18\x04 \x01(\tH\x00R\ahomeDir\x88\x01\x01\x123\n" +
-	"\x13prefer_fleet_launch\x18\x05 \x01(\bH\x01R\x11preferFleetLaunch\x88\x01\x01B\v\n" +
+	"\x13prefer_fleet_launch\x18\x05 \x01(\bH\x01R\x11preferFleetLaunch\x88\x01\x01\x12'\n" +
+	"\x0fbuildkit_server\x18\x06 \x01(\bR\x0ebuildkitServerB\v\n" +
 	"\t_home_dirB\x16\n" +
 	"\x14_prefer_fleet_launch\"\xa2\x01\n" +
 	"\x05Fleet\x12\x12\n" +

--- a/fleetgrpc/domain.proto
+++ b/fleetgrpc/domain.proto
@@ -146,6 +146,13 @@ message FleetSettings {
   bool gh_mount = 3;
   optional string home_dir = 4;
   optional bool prefer_fleet_launch = 5;
+  // buildkit_server enables a shared moby/buildkit container for the fleet
+  // whose unix socket (under ~/.fleet/workspaces/<fleet>/.buildkit/) is
+  // bind-mounted into every instance, giving all instances one shared build
+  // cache. Plain bool (default off): false == "never set" == disabled, like
+  // the *Mount flags. Honored only on backends that SupportsCustomMounts()
+  // (devcontainer); cloud backends silently skip it.
+  bool buildkit_server = 6;
 }
 
 // Fleet mirrors internal/fleet.Fleet. Settings is a NESTED message (not inlined)

--- a/integration/common.sh
+++ b/integration/common.sh
@@ -227,16 +227,17 @@ setup_launch_test() {
 # the settings-driven code paths without driving the TUI.
 #
 # Usage:
-#   seed_fleet_settings <fleet_name> <claude:true|false> <codex:true|false> <homedir> [<gh:true|false>]
+#   seed_fleet_settings <fleet_name> <claude:true|false> <codex:true|false> <homedir> [<gh:true|false>] [<buildkit:true|false>]
 #
-# gh defaults to false so older callers that pre-date the GhMount setting
-# keep working unchanged.
+# gh and buildkit default to false so older callers that pre-date those
+# settings keep working unchanged.
 seed_fleet_settings() {
   local fleet_name="$1"
   local claude="${2:-false}"
   local codex="${3:-false}"
   local homedir="${4:-/home/node}"
   local gh="${5:-false}"
+  local buildkit="${6:-false}"
   mkdir -p "${HOME}/.fleet"
   cat > "${HOME}/.fleet/state.json" <<EOF
 {
@@ -248,6 +249,7 @@ seed_fleet_settings() {
         "claudeCodeMount": ${claude},
         "codexMount": ${codex},
         "ghMount": ${gh},
+        "buildkitServer": ${buildkit},
         "homeDir": "${homedir}"
       },
       "instances": []
@@ -324,6 +326,32 @@ teardown_test() {
     if [ -n "${stale}" ]; then
       docker rm -f ${stale} >/dev/null 2>&1 || true
     fi
+  fi
+
+  # Sweep any shared buildkit servers (named fleet-<fleet>-buildkit). They
+  # carry --restart unless-stopped, so a test that crashed before `fleet
+  # destroy` ran must not leave one to auto-restart across runs. The
+  # per-fleet `destroy` above already removes them on the happy path; this
+  # is the crash-recovery backstop.
+  if command -v docker >/dev/null 2>&1; then
+    local bk
+    bk=$(docker ps -a --format '{{.Names}}' 2>/dev/null | grep -E '^fleet-.*-buildkit$' || true)
+    if [ -n "${bk}" ]; then
+      docker rm -f ${bk} >/dev/null 2>&1 || true
+    fi
+  fi
+
+  # A privileged buildkit server writes a ROOT-owned cache into the
+  # bind-mounted .buildkit/cache dir. Fleet deliberately keeps that cache
+  # across `destroy` (it's the point of a shared cache), but the test harness
+  # wants a pristine ~/.fleet between tests and runs as a non-root user — so
+  # reclaim ownership via a throwaway root container before the wipe. The
+  # buildkit image is guaranteed present whenever such root-owned files exist
+  # (they were written by a buildkit server that already pulled it).
+  if command -v docker >/dev/null 2>&1 && [ -d "${HOME}/.fleet" ] \
+    && find "${HOME}/.fleet" ! -user "$(id -un)" -print -quit 2>/dev/null | grep -q .; then
+    docker run --rm --entrypoint chown -v "${HOME}/.fleet:/reclaim" \
+      moby/buildkit:latest -R "$(id -u):$(id -g)" /reclaim >/dev/null 2>&1 || true
   fi
 
   rm -rf "${HOME}/.fleet"

--- a/integration/tests/450_buildkit_enabled.sh
+++ b/integration/tests/450_buildkit_enabled.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Description: enabling buildkit_server boots a shared buildkit container, exposes a working buildkitd socket, and bind-mounts it into the instance.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test
+# claude=false codex=false homedir=/home/vscode gh=false buildkit=true
+seed_fleet_settings "${FIXTURE_REPO_NAME}" false false /home/vscode false true
+
+bk_container="fleet-${FIXTURE_REPO_NAME}-buildkit"
+host_bk_dir="${HOME}/.fleet/workspaces/${FIXTURE_REPO_NAME}/.buildkit"
+host_sock="${host_bk_dir}/buildkitd.sock"
+
+info "fleet up alpha (buildkit enabled)"
+fleet_up alpha
+
+# 1. The shared buildkit container is up. (fleet up blocks through the docker
+#    run + image pull, so it should already be running; poll briefly to absorb
+#    slow-CI boot.)
+info "asserting the shared buildkit container is running"
+running="missing"
+for _ in $(seq 1 "$(_scale_timeout 30)"); do
+  running=$(docker inspect -f '{{.State.Running}}' "${bk_container}" 2>/dev/null || echo missing)
+  [ "${running}" = "true" ] && break
+  sleep 1
+done
+assert_equals "true" "${running}" "shared buildkit container ${bk_container} is not running"
+
+# 2. The buildkitd socket and the bound cache dir exist on the host.
+info "asserting host socket + cache dir exist under .buildkit/"
+for _ in $(seq 1 "$(_scale_timeout 15)"); do
+  [ -S "${host_sock}" ] && break
+  sleep 1
+done
+[ -S "${host_sock}" ] || fail "host buildkitd.sock missing or not a socket: ${host_sock}"
+assert_file_exists "${host_bk_dir}/cache"
+
+# 3. The server is actually serving: buildctl (shipped in the moby/buildkit
+#    image) lists at least one worker over the unix socket.
+info "asserting the buildkit server answers buildctl debug workers"
+workers=$(docker exec "${bk_container}" \
+  buildctl --addr unix:///run/fleet-buildkit/buildkitd.sock debug workers 2>&1) \
+  || fail "buildctl debug workers failed: ${workers}"
+assert_contains "${workers}" "linux/" "buildkit server reported no usable worker platform"
+
+# 4. The socket is bind-mounted into the instance at the shared path.
+info "asserting the socket is bind-mounted into the instance"
+"${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- test -S /run/fleet-buildkit/buildkitd.sock \
+  || fail "buildkitd.sock is not available inside the instance"
+mountinfo=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- cat /proc/self/mountinfo)
+assert_contains "${mountinfo}" " /run/fleet-buildkit " "/run/fleet-buildkit is not a mount point in the instance"
+
+# 5. The debian fixture has no docker/buildx, so ConfigureInstanceBuildx is a
+#    silent no-op — provisioning must still succeed and the instance is usable.
+info "asserting the instance provisioned cleanly despite no docker/buildx in the image"
+ls_out=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+assert_contains "${ls_out}" "alpha" "instance is missing after buildkit setup"
+
+pass "buildkit enabled: server booted, socket healthy and mounted into the instance"

--- a/integration/tests/455_buildkit_disabled.sh
+++ b/integration/tests/455_buildkit_disabled.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Description: with buildkit_server disabled, no buildkit container or socket is created and nothing is mounted into the instance.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test
+# claude=false codex=false homedir=/home/vscode gh=false buildkit=false
+seed_fleet_settings "${FIXTURE_REPO_NAME}" false false /home/vscode false false
+
+bk_container="fleet-${FIXTURE_REPO_NAME}-buildkit"
+host_bk_dir="${HOME}/.fleet/workspaces/${FIXTURE_REPO_NAME}/.buildkit"
+
+info "fleet up alpha (buildkit disabled)"
+fleet_up alpha
+
+info "asserting no shared buildkit container was created"
+if docker inspect "${bk_container}" >/dev/null 2>&1; then
+  fail "buildkit container ${bk_container} should not exist when the setting is off"
+fi
+
+info "asserting no host .buildkit directory was created"
+assert_file_absent "${host_bk_dir}"
+
+info "asserting nothing is mounted at /run/fleet-buildkit inside the instance"
+if "${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- test -e /run/fleet-buildkit/buildkitd.sock 2>/dev/null; then
+  fail "buildkit socket should not be present inside the instance when disabled"
+fi
+
+pass "buildkit disabled: no server, no socket, no mount"

--- a/integration/tests/460_buildkit_destroy_keeps_cache.sh
+++ b/integration/tests/460_buildkit_destroy_keeps_cache.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Description: destroying a buildkit-enabled fleet removes the server container but preserves the build cache, which a re-created fleet reuses.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test
+# claude=false codex=false homedir=/home/vscode gh=false buildkit=true
+seed_fleet_settings "${FIXTURE_REPO_NAME}" false false /home/vscode false true
+
+bk_container="fleet-${FIXTURE_REPO_NAME}-buildkit"
+host_bk_dir="${HOME}/.fleet/workspaces/${FIXTURE_REPO_NAME}/.buildkit"
+cache_dir="${host_bk_dir}/cache"
+
+wait_for_buildkit_running() {
+  local running="missing"
+  local i
+  for i in $(seq 1 "$(_scale_timeout 30)"); do
+    running=$(docker inspect -f '{{.State.Running}}' "${bk_container}" 2>/dev/null || echo missing)
+    [ "${running}" = "true" ] && return 0
+    sleep 1
+  done
+  fail "buildkit container ${bk_container} not running (state: ${running})"
+}
+
+info "fleet up alpha (buildkit enabled)"
+fleet_up alpha
+wait_for_buildkit_running
+
+info "asserting the build cache populated under .buildkit/cache"
+assert_file_exists "${cache_dir}"
+[ -n "$(ls -A "${cache_dir}" 2>/dev/null)" ] \
+  || fail "expected the buildkit cache to be non-empty after the server booted"
+
+info "fleet destroy ${FIXTURE_REPO_NAME}"
+"${FLEET_BIN}" destroy "${FIXTURE_REPO_NAME}"
+
+info "asserting the server container is removed (no orphan / auto-restart)"
+gone="no"
+for _ in $(seq 1 "$(_scale_timeout 15)"); do
+  if ! docker inspect "${bk_container}" >/dev/null 2>&1; then
+    gone="yes"
+    break
+  fi
+  sleep 1
+done
+[ "${gone}" = "yes" ] || fail "buildkit container ${bk_container} should be removed on destroy"
+
+info "asserting the build cache is PRESERVED across destroy"
+assert_file_exists "${cache_dir}"
+[ -n "$(ls -A "${cache_dir}" 2>/dev/null)" ] \
+  || fail "build cache should survive fleet destroy so it warms the next build"
+
+info "re-creating the fleet brings the server back and reuses the kept cache"
+seed_fleet_settings "${FIXTURE_REPO_NAME}" false false /home/vscode false true
+fleet_up alpha
+wait_for_buildkit_running
+assert_file_exists "${cache_dir}"
+
+pass "buildkit cache persists across destroy and is reused on re-create"

--- a/internal/buildkit/buildkit.go
+++ b/internal/buildkit/buildkit.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
@@ -107,12 +108,37 @@ var waitForSocket = func(path string, timeout time.Duration) error {
 	}
 }
 
+// ensureLocks serializes EnsureSharedServer per fleet so concurrent instance
+// creates in the same fleet don't both `docker run` the one shared container and
+// have the loser fail on a name conflict (losing its socket mount). Keyed per
+// fleet so a slow first-time image pull for one fleet never blocks instance
+// creation in another.
+var ensureLocks sync.Map // fleetName -> *sync.Mutex
+
+func fleetLock(fleetName string) *sync.Mutex {
+	m, _ := ensureLocks.LoadOrStore(fleetName, &sync.Mutex{})
+	return m.(*sync.Mutex)
+}
+
 // ContainerName is the docker container name for a fleet's shared buildkit
 // server. Sanitized so arbitrary fleet names yield a valid, collision-resistant
 // docker name; the fleet/-buildkit affixes namespace it away from instance
 // containers and other fleets.
 func ContainerName(fleetName string) string {
 	return "fleet-" + backend.SanitizeName(fleetName, fleetNameMaxLen) + "-buildkit"
+}
+
+// SharedDir returns the validated host .buildkit directory for a fleet. It
+// refuses fleet names that would let the path escape the workspaces root:
+// EnsureSharedServer creates this path (os.MkdirAll, 0777) and teardown removes
+// it (os.RemoveAll), so a traversing name like "../../x" must never reach those
+// calls. Container names go through SanitizeName separately, so this guards the
+// filesystem side specifically.
+func SharedDir(fleetName string) (string, error) {
+	if fleetName == "" || strings.ContainsAny(fleetName, `/\`) || strings.Contains(fleetName, "..") {
+		return "", fmt.Errorf("invalid fleet name %q for buildkit dir", fleetName)
+	}
+	return state.BuildkitDir(fleetName), nil
 }
 
 // InstanceMount returns the bind mount that exposes the fleet's buildkit socket
@@ -169,7 +195,17 @@ func dockerRunArgs(fleetName string) []string {
 // Callers MUST only invoke this for backends that SupportsCustomMounts; cloud
 // backends cannot reach a host docker daemon.
 func EnsureSharedServer(fleetName string) (string, error) {
-	dir := state.BuildkitDir(fleetName)
+	// Serialize per fleet so two concurrent creates in the same fleet don't both
+	// `docker run` the shared container (the loser would fail on a name conflict
+	// and silently lose its socket mount).
+	lock := fleetLock(fleetName)
+	lock.Lock()
+	defer lock.Unlock()
+
+	dir, err := SharedDir(fleetName)
+	if err != nil {
+		return "", err
+	}
 	if err := ensureDir(dir); err != nil {
 		return "", fmt.Errorf("create buildkit dir: %w", err)
 	}
@@ -182,8 +218,6 @@ func EnsureSharedServer(fleetName string) (string, error) {
 	switch {
 	case exists && running:
 		flog.Info("buildkit server reused", "fleet", fleetName, "container", name)
-		ensureSocketPerms(fleetName, name) // best-effort; converge if a prior fix-up failed
-		return dir, nil
 	case exists && !running:
 		if out, err := runDocker("start", name); err != nil {
 			return "", fmt.Errorf("start buildkit server: %w (%s)", err, out)
@@ -191,14 +225,25 @@ func EnsureSharedServer(fleetName string) (string, error) {
 		flog.Info("buildkit server started", "fleet", fleetName, "container", name)
 	default:
 		if out, err := runDocker(dockerRunArgs(fleetName)...); err != nil {
-			return "", fmt.Errorf("run buildkit server: %w (%s)", err, out)
+			// A concurrent (cross-process) or manual create may have won the
+			// name race; if the container exists now, treat it as success and
+			// fall through to the socket wait. Only a genuine failure aborts.
+			if _, exists2 := inspectState(name); !exists2 {
+				return "", fmt.Errorf("run buildkit server: %w (%s)", err, out)
+			}
+			flog.Info("buildkit server already present", "fleet", fleetName, "container", name)
+		} else {
+			flog.Info("buildkit server created", "fleet", fleetName, "container", name)
 		}
-		flog.Info("buildkit server created", "fleet", fleetName, "container", name)
 	}
 
+	// All paths converge here: wait for buildkitd to create its socket, then
+	// relax its permissions so an instance's non-root user can connect. The
+	// reuse path waits too — a "running" container may have just been revived by
+	// the restart policy and not yet recreated the socket. Non-fatal: the mount
+	// still works once the socket appears; instance buildx config fails soft
+	// until then.
 	if err := waitForSocket(hostSocketPath(fleetName), socketWaitTimeout); err != nil {
-		// Non-fatal: the mount still works once the socket appears; instance
-		// buildx config will simply fail-soft until then.
 		flog.Warn("buildkit socket not ready", "fleet", fleetName, "err", err)
 		return dir, nil
 	}

--- a/internal/buildkit/buildkit.go
+++ b/internal/buildkit/buildkit.go
@@ -1,0 +1,254 @@
+// Package buildkit manages a per-fleet shared moby/buildkit server and the
+// per-instance docker buildx wiring that points every instance in the fleet at
+// it. When a fleet enables the BuildkitServer setting, fleet-man ensures ONE
+// privileged buildkit container per fleet whose buildkitd unix socket lives
+// under ~/.fleet/workspaces/<fleet>/.buildkit/. That directory is bind-mounted
+// into every instance, and each instance's docker buildx is configured as a
+// "remote" builder talking to the socket — so all instances share a single
+// build cache.
+//
+// Everything here is HOST-side orchestration of `docker` (the buildkit
+// container runs on the same docker daemon as the devcontainers) plus a small
+// amount of in-container configuration run through a backend's ExecCommand. It
+// is deliberately a server-side package (it reaches for internal/state paths);
+// the client/TUI only flips the FleetSettings.BuildkitServer bool.
+//
+// The feature is gated to backends that report SupportsCustomMounts()==true
+// (devcontainer); callers must check that before invoking EnsureSharedServer /
+// the instance mount. Even then every step is best-effort: a missing
+// docker/buildx inside an instance is a silent no-op, not an error.
+package buildkit
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// execCommand builds the host command. Package var so tests can stub the docker
+// binary itself when exercising the real runDocker path.
+var execCommand = exec.Command
+
+const (
+	// image is the buildkit image used for the shared server. Matches the
+	// user-facing example; "latest" keeps it simple at the cost of a pull on
+	// first use.
+	image = "moby/buildkit:latest"
+
+	// containerMountPath is where the per-fleet .buildkit host directory is
+	// bind-mounted, both inside the buildkit container (so buildkitd writes its
+	// socket there) and inside every instance (so buildx can reach the socket).
+	// Using the SAME absolute path on both sides means the socket URL is
+	// identical everywhere.
+	containerMountPath = "/run/fleet-buildkit"
+
+	// socketName is the buildkitd unix socket basename. It is created by the
+	// buildkit container inside containerMountPath and therefore appears on the
+	// host inside the fleet's .buildkit directory via the bind mount.
+	socketName = "buildkitd.sock"
+
+	// containerSocketPath is the absolute socket path inside any container that
+	// mounts the .buildkit dir at containerMountPath.
+	containerSocketPath = containerMountPath + "/" + socketName
+
+	// containerCachePath is where buildkitd stores its content-addressable
+	// cache inside the buildkit container; bind-mounted to <.buildkit>/cache on
+	// the host so the cache survives container churn and is removable with the
+	// fleet.
+	containerCachePath = "/var/lib/buildkit"
+
+	// cacheSubdir is the host subdirectory (under .buildkit) holding the cache.
+	cacheSubdir = "cache"
+
+	// builderName is the docker buildx builder created inside each instance. It
+	// is local to the instance's docker config; since one instance belongs to
+	// exactly one fleet, a fixed name is unambiguous and makes the configure
+	// step idempotent (remove-then-create).
+	builderName = "fleet-shared"
+
+	// fleetNameMaxLen caps the sanitized fleet segment of the container name.
+	fleetNameMaxLen = 40
+
+	// socketWaitTimeout bounds how long EnsureSharedServer waits for buildkitd
+	// to create its socket after the container starts before giving up on the
+	// permission fix-up (which is best-effort anyway).
+	socketWaitTimeout = 15 * time.Second
+)
+
+// runDocker runs `docker <args...>` and returns its combined output (trimmed)
+// and error. It is a package var so tests can stub the docker interaction
+// without a daemon. The real implementation intentionally bypasses
+// backend.ExecCommand's event-log entry: these are host-side daemon calls, not
+// in-container execs.
+var runDocker = func(args ...string) (string, error) {
+	out, err := backend.NewCmd(execCommand("docker", args...), nil).CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// waitForSocket blocks until path exists or timeout elapses. Package var so
+// tests can skip the real poll. Returns an error only on timeout.
+var waitForSocket = func(path string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("buildkit socket %s did not appear within %s", path, timeout)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// ContainerName is the docker container name for a fleet's shared buildkit
+// server. Sanitized so arbitrary fleet names yield a valid, collision-resistant
+// docker name; the fleet/-buildkit affixes namespace it away from instance
+// containers and other fleets.
+func ContainerName(fleetName string) string {
+	return "fleet-" + backend.SanitizeName(fleetName, fleetNameMaxLen) + "-buildkit"
+}
+
+// InstanceMount returns the bind mount that exposes the fleet's buildkit socket
+// directory inside an instance. Callers append it to the mounts passed to
+// Backend.Up/Clone (only when the backend SupportsCustomMounts).
+func InstanceMount(fleetName string) backend.Mount {
+	return backend.Mount{
+		LocalPath:     state.BuildkitDir(fleetName),
+		ContainerPath: containerMountPath,
+	}
+}
+
+// hostSocketPath is the buildkitd socket as seen on the host (through the bind
+// mount).
+func hostSocketPath(fleetName string) string {
+	return filepath.Join(state.BuildkitDir(fleetName), socketName)
+}
+
+// hostCacheDir is the host cache directory bind-mounted to containerCachePath.
+func hostCacheDir(fleetName string) string {
+	return filepath.Join(state.BuildkitDir(fleetName), cacheSubdir)
+}
+
+// dockerRunArgs builds the `docker run` argv for a fleet's buildkit server. Pure
+// (no side effects) so it can be asserted in tests. The container is privileged
+// (buildkitd requires it) and uses restart=unless-stopped so a docker daemon
+// restart brings the shared cache back without waiting for a new instance —
+// while still being removable via `docker rm -f` on fleet destroy.
+func dockerRunArgs(fleetName string) []string {
+	dir := state.BuildkitDir(fleetName)
+	return []string{
+		"run", "-d",
+		"--name", ContainerName(fleetName),
+		"--privileged",
+		"--restart", "unless-stopped",
+		"-v", dir + ":" + containerMountPath,
+		"-v", hostCacheDir(fleetName) + ":" + containerCachePath,
+		image,
+		"--addr", "unix://" + containerSocketPath,
+	}
+}
+
+// EnsureSharedServer makes the fleet's shared buildkit container exist and run,
+// returning the host .buildkit directory to bind into instances. It is
+// idempotent and safe to call on every instance create/start: a running
+// container is reused, a stopped one is started, and an absent one is created.
+//
+// After the container is up it waits for buildkitd to create its socket and
+// relaxes the socket permissions to 0666 so an instance's non-root user (whose
+// UID differs from the buildkit container's root) can connect through the bind
+// mount. The permission fix-up is best-effort — a failure is logged, not
+// returned, since the socket may simply be slow to appear.
+//
+// Callers MUST only invoke this for backends that SupportsCustomMounts; cloud
+// backends cannot reach a host docker daemon.
+func EnsureSharedServer(fleetName string) (string, error) {
+	dir := state.BuildkitDir(fleetName)
+	if err := ensureDir(dir); err != nil {
+		return "", fmt.Errorf("create buildkit dir: %w", err)
+	}
+	if err := ensureDir(hostCacheDir(fleetName)); err != nil {
+		return "", fmt.Errorf("create buildkit cache dir: %w", err)
+	}
+
+	name := ContainerName(fleetName)
+	running, exists := inspectState(name)
+	switch {
+	case exists && running:
+		flog.Info("buildkit server reused", "fleet", fleetName, "container", name)
+		ensureSocketPerms(fleetName, name) // best-effort; converge if a prior fix-up failed
+		return dir, nil
+	case exists && !running:
+		if out, err := runDocker("start", name); err != nil {
+			return "", fmt.Errorf("start buildkit server: %w (%s)", err, out)
+		}
+		flog.Info("buildkit server started", "fleet", fleetName, "container", name)
+	default:
+		if out, err := runDocker(dockerRunArgs(fleetName)...); err != nil {
+			return "", fmt.Errorf("run buildkit server: %w (%s)", err, out)
+		}
+		flog.Info("buildkit server created", "fleet", fleetName, "container", name)
+	}
+
+	if err := waitForSocket(hostSocketPath(fleetName), socketWaitTimeout); err != nil {
+		// Non-fatal: the mount still works once the socket appears; instance
+		// buildx config will simply fail-soft until then.
+		flog.Warn("buildkit socket not ready", "fleet", fleetName, "err", err)
+		return dir, nil
+	}
+	ensureSocketPerms(fleetName, name)
+	return dir, nil
+}
+
+// StopSharedServer force-removes a fleet's buildkit container. Best-effort: an
+// already-absent container is treated as success so fleet teardown never fails
+// on a missing server.
+func StopSharedServer(fleetName string) error {
+	name := ContainerName(fleetName)
+	out, err := runDocker("rm", "-f", name)
+	if err != nil {
+		if strings.Contains(out, "No such container") {
+			return nil
+		}
+		return fmt.Errorf("remove buildkit server %s: %w (%s)", name, err, out)
+	}
+	flog.Info("buildkit server removed", "fleet", fleetName, "container", name)
+	return nil
+}
+
+// inspectState reports whether a container exists and whether it is running.
+// `docker inspect` exits non-zero for a missing container, which we map to
+// exists=false.
+func inspectState(name string) (running, exists bool) {
+	out, err := runDocker("inspect", "-f", "{{.State.Running}}", name)
+	if err != nil {
+		return false, false
+	}
+	return strings.TrimSpace(out) == "true", true
+}
+
+// ensureSocketPerms relaxes the buildkitd socket to 0666 from inside the
+// buildkit container (which runs as root). Best-effort and logged: the call is
+// idempotent and a transient failure is retried on the next EnsureSharedServer.
+func ensureSocketPerms(fleetName, name string) {
+	if out, err := runDocker("exec", name, "chmod", "0666", containerSocketPath); err != nil {
+		flog.Warn("buildkit socket chmod failed", "fleet", fleetName, "err", err, "out", out)
+	}
+}
+
+// ensureDir creates path 0777 (and re-chmods an existing one), matching the
+// mount resolver's convention: these dirs are bind-mounted into containers
+// whose user UID differs from the host's, so they must be world-writable. They
+// already live under the user's private ~/.fleet tree.
+func ensureDir(path string) error {
+	if err := os.MkdirAll(path, 0777); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0777)
+}

--- a/internal/buildkit/buildkit_test.go
+++ b/internal/buildkit/buildkit_test.go
@@ -1,0 +1,182 @@
+package buildkit
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// stubDocker replaces runDocker with handler for the duration of the test,
+// recording nothing itself — the handler closes over whatever it needs.
+func stubDocker(t *testing.T, handler func(args []string) (string, error)) {
+	t.Helper()
+	orig := runDocker
+	runDocker = func(args ...string) (string, error) { return handler(args) }
+	t.Cleanup(func() { runDocker = orig })
+}
+
+// stubWaitForSocket makes the socket wait return err immediately.
+func stubWaitForSocket(t *testing.T, err error) {
+	t.Helper()
+	orig := waitForSocket
+	waitForSocket = func(string, time.Duration) error { return err }
+	t.Cleanup(func() { waitForSocket = orig })
+}
+
+func hasCall(calls [][]string, sub string) bool {
+	for _, c := range calls {
+		if len(c) > 0 && c[0] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func TestContainerName(t *testing.T) {
+	cases := map[string]string{
+		"alpha":     "fleet-alpha-buildkit",
+		"My Fleet":  "fleet-my-fleet-buildkit",
+		"a/b:c":     "fleet-a-b-c-buildkit",
+		"UPPER":     "fleet-upper-buildkit",
+		"--weird--": "fleet-weird-buildkit",
+	}
+	for in, want := range cases {
+		if got := ContainerName(in); got != want {
+			t.Errorf("ContainerName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestInstanceMount(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := InstanceMount("alpha")
+	if m.LocalPath != state.BuildkitDir("alpha") {
+		t.Errorf("LocalPath = %q, want %q", m.LocalPath, state.BuildkitDir("alpha"))
+	}
+	if m.ContainerPath != containerMountPath {
+		t.Errorf("ContainerPath = %q, want %q", m.ContainerPath, containerMountPath)
+	}
+}
+
+func TestDockerRunArgs(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	args := dockerRunArgs("alpha")
+	joined := strings.Join(args, " ")
+	for _, want := range []string{
+		"run", "-d", "--privileged", "--restart", "unless-stopped",
+		ContainerName("alpha"),
+		image,
+		"--addr", "unix://" + containerSocketPath,
+		state.BuildkitDir("alpha") + ":" + containerMountPath,
+		hostCacheDir("alpha") + ":" + containerCachePath,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("dockerRunArgs missing %q in: %s", want, joined)
+		}
+	}
+}
+
+func TestEnsureSharedServerCreatesWhenAbsent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	var calls [][]string
+	stubDocker(t, func(args []string) (string, error) {
+		calls = append(calls, args)
+		if args[0] == "inspect" {
+			return "", fmt.Errorf("Error: No such object: x") // absent
+		}
+		return "", nil
+	})
+	stubWaitForSocket(t, nil)
+
+	dir, err := EnsureSharedServer("alpha")
+	if err != nil {
+		t.Fatalf("EnsureSharedServer: %v", err)
+	}
+	if dir != state.BuildkitDir("alpha") {
+		t.Fatalf("dir = %q, want %q", dir, state.BuildkitDir("alpha"))
+	}
+	if !hasCall(calls, "run") {
+		t.Fatalf("expected a docker run, calls = %v", calls)
+	}
+	if hasCall(calls, "start") {
+		t.Fatalf("did not expect docker start for an absent container, calls = %v", calls)
+	}
+	// Host dirs must exist for the bind mount to succeed.
+	if _, err := os.Stat(state.BuildkitDir("alpha")); err != nil {
+		t.Fatalf("buildkit dir not created: %v", err)
+	}
+	if _, err := os.Stat(hostCacheDir("alpha")); err != nil {
+		t.Fatalf("cache dir not created: %v", err)
+	}
+}
+
+func TestEnsureSharedServerStartsWhenStopped(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	var calls [][]string
+	stubDocker(t, func(args []string) (string, error) {
+		calls = append(calls, args)
+		if args[0] == "inspect" {
+			return "false", nil // exists, stopped
+		}
+		return "", nil
+	})
+	stubWaitForSocket(t, nil)
+
+	if _, err := EnsureSharedServer("alpha"); err != nil {
+		t.Fatalf("EnsureSharedServer: %v", err)
+	}
+	if !hasCall(calls, "start") {
+		t.Fatalf("expected a docker start, calls = %v", calls)
+	}
+	if hasCall(calls, "run") {
+		t.Fatalf("did not expect docker run for an existing stopped container, calls = %v", calls)
+	}
+}
+
+func TestEnsureSharedServerReusesWhenRunning(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	var calls [][]string
+	stubDocker(t, func(args []string) (string, error) {
+		calls = append(calls, args)
+		if args[0] == "inspect" {
+			return "true", nil // exists, running
+		}
+		return "", nil
+	})
+	stubWaitForSocket(t, nil)
+
+	if _, err := EnsureSharedServer("alpha"); err != nil {
+		t.Fatalf("EnsureSharedServer: %v", err)
+	}
+	if hasCall(calls, "run") || hasCall(calls, "start") {
+		t.Fatalf("running container should be reused, not run/started: %v", calls)
+	}
+}
+
+func TestStopSharedServer(t *testing.T) {
+	// Clean removal -> nil.
+	stubDocker(t, func(args []string) (string, error) { return "", nil })
+	if err := StopSharedServer("alpha"); err != nil {
+		t.Fatalf("StopSharedServer clean: %v", err)
+	}
+
+	// Already absent -> nil (idempotent teardown).
+	stubDocker(t, func(args []string) (string, error) {
+		return "Error: No such container: fleet-alpha-buildkit", fmt.Errorf("exit status 1")
+	})
+	if err := StopSharedServer("alpha"); err != nil {
+		t.Fatalf("StopSharedServer absent should be nil, got %v", err)
+	}
+
+	// Genuine failure -> error.
+	stubDocker(t, func(args []string) (string, error) {
+		return "permission denied", fmt.Errorf("exit status 1")
+	})
+	if err := StopSharedServer("alpha"); err == nil {
+		t.Fatalf("StopSharedServer genuine failure should error")
+	}
+}

--- a/internal/buildkit/buildkit_test.go
+++ b/internal/buildkit/buildkit_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -154,6 +155,85 @@ func TestEnsureSharedServerReusesWhenRunning(t *testing.T) {
 	}
 	if hasCall(calls, "run") || hasCall(calls, "start") {
 		t.Fatalf("running container should be reused, not run/started: %v", calls)
+	}
+}
+
+func TestSharedDirRejectsTraversal(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	for _, bad := range []string{"", "..", "../../etc", "a/b", `a\b`, "foo/../bar"} {
+		if _, err := SharedDir(bad); err == nil {
+			t.Errorf("SharedDir(%q) should be rejected", bad)
+		}
+	}
+	if dir, err := SharedDir("alpha"); err != nil || dir != state.BuildkitDir("alpha") {
+		t.Errorf("SharedDir(alpha) = %q, %v; want %q, nil", dir, err, state.BuildkitDir("alpha"))
+	}
+}
+
+func TestEnsureSharedServerSocketTimeoutNonFatal(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stubDocker(t, func(args []string) (string, error) {
+		if args[0] == "inspect" {
+			return "", fmt.Errorf("No such object") // absent -> create
+		}
+		return "", nil
+	})
+	stubWaitForSocket(t, fmt.Errorf("timed out"))
+
+	dir, err := EnsureSharedServer("alpha")
+	if err != nil {
+		t.Fatalf("socket-wait timeout must be non-fatal, got %v", err)
+	}
+	if dir != state.BuildkitDir("alpha") {
+		t.Fatalf("dir = %q, want %q", dir, state.BuildkitDir("alpha"))
+	}
+}
+
+// TestEnsureSharedServerConcurrentRunsOnce verifies the per-fleet lock + stateful
+// reuse means two concurrent creates in the same fleet issue exactly one
+// `docker run` and both succeed (neither loses its socket mount to a name race).
+func TestEnsureSharedServerConcurrentRunsOnce(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	var mu sync.Mutex
+	created := false
+	runCount := 0
+	stubDocker(t, func(args []string) (string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch args[0] {
+		case "inspect":
+			if created {
+				return "true", nil // exists & running
+			}
+			return "", fmt.Errorf("No such object")
+		case "run":
+			runCount++
+			created = true
+		}
+		return "", nil
+	})
+	stubWaitForSocket(t, nil)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 4)
+	for i := range errs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = EnsureSharedServer("concurrent-fleet")
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("EnsureSharedServer call %d: %v", i, err)
+		}
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if runCount != 1 {
+		t.Fatalf("docker run issued %d times, want exactly 1", runCount)
 	}
 }
 

--- a/internal/buildkit/instance.go
+++ b/internal/buildkit/instance.go
@@ -62,16 +62,20 @@ func probeScript() string {
 	)
 }
 
-// configureScript (re)creates the shared remote builder and makes it the
+// configureScript (re)creates the shared remote builder and selects it as the
 // default. The remote driver speaks gRPC straight to the buildkitd unix socket
-// at containerSocketPath (no in-instance daemon involved). Remove-then-create
-// keeps it idempotent across re-runs (clone inherits a prior builder; restart
-// re-runs config). The `|| true` on rm tolerates a first run where the builder
-// does not exist yet.
+// at containerSocketPath (no in-instance daemon involved); the endpoint is the
+// documented positional ENDPOINT argument to `buildx create` (not a
+// --driver-opt). `use` is a separate command so the endpoint is never adjacent
+// to a boolean flag. Remove-then-create keeps it idempotent across re-runs
+// (clone inherits a prior builder; restart re-runs config); the `|| true` on rm
+// tolerates a first run where the builder does not exist yet. The `&&` ensures a
+// failed create propagates a non-zero exit (so the caller can warn) rather than
+// being masked by a successful `use`.
 func configureScript() string {
 	return fmt.Sprintf(
-		`docker buildx rm %s >/dev/null 2>&1 || true; docker buildx create --name %s --driver remote --use unix://%s`,
-		builderName, builderName, containerSocketPath,
+		`docker buildx rm %s >/dev/null 2>&1 || true; docker buildx create --name %s --driver remote unix://%s && docker buildx use %s`,
+		builderName, builderName, containerSocketPath, builderName,
 	)
 }
 

--- a/internal/buildkit/instance.go
+++ b/internal/buildkit/instance.go
@@ -1,0 +1,83 @@
+package buildkit
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// instanceExecer is the slice of backend.Backend this package needs to run
+// commands inside an instance. Narrowing the dependency keeps the package
+// testable with a tiny fake instead of the full Backend surface.
+type instanceExecer interface {
+	ExecCommand(workspaceDir string, command []string) *backend.Cmd
+}
+
+// probeMarkerPresent / probeMarkerAbsent are the single-token stdout signals the
+// probe script emits so the outcome is unambiguous regardless of locale or
+// extra warnings on stderr.
+const (
+	probeMarkerPresent = "PRESENT"
+	probeMarkerAbsent  = "ABSENT"
+)
+
+// ConfigureInstanceBuildx points an instance's docker buildx at the fleet's
+// shared buildkit server. It first probes for BOTH docker and the buildx plugin
+// inside the instance; if either is missing it returns nil WITHOUT touching the
+// instance — the documented "do nothing, no error" behaviour for images that
+// lack docker tooling. When both are present it (re)creates a "remote" builder
+// bound to the bind-mounted socket and selects it as the default.
+//
+// The configure step is idempotent (remove-then-create), so it is safe to call
+// on every create, clone, and start. Callers should treat a returned error as
+// non-fatal (warn and continue) — a build-cache wiring failure must not block
+// an otherwise-usable instance.
+func ConfigureInstanceBuildx(b instanceExecer, workspaceDir string) error {
+	out, err := b.ExecCommand(workspaceDir, []string{"sh", "-c", probeScript()}).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("probe docker/buildx: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	if !buildxPresent(string(out)) {
+		// docker or buildx absent — silently skip per the feature contract.
+		return nil
+	}
+
+	out, err = b.ExecCommand(workspaceDir, []string{"sh", "-c", configureScript()}).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("configure buildx: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// probeScript reports whether docker AND the buildx plugin are usable inside the
+// instance. It always exits 0 and prints exactly one marker so an exec failure
+// (a non-zero exit / unreachable container) is distinguishable from a clean
+// "not present" answer. `docker buildx version` needs no daemon — it only
+// verifies the CLI plugin is installed.
+func probeScript() string {
+	return fmt.Sprintf(
+		`if command -v docker >/dev/null 2>&1 && docker buildx version >/dev/null 2>&1; then echo %s; else echo %s; fi`,
+		probeMarkerPresent, probeMarkerAbsent,
+	)
+}
+
+// configureScript (re)creates the shared remote builder and makes it the
+// default. The remote driver speaks gRPC straight to the buildkitd unix socket
+// at containerSocketPath (no in-instance daemon involved). Remove-then-create
+// keeps it idempotent across re-runs (clone inherits a prior builder; restart
+// re-runs config). The `|| true` on rm tolerates a first run where the builder
+// does not exist yet.
+func configureScript() string {
+	return fmt.Sprintf(
+		`docker buildx rm %s >/dev/null 2>&1 || true; docker buildx create --name %s --driver remote --use unix://%s`,
+		builderName, builderName, containerSocketPath,
+	)
+}
+
+// buildxPresent reports whether the probe output indicates docker+buildx are
+// available. It scans for the PRESENT marker as a substring so leading warnings
+// on the combined stream don't mask a positive result.
+func buildxPresent(probeOutput string) bool {
+	return strings.Contains(probeOutput, probeMarkerPresent)
+}

--- a/internal/buildkit/instance_test.go
+++ b/internal/buildkit/instance_test.go
@@ -1,0 +1,93 @@
+package buildkit
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// fakeExecer satisfies instanceExecer. It records the joined commands it is
+// asked to run and returns canned stdout: the probe (detected by the
+// "buildx version" substring) yields probeOut; every other command succeeds
+// with empty output. Backing each call with a real `printf` keeps the
+// *backend.Cmd run methods working exactly as in production.
+type fakeExecer struct {
+	probeOut string
+	calls    []string
+}
+
+func (f *fakeExecer) ExecCommand(workspaceDir string, command []string) *backend.Cmd {
+	joined := strings.Join(command, " ")
+	f.calls = append(f.calls, joined)
+	out := ""
+	if strings.Contains(joined, "buildx version") {
+		out = f.probeOut
+	}
+	return backend.NewCmd(exec.Command("printf", "%s", out), nil)
+}
+
+func TestBuildxPresent(t *testing.T) {
+	cases := map[string]bool{
+		"PRESENT":            true,
+		"PRESENT\n":          true,
+		"warning\nPRESENT\n": true,
+		"ABSENT":             false,
+		"ABSENT\n":           false,
+		"":                   false,
+	}
+	for in, want := range cases {
+		if got := buildxPresent(in); got != want {
+			t.Errorf("buildxPresent(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestProbeAndConfigureScripts(t *testing.T) {
+	probe := probeScript()
+	for _, want := range []string{"command -v docker", "docker buildx version", probeMarkerPresent, probeMarkerAbsent} {
+		if !strings.Contains(probe, want) {
+			t.Errorf("probeScript missing %q: %s", want, probe)
+		}
+	}
+	cfg := configureScript()
+	for _, want := range []string{
+		"docker buildx rm " + builderName,
+		"docker buildx create --name " + builderName,
+		"--driver remote",
+		"--use unix://" + containerSocketPath,
+	} {
+		if !strings.Contains(cfg, want) {
+			t.Errorf("configureScript missing %q: %s", want, cfg)
+		}
+	}
+}
+
+func TestConfigureInstanceBuildxSkipsWithoutDocker(t *testing.T) {
+	fe := &fakeExecer{probeOut: probeMarkerAbsent}
+	if err := ConfigureInstanceBuildx(fe, "/ws"); err != nil {
+		t.Fatalf("ConfigureInstanceBuildx (absent) = %v, want nil", err)
+	}
+	if len(fe.calls) != 1 {
+		t.Fatalf("expected only the probe call, got %d: %v", len(fe.calls), fe.calls)
+	}
+	for _, c := range fe.calls {
+		if strings.Contains(c, "buildx create") {
+			t.Fatalf("must NOT configure buildx when docker/buildx absent: %v", fe.calls)
+		}
+	}
+}
+
+func TestConfigureInstanceBuildxConfiguresWhenPresent(t *testing.T) {
+	fe := &fakeExecer{probeOut: probeMarkerPresent}
+	if err := ConfigureInstanceBuildx(fe, "/ws"); err != nil {
+		t.Fatalf("ConfigureInstanceBuildx (present) = %v, want nil", err)
+	}
+	if len(fe.calls) != 2 {
+		t.Fatalf("expected probe + configure, got %d: %v", len(fe.calls), fe.calls)
+	}
+	if !strings.Contains(fe.calls[1], "buildx create --name "+builderName) {
+		t.Fatalf("configure call did not create the shared builder: %v", fe.calls[1])
+	}
+}

--- a/internal/buildkit/instance_test.go
+++ b/internal/buildkit/instance_test.go
@@ -55,8 +55,8 @@ func TestProbeAndConfigureScripts(t *testing.T) {
 	for _, want := range []string{
 		"docker buildx rm " + builderName,
 		"docker buildx create --name " + builderName,
-		"--driver remote",
-		"--use unix://" + containerSocketPath,
+		"--driver remote unix://" + containerSocketPath,
+		"docker buildx use " + builderName,
 	} {
 		if !strings.Contains(cfg, want) {
 			t.Errorf("configureScript missing %q: %s", want, cfg)

--- a/internal/create/buildkit_setup.go
+++ b/internal/create/buildkit_setup.go
@@ -1,0 +1,52 @@
+package create
+
+import (
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+	"github.com/BenjaminBenetti/fleet-man/internal/buildkit"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// prepareBuildkitMount ensures the fleet's shared buildkit server is up and
+// returns the bind mount that exposes its socket directory inside the instance.
+//
+// It returns ok=false (with no error) when the feature does not apply — the
+// backend cannot honor custom mounts (cloud backends) or the fleet has the
+// BuildkitServer setting off. A genuine failure to start the server is returned
+// so the caller can surface a warning; per the feature contract this is
+// best-effort and must NOT abort provisioning.
+func prepareBuildkitMount(instanceBackend backend.Backend, fleetName string) (backend.Mount, bool, error) {
+	if !instanceBackend.SupportsCustomMounts() || !fleetBuildkitEnabled(fleetName) {
+		return backend.Mount{}, false, nil
+	}
+	if _, err := buildkit.EnsureSharedServer(fleetName); err != nil {
+		return backend.Mount{}, false, err
+	}
+	return buildkit.InstanceMount(fleetName), true, nil
+}
+
+// configureBuildkit points the instance's docker buildx at the fleet's shared
+// buildkit server. It is a no-op (nil) when the feature does not apply. When it
+// does, ConfigureInstanceBuildx itself silently skips images that lack
+// docker/buildx, so an error here is only a real configuration failure — which
+// the caller should treat as non-fatal.
+func configureBuildkit(instanceBackend backend.Backend, fleetName, workspaceDir string) error {
+	if !instanceBackend.SupportsCustomMounts() || !fleetBuildkitEnabled(fleetName) {
+		return nil
+	}
+	return buildkit.ConfigureInstanceBuildx(instanceBackend, workspaceDir)
+}
+
+// fleetBuildkitEnabled reports whether the named fleet has the BuildkitServer
+// setting enabled. A state-load miss is treated as "disabled" so a transient
+// read failure never spins up a buildkit container the user didn't ask for.
+func fleetBuildkitEnabled(fleetName string) bool {
+	st, err := state.Load()
+	if err != nil {
+		return false
+	}
+	f, ok := st.Fleets[fleetName]
+	if !ok {
+		return false
+	}
+	return f.Settings.BuildkitServer
+}

--- a/internal/create/clone.go
+++ b/internal/create/clone.go
@@ -114,6 +114,14 @@ func RunClone(fleetName, srcInstance, destInstance string, verbose bool) (err er
 		}
 	}
 
+	// Bind the fleet's shared buildkit socket into the clone too (ensuring the
+	// server is up), so the clone shares the same build cache. Non-fatal.
+	if mount, ok, err := prepareBuildkitMount(instanceBackend, fleetName); err != nil {
+		state.WriteWarn(fleetName, destInstance, fmt.Sprintf("buildkit server: %v", err))
+	} else if ok {
+		resolvedMounts.Mounts = append(resolvedMounts.Mounts, mount)
+	}
+
 	result, err := instanceBackend.Clone(src.ContainerID, destWorkspaceDir, resolvedMounts.Mounts)
 	if err != nil {
 		setFailed(fleetName, destInstance, err)
@@ -138,6 +146,14 @@ func RunClone(fleetName, srcInstance, destInstance string, verbose bool) (err er
 	// Non-fatal: surface as a warning if it fails.
 	if err := applyMountSymlinks(instanceBackend, destWorkspaceDir, resolvedMounts.Symlinks); err != nil {
 		state.WriteWarn(fleetName, destInstance, fmt.Sprintf("setting up agentic mount symlinks: %v", err))
+	}
+
+	// Re-point the clone's docker buildx at the fleet's shared buildkit server.
+	// The committed image may carry the source's builder config; the
+	// remove-then-create in ConfigureInstanceBuildx makes this idempotent.
+	// Non-fatal, and a silent no-op without docker/buildx.
+	if err := configureBuildkit(instanceBackend, fleetName, destWorkspaceDir); err != nil {
+		state.WriteWarn(fleetName, destInstance, fmt.Sprintf("configure buildkit buildx: %v", err))
 	}
 
 	if err := markInstanceRunning(fleetName, destInstance, result.ContainerID); err != nil {

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -106,6 +106,16 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backen
 		}
 	}
 
+	// When the fleet enables a shared buildkit server, ensure its container is
+	// running and bind its socket directory into the instance so docker buildx
+	// can use the fleet-wide build cache. Non-fatal: a failure to start the
+	// server just means this instance builds without the shared cache.
+	if mount, ok, err := prepareBuildkitMount(instanceBackend, fleetName); err != nil {
+		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("buildkit server: %v", err))
+	} else if ok {
+		resolvedMounts.Mounts = append(resolvedMounts.Mounts, mount)
+	}
+
 	result, err := instanceBackend.Up(wsDir, resolvedMounts.Mounts)
 	if err != nil {
 		setFailed(fleetName, instanceName, err)
@@ -135,6 +145,13 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backen
 	// warning and keep going.
 	if err := applyMountSymlinks(instanceBackend, wsDir, resolvedMounts.Symlinks); err != nil {
 		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("setting up agentic mount symlinks: %v", err))
+	}
+
+	// Point the instance's docker buildx at the fleet's shared buildkit server
+	// (when enabled). A silent no-op for images without docker/buildx, and
+	// non-fatal otherwise — the instance is usable regardless of buildx wiring.
+	if err := configureBuildkit(instanceBackend, fleetName, wsDir); err != nil {
+		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("configure buildkit buildx: %v", err))
 	}
 
 	// Auto-install dotfiles. A failure here is non-fatal — the instance

--- a/internal/fleet/fleet_settings.go
+++ b/internal/fleet/fleet_settings.go
@@ -31,6 +31,21 @@ type FleetSettings struct {
 	// config.yml.
 	GhMount bool `json:"ghMount,omitempty"`
 
+	// BuildkitServer enables a shared moby/buildkit container for this fleet.
+	// When set, instance provisioning ensures one buildkit container per fleet
+	// whose unix socket lives at ~/.fleet/workspaces/<fleet>/.buildkit/ and is
+	// bind-mounted into every instance; each instance's docker buildx is then
+	// pointed at it (a "remote" builder) so all instances share one build
+	// cache. Plain bool (default off), matching the *Mount flags: false ==
+	// "never set" == disabled.
+	//
+	// This declares intent only. At provisioning time it is honored solely on
+	// backends that report SupportsCustomMounts()==true (devcontainer); cloud
+	// backends silently skip it. Even on a supporting backend, setup is
+	// best-effort: if docker or buildx is absent inside an instance the
+	// configuration is skipped without error (the instance stays usable).
+	BuildkitServer bool `json:"buildkitServer,omitempty"`
+
 	// HomeDir is the absolute path inside the container that should be
 	// treated as the home directory when computing mount targets — e.g.
 	// "/home/vscode" so a Claude Code mount lands at "/home/vscode/.claude".

--- a/internal/instanceops/lifecycle.go
+++ b/internal/instanceops/lifecycle.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
+	"github.com/BenjaminBenetti/fleet-man/internal/buildkit"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
@@ -87,6 +89,18 @@ func transitionLoadedInstance(st *state.State, instance *fleet.Instance, fleetNa
 		var homeDir string
 		if f, ok := st.Fleets[fleetName]; ok {
 			homeDir = f.Settings.HomeDir
+			// Re-ensure the fleet's shared buildkit server in case the host
+			// rebooted (or it was manually removed) while this instance was
+			// stopped. Gated to local-docker backends (those that honor custom
+			// mounts); cloud backends can't reach a host docker daemon. The
+			// instance's own buildx config persists across stop/start, so only
+			// the server container needs reviving. Best-effort: a failure just
+			// means no shared cache this session.
+			if f.Settings.BuildkitServer && backendutil.New(instance.Backend, false).SupportsCustomMounts() {
+				if _, err := buildkit.EnsureSharedServer(fleetName); err != nil {
+					state.WriteWarn(fleetName, instanceName, fmt.Sprintf("buildkit server: %v", err))
+				}
+			}
 		}
 		postStartHook(fleetName, instance, homeDir)
 	default:

--- a/internal/server/buildkit_cleanup_test.go
+++ b/internal/server/buildkit_cleanup_test.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// stubStopBuildkit swaps the buildkit teardown seam for a recorder so the
+// cleanup paths can be exercised without a docker daemon. Returns a pointer to
+// the "was called" flag.
+func stubStopBuildkit(t *testing.T) *bool {
+	t.Helper()
+	called := false
+	orig := stopBuildkitServer
+	stopBuildkitServer = func(string) error { called = true; return nil }
+	t.Cleanup(func() { stopBuildkitServer = orig })
+	return &called
+}
+
+func seedBuildkitFleet(t *testing.T, instances ...*fleet.Instance) {
+	t.Helper()
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Settings: fleet.FleetSettings{BuildkitServer: true}, Instances: instances},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := os.MkdirAll(state.BuildkitDir("alpha"), 0o777); err != nil {
+		t.Fatalf("mkdir buildkit dir: %v", err)
+	}
+}
+
+// TestDestroyInstanceFleetTearsDownBuildkit verifies that destroying the whole
+// fleet stops the shared server and removes its .buildkit directory.
+func TestDestroyInstanceFleetTearsDownBuildkit(t *testing.T) {
+	isolateFleetDir(t)
+	called := stubStopBuildkit(t)
+	seedBuildkitFleet(t, &fleet.Instance{Name: "i1"})
+
+	newService().destroy("alpha", "i1", true)
+
+	if !*called {
+		t.Fatalf("StopSharedServer not called on destroy_fleet")
+	}
+	if _, err := os.Stat(state.BuildkitDir("alpha")); !os.IsNotExist(err) {
+		t.Fatalf("buildkit dir not removed on destroy_fleet: %v", err)
+	}
+}
+
+// TestDestroyInstanceSingleLeavesBuildkit verifies a single-instance destroy
+// leaves the shared server (other instances may still use it) up and its dir
+// intact.
+func TestDestroyInstanceSingleLeavesBuildkit(t *testing.T) {
+	isolateFleetDir(t)
+	called := stubStopBuildkit(t)
+	seedBuildkitFleet(t, &fleet.Instance{Name: "i1"}, &fleet.Instance{Name: "i2"})
+
+	newService().destroy("alpha", "i1", false)
+
+	if *called {
+		t.Fatalf("StopSharedServer must NOT be called on a single-instance destroy")
+	}
+	if _, err := os.Stat(state.BuildkitDir("alpha")); err != nil {
+		t.Fatalf("buildkit dir wrongly removed on single-instance destroy: %v", err)
+	}
+}
+
+// TestDestroyFleetTearsDownBuildkit verifies the synchronous DestroyFleet RPC
+// (used by the TUI to remove an already-empty fleet) also reclaims the buildkit
+// server — previously it bypassed the job-based destroy() cleanup.
+func TestDestroyFleetTearsDownBuildkit(t *testing.T) {
+	isolateFleetDir(t)
+	called := stubStopBuildkit(t)
+	seedBuildkitFleet(t) // empty fleet
+
+	if _, err := newService().DestroyFleet(context.Background(), &fleetgrpc.DestroyFleetRequest{Name: "alpha"}); err != nil {
+		t.Fatalf("DestroyFleet: %v", err)
+	}
+
+	if !*called {
+		t.Fatalf("StopSharedServer not called on DestroyFleet")
+	}
+	if _, err := os.Stat(state.BuildkitDir("alpha")); !os.IsNotExist(err) {
+		t.Fatalf("buildkit dir not removed on DestroyFleet: %v", err)
+	}
+}

--- a/internal/server/buildkit_cleanup_test.go
+++ b/internal/server/buildkit_cleanup_test.go
@@ -34,9 +34,10 @@ func seedBuildkitFleet(t *testing.T, instances ...*fleet.Instance) {
 	}
 }
 
-// TestDestroyInstanceFleetTearsDownBuildkit verifies that destroying the whole
-// fleet stops the shared server and removes its .buildkit directory.
-func TestDestroyInstanceFleetTearsDownBuildkit(t *testing.T) {
+// TestDestroyInstanceFleetStopsBuildkitKeepsCache verifies that destroying the
+// whole fleet stops (removes) the shared server container but PRESERVES the
+// .buildkit cache directory so a future fleet of the same name warms from it.
+func TestDestroyInstanceFleetStopsBuildkitKeepsCache(t *testing.T) {
 	isolateFleetDir(t)
 	called := stubStopBuildkit(t)
 	seedBuildkitFleet(t, &fleet.Instance{Name: "i1"})
@@ -46,8 +47,8 @@ func TestDestroyInstanceFleetTearsDownBuildkit(t *testing.T) {
 	if !*called {
 		t.Fatalf("StopSharedServer not called on destroy_fleet")
 	}
-	if _, err := os.Stat(state.BuildkitDir("alpha")); !os.IsNotExist(err) {
-		t.Fatalf("buildkit dir not removed on destroy_fleet: %v", err)
+	if _, err := os.Stat(state.BuildkitDir("alpha")); err != nil {
+		t.Fatalf("buildkit cache dir should persist across destroy_fleet, got: %v", err)
 	}
 }
 
@@ -69,10 +70,11 @@ func TestDestroyInstanceSingleLeavesBuildkit(t *testing.T) {
 	}
 }
 
-// TestDestroyFleetTearsDownBuildkit verifies the synchronous DestroyFleet RPC
-// (used by the TUI to remove an already-empty fleet) also reclaims the buildkit
-// server — previously it bypassed the job-based destroy() cleanup.
-func TestDestroyFleetTearsDownBuildkit(t *testing.T) {
+// TestDestroyFleetStopsBuildkitKeepsCache verifies the synchronous DestroyFleet
+// RPC (used by the TUI to remove an already-empty fleet) also stops the shared
+// server container — previously it bypassed the job-based cleanup and orphaned
+// it — while preserving the cache directory.
+func TestDestroyFleetStopsBuildkitKeepsCache(t *testing.T) {
 	isolateFleetDir(t)
 	called := stubStopBuildkit(t)
 	seedBuildkitFleet(t) // empty fleet
@@ -84,7 +86,7 @@ func TestDestroyFleetTearsDownBuildkit(t *testing.T) {
 	if !*called {
 		t.Fatalf("StopSharedServer not called on DestroyFleet")
 	}
-	if _, err := os.Stat(state.BuildkitDir("alpha")); !os.IsNotExist(err) {
-		t.Fatalf("buildkit dir not removed on DestroyFleet: %v", err)
+	if _, err := os.Stat(state.BuildkitDir("alpha")); err != nil {
+		t.Fatalf("buildkit cache dir should persist across DestroyFleet, got: %v", err)
 	}
 }

--- a/internal/server/convert.go
+++ b/internal/server/convert.go
@@ -52,6 +52,7 @@ func fleetSettingsToProto(s fleet.FleetSettings) *fleetgrpc.FleetSettings {
 		ClaudeCodeMount: s.ClaudeCodeMount,
 		CodexMount:      s.CodexMount,
 		GhMount:         s.GhMount,
+		BuildkitServer:  s.BuildkitServer,
 	}
 	if s.HomeDir != "" {
 		ps.HomeDir = strptr(s.HomeDir)

--- a/internal/server/jobs.go
+++ b/internal/server/jobs.go
@@ -58,6 +58,33 @@ var jobRunStop = func(fleetName, instanceName string) error {
 	return err
 }
 
+// stopBuildkitServer is the buildkit teardown seam (a package var so the destroy
+// paths can be exercised in tests without docker).
+var stopBuildkitServer = buildkit.StopSharedServer
+
+// teardownFleetBuildkit removes a fleet's shared buildkit server and cache
+// directory when the fleet had the feature enabled. Best-effort: every failure
+// becomes a warning, never an abort. Shared by the destroy job and the
+// DestroyFleet RPC so a fleet's buildkit resources are reclaimed no matter which
+// delete path runs (destroy_fleet=true vs. removing an already-empty fleet).
+func teardownFleetBuildkit(fleetName string, enabled bool) []string {
+	if !enabled {
+		return nil
+	}
+	var warnings []string
+	if err := stopBuildkitServer(fleetName); err != nil {
+		warnings = append(warnings, fmt.Sprintf("stop buildkit server: %v", err))
+	}
+	dir, err := buildkit.SharedDir(fleetName)
+	if err != nil {
+		return append(warnings, fmt.Sprintf("buildkit dir: %v", err))
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		warnings = append(warnings, fmt.Sprintf("remove buildkit dir %s: %v", dir, err))
+	}
+	return warnings
+}
+
 // jobDownInstance tears down one provisioned instance's container. Best-effort:
 // a backend failure is returned so the caller can WARN, but teardown proceeds.
 var jobDownInstance = func(inst *fleet.Instance) error {
@@ -498,15 +525,7 @@ func (s *service) destroy(fleetName, instanceName string, destroyFleet bool) []s
 	// Fleet-level teardown: once every instance is down, remove the fleet's
 	// shared buildkit container and its cache directory. Single-instance
 	// destroys leave the server up — its other instances may still use it.
-	// Best-effort, so failures surface as warnings rather than aborting.
-	if destroyFleet && buildkitEnabled {
-		if err := buildkit.StopSharedServer(fleetName); err != nil {
-			warnings = append(warnings, fmt.Sprintf("stop buildkit server: %v", err))
-		}
-		if err := os.RemoveAll(state.BuildkitDir(fleetName)); err != nil {
-			warnings = append(warnings, fmt.Sprintf("remove buildkit dir %s: %v", state.BuildkitDir(fleetName), err))
-		}
-	}
+	warnings = append(warnings, teardownFleetBuildkit(fleetName, destroyFleet && buildkitEnabled)...)
 
 	_ = state.Update(func(st *state.State) error {
 		f, ok := st.Fleets[fleetName]

--- a/internal/server/jobs.go
+++ b/internal/server/jobs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
+	"github.com/BenjaminBenetti/fleet-man/internal/buildkit"
 	"github.com/BenjaminBenetti/fleet-man/internal/create"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/instanceops"
@@ -468,8 +469,13 @@ func (s *service) destroy(fleetName, instanceName string, destroyFleet bool) []s
 		inst               *fleet.Instance
 	}
 	var targets []target
+	// buildkitEnabled is read from the live record before mutation so a
+	// destroy_fleet can tear down the fleet's shared buildkit server after its
+	// instances are down. Only meaningful when destroyFleet is set.
+	var buildkitEnabled bool
 	if st, err := state.Load(); err == nil {
 		if f, ok := st.Fleets[fleetName]; ok {
+			buildkitEnabled = f.Settings.BuildkitServer
 			for _, inst := range f.Instances {
 				if destroyFleet || inst.Name == instanceName {
 					targets = append(targets, target{name: inst.Name, workspaceDir: inst.WorkspaceDir, inst: inst})
@@ -486,6 +492,19 @@ func (s *service) destroy(fleetName, instanceName string, destroyFleet bool) []s
 			if err := os.RemoveAll(t.workspaceDir); err != nil {
 				warnings = append(warnings, fmt.Sprintf("remove workspace %s: %v", t.workspaceDir, err))
 			}
+		}
+	}
+
+	// Fleet-level teardown: once every instance is down, remove the fleet's
+	// shared buildkit container and its cache directory. Single-instance
+	// destroys leave the server up — its other instances may still use it.
+	// Best-effort, so failures surface as warnings rather than aborting.
+	if destroyFleet && buildkitEnabled {
+		if err := buildkit.StopSharedServer(fleetName); err != nil {
+			warnings = append(warnings, fmt.Sprintf("stop buildkit server: %v", err))
+		}
+		if err := os.RemoveAll(state.BuildkitDir(fleetName)); err != nil {
+			warnings = append(warnings, fmt.Sprintf("remove buildkit dir %s: %v", state.BuildkitDir(fleetName), err))
 		}
 	}
 

--- a/internal/server/jobs.go
+++ b/internal/server/jobs.go
@@ -62,27 +62,24 @@ var jobRunStop = func(fleetName, instanceName string) error {
 // paths can be exercised in tests without docker).
 var stopBuildkitServer = buildkit.StopSharedServer
 
-// teardownFleetBuildkit removes a fleet's shared buildkit server and cache
-// directory when the fleet had the feature enabled. Best-effort: every failure
-// becomes a warning, never an abort. Shared by the destroy job and the
-// DestroyFleet RPC so a fleet's buildkit resources are reclaimed no matter which
-// delete path runs (destroy_fleet=true vs. removing an already-empty fleet).
+// teardownFleetBuildkit removes a fleet's shared buildkit CONTAINER when the
+// fleet had the feature enabled, so it doesn't orphan or (given its
+// restart=unless-stopped policy) auto-restart after the fleet is gone. It
+// deliberately LEAVES the .buildkit cache directory on disk: a shared build
+// cache is the whole point of the feature, so it should persist across a fleet
+// teardown and warm the next instance created for a fleet of the same name —
+// exactly like the persisted .claude/.codex/.config/gh mount dirs already do.
+// Best-effort: a failure becomes a warning, never an abort. Shared by the
+// destroy job and the DestroyFleet RPC so the container is reclaimed no matter
+// which delete path runs (destroy_fleet=true vs. removing an already-empty fleet).
 func teardownFleetBuildkit(fleetName string, enabled bool) []string {
 	if !enabled {
 		return nil
 	}
-	var warnings []string
 	if err := stopBuildkitServer(fleetName); err != nil {
-		warnings = append(warnings, fmt.Sprintf("stop buildkit server: %v", err))
+		return []string{fmt.Sprintf("stop buildkit server: %v", err)}
 	}
-	dir, err := buildkit.SharedDir(fleetName)
-	if err != nil {
-		return append(warnings, fmt.Sprintf("buildkit dir: %v", err))
-	}
-	if err := os.RemoveAll(dir); err != nil {
-		warnings = append(warnings, fmt.Sprintf("remove buildkit dir %s: %v", dir, err))
-	}
-	return warnings
+	return nil
 }
 
 // jobDownInstance tears down one provisioned instance's container. Best-effort:

--- a/internal/server/mutations.go
+++ b/internal/server/mutations.go
@@ -204,6 +204,7 @@ func protoFleetSettingsToLegacy(ps *fleetgrpc.FleetSettings) fleet.FleetSettings
 	s.ClaudeCodeMount = ps.GetClaudeCodeMount()
 	s.CodexMount = ps.GetCodexMount()
 	s.GhMount = ps.GetGhMount()
+	s.BuildkitServer = ps.GetBuildkitServer()
 	s.HomeDir = ps.GetHomeDir()
 	if ps.PreferFleetLaunch != nil {
 		v := ps.GetPreferFleetLaunch()

--- a/internal/server/mutations.go
+++ b/internal/server/mutations.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -67,6 +68,17 @@ func (s *service) CreateFleet(_ context.Context, req *fleetgrpc.CreateFleetReque
 // never outlives — or orphans — live containers. Removing an already-absent
 // fleet is a no-op success (idempotent).
 func (s *service) DestroyFleet(_ context.Context, req *fleetgrpc.DestroyFleetRequest) (*fleetgrpc.MutationReply, error) {
+	// Read the buildkit setting BEFORE the record is deleted. DestroyFleet only
+	// removes an EMPTY fleet, so its shared buildkit server (kept alive by the
+	// earlier single-instance destroys) would otherwise be orphaned here — the
+	// destroy_fleet job path tears it down, but this synchronous path must too.
+	buildkitEnabled := false
+	if st, err := state.Load(); err == nil {
+		if f, ok := st.Fleets[req.GetName()]; ok {
+			buildkitEnabled = f.Settings.BuildkitServer
+		}
+	}
+
 	snapshot, err := s.mutate(func(st *state.State) error {
 		f, ok := st.Fleets[req.GetName()]
 		if !ok {
@@ -81,6 +93,12 @@ func (s *service) DestroyFleet(_ context.Context, req *fleetgrpc.DestroyFleetReq
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// Best-effort fleet-level buildkit teardown (no warning channel on this
+	// synchronous RPC, so surface failures to the event log).
+	for _, w := range teardownFleetBuildkit(req.GetName(), buildkitEnabled) {
+		flog.Warn("destroy fleet buildkit teardown", "fleet", req.GetName(), "warn", w)
 	}
 	return &fleetgrpc.MutationReply{State: snapshot}, nil
 }

--- a/internal/server/mutations_test.go
+++ b/internal/server/mutations_test.go
@@ -102,6 +102,7 @@ func TestSetFleetSettingsPreservesPresence(t *testing.T) {
 		Settings: &fleetgrpc.FleetSettings{
 			ClaudeCodeMount:   true,
 			GhMount:           true,
+			BuildkitServer:    true,
 			HomeDir:           ptr("/home/vscode"),
 			PreferFleetLaunch: &prefer,
 		},
@@ -113,12 +114,18 @@ func TestSetFleetSettingsPreservesPresence(t *testing.T) {
 	if !got.GetClaudeCodeMount() || got.GetCodexMount() || !got.GetGhMount() || got.GetHomeDir() != "/home/vscode" {
 		t.Fatalf("settings mismatch: %v", got)
 	}
+	if !got.GetBuildkitServer() {
+		t.Fatalf("BuildkitServer lost in reply: %v", got)
+	}
 
 	// Verify the persisted tri-state survives (PreferFleetLaunch set to true).
 	st, _ := state.Load()
 	s := st.Fleets["alpha"].Settings
 	if s.PreferFleetLaunch == nil || !*s.PreferFleetLaunch {
 		t.Fatalf("PreferFleetLaunch tri-state lost: %+v", s)
+	}
+	if !s.BuildkitServer {
+		t.Fatalf("BuildkitServer not persisted: %+v", s)
 	}
 
 	// Unknown fleet -> NotFound.

--- a/internal/state/paths.go
+++ b/internal/state/paths.go
@@ -31,6 +31,16 @@ func WarnPath(fleetName, instanceName string) string {
 	return filepath.Join(FleetDir(), "logs", fleetName+"-"+instanceName+".warn")
 }
 
+// BuildkitDir returns the per-fleet host directory that holds the shared
+// buildkit server's unix socket and build cache. It lives next to (not inside)
+// the per-instance workspace clones — like the agentic mount dirs — so it
+// survives instance churn and is shared by every instance in the fleet. The
+// buildkit container bind-mounts this directory and creates buildkitd.sock
+// inside it; instances bind-mount it read-write to reach that socket.
+func BuildkitDir(fleetName string) string {
+	return filepath.Join(WorkspacesDir(), fleetName, ".buildkit")
+}
+
 // ControlDir returns the host directory bind-mounted into an instance to
 // carry the control socket. It is per-instance (not per-fleet) so the host
 // can tell which instance a received message came from, and it lives under

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -285,6 +285,7 @@ func fleetSettingsToProto(s fleet.FleetSettings) *fleetgrpc.FleetSettings {
 		ClaudeCodeMount: s.ClaudeCodeMount,
 		CodexMount:      s.CodexMount,
 		GhMount:         s.GhMount,
+		BuildkitServer:  s.BuildkitServer,
 	}
 	if s.HomeDir != "" {
 		ps.HomeDir = &s.HomeDir
@@ -460,6 +461,7 @@ func protoFleetToLegacy(pf *fleetgrpc.Fleet) *fleet.Fleet {
 			ClaudeCodeMount: ps.GetClaudeCodeMount(),
 			CodexMount:      ps.GetCodexMount(),
 			GhMount:         ps.GetGhMount(),
+			BuildkitServer:  ps.GetBuildkitServer(),
 			HomeDir:         ps.GetHomeDir(),
 		}
 		if ps.PreferFleetLaunch != nil {

--- a/internal/tui/client_test.go
+++ b/internal/tui/client_test.go
@@ -78,3 +78,22 @@ func TestFleetSettingsToProtoPreservesTriState(t *testing.T) {
 		t.Fatalf("home dir: %q", got.GetHomeDir())
 	}
 }
+
+// TestFleetSettingsBuildkitServerRoundTrip checks the BuildkitServer bool
+// survives both client converters (legacy->proto and proto->legacy).
+func TestFleetSettingsBuildkitServerRoundTrip(t *testing.T) {
+	// Off by default -> false on the wire.
+	if fleetSettingsToProto(fleet.FleetSettings{}).GetBuildkitServer() {
+		t.Fatalf("unset BuildkitServer should be false on the wire")
+	}
+	// Enabled survives legacy->proto.
+	ps := fleetSettingsToProto(fleet.FleetSettings{BuildkitServer: true})
+	if !ps.GetBuildkitServer() {
+		t.Fatalf("BuildkitServer lost in fleetSettingsToProto")
+	}
+	// And proto->legacy.
+	back := protoFleetToLegacy(&fleetgrpc.Fleet{Name: "alpha", Settings: ps})
+	if !back.Settings.BuildkitServer {
+		t.Fatalf("BuildkitServer lost in protoFleetToLegacy: %+v", back.Settings)
+	}
+}

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -1056,6 +1056,7 @@ const (
 	editFleetRowClaude = iota
 	editFleetRowCodex
 	editFleetRowGh
+	editFleetRowBuildkit
 	editFleetRowHomeDir
 	editFleetRowPreferFleetLaunch
 	editFleetRowCount
@@ -1118,6 +1119,7 @@ func (fleetPage *fleetPage) openEditFleetDialog(m *model) tea.Cmd {
 	fleetPage.dialogClaudeMount = f.Settings.ClaudeCodeMount
 	fleetPage.dialogCodexMount = f.Settings.CodexMount
 	fleetPage.dialogGhMount = f.Settings.GhMount
+	fleetPage.dialogBuildkitServer = f.Settings.BuildkitServer
 	fleetPage.dialogPreferFleetLaunch = f.Settings.PreferFleetLaunchEnabled()
 	fleetPage.dialogRow = editFleetRowClaude
 	fleetPage.dialogDetecting = false
@@ -1192,7 +1194,7 @@ func (fleetPage *fleetPage) updateEditFleet(m *model, msg tea.Msg) tea.Cmd {
 
 	// Toggle / character input is row-specific.
 	switch fleetPage.dialogRow {
-	case editFleetRowClaude, editFleetRowCodex, editFleetRowGh, editFleetRowPreferFleetLaunch:
+	case editFleetRowClaude, editFleetRowCodex, editFleetRowGh, editFleetRowBuildkit, editFleetRowPreferFleetLaunch:
 		switch keyMsg.String() {
 		case " ", "left", "right", "h", "l", "x":
 			return fleetPage.toggleEditFleetRow(m)
@@ -1233,6 +1235,10 @@ func (fleetPage *fleetPage) toggleEditFleetRow(m *model) tea.Cmd {
 	case editFleetRowGh:
 		fleetPage.dialogGhMount = !fleetPage.dialogGhMount
 		turnedOn = fleetPage.dialogGhMount
+	case editFleetRowBuildkit:
+		// Not a home-dir mount, so no detection to kick off — just flip it.
+		fleetPage.dialogBuildkitServer = !fleetPage.dialogBuildkitServer
+		return nil
 	case editFleetRowPreferFleetLaunch:
 		// Not a mount, so no home-dir detection to kick off — just flip it.
 		fleetPage.dialogPreferFleetLaunch = !fleetPage.dialogPreferFleetLaunch
@@ -1323,6 +1329,7 @@ func (fleetPage *fleetPage) saveFleetEdits(m *model) tea.Cmd {
 	f.Settings.ClaudeCodeMount = fleetPage.dialogClaudeMount
 	f.Settings.CodexMount = fleetPage.dialogCodexMount
 	f.Settings.GhMount = fleetPage.dialogGhMount
+	f.Settings.BuildkitServer = fleetPage.dialogBuildkitServer
 	preferFleetLaunch := fleetPage.dialogPreferFleetLaunch
 	f.Settings.PreferFleetLaunch = &preferFleetLaunch
 	f.Settings.HomeDir = strings.TrimSpace(fleetPage.homedirInput.Value())

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -45,6 +45,7 @@ type fleetPage struct {
 	dialogClaudeMount       bool
 	dialogCodexMount        bool
 	dialogGhMount           bool
+	dialogBuildkitServer    bool
 	dialogPreferFleetLaunch bool
 	dialogDetecting         bool // true while a homedir auto-detect cmd is in flight
 
@@ -1452,7 +1453,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 		}
 
 		dialog := fmt.Sprintf(
-			"%s\n\n  %s %s\n%s%s %s\n%s%s %s\n%s%s %s\n%s%s %s\n%s%s %s\n\n  %s\n\n%s",
+			"%s\n\n  %s %s\n%s%s %s\n%s%s %s\n%s%s %s\n%s%s %s\n%s%s %s\n%s%s %s\n\n  %s\n\n%s",
 			dialogTitle.Render("Edit fleet"),
 			dialogLabel.Render("Fleet:    "),
 			fleetExpandedStyle.Render(fleetPage.dialogFleet),
@@ -1465,6 +1466,9 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			rowMarker(editFleetRowGh),
 			checkbox(fleetPage.dialogGhMount),
 			dialogLabel.Render("GitHub CLI mount"),
+			rowMarker(editFleetRowBuildkit),
+			checkbox(fleetPage.dialogBuildkitServer),
+			dialogLabel.Render("Buildkit server"),
 			rowMarker(editFleetRowHomeDir),
 			dialogLabel.Render("Home dir: "),
 			homedirField,

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -622,6 +622,44 @@ func TestEditFleetSavesPreferFleetLaunch(t *testing.T) {
 	}
 }
 
+// TestEditFleetSavesBuildkitServer verifies the "Buildkit server"
+// checkbox toggles and persists to FleetSettings on submit, and that
+// toggling it does NOT kick off home-dir detection (it is not a mount).
+func TestEditFleetSavesBuildkitServer(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	f := &fleet.Fleet{Name: "alpha"}
+	fp := newFleetPage()
+	fp.rows = []row{{kind: rowFleetHeader, fleetName: "alpha"}}
+	m := &model{
+		st:        &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}},
+		fleetPage: fp,
+	}
+
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	if fp.dialogBuildkitServer {
+		t.Fatalf("expected BuildkitServer off by default")
+	}
+
+	for fp.dialogRow != editFleetRowBuildkit {
+		fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace})
+	if !fp.dialogBuildkitServer {
+		t.Fatalf("toggle did not set dialogBuildkitServer")
+	}
+	// Buildkit is not a home-dir mount, so toggling it must not start detection.
+	if fp.dialogDetecting {
+		t.Fatalf("buildkit toggle should not kick off home-dir detection")
+	}
+
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if !f.Settings.BuildkitServer {
+		t.Fatalf("Settings.BuildkitServer = %v, want true", f.Settings.BuildkitServer)
+	}
+}
+
 // TestEditFleetHomedirDetectedFillsEmptyInput verifies the success
 // path of auto-detection: when the result arrives and the user has
 // not typed anything, the home-dir input is populated.
@@ -963,6 +1001,14 @@ func TestEditFleetDialogVimKeysAndActiveHomedir(t *testing.T) {
 		t.Fatal("l should toggle selected gh row")
 	}
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if fp.dialogRow != editFleetRowBuildkit {
+		t.Fatalf("dialogRow = %d, want buildkit row", fp.dialogRow)
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if !fp.dialogBuildkitServer {
+		t.Fatal("l should toggle selected buildkit row")
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	if fp.dialogRow != editFleetRowHomeDir {
 		t.Fatalf("dialogRow = %d, want home-dir row", fp.dialogRow)
 	}
@@ -980,6 +1026,10 @@ func TestEditFleetDialogVimKeysAndActiveHomedir(t *testing.T) {
 	}
 
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEsc})
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if fp.dialogRow != editFleetRowBuildkit {
+		t.Fatalf("dialogRow = %d, want buildkit row after inactive k", fp.dialogRow)
+	}
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
 	if fp.dialogRow != editFleetRowGh {
 		t.Fatalf("dialogRow = %d, want gh row after inactive k", fp.dialogRow)


### PR DESCRIPTION
## Summary

Adds a per-fleet **Buildkit server** setting. When enabled on a devcontainer-backed fleet, fleetd ensures one shared `moby/buildkit` container per fleet whose buildkitd unix socket lives under `~/.fleet/workspaces/<fleet>/.buildkit/`. That directory is bind-mounted into every instance, and each instance's `docker buildx` is pointed at it as a `remote` builder — so all instances in the fleet share one build cache.

Gated to backends that report `SupportsCustomMounts()` (devcontainer); cloud backends silently skip. Every step is best-effort: a missing `docker`/`buildx` inside an instance, or a server-start failure, never aborts provisioning.

## Design decisions (confirmed with the maintainer)
- **Transport:** unix socket (no host ports / port-collision); buildx uses `--driver remote unix://…`.
- **Cache:** bind dir at `~/.fleet/workspaces/<fleet>/.buildkit/cache`.
- **Lifecycle:** server starts on instance create (idempotent, per-fleet serialized); on `fleet destroy` the **container is removed but the cache directory is kept** so it warms the next build — like the persisted `.claude`/`.codex`/`.config/gh` mount dirs.

## What's included
- `FleetSettings.BuildkitServer` (proto field 6) through both server + client converters and the TUI edit-fleet dialog (new toggle row).
- New `internal/buildkit` package: `EnsureSharedServer` / `ConfigureInstanceBuildx` / `StopSharedServer` / `SharedDir`, with docker + socket-wait test seams.
- Wiring in `create`/`clone` (mount pre-Up, buildx config post-Up), `instanceops` Start (re-ensure after reboot), and fleet-destroy teardown on both the destroy job and the synchronous `DestroyFleet` RPC.

## Hardening (from an adversarial self-review)
- Per-fleet serialization + conflict-as-success so concurrent creates don't race on `docker run`.
- Socket wait on all paths (incl. container reuse).
- `SharedDir` path-traversal guard before any `os.MkdirAll`.
- Correct buildx remote-driver invocation (positional endpoint + separate `buildx use`).

## Tests
- Unit: converter round-trips, TUI toggle/persist, buildkit package (decision paths, concurrency run-once, socket-timeout non-fatal, traversal guard), fleet-destroy cleanup (job + `DestroyFleet`).
- Integration (real docker + devcontainer): `450_buildkit_enabled` (server boots, `buildctl` answers over the socket, socket mounted into the instance), `455_buildkit_disabled` (no server/socket/mount), `460_buildkit_destroy_keeps_cache` (container removed, cache preserved + reused on re-create).

Local gate green: `go vet`, `golangci-lint` (0 issues), full `go test`, `-race` on buildkit, and the three integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)