### PR TITLE
feat(buildkit): re-ensure shared servers on TUI connect (FleetTUIConnected RPC)

### DIFF
--- a/fleetgrpc/control.pb.go
+++ b/fleetgrpc/control.pb.go
@@ -248,6 +248,87 @@ func (x *ShutdownReply) GetDrainingJobs() int32 {
 	return 0
 }
 
+// FleetTUIConnectedRequest signals that a TUI client has just opened (sent once
+// per TUI launch, NOT per CLI command — CLI invocations only Hello). The server
+// uses it as a hook for once-per-open, fire-and-forget state reconciliation —
+// today: re-ensuring any configured shared buildkit servers that were killed
+// externally / lost to a host reboot while no instance lifecycle action would
+// have revived them. Empty by design; it is a pure nudge. Multiple TUIs may
+// send it concurrently, so the server coalesces the work.
+type FleetTUIConnectedRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FleetTUIConnectedRequest) Reset() {
+	*x = FleetTUIConnectedRequest{}
+	mi := &file_control_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FleetTUIConnectedRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FleetTUIConnectedRequest) ProtoMessage() {}
+
+func (x *FleetTUIConnectedRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_control_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FleetTUIConnectedRequest.ProtoReflect.Descriptor instead.
+func (*FleetTUIConnectedRequest) Descriptor() ([]byte, []int) {
+	return file_control_proto_rawDescGZIP(), []int{4}
+}
+
+// FleetTUIConnectedReply is intentionally empty: the reconciliation is
+// fire-and-forget on the server, so the client does not wait on its outcome.
+type FleetTUIConnectedReply struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FleetTUIConnectedReply) Reset() {
+	*x = FleetTUIConnectedReply{}
+	mi := &file_control_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FleetTUIConnectedReply) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FleetTUIConnectedReply) ProtoMessage() {}
+
+func (x *FleetTUIConnectedReply) ProtoReflect() protoreflect.Message {
+	mi := &file_control_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FleetTUIConnectedReply.ProtoReflect.Descriptor instead.
+func (*FleetTUIConnectedReply) Descriptor() ([]byte, []int) {
+	return file_control_proto_rawDescGZIP(), []int{5}
+}
+
 type GetStateRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -256,7 +337,7 @@ type GetStateRequest struct {
 
 func (x *GetStateRequest) Reset() {
 	*x = GetStateRequest{}
-	mi := &file_control_proto_msgTypes[4]
+	mi := &file_control_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -268,7 +349,7 @@ func (x *GetStateRequest) String() string {
 func (*GetStateRequest) ProtoMessage() {}
 
 func (x *GetStateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[4]
+	mi := &file_control_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -281,7 +362,7 @@ func (x *GetStateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStateRequest.ProtoReflect.Descriptor instead.
 func (*GetStateRequest) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{4}
+	return file_control_proto_rawDescGZIP(), []int{6}
 }
 
 // GetStateReply is the one-stop snapshot of EVERYTHING the TUI renders:
@@ -300,7 +381,7 @@ type GetStateReply struct {
 
 func (x *GetStateReply) Reset() {
 	*x = GetStateReply{}
-	mi := &file_control_proto_msgTypes[5]
+	mi := &file_control_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -312,7 +393,7 @@ func (x *GetStateReply) String() string {
 func (*GetStateReply) ProtoMessage() {}
 
 func (x *GetStateReply) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[5]
+	mi := &file_control_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -325,7 +406,7 @@ func (x *GetStateReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStateReply.ProtoReflect.Descriptor instead.
 func (*GetStateReply) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{5}
+	return file_control_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *GetStateReply) GetState() *State {
@@ -361,7 +442,7 @@ type CreateFleetRequest struct {
 
 func (x *CreateFleetRequest) Reset() {
 	*x = CreateFleetRequest{}
-	mi := &file_control_proto_msgTypes[6]
+	mi := &file_control_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -373,7 +454,7 @@ func (x *CreateFleetRequest) String() string {
 func (*CreateFleetRequest) ProtoMessage() {}
 
 func (x *CreateFleetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[6]
+	mi := &file_control_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -386,7 +467,7 @@ func (x *CreateFleetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateFleetRequest.ProtoReflect.Descriptor instead.
 func (*CreateFleetRequest) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{6}
+	return file_control_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *CreateFleetRequest) GetName() string {
@@ -415,7 +496,7 @@ type DestroyFleetRequest struct {
 
 func (x *DestroyFleetRequest) Reset() {
 	*x = DestroyFleetRequest{}
-	mi := &file_control_proto_msgTypes[7]
+	mi := &file_control_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -427,7 +508,7 @@ func (x *DestroyFleetRequest) String() string {
 func (*DestroyFleetRequest) ProtoMessage() {}
 
 func (x *DestroyFleetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[7]
+	mi := &file_control_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -440,7 +521,7 @@ func (x *DestroyFleetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DestroyFleetRequest.ProtoReflect.Descriptor instead.
 func (*DestroyFleetRequest) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{7}
+	return file_control_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *DestroyFleetRequest) GetName() string {
@@ -463,7 +544,7 @@ type SetFleetSettingsRequest struct {
 
 func (x *SetFleetSettingsRequest) Reset() {
 	*x = SetFleetSettingsRequest{}
-	mi := &file_control_proto_msgTypes[8]
+	mi := &file_control_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -475,7 +556,7 @@ func (x *SetFleetSettingsRequest) String() string {
 func (*SetFleetSettingsRequest) ProtoMessage() {}
 
 func (x *SetFleetSettingsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[8]
+	mi := &file_control_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -488,7 +569,7 @@ func (x *SetFleetSettingsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetFleetSettingsRequest.ProtoReflect.Descriptor instead.
 func (*SetFleetSettingsRequest) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{8}
+	return file_control_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *SetFleetSettingsRequest) GetFleet() string {
@@ -522,7 +603,7 @@ type SetInstanceMetadataRequest struct {
 
 func (x *SetInstanceMetadataRequest) Reset() {
 	*x = SetInstanceMetadataRequest{}
-	mi := &file_control_proto_msgTypes[9]
+	mi := &file_control_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -534,7 +615,7 @@ func (x *SetInstanceMetadataRequest) String() string {
 func (*SetInstanceMetadataRequest) ProtoMessage() {}
 
 func (x *SetInstanceMetadataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[9]
+	mi := &file_control_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -547,7 +628,7 @@ func (x *SetInstanceMetadataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetInstanceMetadataRequest.ProtoReflect.Descriptor instead.
 func (*SetInstanceMetadataRequest) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{9}
+	return file_control_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *SetInstanceMetadataRequest) GetFleet() string {
@@ -597,7 +678,7 @@ type SetGroupLayoutRequest struct {
 
 func (x *SetGroupLayoutRequest) Reset() {
 	*x = SetGroupLayoutRequest{}
-	mi := &file_control_proto_msgTypes[10]
+	mi := &file_control_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -609,7 +690,7 @@ func (x *SetGroupLayoutRequest) String() string {
 func (*SetGroupLayoutRequest) ProtoMessage() {}
 
 func (x *SetGroupLayoutRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[10]
+	mi := &file_control_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -622,7 +703,7 @@ func (x *SetGroupLayoutRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetGroupLayoutRequest.ProtoReflect.Descriptor instead.
 func (*SetGroupLayoutRequest) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{10}
+	return file_control_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *SetGroupLayoutRequest) GetLayout() *GroupLayout {
@@ -645,7 +726,7 @@ type DeleteGroupLayoutRequest struct {
 
 func (x *DeleteGroupLayoutRequest) Reset() {
 	*x = DeleteGroupLayoutRequest{}
-	mi := &file_control_proto_msgTypes[11]
+	mi := &file_control_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -657,7 +738,7 @@ func (x *DeleteGroupLayoutRequest) String() string {
 func (*DeleteGroupLayoutRequest) ProtoMessage() {}
 
 func (x *DeleteGroupLayoutRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[11]
+	mi := &file_control_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -670,7 +751,7 @@ func (x *DeleteGroupLayoutRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteGroupLayoutRequest.ProtoReflect.Descriptor instead.
 func (*DeleteGroupLayoutRequest) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{11}
+	return file_control_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *DeleteGroupLayoutRequest) GetInstanceName() string {
@@ -697,7 +778,7 @@ type SetLastSeenVersionRequest struct {
 
 func (x *SetLastSeenVersionRequest) Reset() {
 	*x = SetLastSeenVersionRequest{}
-	mi := &file_control_proto_msgTypes[12]
+	mi := &file_control_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -709,7 +790,7 @@ func (x *SetLastSeenVersionRequest) String() string {
 func (*SetLastSeenVersionRequest) ProtoMessage() {}
 
 func (x *SetLastSeenVersionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[12]
+	mi := &file_control_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -722,7 +803,7 @@ func (x *SetLastSeenVersionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetLastSeenVersionRequest.ProtoReflect.Descriptor instead.
 func (*SetLastSeenVersionRequest) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{12}
+	return file_control_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *SetLastSeenVersionRequest) GetVersion() string {
@@ -742,7 +823,7 @@ type MutationReply struct {
 
 func (x *MutationReply) Reset() {
 	*x = MutationReply{}
-	mi := &file_control_proto_msgTypes[13]
+	mi := &file_control_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -754,7 +835,7 @@ func (x *MutationReply) String() string {
 func (*MutationReply) ProtoMessage() {}
 
 func (x *MutationReply) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[13]
+	mi := &file_control_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -767,7 +848,7 @@ func (x *MutationReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MutationReply.ProtoReflect.Descriptor instead.
 func (*MutationReply) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{13}
+	return file_control_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *MutationReply) GetState() *State {
@@ -797,7 +878,9 @@ const file_control_proto_rawDesc = "" +
 	"\a_reason\"P\n" +
 	"\rShutdownReply\x12\x1a\n" +
 	"\baccepted\x18\x01 \x01(\bR\baccepted\x12#\n" +
-	"\rdraining_jobs\x18\x02 \x01(\x05R\fdrainingJobs\"\x11\n" +
+	"\rdraining_jobs\x18\x02 \x01(\x05R\fdrainingJobs\"\x1a\n" +
+	"\x18FleetTUIConnectedRequest\"\x18\n" +
+	"\x16FleetTUIConnectedReply\"\x11\n" +
 	"\x0fGetStateRequest\"\xa5\x01\n" +
 	"\rGetStateReply\x12&\n" +
 	"\x05state\x18\x01 \x01(\v2\x10.fleetgrpc.StateR\x05state\x124\n" +
@@ -843,37 +926,39 @@ func file_control_proto_rawDescGZIP() []byte {
 	return file_control_proto_rawDescData
 }
 
-var file_control_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_control_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_control_proto_goTypes = []any{
 	(*HelloRequest)(nil),               // 0: fleetgrpc.HelloRequest
 	(*HelloReply)(nil),                 // 1: fleetgrpc.HelloReply
 	(*ShutdownRequest)(nil),            // 2: fleetgrpc.ShutdownRequest
 	(*ShutdownReply)(nil),              // 3: fleetgrpc.ShutdownReply
-	(*GetStateRequest)(nil),            // 4: fleetgrpc.GetStateRequest
-	(*GetStateReply)(nil),              // 5: fleetgrpc.GetStateReply
-	(*CreateFleetRequest)(nil),         // 6: fleetgrpc.CreateFleetRequest
-	(*DestroyFleetRequest)(nil),        // 7: fleetgrpc.DestroyFleetRequest
-	(*SetFleetSettingsRequest)(nil),    // 8: fleetgrpc.SetFleetSettingsRequest
-	(*SetInstanceMetadataRequest)(nil), // 9: fleetgrpc.SetInstanceMetadataRequest
-	(*SetGroupLayoutRequest)(nil),      // 10: fleetgrpc.SetGroupLayoutRequest
-	(*DeleteGroupLayoutRequest)(nil),   // 11: fleetgrpc.DeleteGroupLayoutRequest
-	(*SetLastSeenVersionRequest)(nil),  // 12: fleetgrpc.SetLastSeenVersionRequest
-	(*MutationReply)(nil),              // 13: fleetgrpc.MutationReply
-	(*timestamppb.Timestamp)(nil),      // 14: google.protobuf.Timestamp
-	(*State)(nil),                      // 15: fleetgrpc.State
-	(*InstanceRuntime)(nil),            // 16: fleetgrpc.InstanceRuntime
-	(*JobSummary)(nil),                 // 17: fleetgrpc.JobSummary
-	(*FleetSettings)(nil),              // 18: fleetgrpc.FleetSettings
-	(*GroupLayout)(nil),                // 19: fleetgrpc.GroupLayout
+	(*FleetTUIConnectedRequest)(nil),   // 4: fleetgrpc.FleetTUIConnectedRequest
+	(*FleetTUIConnectedReply)(nil),     // 5: fleetgrpc.FleetTUIConnectedReply
+	(*GetStateRequest)(nil),            // 6: fleetgrpc.GetStateRequest
+	(*GetStateReply)(nil),              // 7: fleetgrpc.GetStateReply
+	(*CreateFleetRequest)(nil),         // 8: fleetgrpc.CreateFleetRequest
+	(*DestroyFleetRequest)(nil),        // 9: fleetgrpc.DestroyFleetRequest
+	(*SetFleetSettingsRequest)(nil),    // 10: fleetgrpc.SetFleetSettingsRequest
+	(*SetInstanceMetadataRequest)(nil), // 11: fleetgrpc.SetInstanceMetadataRequest
+	(*SetGroupLayoutRequest)(nil),      // 12: fleetgrpc.SetGroupLayoutRequest
+	(*DeleteGroupLayoutRequest)(nil),   // 13: fleetgrpc.DeleteGroupLayoutRequest
+	(*SetLastSeenVersionRequest)(nil),  // 14: fleetgrpc.SetLastSeenVersionRequest
+	(*MutationReply)(nil),              // 15: fleetgrpc.MutationReply
+	(*timestamppb.Timestamp)(nil),      // 16: google.protobuf.Timestamp
+	(*State)(nil),                      // 17: fleetgrpc.State
+	(*InstanceRuntime)(nil),            // 18: fleetgrpc.InstanceRuntime
+	(*JobSummary)(nil),                 // 19: fleetgrpc.JobSummary
+	(*FleetSettings)(nil),              // 20: fleetgrpc.FleetSettings
+	(*GroupLayout)(nil),                // 21: fleetgrpc.GroupLayout
 }
 var file_control_proto_depIdxs = []int32{
-	14, // 0: fleetgrpc.HelloReply.started_at:type_name -> google.protobuf.Timestamp
-	15, // 1: fleetgrpc.GetStateReply.state:type_name -> fleetgrpc.State
-	16, // 2: fleetgrpc.GetStateReply.runtime:type_name -> fleetgrpc.InstanceRuntime
-	17, // 3: fleetgrpc.GetStateReply.active_jobs:type_name -> fleetgrpc.JobSummary
-	18, // 4: fleetgrpc.SetFleetSettingsRequest.settings:type_name -> fleetgrpc.FleetSettings
-	19, // 5: fleetgrpc.SetGroupLayoutRequest.layout:type_name -> fleetgrpc.GroupLayout
-	15, // 6: fleetgrpc.MutationReply.state:type_name -> fleetgrpc.State
+	16, // 0: fleetgrpc.HelloReply.started_at:type_name -> google.protobuf.Timestamp
+	17, // 1: fleetgrpc.GetStateReply.state:type_name -> fleetgrpc.State
+	18, // 2: fleetgrpc.GetStateReply.runtime:type_name -> fleetgrpc.InstanceRuntime
+	19, // 3: fleetgrpc.GetStateReply.active_jobs:type_name -> fleetgrpc.JobSummary
+	20, // 4: fleetgrpc.SetFleetSettingsRequest.settings:type_name -> fleetgrpc.FleetSettings
+	21, // 5: fleetgrpc.SetGroupLayoutRequest.layout:type_name -> fleetgrpc.GroupLayout
+	17, // 6: fleetgrpc.MutationReply.state:type_name -> fleetgrpc.State
 	7,  // [7:7] is the sub-list for method output_type
 	7,  // [7:7] is the sub-list for method input_type
 	7,  // [7:7] is the sub-list for extension type_name
@@ -890,14 +975,14 @@ func file_control_proto_init() {
 	file_runtime_proto_init()
 	file_jobs_proto_init()
 	file_control_proto_msgTypes[2].OneofWrappers = []any{}
-	file_control_proto_msgTypes[9].OneofWrappers = []any{}
+	file_control_proto_msgTypes[11].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_control_proto_rawDesc), len(file_control_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   14,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/fleetgrpc/control.proto
+++ b/fleetgrpc/control.proto
@@ -53,6 +53,19 @@ message ShutdownReply {
   int32 draining_jobs = 2;
 }
 
+// FleetTUIConnectedRequest signals that a TUI client has just opened (sent once
+// per TUI launch, NOT per CLI command — CLI invocations only Hello). The server
+// uses it as a hook for once-per-open, fire-and-forget state reconciliation —
+// today: re-ensuring any configured shared buildkit servers that were killed
+// externally / lost to a host reboot while no instance lifecycle action would
+// have revived them. Empty by design; it is a pure nudge. Multiple TUIs may
+// send it concurrently, so the server coalesces the work.
+message FleetTUIConnectedRequest {}
+
+// FleetTUIConnectedReply is intentionally empty: the reconciliation is
+// fire-and-forget on the server, so the client does not wait on its outcome.
+message FleetTUIConnectedReply {}
+
 message GetStateRequest {}
 
 // GetStateReply is the one-stop snapshot of EVERYTHING the TUI renders:

--- a/fleetgrpc/service.pb.go
+++ b/fleetgrpc/service.pb.go
@@ -26,10 +26,11 @@ const file_service_proto_rawDesc = "" +
 	"\n" +
 	"\rservice.proto\x12\tfleetgrpc\x1a\rcontrol.proto\x1a\vwatch.proto\x1a\n" +
 	"jobs.proto\x1a\fconfig.proto\x1a\n" +
-	"exec.proto2\xbe\x0f\n" +
+	"exec.proto2\x9b\x10\n" +
 	"\fFleetService\x127\n" +
 	"\x05Hello\x12\x17.fleetgrpc.HelloRequest\x1a\x15.fleetgrpc.HelloReply\x12@\n" +
-	"\bShutdown\x12\x1a.fleetgrpc.ShutdownRequest\x1a\x18.fleetgrpc.ShutdownReply\x12@\n" +
+	"\bShutdown\x12\x1a.fleetgrpc.ShutdownRequest\x1a\x18.fleetgrpc.ShutdownReply\x12[\n" +
+	"\x11FleetTUIConnected\x12#.fleetgrpc.FleetTUIConnectedRequest\x1a!.fleetgrpc.FleetTUIConnectedReply\x12@\n" +
 	"\bGetState\x12\x1a.fleetgrpc.GetStateRequest\x1a\x18.fleetgrpc.GetStateReply\x124\n" +
 	"\x05Watch\x12\x17.fleetgrpc.WatchRequest\x1a\x10.fleetgrpc.Event0\x01\x12I\n" +
 	"\x0eCreateInstance\x12 .fleetgrpc.CreateInstanceRequest\x1a\x13.fleetgrpc.JobEvent0\x01\x12K\n" +
@@ -58,102 +59,106 @@ const file_service_proto_rawDesc = "" +
 var file_service_proto_goTypes = []any{
 	(*HelloRequest)(nil),                  // 0: fleetgrpc.HelloRequest
 	(*ShutdownRequest)(nil),               // 1: fleetgrpc.ShutdownRequest
-	(*GetStateRequest)(nil),               // 2: fleetgrpc.GetStateRequest
-	(*WatchRequest)(nil),                  // 3: fleetgrpc.WatchRequest
-	(*CreateInstanceRequest)(nil),         // 4: fleetgrpc.CreateInstanceRequest
-	(*DestroyInstanceRequest)(nil),        // 5: fleetgrpc.DestroyInstanceRequest
-	(*StartInstanceRequest)(nil),          // 6: fleetgrpc.StartInstanceRequest
-	(*StopInstanceRequest)(nil),           // 7: fleetgrpc.StopInstanceRequest
-	(*CloneInstanceRequest)(nil),          // 8: fleetgrpc.CloneInstanceRequest
-	(*CreateFleetRequest)(nil),            // 9: fleetgrpc.CreateFleetRequest
-	(*DestroyFleetRequest)(nil),           // 10: fleetgrpc.DestroyFleetRequest
-	(*SetFleetSettingsRequest)(nil),       // 11: fleetgrpc.SetFleetSettingsRequest
-	(*SetInstanceMetadataRequest)(nil),    // 12: fleetgrpc.SetInstanceMetadataRequest
-	(*SetGroupLayoutRequest)(nil),         // 13: fleetgrpc.SetGroupLayoutRequest
-	(*DeleteGroupLayoutRequest)(nil),      // 14: fleetgrpc.DeleteGroupLayoutRequest
-	(*SetLastSeenVersionRequest)(nil),     // 15: fleetgrpc.SetLastSeenVersionRequest
-	(*GetConfigRequest)(nil),              // 16: fleetgrpc.GetConfigRequest
-	(*SetConfigRequest)(nil),              // 17: fleetgrpc.SetConfigRequest
-	(*ExecIn)(nil),                        // 18: fleetgrpc.ExecIn
-	(*ResolveExecCommandRequest)(nil),     // 19: fleetgrpc.ResolveExecCommandRequest
-	(*ResolveLogsCommandRequest)(nil),     // 20: fleetgrpc.ResolveLogsCommandRequest
-	(*LogsRequest)(nil),                   // 21: fleetgrpc.LogsRequest
-	(*PortForwardRequest)(nil),            // 22: fleetgrpc.PortForwardRequest
-	(*GetCoderTemplateParamsRequest)(nil), // 23: fleetgrpc.GetCoderTemplateParamsRequest
-	(*GetBrowserConfigRequest)(nil),       // 24: fleetgrpc.GetBrowserConfigRequest
-	(*PrepareBrowserRequest)(nil),         // 25: fleetgrpc.PrepareBrowserRequest
-	(*HelloReply)(nil),                    // 26: fleetgrpc.HelloReply
-	(*ShutdownReply)(nil),                 // 27: fleetgrpc.ShutdownReply
-	(*GetStateReply)(nil),                 // 28: fleetgrpc.GetStateReply
-	(*Event)(nil),                         // 29: fleetgrpc.Event
-	(*JobEvent)(nil),                      // 30: fleetgrpc.JobEvent
-	(*MutationReply)(nil),                 // 31: fleetgrpc.MutationReply
-	(*GetConfigReply)(nil),                // 32: fleetgrpc.GetConfigReply
-	(*SetConfigReply)(nil),                // 33: fleetgrpc.SetConfigReply
-	(*ExecOut)(nil),                       // 34: fleetgrpc.ExecOut
-	(*ResolveExecCommandReply)(nil),       // 35: fleetgrpc.ResolveExecCommandReply
-	(*ResolveLogsCommandReply)(nil),       // 36: fleetgrpc.ResolveLogsCommandReply
-	(*LogLine)(nil),                       // 37: fleetgrpc.LogLine
-	(*PortForwardReply)(nil),              // 38: fleetgrpc.PortForwardReply
-	(*GetCoderTemplateParamsReply)(nil),   // 39: fleetgrpc.GetCoderTemplateParamsReply
-	(*GetBrowserConfigReply)(nil),         // 40: fleetgrpc.GetBrowserConfigReply
-	(*PrepareBrowserReply)(nil),           // 41: fleetgrpc.PrepareBrowserReply
+	(*FleetTUIConnectedRequest)(nil),      // 2: fleetgrpc.FleetTUIConnectedRequest
+	(*GetStateRequest)(nil),               // 3: fleetgrpc.GetStateRequest
+	(*WatchRequest)(nil),                  // 4: fleetgrpc.WatchRequest
+	(*CreateInstanceRequest)(nil),         // 5: fleetgrpc.CreateInstanceRequest
+	(*DestroyInstanceRequest)(nil),        // 6: fleetgrpc.DestroyInstanceRequest
+	(*StartInstanceRequest)(nil),          // 7: fleetgrpc.StartInstanceRequest
+	(*StopInstanceRequest)(nil),           // 8: fleetgrpc.StopInstanceRequest
+	(*CloneInstanceRequest)(nil),          // 9: fleetgrpc.CloneInstanceRequest
+	(*CreateFleetRequest)(nil),            // 10: fleetgrpc.CreateFleetRequest
+	(*DestroyFleetRequest)(nil),           // 11: fleetgrpc.DestroyFleetRequest
+	(*SetFleetSettingsRequest)(nil),       // 12: fleetgrpc.SetFleetSettingsRequest
+	(*SetInstanceMetadataRequest)(nil),    // 13: fleetgrpc.SetInstanceMetadataRequest
+	(*SetGroupLayoutRequest)(nil),         // 14: fleetgrpc.SetGroupLayoutRequest
+	(*DeleteGroupLayoutRequest)(nil),      // 15: fleetgrpc.DeleteGroupLayoutRequest
+	(*SetLastSeenVersionRequest)(nil),     // 16: fleetgrpc.SetLastSeenVersionRequest
+	(*GetConfigRequest)(nil),              // 17: fleetgrpc.GetConfigRequest
+	(*SetConfigRequest)(nil),              // 18: fleetgrpc.SetConfigRequest
+	(*ExecIn)(nil),                        // 19: fleetgrpc.ExecIn
+	(*ResolveExecCommandRequest)(nil),     // 20: fleetgrpc.ResolveExecCommandRequest
+	(*ResolveLogsCommandRequest)(nil),     // 21: fleetgrpc.ResolveLogsCommandRequest
+	(*LogsRequest)(nil),                   // 22: fleetgrpc.LogsRequest
+	(*PortForwardRequest)(nil),            // 23: fleetgrpc.PortForwardRequest
+	(*GetCoderTemplateParamsRequest)(nil), // 24: fleetgrpc.GetCoderTemplateParamsRequest
+	(*GetBrowserConfigRequest)(nil),       // 25: fleetgrpc.GetBrowserConfigRequest
+	(*PrepareBrowserRequest)(nil),         // 26: fleetgrpc.PrepareBrowserRequest
+	(*HelloReply)(nil),                    // 27: fleetgrpc.HelloReply
+	(*ShutdownReply)(nil),                 // 28: fleetgrpc.ShutdownReply
+	(*FleetTUIConnectedReply)(nil),        // 29: fleetgrpc.FleetTUIConnectedReply
+	(*GetStateReply)(nil),                 // 30: fleetgrpc.GetStateReply
+	(*Event)(nil),                         // 31: fleetgrpc.Event
+	(*JobEvent)(nil),                      // 32: fleetgrpc.JobEvent
+	(*MutationReply)(nil),                 // 33: fleetgrpc.MutationReply
+	(*GetConfigReply)(nil),                // 34: fleetgrpc.GetConfigReply
+	(*SetConfigReply)(nil),                // 35: fleetgrpc.SetConfigReply
+	(*ExecOut)(nil),                       // 36: fleetgrpc.ExecOut
+	(*ResolveExecCommandReply)(nil),       // 37: fleetgrpc.ResolveExecCommandReply
+	(*ResolveLogsCommandReply)(nil),       // 38: fleetgrpc.ResolveLogsCommandReply
+	(*LogLine)(nil),                       // 39: fleetgrpc.LogLine
+	(*PortForwardReply)(nil),              // 40: fleetgrpc.PortForwardReply
+	(*GetCoderTemplateParamsReply)(nil),   // 41: fleetgrpc.GetCoderTemplateParamsReply
+	(*GetBrowserConfigReply)(nil),         // 42: fleetgrpc.GetBrowserConfigReply
+	(*PrepareBrowserReply)(nil),           // 43: fleetgrpc.PrepareBrowserReply
 }
 var file_service_proto_depIdxs = []int32{
 	0,  // 0: fleetgrpc.FleetService.Hello:input_type -> fleetgrpc.HelloRequest
 	1,  // 1: fleetgrpc.FleetService.Shutdown:input_type -> fleetgrpc.ShutdownRequest
-	2,  // 2: fleetgrpc.FleetService.GetState:input_type -> fleetgrpc.GetStateRequest
-	3,  // 3: fleetgrpc.FleetService.Watch:input_type -> fleetgrpc.WatchRequest
-	4,  // 4: fleetgrpc.FleetService.CreateInstance:input_type -> fleetgrpc.CreateInstanceRequest
-	5,  // 5: fleetgrpc.FleetService.DestroyInstance:input_type -> fleetgrpc.DestroyInstanceRequest
-	6,  // 6: fleetgrpc.FleetService.StartInstance:input_type -> fleetgrpc.StartInstanceRequest
-	7,  // 7: fleetgrpc.FleetService.StopInstance:input_type -> fleetgrpc.StopInstanceRequest
-	8,  // 8: fleetgrpc.FleetService.CloneInstance:input_type -> fleetgrpc.CloneInstanceRequest
-	9,  // 9: fleetgrpc.FleetService.CreateFleet:input_type -> fleetgrpc.CreateFleetRequest
-	10, // 10: fleetgrpc.FleetService.DestroyFleet:input_type -> fleetgrpc.DestroyFleetRequest
-	11, // 11: fleetgrpc.FleetService.SetFleetSettings:input_type -> fleetgrpc.SetFleetSettingsRequest
-	12, // 12: fleetgrpc.FleetService.SetInstanceMetadata:input_type -> fleetgrpc.SetInstanceMetadataRequest
-	13, // 13: fleetgrpc.FleetService.SetGroupLayout:input_type -> fleetgrpc.SetGroupLayoutRequest
-	14, // 14: fleetgrpc.FleetService.DeleteGroupLayout:input_type -> fleetgrpc.DeleteGroupLayoutRequest
-	15, // 15: fleetgrpc.FleetService.SetLastSeenVersion:input_type -> fleetgrpc.SetLastSeenVersionRequest
-	16, // 16: fleetgrpc.FleetService.GetConfig:input_type -> fleetgrpc.GetConfigRequest
-	17, // 17: fleetgrpc.FleetService.SetConfig:input_type -> fleetgrpc.SetConfigRequest
-	18, // 18: fleetgrpc.FleetService.Exec:input_type -> fleetgrpc.ExecIn
-	19, // 19: fleetgrpc.FleetService.ResolveExecCommand:input_type -> fleetgrpc.ResolveExecCommandRequest
-	20, // 20: fleetgrpc.FleetService.ResolveLogsCommand:input_type -> fleetgrpc.ResolveLogsCommandRequest
-	21, // 21: fleetgrpc.FleetService.Logs:input_type -> fleetgrpc.LogsRequest
-	22, // 22: fleetgrpc.FleetService.PortForward:input_type -> fleetgrpc.PortForwardRequest
-	23, // 23: fleetgrpc.FleetService.GetCoderTemplateParams:input_type -> fleetgrpc.GetCoderTemplateParamsRequest
-	24, // 24: fleetgrpc.FleetService.GetBrowserConfig:input_type -> fleetgrpc.GetBrowserConfigRequest
-	25, // 25: fleetgrpc.FleetService.PrepareBrowser:input_type -> fleetgrpc.PrepareBrowserRequest
-	26, // 26: fleetgrpc.FleetService.Hello:output_type -> fleetgrpc.HelloReply
-	27, // 27: fleetgrpc.FleetService.Shutdown:output_type -> fleetgrpc.ShutdownReply
-	28, // 28: fleetgrpc.FleetService.GetState:output_type -> fleetgrpc.GetStateReply
-	29, // 29: fleetgrpc.FleetService.Watch:output_type -> fleetgrpc.Event
-	30, // 30: fleetgrpc.FleetService.CreateInstance:output_type -> fleetgrpc.JobEvent
-	30, // 31: fleetgrpc.FleetService.DestroyInstance:output_type -> fleetgrpc.JobEvent
-	30, // 32: fleetgrpc.FleetService.StartInstance:output_type -> fleetgrpc.JobEvent
-	30, // 33: fleetgrpc.FleetService.StopInstance:output_type -> fleetgrpc.JobEvent
-	30, // 34: fleetgrpc.FleetService.CloneInstance:output_type -> fleetgrpc.JobEvent
-	31, // 35: fleetgrpc.FleetService.CreateFleet:output_type -> fleetgrpc.MutationReply
-	31, // 36: fleetgrpc.FleetService.DestroyFleet:output_type -> fleetgrpc.MutationReply
-	31, // 37: fleetgrpc.FleetService.SetFleetSettings:output_type -> fleetgrpc.MutationReply
-	31, // 38: fleetgrpc.FleetService.SetInstanceMetadata:output_type -> fleetgrpc.MutationReply
-	31, // 39: fleetgrpc.FleetService.SetGroupLayout:output_type -> fleetgrpc.MutationReply
-	31, // 40: fleetgrpc.FleetService.DeleteGroupLayout:output_type -> fleetgrpc.MutationReply
-	31, // 41: fleetgrpc.FleetService.SetLastSeenVersion:output_type -> fleetgrpc.MutationReply
-	32, // 42: fleetgrpc.FleetService.GetConfig:output_type -> fleetgrpc.GetConfigReply
-	33, // 43: fleetgrpc.FleetService.SetConfig:output_type -> fleetgrpc.SetConfigReply
-	34, // 44: fleetgrpc.FleetService.Exec:output_type -> fleetgrpc.ExecOut
-	35, // 45: fleetgrpc.FleetService.ResolveExecCommand:output_type -> fleetgrpc.ResolveExecCommandReply
-	36, // 46: fleetgrpc.FleetService.ResolveLogsCommand:output_type -> fleetgrpc.ResolveLogsCommandReply
-	37, // 47: fleetgrpc.FleetService.Logs:output_type -> fleetgrpc.LogLine
-	38, // 48: fleetgrpc.FleetService.PortForward:output_type -> fleetgrpc.PortForwardReply
-	39, // 49: fleetgrpc.FleetService.GetCoderTemplateParams:output_type -> fleetgrpc.GetCoderTemplateParamsReply
-	40, // 50: fleetgrpc.FleetService.GetBrowserConfig:output_type -> fleetgrpc.GetBrowserConfigReply
-	41, // 51: fleetgrpc.FleetService.PrepareBrowser:output_type -> fleetgrpc.PrepareBrowserReply
-	26, // [26:52] is the sub-list for method output_type
-	0,  // [0:26] is the sub-list for method input_type
+	2,  // 2: fleetgrpc.FleetService.FleetTUIConnected:input_type -> fleetgrpc.FleetTUIConnectedRequest
+	3,  // 3: fleetgrpc.FleetService.GetState:input_type -> fleetgrpc.GetStateRequest
+	4,  // 4: fleetgrpc.FleetService.Watch:input_type -> fleetgrpc.WatchRequest
+	5,  // 5: fleetgrpc.FleetService.CreateInstance:input_type -> fleetgrpc.CreateInstanceRequest
+	6,  // 6: fleetgrpc.FleetService.DestroyInstance:input_type -> fleetgrpc.DestroyInstanceRequest
+	7,  // 7: fleetgrpc.FleetService.StartInstance:input_type -> fleetgrpc.StartInstanceRequest
+	8,  // 8: fleetgrpc.FleetService.StopInstance:input_type -> fleetgrpc.StopInstanceRequest
+	9,  // 9: fleetgrpc.FleetService.CloneInstance:input_type -> fleetgrpc.CloneInstanceRequest
+	10, // 10: fleetgrpc.FleetService.CreateFleet:input_type -> fleetgrpc.CreateFleetRequest
+	11, // 11: fleetgrpc.FleetService.DestroyFleet:input_type -> fleetgrpc.DestroyFleetRequest
+	12, // 12: fleetgrpc.FleetService.SetFleetSettings:input_type -> fleetgrpc.SetFleetSettingsRequest
+	13, // 13: fleetgrpc.FleetService.SetInstanceMetadata:input_type -> fleetgrpc.SetInstanceMetadataRequest
+	14, // 14: fleetgrpc.FleetService.SetGroupLayout:input_type -> fleetgrpc.SetGroupLayoutRequest
+	15, // 15: fleetgrpc.FleetService.DeleteGroupLayout:input_type -> fleetgrpc.DeleteGroupLayoutRequest
+	16, // 16: fleetgrpc.FleetService.SetLastSeenVersion:input_type -> fleetgrpc.SetLastSeenVersionRequest
+	17, // 17: fleetgrpc.FleetService.GetConfig:input_type -> fleetgrpc.GetConfigRequest
+	18, // 18: fleetgrpc.FleetService.SetConfig:input_type -> fleetgrpc.SetConfigRequest
+	19, // 19: fleetgrpc.FleetService.Exec:input_type -> fleetgrpc.ExecIn
+	20, // 20: fleetgrpc.FleetService.ResolveExecCommand:input_type -> fleetgrpc.ResolveExecCommandRequest
+	21, // 21: fleetgrpc.FleetService.ResolveLogsCommand:input_type -> fleetgrpc.ResolveLogsCommandRequest
+	22, // 22: fleetgrpc.FleetService.Logs:input_type -> fleetgrpc.LogsRequest
+	23, // 23: fleetgrpc.FleetService.PortForward:input_type -> fleetgrpc.PortForwardRequest
+	24, // 24: fleetgrpc.FleetService.GetCoderTemplateParams:input_type -> fleetgrpc.GetCoderTemplateParamsRequest
+	25, // 25: fleetgrpc.FleetService.GetBrowserConfig:input_type -> fleetgrpc.GetBrowserConfigRequest
+	26, // 26: fleetgrpc.FleetService.PrepareBrowser:input_type -> fleetgrpc.PrepareBrowserRequest
+	27, // 27: fleetgrpc.FleetService.Hello:output_type -> fleetgrpc.HelloReply
+	28, // 28: fleetgrpc.FleetService.Shutdown:output_type -> fleetgrpc.ShutdownReply
+	29, // 29: fleetgrpc.FleetService.FleetTUIConnected:output_type -> fleetgrpc.FleetTUIConnectedReply
+	30, // 30: fleetgrpc.FleetService.GetState:output_type -> fleetgrpc.GetStateReply
+	31, // 31: fleetgrpc.FleetService.Watch:output_type -> fleetgrpc.Event
+	32, // 32: fleetgrpc.FleetService.CreateInstance:output_type -> fleetgrpc.JobEvent
+	32, // 33: fleetgrpc.FleetService.DestroyInstance:output_type -> fleetgrpc.JobEvent
+	32, // 34: fleetgrpc.FleetService.StartInstance:output_type -> fleetgrpc.JobEvent
+	32, // 35: fleetgrpc.FleetService.StopInstance:output_type -> fleetgrpc.JobEvent
+	32, // 36: fleetgrpc.FleetService.CloneInstance:output_type -> fleetgrpc.JobEvent
+	33, // 37: fleetgrpc.FleetService.CreateFleet:output_type -> fleetgrpc.MutationReply
+	33, // 38: fleetgrpc.FleetService.DestroyFleet:output_type -> fleetgrpc.MutationReply
+	33, // 39: fleetgrpc.FleetService.SetFleetSettings:output_type -> fleetgrpc.MutationReply
+	33, // 40: fleetgrpc.FleetService.SetInstanceMetadata:output_type -> fleetgrpc.MutationReply
+	33, // 41: fleetgrpc.FleetService.SetGroupLayout:output_type -> fleetgrpc.MutationReply
+	33, // 42: fleetgrpc.FleetService.DeleteGroupLayout:output_type -> fleetgrpc.MutationReply
+	33, // 43: fleetgrpc.FleetService.SetLastSeenVersion:output_type -> fleetgrpc.MutationReply
+	34, // 44: fleetgrpc.FleetService.GetConfig:output_type -> fleetgrpc.GetConfigReply
+	35, // 45: fleetgrpc.FleetService.SetConfig:output_type -> fleetgrpc.SetConfigReply
+	36, // 46: fleetgrpc.FleetService.Exec:output_type -> fleetgrpc.ExecOut
+	37, // 47: fleetgrpc.FleetService.ResolveExecCommand:output_type -> fleetgrpc.ResolveExecCommandReply
+	38, // 48: fleetgrpc.FleetService.ResolveLogsCommand:output_type -> fleetgrpc.ResolveLogsCommandReply
+	39, // 49: fleetgrpc.FleetService.Logs:output_type -> fleetgrpc.LogLine
+	40, // 50: fleetgrpc.FleetService.PortForward:output_type -> fleetgrpc.PortForwardReply
+	41, // 51: fleetgrpc.FleetService.GetCoderTemplateParams:output_type -> fleetgrpc.GetCoderTemplateParamsReply
+	42, // 52: fleetgrpc.FleetService.GetBrowserConfig:output_type -> fleetgrpc.GetBrowserConfigReply
+	43, // 53: fleetgrpc.FleetService.PrepareBrowser:output_type -> fleetgrpc.PrepareBrowserReply
+	27, // [27:54] is the sub-list for method output_type
+	0,  // [0:27] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/fleetgrpc/service.proto
+++ b/fleetgrpc/service.proto
@@ -24,6 +24,12 @@ service FleetService {
   rpc Hello(HelloRequest) returns (HelloReply);
   rpc Shutdown(ShutdownRequest) returns (ShutdownReply);
 
+  // FleetTUIConnected is sent ONCE when a TUI opens (not by CLI commands): a
+  // hook for once-per-open, fire-and-forget server-side state reconciliation
+  // (e.g. re-ensuring configured shared buildkit servers after an external
+  // kill / reboot). Kept off Hello so a burst of CLI Hellos can't trigger it.
+  rpc FleetTUIConnected(FleetTUIConnectedRequest) returns (FleetTUIConnectedReply);
+
   // GetState is the one-stop snapshot of everything the TUI renders (persisted
   // State + live runtime + active jobs).
   rpc GetState(GetStateRequest) returns (GetStateReply);

--- a/fleetgrpc/service_grpc.pb.go
+++ b/fleetgrpc/service_grpc.pb.go
@@ -21,6 +21,7 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	FleetService_Hello_FullMethodName                  = "/fleetgrpc.FleetService/Hello"
 	FleetService_Shutdown_FullMethodName               = "/fleetgrpc.FleetService/Shutdown"
+	FleetService_FleetTUIConnected_FullMethodName      = "/fleetgrpc.FleetService/FleetTUIConnected"
 	FleetService_GetState_FullMethodName               = "/fleetgrpc.FleetService/GetState"
 	FleetService_Watch_FullMethodName                  = "/fleetgrpc.FleetService/Watch"
 	FleetService_CreateInstance_FullMethodName         = "/fleetgrpc.FleetService/CreateInstance"
@@ -60,6 +61,11 @@ type FleetServiceClient interface {
 	// ---- Lifecycle / handshake ----
 	Hello(ctx context.Context, in *HelloRequest, opts ...grpc.CallOption) (*HelloReply, error)
 	Shutdown(ctx context.Context, in *ShutdownRequest, opts ...grpc.CallOption) (*ShutdownReply, error)
+	// FleetTUIConnected is sent ONCE when a TUI opens (not by CLI commands): a
+	// hook for once-per-open, fire-and-forget server-side state reconciliation
+	// (e.g. re-ensuring configured shared buildkit servers after an external
+	// kill / reboot). Kept off Hello so a burst of CLI Hellos can't trigger it.
+	FleetTUIConnected(ctx context.Context, in *FleetTUIConnectedRequest, opts ...grpc.CallOption) (*FleetTUIConnectedReply, error)
 	// GetState is the one-stop snapshot of everything the TUI renders (persisted
 	// State + live runtime + active jobs).
 	GetState(ctx context.Context, in *GetStateRequest, opts ...grpc.CallOption) (*GetStateReply, error)
@@ -119,6 +125,16 @@ func (c *fleetServiceClient) Shutdown(ctx context.Context, in *ShutdownRequest, 
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ShutdownReply)
 	err := c.cc.Invoke(ctx, FleetService_Shutdown_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *fleetServiceClient) FleetTUIConnected(ctx context.Context, in *FleetTUIConnectedRequest, opts ...grpc.CallOption) (*FleetTUIConnectedReply, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(FleetTUIConnectedReply)
+	err := c.cc.Invoke(ctx, FleetService_FleetTUIConnected_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -444,6 +460,11 @@ type FleetServiceServer interface {
 	// ---- Lifecycle / handshake ----
 	Hello(context.Context, *HelloRequest) (*HelloReply, error)
 	Shutdown(context.Context, *ShutdownRequest) (*ShutdownReply, error)
+	// FleetTUIConnected is sent ONCE when a TUI opens (not by CLI commands): a
+	// hook for once-per-open, fire-and-forget server-side state reconciliation
+	// (e.g. re-ensuring configured shared buildkit servers after an external
+	// kill / reboot). Kept off Hello so a burst of CLI Hellos can't trigger it.
+	FleetTUIConnected(context.Context, *FleetTUIConnectedRequest) (*FleetTUIConnectedReply, error)
 	// GetState is the one-stop snapshot of everything the TUI renders (persisted
 	// State + live runtime + active jobs).
 	GetState(context.Context, *GetStateRequest) (*GetStateReply, error)
@@ -494,6 +515,9 @@ func (UnimplementedFleetServiceServer) Hello(context.Context, *HelloRequest) (*H
 }
 func (UnimplementedFleetServiceServer) Shutdown(context.Context, *ShutdownRequest) (*ShutdownReply, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Shutdown not implemented")
+}
+func (UnimplementedFleetServiceServer) FleetTUIConnected(context.Context, *FleetTUIConnectedRequest) (*FleetTUIConnectedReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method FleetTUIConnected not implemented")
 }
 func (UnimplementedFleetServiceServer) GetState(context.Context, *GetStateRequest) (*GetStateReply, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetState not implemented")
@@ -620,6 +644,24 @@ func _FleetService_Shutdown_Handler(srv interface{}, ctx context.Context, dec fu
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(FleetServiceServer).Shutdown(ctx, req.(*ShutdownRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _FleetService_FleetTUIConnected_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(FleetTUIConnectedRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FleetServiceServer).FleetTUIConnected(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: FleetService_FleetTUIConnected_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FleetServiceServer).FleetTUIConnected(ctx, req.(*FleetTUIConnectedRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1010,6 +1052,10 @@ var FleetService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Shutdown",
 			Handler:    _FleetService_Shutdown_Handler,
+		},
+		{
+			MethodName: "FleetTUIConnected",
+			Handler:    _FleetService_FleetTUIConnected_Handler,
 		},
 		{
 			MethodName: "GetState",

--- a/internal/server/buildkit.go
+++ b/internal/server/buildkit.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"context"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
+	"github.com/BenjaminBenetti/fleet-man/internal/buildkit"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// ensureBuildkitServer is the re-ensure seam (a package var so the TUI-connect
+// sweep can be exercised in tests without docker). Mirrors stopBuildkitServer in
+// jobs.go.
+var ensureBuildkitServer = buildkit.EnsureSharedServer
+
+// ensureConfiguredBuildkitServers re-ensures the shared buildkit server for
+// every fleet that has the feature enabled AND actually uses it. It is the
+// fire-and-forget reconciliation kicked off when a TUI connects (see
+// service.onTUIConnected), recovering from a server that was killed externally
+// or lost to a host reboot while no instance create/clone/start would otherwise
+// have revived it.
+//
+// Gating mirrors the per-instance paths: a fleet is only ensured when it has at
+// least one instance on a backend that SupportsCustomMounts (devcontainer) — so
+// empty fleets and cloud-only fleets never spin up an unused host container.
+// Best-effort throughout: a state-load or per-fleet failure is logged, never
+// surfaced (the caller does not wait on the result). EnsureSharedServer is
+// idempotent and per-fleet serialized, so this is safe to run concurrently with
+// instance lifecycle jobs and with itself.
+//
+// ctx bounds the sweep: it is checked between fleets so the sweep stops promptly
+// on server shutdown or the caller's timeout (it does not interrupt an
+// individual EnsureSharedServer mid-docker-call).
+func ensureConfiguredBuildkitServers(ctx context.Context) {
+	st, err := state.Load()
+	if err != nil {
+		flog.Warn("buildkit reconcile: load state failed", "err", err)
+		return
+	}
+	for name, f := range st.Fleets {
+		if ctx.Err() != nil {
+			return
+		}
+		if f == nil || !f.Settings.BuildkitServer {
+			continue
+		}
+		if !fleetHasCustomMountInstance(f) {
+			continue
+		}
+		if _, err := ensureBuildkitServer(name); err != nil {
+			flog.Warn("buildkit reconcile: ensure failed", "fleet", name, "err", err)
+		}
+	}
+}
+
+// fleetHasCustomMountInstance reports whether any instance in the fleet runs on
+// a backend that honors custom mounts (devcontainer). An empty Backend defaults
+// to devcontainer, matching backendutil.New / jobDownInstance. Cloud-only and
+// instance-less fleets return false so they are skipped by the reconcile.
+func fleetHasCustomMountInstance(f *fleet.Fleet) bool {
+	for _, inst := range f.Instances {
+		if inst == nil {
+			continue // tolerate a malformed/hand-edited state.json
+		}
+		if backendutil.New(inst.Backend, false).SupportsCustomMounts() {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/buildkit_reconcile_test.go
+++ b/internal/server/buildkit_reconcile_test.go
@@ -1,0 +1,193 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// stubEnsureBuildkit swaps the re-ensure seam for recordFn and restores it.
+func stubEnsureBuildkit(t *testing.T, recordFn func(string) (string, error)) {
+	t.Helper()
+	orig := ensureBuildkitServer
+	ensureBuildkitServer = recordFn
+	t.Cleanup(func() { ensureBuildkitServer = orig })
+}
+
+// TestEnsureConfiguredBuildkitServersFiltering verifies the reconcile only
+// ensures fleets that have the setting on AND at least one devcontainer
+// instance — skipping disabled, empty, and cloud-only fleets.
+func TestEnsureConfiguredBuildkitServersFiltering(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"enabled-dev": {Name: "enabled-dev", Settings: fleet.FleetSettings{BuildkitServer: true},
+			Instances: []*fleet.Instance{{Name: "i1", Backend: fleet.BackendDevcontainer}}},
+		"enabled-empty": {Name: "enabled-empty", Settings: fleet.FleetSettings{BuildkitServer: true}},
+		"enabled-cloud": {Name: "enabled-cloud", Settings: fleet.FleetSettings{BuildkitServer: true},
+			Instances: []*fleet.Instance{{Name: "i1", Backend: fleet.BackendCodespaces}}},
+		"disabled": {Name: "disabled", Settings: fleet.FleetSettings{BuildkitServer: false},
+			Instances: []*fleet.Instance{{Name: "i1", Backend: fleet.BackendDevcontainer}}},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var mu sync.Mutex
+	var ensured []string
+	stubEnsureBuildkit(t, func(name string) (string, error) {
+		mu.Lock()
+		ensured = append(ensured, name)
+		mu.Unlock()
+		return "", nil
+	})
+
+	ensureConfiguredBuildkitServers(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(ensured) != 1 || ensured[0] != "enabled-dev" {
+		t.Fatalf("ensured = %v, want exactly [enabled-dev]", ensured)
+	}
+}
+
+// TestEnsureConfiguredBuildkitServersFiltersAllOut is the zero-match boundary:
+// only disabled / empty / cloud-only fleets → nothing is ensured.
+func TestEnsureConfiguredBuildkitServersFiltersAllOut(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"disabled":      {Name: "disabled", Instances: []*fleet.Instance{{Name: "i1", Backend: fleet.BackendDevcontainer}}},
+		"enabled-empty": {Name: "enabled-empty", Settings: fleet.FleetSettings{BuildkitServer: true}},
+		"enabled-cloud": {Name: "enabled-cloud", Settings: fleet.FleetSettings{BuildkitServer: true},
+			Instances: []*fleet.Instance{{Name: "i1", Backend: fleet.BackendCodespaces}}},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	var calls atomic.Int32
+	stubEnsureBuildkit(t, func(string) (string, error) { calls.Add(1); return "", nil })
+
+	ensureConfiguredBuildkitServers(context.Background())
+
+	if calls.Load() != 0 {
+		t.Fatalf("ensure called %d times, want 0 (all fleets filtered)", calls.Load())
+	}
+}
+
+// TestEnsureConfiguredBuildkitServersHandlesLoadError verifies a corrupt
+// state.json is tolerated: the reconcile returns without panicking and without
+// ensuring anything.
+func TestEnsureConfiguredBuildkitServersHandlesLoadError(t *testing.T) {
+	isolateFleetDir(t)
+	if err := os.MkdirAll(filepath.Dir(state.StatePath()), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(state.StatePath(), []byte("{ not valid json"), 0o644); err != nil {
+		t.Fatalf("write corrupt state: %v", err)
+	}
+	var calls atomic.Int32
+	stubEnsureBuildkit(t, func(string) (string, error) { calls.Add(1); return "", nil })
+
+	ensureConfiguredBuildkitServers(context.Background()) // must not panic
+
+	if calls.Load() != 0 {
+		t.Fatalf("ensure called %d times on load error, want 0", calls.Load())
+	}
+}
+
+// TestFleetTUIConnectedCoalesces verifies that concurrent TUI connects run the
+// reconcile only once while one is in flight (multiple TUIs opening at once).
+func TestFleetTUIConnectedCoalesces(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Settings: fleet.FleetSettings{BuildkitServer: true},
+			Instances: []*fleet.Instance{{Name: "i1", Backend: fleet.BackendDevcontainer}}},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var count atomic.Int32
+	started := make(chan struct{}, 8)
+	release := make(chan struct{})
+	stubEnsureBuildkit(t, func(name string) (string, error) {
+		count.Add(1)
+		started <- struct{}{}
+		<-release
+		return "", nil
+	})
+
+	svc := newService()
+	svc.onTUIConnected() // #1 — wins the CAS, sweep runs and blocks in ensure
+	<-started            // ensure is now in flight, flag held
+
+	svc.onTUIConnected() // #2 — coalesced (skipped)
+	svc.onTUIConnected() // #3 — coalesced (skipped)
+
+	if got := count.Load(); got != 1 {
+		t.Fatalf("ensure called %d times while one was in flight, want 1 (coalescing broken)", got)
+	}
+
+	close(release) // let #1's sweep finish and reset the flag
+	deadline := time.Now().Add(2 * time.Second)
+	for svc.buildkitReconciling.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if svc.buildkitReconciling.Load() {
+		t.Fatal("reconcile flag never reset after the sweep finished")
+	}
+	if got := count.Load(); got != 1 {
+		t.Fatalf("ensure called %d times total, want 1", got)
+	}
+
+	// Re-arm: a connect AFTER the flag reset must trigger a fresh sweep (guards
+	// against the flag-reset path regressing into a permanent lockout). `release`
+	// is already closed, so this sweep's ensure returns immediately.
+	svc.onTUIConnected()
+	deadline = time.Now().Add(2 * time.Second)
+	for count.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := count.Load(); got != 2 {
+		t.Fatalf("re-arm: ensure called %d times after flag reset, want 2", got)
+	}
+}
+
+// TestFleetTUIConnectedRPCReturnsReply verifies the RPC handler returns a
+// non-nil reply without error and triggers the reconcile.
+func TestFleetTUIConnectedRPCReturnsReply(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Settings: fleet.FleetSettings{BuildkitServer: true},
+			Instances: []*fleet.Instance{{Name: "i1", Backend: fleet.BackendDevcontainer}}},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	var called atomic.Bool
+	done := make(chan struct{})
+	stubEnsureBuildkit(t, func(name string) (string, error) {
+		called.Store(true)
+		close(done)
+		return "", nil
+	})
+
+	reply, err := newService().FleetTUIConnected(context.Background(), &fleetgrpc.FleetTUIConnectedRequest{})
+	if err != nil {
+		t.Fatalf("FleetTUIConnected: %v", err)
+	}
+	if reply == nil {
+		t.Fatal("FleetTUIConnected returned nil reply")
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconcile was not triggered by FleetTUIConnected")
+	}
+	if !called.Load() {
+		t.Fatal("ensure seam not invoked")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -68,6 +68,10 @@ func Serve(ctx context.Context) error {
 	// long-lived Watch stream.
 	hubCtx, cancelHub := context.WithCancel(ctx)
 	defer cancelHub()
+	// Background work spawned by RPC handlers (e.g. the TUI-connect buildkit
+	// reconcile) derives from hubCtx so it stops on shutdown. Set before Serve
+	// starts accepting RPCs, so no handler observes the zero value.
+	svc.bgCtx = hubCtx
 	go svc.hub.run(hubCtx)
 	go runStatePoller(hubCtx, svc.hub)
 	// Runtime pollers (live status / stats+activity / sessions). Gated on a

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
@@ -25,6 +26,13 @@ type service struct {
 	hub       *hub
 	jobs      *jobManager
 
+	// bgCtx is cancelled at server shutdown (set to the serve loop's hubCtx in
+	// server.go). Background work spawned by RPC handlers — e.g. the TUI-connect
+	// buildkit reconcile — derives from it so it stops promptly on shutdown
+	// rather than orphaning. Defaults to context.Background() for tests that use
+	// newService() without a running serve loop.
+	bgCtx context.Context
+
 	// muWrite serializes config.json writes (config.go SetConfig), which have no
 	// package-level lock of their own. State.json mutations no longer use this —
 	// they go through state.Update (mutations.go + the provisioning jobs), whose
@@ -34,11 +42,20 @@ type service struct {
 
 	shutdownOnce sync.Once
 	shutdownCh   chan struct{}
+
+	// buildkitReconciling coalesces the TUI-connect buildkit re-ensure so that
+	// several TUIs opening at once trigger one sweep, not one per client.
+	buildkitReconciling atomic.Bool
 }
 
 func newService() *service {
-	return &service{startedAt: time.Now(), hub: newHub(), jobs: newJobManager(), shutdownCh: make(chan struct{})}
+	return &service{startedAt: time.Now(), hub: newHub(), jobs: newJobManager(), shutdownCh: make(chan struct{}), bgCtx: context.Background()}
 }
+
+// reconcileTimeout bounds the TUI-connect buildkit reconcile so a slow/wedged
+// docker daemon can't keep the coalescing flag held indefinitely (which would
+// lock out future reconciles). It also frees the flag on shutdown via bgCtx.
+const reconcileTimeout = 3 * time.Minute
 
 // Hello is the authoritative version handshake. It reports the server's
 // compiled-in version plus host-local liveness hints (pid, start time).
@@ -48,6 +65,50 @@ func (s *service) Hello(_ context.Context, _ *fleetgrpc.HelloRequest) (*fleetgrp
 		Pid:           int64(os.Getpid()),
 		StartedAt:     timestamppb.New(s.startedAt),
 	}, nil
+}
+
+// FleetTUIConnected is sent once when a TUI opens (CLI commands never send it).
+// It kicks off fire-and-forget, once-per-open state reconciliation and returns
+// immediately — the client does not wait on the outcome.
+func (s *service) FleetTUIConnected(_ context.Context, _ *fleetgrpc.FleetTUIConnectedRequest) (*fleetgrpc.FleetTUIConnectedReply, error) {
+	s.onTUIConnected()
+	return &fleetgrpc.FleetTUIConnectedReply{}, nil
+}
+
+// onTUIConnected runs the once-per-connect, fire-and-forget reconciliation in a
+// background goroutine. Today it re-ensures configured shared buildkit servers
+// (recovering from an external kill / reboot).
+//
+// Coalesced via an atomic flag so N TUIs connecting simultaneously run the sweep
+// once, not N times. NOTE the in-flight sweep reflects state as of WHEN IT
+// STARTED: a setting toggled mid-sweep is not picked up by a coalesced late
+// arrival until the sweep finishes and a subsequent TUI connects. That's
+// acceptable here — it mirrors the rest of the feature, where a settings change
+// only takes effect on the next instance create/clone/start.
+//
+// The flag is released when the sweep completes OR when reconcileTimeout elapses
+// OR on shutdown (bgCtx) — released even if a docker call inside the sweep is
+// wedged, so a broken daemon can never permanently lock out future reconciles
+// (the inner sweep goroutine may then outlive this one, but it dies with the
+// process and does no harm).
+func (s *service) onTUIConnected() {
+	if !s.buildkitReconciling.CompareAndSwap(false, true) {
+		return // a reconcile is already in flight; it covers this connect
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(s.bgCtx, reconcileTimeout)
+		defer cancel()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			ensureConfiguredBuildkitServers(ctx)
+		}()
+		select {
+		case <-done:
+		case <-ctx.Done(): // timeout or shutdown
+		}
+		s.buildkitReconciling.Store(false)
+	}()
 }
 
 // GetState returns the full snapshot the TUI/CLI render.

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -205,6 +205,18 @@ var destroyFleetRemote = func(name string) error {
 	})
 }
 
+// notifyTUIConnectedRemote tells the server a TUI has opened so it can run its
+// once-per-open state reconciliation (e.g. re-ensuring configured buildkit
+// servers). Fire-and-forget: the server returns immediately and does the work
+// in the background, and any error here is irrelevant to the TUI — it is a
+// best-effort nudge, sent once per launch (see watch.go).
+var notifyTUIConnectedRemote = func() error {
+	return mutate(func(ctx context.Context, svc fleetgrpc.FleetServiceClient) error {
+		_, err := svc.FleetTUIConnected(ctx, &fleetgrpc.FleetTUIConnectedRequest{})
+		return err
+	})
+}
+
 // setFleetSettingsRemote replaces a fleet's settings (full FleetSettings,
 // preserving tri-state presence).
 var setFleetSettingsRemote = func(fleetName string, s fleet.FleetSettings) error {

--- a/internal/tui/watch.go
+++ b/internal/tui/watch.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
@@ -9,6 +10,12 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"google.golang.org/grpc"
 )
+
+// tuiConnectedOnce ensures the server's FleetTUIConnected hook fires exactly
+// once per TUI process — on the first successful Watch open — rather than on
+// every reconnect. "Once per TUI opening" is the contract; the server coalesces
+// across multiple TUIs anyway.
+var tuiConnectedOnce sync.Once
 
 // Watch-stream messages injected into the bubbletea loop by the watcher
 // goroutine. In P2 Step 5 these only populate the m.pstate / m.runtime caches;
@@ -75,6 +82,16 @@ func watchOnce(ctx context.Context, program *tea.Program) bool {
 		program.Send(watchErrMsg{err: err})
 		return false
 	}
+
+	// A successful Watch open means the TUI has connected to a live server.
+	// Nudge the server's once-per-open reconciliation, on a separate goroutine
+	// so the bounded RPC never stalls this event pump, and only once per launch
+	// (not on reconnects). The error is intentionally dropped: this is a pure
+	// best-effort nudge, the SERVER logs the reconcile's own outcome, and a
+	// failed nudge means the server is unreachable — already surfaced to the
+	// user via watchErrMsg. (Client code also must not write the server-owned
+	// event log, per the import boundary.)
+	tuiConnectedOnce.Do(func() { go func() { _ = notifyTUIConnectedRemote() }() })
 
 	for {
 		ev, err := stream.Recv()


### PR DESCRIPTION
## Summary

Adds a dedicated **`FleetTUIConnected`** RPC, sent **once when a TUI opens** (CLI commands only `Hello`, so this never fires on the CLI-spammed path). The server uses it as a once-per-open, fire-and-forget reconciliation hook: it re-ensures any configured shared buildkit server that was killed externally or lost to a host reboot while no instance create/clone/start would otherwise have revived it.

Motivation: `EnsureSharedServer` previously only fired on instance create/clone/start. If the server was externally killed, nothing brought it back until the next lifecycle action — this catches "user re-opens fleet → make sure configured buildkit servers come up."

## Design
- **proto:** `FleetTUIConnected` + empty request/reply (regenerated at v1.36.10 to avoid version-stamp drift; diff scoped to `control`/`service`).
- **server:** `onTUIConnected` coalesces concurrent TUI connects via an atomic flag (N TUIs → one sweep). The sweep (`ensureConfiguredBuildkitServers`) ensures only fleets that are enabled **and** have a devcontainer instance (empty / cloud-only skipped). `EnsureSharedServer` is idempotent + per-fleet serialized, so it's safe alongside lifecycle jobs.
- **TUI:** fires it once per launch (`sync.Once`) on the first successful Watch open, in a separate goroutine so the bounded RPC never stalls the event pump; not re-fired on reconnects.

## Hardening (from an adversarial self-review)
- Reconcile derives from the server's shutdown ctx (`svc.bgCtx`) + a 3-min timeout; the coalescing flag is released on completion **or** timeout **or** shutdown, so a wedged docker daemon can't permanently lock out future reconciles and shutdown isn't blocked.
- nil-instance guard in `fleetHasCustomMountInstance` (tolerate hand-edited `state.json`).
- Client-side nudge error is intentionally dropped — the server logs the reconcile outcome, and client code must not write the server-owned event log (import boundary). Verified `golangci-lint` stays at 0 issues.
- Coalescing reflects state as of sweep start (documented): a setting toggled mid-sweep is picked up on the next open — consistent with the rest of the feature.

## Tests
- Filtering (incl. zero-match), state-load-error tolerance, and multi-TUI coalescing + re-arm-after-reset (race-clean).

Local gate green: `go vet`, `golangci-lint` (0 issues), full `go test`, `-race` on the server package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)