### PR TITLE
fix(tui): re-enable mouse after exec so TUI mouse control survives (#88)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -366,6 +366,20 @@ func (m model) Init() tea.Cmd {
 // handled here and returned early. Mixed messages handle their shared
 // part then fall through. Everything else is forwarded to the active page.
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// 0a. Resume after an execProcess child exited. bubbletea's
+	// RestoreTerminal does not re-enable mouse tracking, so re-assert it
+	// here, then dispatch the wrapped message through Update unchanged so
+	// callers see the same behaviour as a bare tea.ExecProcess callback.
+	// See execProcess / issue #88.
+	if resume, ok := msg.(resumeMsg); ok {
+		var next tea.Model = m
+		var cmd tea.Cmd
+		if resume.inner != nil {
+			next, cmd = m.Update(resume.inner)
+		}
+		return next, tea.Batch(tea.EnableMouseCellMotion, cmd)
+	}
+
 	// 0. Mouse — left-button press moves the cursor to the clicked row
 	// (on the fleet list and settings pages) and is then translated to
 	// a key event so existing keyboard handlers do the rest: clicks on

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -51,6 +51,49 @@ func TestUpdateSettingsEscReturnsToFleetList(t *testing.T) {
 	_ = cmd
 }
 
+// TestResumeMsgRedispatchesInnerAndReturnsCmd verifies the resumeMsg handler
+// (issue #88): after an execProcess child exits, the wrapped inner message is
+// dispatched through Update unchanged AND a command is returned (the mouse
+// re-enable batch). Without the handler the inner message would be dropped and
+// mouse tracking would stay dead.
+func TestResumeMsgRedispatchesInnerAndReturnsCmd(t *testing.T) {
+	m := model{
+		currentPage: newFleetPage(),
+		fleetPage:   newFleetPage(),
+		st:          &state.State{Fleets: map[string]*fleet.Fleet{}},
+	}
+
+	// Inner WindowSizeMsg has an observable model side-effect (width/height),
+	// so we can confirm the handler re-dispatched it rather than swallowing it.
+	next, cmd := m.Update(resumeMsg{inner: tea.WindowSizeMsg{Width: 123, Height: 45}})
+
+	nm, ok := next.(model)
+	if !ok {
+		t.Fatalf("Update returned %T, want model", next)
+	}
+	if nm.width != 123 || nm.height != 45 {
+		t.Fatalf("inner WindowSizeMsg not applied: width=%d height=%d", nm.width, nm.height)
+	}
+	if cmd == nil {
+		t.Fatalf("resumeMsg should return a command (mouse re-enable), got nil")
+	}
+}
+
+// TestResumeMsgNilInnerReturnsCmd verifies a resumeMsg with no inner message
+// still re-enables the mouse (returns a non-nil command).
+func TestResumeMsgNilInnerReturnsCmd(t *testing.T) {
+	m := model{
+		currentPage: newFleetPage(),
+		fleetPage:   newFleetPage(),
+		st:          &state.State{Fleets: map[string]*fleet.Fleet{}},
+	}
+
+	_, cmd := m.Update(resumeMsg{inner: nil})
+	if cmd == nil {
+		t.Fatalf("resumeMsg with nil inner should still return the mouse re-enable command")
+	}
+}
+
 func TestUpdateNormalWrapsCursorFromTopToBottom(t *testing.T) {
 	fp := newFleetPage()
 	fp.rows = []row{

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -19,6 +19,29 @@ import (
 
 type execDoneMsg struct{ err error }
 
+// resumeMsg wraps the message produced by an execProcess callback so the
+// central Update handler can re-assert mouse tracking after the child exits.
+// inner is the message the original callback returned (may be nil); it is
+// dispatched through Update unchanged.
+type resumeMsg struct{ inner tea.Msg }
+
+// execProcess wraps tea.ExecProcess to re-enable mouse tracking once the
+// child process exits. bubbletea v1.3.10's RestoreTerminal restores
+// alt-screen, bracketed-paste and report-focus but NOT mouse mode, while
+// ReleaseTerminal unconditionally disables it — so without this every exec
+// permanently kills mouse support in the TUI (issue #88). The re-enable is
+// threaded through the callback (not batched alongside ExecProcess) so it
+// runs strictly after the program resumes, never racing the pause.
+func execProcess(c *exec.Cmd, fn tea.ExecCallback) tea.Cmd {
+	return tea.ExecProcess(c, func(err error) tea.Msg {
+		var inner tea.Msg
+		if fn != nil {
+			inner = fn(err)
+		}
+		return resumeMsg{inner: inner}
+	})
+}
+
 type instanceSpawnedMsg struct {
 	fleet    string
 	instance string

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -1036,7 +1036,7 @@ func (fleetPage *fleetPage) updateAddFleetNoDevcontainer(m *model, msg tea.Msg) 
 		fleetPage.clearPendingFleet()
 		fleetPage.mode = viewNormal
 
-		return tea.ExecProcess(cmd, func(err error) tea.Msg { return execDoneMsg{err} })
+		return execProcess(cmd, func(err error) tea.Msg { return execDoneMsg{err} })
 
 	case "a", "A", "n", "N", "q", "Q", "esc", "ctrl+c", "enter":
 		fleetPage.mode = viewNormal
@@ -1484,7 +1484,7 @@ func (fleetPage *fleetPage) updateCodespacesAuth(m *model, msg tea.Msg) tea.Cmd 
 		case "enter":
 			fleetPage.mode = viewNormal
 			m.message = "Launching GitHub auth..."
-			return tea.ExecProcess(
+			return execProcess(
 				exec.Command("gh", "auth", "login", "-h", "github.com", "-s", "codespace"),
 				func(err error) tea.Msg {
 					if err != nil {

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -729,7 +729,7 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 				break
 			}
 			r := fleetPage.rows[fleetPage.cursor]
-			return tea.ExecProcess(
+			return execProcess(
 				logsCommand(r.fleetName, instance),
 				func(err error) tea.Msg { return execDoneMsg{err} },
 			)
@@ -848,7 +848,7 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 		}
 		banner := renderGradient(nameToBanner(instance.GetDisplayName()))
 		banner += "\n  " + dimStyle.Render("ctrl+q/ctrl+o to detach (session persists)")
-		return tea.ExecProcess(
+		return execProcess(
 			execWithBannerCmd(banner, cmd),
 			func(err error) tea.Msg { return execDoneMsg{err} },
 		)
@@ -893,7 +893,7 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 		}
 		banner := renderGradient(nameToBanner(instance.GetDisplayName()))
 		banner += "\n  " + dimStyle.Render("ctrl+q/ctrl+o to detach (session persists)")
-		return tea.ExecProcess(
+		return execProcess(
 			execWithBannerCmd(banner, cmd),
 			func(err error) tea.Msg { return execDoneMsg{err} },
 		)

--- a/internal/tui/page_settings.go
+++ b/internal/tui/page_settings.go
@@ -517,7 +517,7 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 					m.message = err.Error()
 					return nil
 				}
-				return tea.ExecProcess(cmd, func(err error) tea.Msg { return execDoneMsg{err} })
+				return execProcess(cmd, func(err error) tea.Msg { return execDoneMsg{err} })
 			}
 			if item == settingsItemKeybindings {
 				settingsPage.showKeybindings = true
@@ -529,7 +529,7 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 					m.message = err.Error()
 					return nil
 				}
-				return tea.ExecProcess(cmd, func(err error) tea.Msg { return execDoneMsg{err} })
+				return execProcess(cmd, func(err error) tea.Msg { return execDoneMsg{err} })
 			}
 			if item >= settingsItemToolStatusBase {
 				idx := item - settingsItemToolStatusBase


### PR DESCRIPTION
## Problem

Fixes #88 — mouse control of the fleet TUI stops working "randomly after a bit," while other tmux programs (nvim) keep working.

## Root cause

A bubbletea **v1.3.10** bug, triggered by `tea.ExecProcess`:

- `tea.ExecProcess` → `ReleaseTerminal()` unconditionally calls `disableMouse()` (modes 1002/1003/1006).
- On resume, `RestoreTerminal()` restores alt-screen, bracketed-paste, and report-focus — **but never re-enables mouse mode**.

The TUI starts with `tea.WithMouseCellMotion()`, so the **first** exec action — attaching to a session, viewing logs (`l`), `gh auth login`, settings actions — leaves the fleet pane with mouse tracking permanently off until restart. It's not random timing; it's the first exec. nvim is unaffected because it re-asserts its own mouse mode, and tmux tracks mouse state per-pane.

## Fix

- Add an `execProcess(cmd, fn)` wrapper that threads the callback's result through a new `resumeMsg`.
- Handle `resumeMsg` centrally at the top of `model.Update`: re-assert `tea.EnableMouseCellMotion` (restores cell-motion 1002 **and** SGR 1006, matching startup) and re-dispatch the inner message unchanged so existing behavior is preserved.
- Re-enabling is threaded through the callback rather than batched alongside `ExecProcess`, so it runs strictly **after** the program resumes and can't race the pause.
- Converted all 7 resuming call sites (`page_fleet.go`, `dialogs.go`, `page_settings.go`). The updater (`update.go`) stays on bare `tea.ExecProcess` — it quits and re-execs, so there's no resume.

## Testing

- Added regression tests (`resumeMsg` re-dispatches inner message + returns the mouse re-enable command, with and without an inner message).
- `go build ./...`, `go vet ./internal/tui/`, and the full TUI test suite pass.
- Verified live: mouse control survives session attach / logs / detach cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)