### PR TITLE
fix(devcontainer): remove a destroyed instance's volumes on teardown

### DIFF
--- a/internal/backend/devcontainer/clone.go
+++ b/internal/backend/devcontainer/clone.go
@@ -33,6 +33,7 @@ const (
 type inspectedContainer struct {
 	Mounts []struct {
 		Type        string `json:"Type"`
+		Name        string `json:"Name"`
 		Source      string `json:"Source"`
 		Destination string `json:"Destination"`
 	} `json:"Mounts"`
@@ -266,6 +267,26 @@ func newCloneImageTag() (string, error) {
 		return "", err
 	}
 	return "fleet-clone-" + hex.EncodeToString(randomBytes[:]) + ":latest", nil
+}
+
+// volumesForContainer returns the names of the docker volumes a container
+// mounts, read from `docker inspect` before the container is removed.
+// Covers both named volumes (a devcontainer.json `type=volume` mount or a
+// feature such as docker-in-docker) and anonymous ones; both outlive
+// `docker rm` and would otherwise leak after an instance is destroyed.
+// Returns nil when the container cannot be inspected.
+func volumesForContainer(containerID string) []string {
+	inspected, err := inspectContainer(containerID)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, mount := range inspected.Mounts {
+		if mount.Type == "volume" && mount.Name != "" {
+			names = append(names, mount.Name)
+		}
+	}
+	return names
 }
 
 // cloneImageForContainer returns the fleet.clone.image label value for a

--- a/internal/backend/devcontainer/devcontainer_backend.go
+++ b/internal/backend/devcontainer/devcontainer_backend.go
@@ -239,11 +239,30 @@ func (devcontainerBackend *DevcontainerBackend) pruneStaleContainers(workspaceDi
 // callers actually need.
 func (devcontainerBackend *DevcontainerBackend) Down(containerID string) error {
 	cloneImage := cloneImageForContainer(containerID)
+	// Capture the container's volumes before removing it — `docker inspect`
+	// no longer reports them once the container is gone.
+	volumes := volumesForContainer(containerID)
 
 	cmd := exec.Command("docker", "rm", "-f", containerID)
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return err
+	}
+
+	// Remove the volumes the container mounted. `docker rm` leaves named
+	// volumes behind, so an instance whose devcontainer declared a
+	// `type=volume` mount (or pulled in a feature like docker-in-docker)
+	// would otherwise leak a volume on every teardown. Docker refuses to
+	// delete a volume still referenced by another container, so anything
+	// shared with a sibling instance survives — only this instance's own
+	// volumes go. Best-effort: a failure leaks a volume but the container
+	// (what callers need gone) is already removed.
+	for _, vol := range volumes {
+		rmCmd := exec.Command("docker", "volume", "rm", vol)
+		if rmOut, err := rmCmd.CombinedOutput(); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to remove volume %s: %v\n%s\n",
+				vol, err, strings.TrimSpace(string(rmOut)))
+		}
 	}
 
 	if cloneImage != "" {


### PR DESCRIPTION
## Problem

Deleting a fleet instance removed the devcontainer but left its volumes behind. `DevcontainerBackend.Down` ran `docker rm -f` without cleaning up the volumes the container mounted.

Docker preserves **named** volumes across `docker rm` — even `docker rm -v` only reaps *anonymous* volumes. So every instance using the **docker-in-docker** feature leaked its `dind-var-lib-docker-<id>` and `dind-var-lib-containerd-<id>` volumes. Over many instance lifecycles these pile up into hundreds of orphaned volumes (confirmed on a real host).

## Fix

Inspect the container's mounts *before* removing it (docker can't report them once the container is gone), then best-effort `docker volume rm` each volume after `docker rm -f`.

Docker refuses to delete a volume still referenced by another container, so anything genuinely shared with a sibling instance survives — only the destroyed instance's own volumes are removed.

The change mirrors patterns already in the file:
- a `Name` field on the existing inspect-mounts struct,
- a `volumesForContainer` helper modeled on the adjacent `cloneImageForContainer`,
- a removal loop in `Down` modeled on the adjacent clone-image `docker rmi` cleanup.

This lives in the backend's `Down`, so it covers both `fleet down` (single instance) and `fleet destroy` (whole fleet), which both route through `jobDownInstance` → `Down`.

## Testing

- `go build ./...`, `go vet`, and the `internal/backend/devcontainer` package tests pass.
- Manually verified on a live host: an instance's `dind-*` volume pair is gone after teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)