### PR TITLE
fix(tui): self-heal stale window size to stop garbled output after layout changes

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -600,21 +600,40 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case forceRepaintTickMsg:
 		// Scrub artifacts left by outer-tmux pane resizes without
-		// flicker. A synthetic WindowSizeMsg (with the current
-		// dimensions so no app-level resize happens) causes
-		// bubbletea's renderer to invalidate its per-line cache; on
-		// the next flush every tracked line is rewritten with
-		// EraseLineRight appended, scrubbing stale chars inside the
-		// TUI's bounds. The trailing EraseScreenBelow escape that
-		// View() tacks onto the last line then clears everything
-		// beneath the TUI — and because that escape is part of the
-		// view string, the clear lands in the same atomic buffer
-		// flush as the redraw, so the terminal never sees a blank
-		// frame (unlike tea.ClearScreen which writes the erase
-		// ahead of the next render tick).
+		// flicker, AND self-heal a stale window size. We emit a
+		// synthetic WindowSizeMsg carrying the *actual* current pty
+		// dimensions (read via ioctl, exactly what bubbletea's own
+		// SIGWINCH handler reads) rather than the cached m.width/
+		// m.height.
+		//
+		// Why the live read matters: opening/closing sessions and
+		// restoring layouts fires a burst of pane resizes, and SIGWINCH
+		// does not queue — the burst coalesces, so bubbletea can read
+		// the pty at an intermediate moment and never get a fresh
+		// signal for the final settled geometry. That left m.width
+		// stale (too wide), so the TUI rendered lines wider than the
+		// pane and tmux wrapped them — garbled output that only a
+		// manual divider drag (a fresh SIGWINCH) corrected. Reading the
+		// true size here recovers within one tick with no manual drag.
+		// When the size is unchanged this is a pure repaint.
+		//
+		// The repaint itself: the WindowSizeMsg invalidates bubbletea's
+		// per-line cache; on the next flush every tracked line is
+		// rewritten with EraseLineRight appended, scrubbing stale chars
+		// inside the TUI's bounds. The trailing EraseScreenBelow escape
+		// that View() tacks onto the last line then clears everything
+		// beneath the TUI — and because that escape is part of the view
+		// string, the clear lands in the same atomic buffer flush as
+		// the redraw, so the terminal never sees a blank frame (unlike
+		// tea.ClearScreen which writes the erase ahead of the next
+		// render tick).
+		w, h := currentTermSize()
+		if w == 0 || h == 0 {
+			w, h = m.width, m.height
+		}
 		return m, tea.Batch(
 			spinCmd,
-			func() tea.Msg { return tea.WindowSizeMsg{Width: m.width, Height: m.height} },
+			func() tea.Msg { return tea.WindowSizeMsg{Width: w, Height: h} },
 			forceRepaintCmd(),
 		)
 	}

--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -12,6 +12,7 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/configutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	tea "github.com/charmbracelet/bubbletea"
+	"golang.org/x/sys/unix"
 )
 
 // splitPaneMsg is sent after a tmux split-window command completes.
@@ -23,6 +24,20 @@ type splitPaneMsg struct {
 	command    string      // command(s) launched in the pane(s); for the event log
 	restoreSeq int         // async restore token; zero means not a group restore
 	err        error
+}
+
+// currentTermSize reads the TUI's own pty dimensions via ioctl (TIOCGWINSZ on
+// stdout) — the authoritative size of the terminal bubbletea renders into, and
+// exactly what bubbletea's SIGWINCH handler reads. This is the fleet *pane*
+// size (not the whole tmux window), so it stays correct even when the TUI is
+// only occupying part of a split window. Returns (cols, rows) or (0, 0) on
+// failure.
+func currentTermSize() (int, int) {
+	ws, err := unix.IoctlGetWinsize(int(os.Stdout.Fd()), unix.TIOCGWINSZ)
+	if err != nil || ws == nil {
+		return 0, 0
+	}
+	return int(ws.Col), int(ws.Row)
 }
 
 // tmuxWindowSize queries the host tmux for the current window dimensions.


### PR DESCRIPTION
## Problem

After restoring layouts or opening/closing sessions, the fleet TUI becomes garbled and **stays** garbled — it only snaps back when you manually drag the tmux divider.

## Root cause

The TUI sizes everything it renders from `m.width`/`m.height` (e.g. `page_fleet.go` sets box width to `m.width - 2`). That value is only ever updated by a real `tea.WindowSizeMsg`, which bubbletea derives from `SIGWINCH` by reading the pty winsize *at signal time*.

A restore / open-close fires a **burst** of pane resizes in `restoreGroupCmd` (kill → split N placeholders → `select-layout` → respawn ×N). `SIGWINCH` does not queue, so the burst **coalesces**: bubbletea reads the pty at an intermediate moment and never gets a fresh signal for the *final settled* geometry. `m.width` is left stale (too wide), so lipgloss emits lines wider than the pane and tmux wraps them → garbled.

The 1‑second `forceRepaintTickMsg` made it worse: it re-emitted the **stale cached** dimensions every tick, so the TUI never self-corrected. A manual divider drag produces a fresh, distinct `SIGWINCH` carrying the correct size → the only thing that fixed it.

## Fix

The repaint tick now emits a `WindowSizeMsg` carrying the **live** pty size, read via `ioctl(TIOCGWINSZ)` on stdout (the authoritative fleet-*pane* size — exactly what bubbletea's own SIGWINCH handler reads), falling back to the cached size on read failure.

- Size unchanged → harmless repaint, same as before (artifact scrubbing intact).
- Missed/coalesced SIGWINCH → recovered within ~1s, no manual drag needed.

New helper `currentTermSize()` lives next to `tmuxWindowSize()` in `splitpane.go`.

## Testing

- `go build ./internal/tui/` ✅
- `go vet ./internal/tui/` clean ✅
- `go test ./internal/tui/` green ✅
- Verified live: open/close session groups repeatedly — garbling now clears on its own within ~1s instead of requiring a divider drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)