### PR TITLE
feat(tui): instant-save edit-fleet + Caching section with Delete-cache

### DIFF
--- a/fleetgrpc/control.pb.go
+++ b/fleetgrpc/control.pb.go
@@ -330,10 +330,12 @@ func (*FleetTUIConnectedReply) Descriptor() ([]byte, []int) {
 }
 
 // DeleteBuildkitCacheRequest asks the server to wipe a fleet's shared build
-// cache: stop the buildkit container, delete ~/.fleet/workspaces/<fleet>/
-// .buildkit (incl. the root-owned cache), then restart the server empty. It is
-// a synchronous action (takes a few seconds), so the client shows progress and
-// uses a longer deadline than ordinary mutations.
+// cache: stop the buildkit container, clear the CONTENTS of
+// ~/.fleet/workspaces/<fleet>/.buildkit (incl. the root-owned cache) while
+// KEEPING the directory itself so running instances' bind mounts stay valid,
+// then restart the server empty. It is a synchronous action (takes a few
+// seconds), so the client shows progress and uses a longer deadline than
+// ordinary mutations.
 type DeleteBuildkitCacheRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Fleet         string                 `protobuf:"bytes,1,opt,name=fleet,proto3" json:"fleet,omitempty"`

--- a/fleetgrpc/control.pb.go
+++ b/fleetgrpc/control.pb.go
@@ -329,6 +329,92 @@ func (*FleetTUIConnectedReply) Descriptor() ([]byte, []int) {
 	return file_control_proto_rawDescGZIP(), []int{5}
 }
 
+// DeleteBuildkitCacheRequest asks the server to wipe a fleet's shared build
+// cache: stop the buildkit container, delete ~/.fleet/workspaces/<fleet>/
+// .buildkit (incl. the root-owned cache), then restart the server empty. It is
+// a synchronous action (takes a few seconds), so the client shows progress and
+// uses a longer deadline than ordinary mutations.
+type DeleteBuildkitCacheRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Fleet         string                 `protobuf:"bytes,1,opt,name=fleet,proto3" json:"fleet,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteBuildkitCacheRequest) Reset() {
+	*x = DeleteBuildkitCacheRequest{}
+	mi := &file_control_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteBuildkitCacheRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteBuildkitCacheRequest) ProtoMessage() {}
+
+func (x *DeleteBuildkitCacheRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_control_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteBuildkitCacheRequest.ProtoReflect.Descriptor instead.
+func (*DeleteBuildkitCacheRequest) Descriptor() ([]byte, []int) {
+	return file_control_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *DeleteBuildkitCacheRequest) GetFleet() string {
+	if x != nil {
+		return x.Fleet
+	}
+	return ""
+}
+
+// DeleteBuildkitCacheReply is empty: success is signalled by a nil error.
+type DeleteBuildkitCacheReply struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteBuildkitCacheReply) Reset() {
+	*x = DeleteBuildkitCacheReply{}
+	mi := &file_control_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteBuildkitCacheReply) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteBuildkitCacheReply) ProtoMessage() {}
+
+func (x *DeleteBuildkitCacheReply) ProtoReflect() protoreflect.Message {
+	mi := &file_control_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteBuildkitCacheReply.ProtoReflect.Descriptor instead.
+func (*DeleteBuildkitCacheReply) Descriptor() ([]byte, []int) {
+	return file_control_proto_rawDescGZIP(), []int{7}
+}
+
 type GetStateRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -337,7 +423,7 @@ type GetStateRequest struct {
 
 func (x *GetStateRequest) Reset() {
 	*x = GetStateRequest{}
-	mi := &file_control_proto_msgTypes[6]
+	mi := &file_control_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -349,7 +435,7 @@ func (x *GetStateRequest) String() string {
 func (*GetStateRequest) ProtoMessage() {}
 
 func (x *GetStateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[6]
+	mi := &file_control_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -362,7 +448,7 @@ func (x *GetStateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStateRequest.ProtoReflect.Descriptor instead.
 func (*GetStateRequest) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{6}
+	return file_control_proto_rawDescGZIP(), []int{8}
 }
 
 // GetStateReply is the one-stop snapshot of EVERYTHING the TUI renders:
@@ -381,7 +467,7 @@ type GetStateReply struct {
 
 func (x *GetStateReply) Reset() {
 	*x = GetStateReply{}
-	mi := &file_control_proto_msgTypes[7]
+	mi := &file_control_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -393,7 +479,7 @@ func (x *GetStateReply) String() string {
 func (*GetStateReply) ProtoMessage() {}
 
 func (x *GetStateReply) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[7]
+	mi := &file_control_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -406,7 +492,7 @@ func (x *GetStateReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStateReply.ProtoReflect.Descriptor instead.
 func (*GetStateReply) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{7}
+	return file_control_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *GetStateReply) GetState() *State {
@@ -442,7 +528,7 @@ type CreateFleetRequest struct {
 
 func (x *CreateFleetRequest) Reset() {
 	*x = CreateFleetRequest{}
-	mi := &file_control_proto_msgTypes[8]
+	mi := &file_control_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -454,7 +540,7 @@ func (x *CreateFleetRequest) String() string {
 func (*CreateFleetRequest) ProtoMessage() {}
 
 func (x *CreateFleetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[8]
+	mi := &file_control_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -467,7 +553,7 @@ func (x *CreateFleetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateFleetRequest.ProtoReflect.Descriptor instead.
 func (*CreateFleetRequest) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{8}
+	return file_control_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *CreateFleetRequest) GetName() string {
@@ -496,7 +582,7 @@ type DestroyFleetRequest struct {
 
 func (x *DestroyFleetRequest) Reset() {
 	*x = DestroyFleetRequest{}
-	mi := &file_control_proto_msgTypes[9]
+	mi := &file_control_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -508,7 +594,7 @@ func (x *DestroyFleetRequest) String() string {
 func (*DestroyFleetRequest) ProtoMessage() {}
 
 func (x *DestroyFleetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[9]
+	mi := &file_control_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -521,7 +607,7 @@ func (x *DestroyFleetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DestroyFleetRequest.ProtoReflect.Descriptor instead.
 func (*DestroyFleetRequest) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{9}
+	return file_control_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *DestroyFleetRequest) GetName() string {
@@ -544,7 +630,7 @@ type SetFleetSettingsRequest struct {
 
 func (x *SetFleetSettingsRequest) Reset() {
 	*x = SetFleetSettingsRequest{}
-	mi := &file_control_proto_msgTypes[10]
+	mi := &file_control_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -556,7 +642,7 @@ func (x *SetFleetSettingsRequest) String() string {
 func (*SetFleetSettingsRequest) ProtoMessage() {}
 
 func (x *SetFleetSettingsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[10]
+	mi := &file_control_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -569,7 +655,7 @@ func (x *SetFleetSettingsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetFleetSettingsRequest.ProtoReflect.Descriptor instead.
 func (*SetFleetSettingsRequest) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{10}
+	return file_control_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *SetFleetSettingsRequest) GetFleet() string {
@@ -603,7 +689,7 @@ type SetInstanceMetadataRequest struct {
 
 func (x *SetInstanceMetadataRequest) Reset() {
 	*x = SetInstanceMetadataRequest{}
-	mi := &file_control_proto_msgTypes[11]
+	mi := &file_control_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -615,7 +701,7 @@ func (x *SetInstanceMetadataRequest) String() string {
 func (*SetInstanceMetadataRequest) ProtoMessage() {}
 
 func (x *SetInstanceMetadataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[11]
+	mi := &file_control_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -628,7 +714,7 @@ func (x *SetInstanceMetadataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetInstanceMetadataRequest.ProtoReflect.Descriptor instead.
 func (*SetInstanceMetadataRequest) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{11}
+	return file_control_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *SetInstanceMetadataRequest) GetFleet() string {
@@ -678,7 +764,7 @@ type SetGroupLayoutRequest struct {
 
 func (x *SetGroupLayoutRequest) Reset() {
 	*x = SetGroupLayoutRequest{}
-	mi := &file_control_proto_msgTypes[12]
+	mi := &file_control_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -690,7 +776,7 @@ func (x *SetGroupLayoutRequest) String() string {
 func (*SetGroupLayoutRequest) ProtoMessage() {}
 
 func (x *SetGroupLayoutRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[12]
+	mi := &file_control_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -703,7 +789,7 @@ func (x *SetGroupLayoutRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetGroupLayoutRequest.ProtoReflect.Descriptor instead.
 func (*SetGroupLayoutRequest) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{12}
+	return file_control_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *SetGroupLayoutRequest) GetLayout() *GroupLayout {
@@ -726,7 +812,7 @@ type DeleteGroupLayoutRequest struct {
 
 func (x *DeleteGroupLayoutRequest) Reset() {
 	*x = DeleteGroupLayoutRequest{}
-	mi := &file_control_proto_msgTypes[13]
+	mi := &file_control_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -738,7 +824,7 @@ func (x *DeleteGroupLayoutRequest) String() string {
 func (*DeleteGroupLayoutRequest) ProtoMessage() {}
 
 func (x *DeleteGroupLayoutRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[13]
+	mi := &file_control_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -751,7 +837,7 @@ func (x *DeleteGroupLayoutRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteGroupLayoutRequest.ProtoReflect.Descriptor instead.
 func (*DeleteGroupLayoutRequest) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{13}
+	return file_control_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *DeleteGroupLayoutRequest) GetInstanceName() string {
@@ -778,7 +864,7 @@ type SetLastSeenVersionRequest struct {
 
 func (x *SetLastSeenVersionRequest) Reset() {
 	*x = SetLastSeenVersionRequest{}
-	mi := &file_control_proto_msgTypes[14]
+	mi := &file_control_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -790,7 +876,7 @@ func (x *SetLastSeenVersionRequest) String() string {
 func (*SetLastSeenVersionRequest) ProtoMessage() {}
 
 func (x *SetLastSeenVersionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[14]
+	mi := &file_control_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -803,7 +889,7 @@ func (x *SetLastSeenVersionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetLastSeenVersionRequest.ProtoReflect.Descriptor instead.
 func (*SetLastSeenVersionRequest) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{14}
+	return file_control_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *SetLastSeenVersionRequest) GetVersion() string {
@@ -823,7 +909,7 @@ type MutationReply struct {
 
 func (x *MutationReply) Reset() {
 	*x = MutationReply{}
-	mi := &file_control_proto_msgTypes[15]
+	mi := &file_control_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -835,7 +921,7 @@ func (x *MutationReply) String() string {
 func (*MutationReply) ProtoMessage() {}
 
 func (x *MutationReply) ProtoReflect() protoreflect.Message {
-	mi := &file_control_proto_msgTypes[15]
+	mi := &file_control_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -848,7 +934,7 @@ func (x *MutationReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MutationReply.ProtoReflect.Descriptor instead.
 func (*MutationReply) Descriptor() ([]byte, []int) {
-	return file_control_proto_rawDescGZIP(), []int{15}
+	return file_control_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *MutationReply) GetState() *State {
@@ -880,7 +966,10 @@ const file_control_proto_rawDesc = "" +
 	"\baccepted\x18\x01 \x01(\bR\baccepted\x12#\n" +
 	"\rdraining_jobs\x18\x02 \x01(\x05R\fdrainingJobs\"\x1a\n" +
 	"\x18FleetTUIConnectedRequest\"\x18\n" +
-	"\x16FleetTUIConnectedReply\"\x11\n" +
+	"\x16FleetTUIConnectedReply\"2\n" +
+	"\x1aDeleteBuildkitCacheRequest\x12\x14\n" +
+	"\x05fleet\x18\x01 \x01(\tR\x05fleet\"\x1a\n" +
+	"\x18DeleteBuildkitCacheReply\"\x11\n" +
 	"\x0fGetStateRequest\"\xa5\x01\n" +
 	"\rGetStateReply\x12&\n" +
 	"\x05state\x18\x01 \x01(\v2\x10.fleetgrpc.StateR\x05state\x124\n" +
@@ -926,7 +1015,7 @@ func file_control_proto_rawDescGZIP() []byte {
 	return file_control_proto_rawDescData
 }
 
-var file_control_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
+var file_control_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_control_proto_goTypes = []any{
 	(*HelloRequest)(nil),               // 0: fleetgrpc.HelloRequest
 	(*HelloReply)(nil),                 // 1: fleetgrpc.HelloReply
@@ -934,31 +1023,33 @@ var file_control_proto_goTypes = []any{
 	(*ShutdownReply)(nil),              // 3: fleetgrpc.ShutdownReply
 	(*FleetTUIConnectedRequest)(nil),   // 4: fleetgrpc.FleetTUIConnectedRequest
 	(*FleetTUIConnectedReply)(nil),     // 5: fleetgrpc.FleetTUIConnectedReply
-	(*GetStateRequest)(nil),            // 6: fleetgrpc.GetStateRequest
-	(*GetStateReply)(nil),              // 7: fleetgrpc.GetStateReply
-	(*CreateFleetRequest)(nil),         // 8: fleetgrpc.CreateFleetRequest
-	(*DestroyFleetRequest)(nil),        // 9: fleetgrpc.DestroyFleetRequest
-	(*SetFleetSettingsRequest)(nil),    // 10: fleetgrpc.SetFleetSettingsRequest
-	(*SetInstanceMetadataRequest)(nil), // 11: fleetgrpc.SetInstanceMetadataRequest
-	(*SetGroupLayoutRequest)(nil),      // 12: fleetgrpc.SetGroupLayoutRequest
-	(*DeleteGroupLayoutRequest)(nil),   // 13: fleetgrpc.DeleteGroupLayoutRequest
-	(*SetLastSeenVersionRequest)(nil),  // 14: fleetgrpc.SetLastSeenVersionRequest
-	(*MutationReply)(nil),              // 15: fleetgrpc.MutationReply
-	(*timestamppb.Timestamp)(nil),      // 16: google.protobuf.Timestamp
-	(*State)(nil),                      // 17: fleetgrpc.State
-	(*InstanceRuntime)(nil),            // 18: fleetgrpc.InstanceRuntime
-	(*JobSummary)(nil),                 // 19: fleetgrpc.JobSummary
-	(*FleetSettings)(nil),              // 20: fleetgrpc.FleetSettings
-	(*GroupLayout)(nil),                // 21: fleetgrpc.GroupLayout
+	(*DeleteBuildkitCacheRequest)(nil), // 6: fleetgrpc.DeleteBuildkitCacheRequest
+	(*DeleteBuildkitCacheReply)(nil),   // 7: fleetgrpc.DeleteBuildkitCacheReply
+	(*GetStateRequest)(nil),            // 8: fleetgrpc.GetStateRequest
+	(*GetStateReply)(nil),              // 9: fleetgrpc.GetStateReply
+	(*CreateFleetRequest)(nil),         // 10: fleetgrpc.CreateFleetRequest
+	(*DestroyFleetRequest)(nil),        // 11: fleetgrpc.DestroyFleetRequest
+	(*SetFleetSettingsRequest)(nil),    // 12: fleetgrpc.SetFleetSettingsRequest
+	(*SetInstanceMetadataRequest)(nil), // 13: fleetgrpc.SetInstanceMetadataRequest
+	(*SetGroupLayoutRequest)(nil),      // 14: fleetgrpc.SetGroupLayoutRequest
+	(*DeleteGroupLayoutRequest)(nil),   // 15: fleetgrpc.DeleteGroupLayoutRequest
+	(*SetLastSeenVersionRequest)(nil),  // 16: fleetgrpc.SetLastSeenVersionRequest
+	(*MutationReply)(nil),              // 17: fleetgrpc.MutationReply
+	(*timestamppb.Timestamp)(nil),      // 18: google.protobuf.Timestamp
+	(*State)(nil),                      // 19: fleetgrpc.State
+	(*InstanceRuntime)(nil),            // 20: fleetgrpc.InstanceRuntime
+	(*JobSummary)(nil),                 // 21: fleetgrpc.JobSummary
+	(*FleetSettings)(nil),              // 22: fleetgrpc.FleetSettings
+	(*GroupLayout)(nil),                // 23: fleetgrpc.GroupLayout
 }
 var file_control_proto_depIdxs = []int32{
-	16, // 0: fleetgrpc.HelloReply.started_at:type_name -> google.protobuf.Timestamp
-	17, // 1: fleetgrpc.GetStateReply.state:type_name -> fleetgrpc.State
-	18, // 2: fleetgrpc.GetStateReply.runtime:type_name -> fleetgrpc.InstanceRuntime
-	19, // 3: fleetgrpc.GetStateReply.active_jobs:type_name -> fleetgrpc.JobSummary
-	20, // 4: fleetgrpc.SetFleetSettingsRequest.settings:type_name -> fleetgrpc.FleetSettings
-	21, // 5: fleetgrpc.SetGroupLayoutRequest.layout:type_name -> fleetgrpc.GroupLayout
-	17, // 6: fleetgrpc.MutationReply.state:type_name -> fleetgrpc.State
+	18, // 0: fleetgrpc.HelloReply.started_at:type_name -> google.protobuf.Timestamp
+	19, // 1: fleetgrpc.GetStateReply.state:type_name -> fleetgrpc.State
+	20, // 2: fleetgrpc.GetStateReply.runtime:type_name -> fleetgrpc.InstanceRuntime
+	21, // 3: fleetgrpc.GetStateReply.active_jobs:type_name -> fleetgrpc.JobSummary
+	22, // 4: fleetgrpc.SetFleetSettingsRequest.settings:type_name -> fleetgrpc.FleetSettings
+	23, // 5: fleetgrpc.SetGroupLayoutRequest.layout:type_name -> fleetgrpc.GroupLayout
+	19, // 6: fleetgrpc.MutationReply.state:type_name -> fleetgrpc.State
 	7,  // [7:7] is the sub-list for method output_type
 	7,  // [7:7] is the sub-list for method input_type
 	7,  // [7:7] is the sub-list for extension type_name
@@ -975,14 +1066,14 @@ func file_control_proto_init() {
 	file_runtime_proto_init()
 	file_jobs_proto_init()
 	file_control_proto_msgTypes[2].OneofWrappers = []any{}
-	file_control_proto_msgTypes[11].OneofWrappers = []any{}
+	file_control_proto_msgTypes[13].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_control_proto_rawDesc), len(file_control_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   16,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/fleetgrpc/control.proto
+++ b/fleetgrpc/control.proto
@@ -66,6 +66,18 @@ message FleetTUIConnectedRequest {}
 // fire-and-forget on the server, so the client does not wait on its outcome.
 message FleetTUIConnectedReply {}
 
+// DeleteBuildkitCacheRequest asks the server to wipe a fleet's shared build
+// cache: stop the buildkit container, delete ~/.fleet/workspaces/<fleet>/
+// .buildkit (incl. the root-owned cache), then restart the server empty. It is
+// a synchronous action (takes a few seconds), so the client shows progress and
+// uses a longer deadline than ordinary mutations.
+message DeleteBuildkitCacheRequest {
+  string fleet = 1;
+}
+
+// DeleteBuildkitCacheReply is empty: success is signalled by a nil error.
+message DeleteBuildkitCacheReply {}
+
 message GetStateRequest {}
 
 // GetStateReply is the one-stop snapshot of EVERYTHING the TUI renders:

--- a/fleetgrpc/control.proto
+++ b/fleetgrpc/control.proto
@@ -67,10 +67,12 @@ message FleetTUIConnectedRequest {}
 message FleetTUIConnectedReply {}
 
 // DeleteBuildkitCacheRequest asks the server to wipe a fleet's shared build
-// cache: stop the buildkit container, delete ~/.fleet/workspaces/<fleet>/
-// .buildkit (incl. the root-owned cache), then restart the server empty. It is
-// a synchronous action (takes a few seconds), so the client shows progress and
-// uses a longer deadline than ordinary mutations.
+// cache: stop the buildkit container, clear the CONTENTS of
+// ~/.fleet/workspaces/<fleet>/.buildkit (incl. the root-owned cache) while
+// KEEPING the directory itself so running instances' bind mounts stay valid,
+// then restart the server empty. It is a synchronous action (takes a few
+// seconds), so the client shows progress and uses a longer deadline than
+// ordinary mutations.
 message DeleteBuildkitCacheRequest {
   string fleet = 1;
 }

--- a/fleetgrpc/service.pb.go
+++ b/fleetgrpc/service.pb.go
@@ -26,7 +26,7 @@ const file_service_proto_rawDesc = "" +
 	"\n" +
 	"\rservice.proto\x12\tfleetgrpc\x1a\rcontrol.proto\x1a\vwatch.proto\x1a\n" +
 	"jobs.proto\x1a\fconfig.proto\x1a\n" +
-	"exec.proto2\x9b\x10\n" +
+	"exec.proto2\xfe\x10\n" +
 	"\fFleetService\x127\n" +
 	"\x05Hello\x12\x17.fleetgrpc.HelloRequest\x1a\x15.fleetgrpc.HelloReply\x12@\n" +
 	"\bShutdown\x12\x1a.fleetgrpc.ShutdownRequest\x1a\x18.fleetgrpc.ShutdownReply\x12[\n" +
@@ -40,7 +40,8 @@ const file_service_proto_rawDesc = "" +
 	"\rCloneInstance\x12\x1f.fleetgrpc.CloneInstanceRequest\x1a\x13.fleetgrpc.JobEvent0\x01\x12F\n" +
 	"\vCreateFleet\x12\x1d.fleetgrpc.CreateFleetRequest\x1a\x18.fleetgrpc.MutationReply\x12H\n" +
 	"\fDestroyFleet\x12\x1e.fleetgrpc.DestroyFleetRequest\x1a\x18.fleetgrpc.MutationReply\x12P\n" +
-	"\x10SetFleetSettings\x12\".fleetgrpc.SetFleetSettingsRequest\x1a\x18.fleetgrpc.MutationReply\x12V\n" +
+	"\x10SetFleetSettings\x12\".fleetgrpc.SetFleetSettingsRequest\x1a\x18.fleetgrpc.MutationReply\x12a\n" +
+	"\x13DeleteBuildkitCache\x12%.fleetgrpc.DeleteBuildkitCacheRequest\x1a#.fleetgrpc.DeleteBuildkitCacheReply\x12V\n" +
 	"\x13SetInstanceMetadata\x12%.fleetgrpc.SetInstanceMetadataRequest\x1a\x18.fleetgrpc.MutationReply\x12L\n" +
 	"\x0eSetGroupLayout\x12 .fleetgrpc.SetGroupLayoutRequest\x1a\x18.fleetgrpc.MutationReply\x12R\n" +
 	"\x11DeleteGroupLayout\x12#.fleetgrpc.DeleteGroupLayoutRequest\x1a\x18.fleetgrpc.MutationReply\x12T\n" +
@@ -70,37 +71,39 @@ var file_service_proto_goTypes = []any{
 	(*CreateFleetRequest)(nil),            // 10: fleetgrpc.CreateFleetRequest
 	(*DestroyFleetRequest)(nil),           // 11: fleetgrpc.DestroyFleetRequest
 	(*SetFleetSettingsRequest)(nil),       // 12: fleetgrpc.SetFleetSettingsRequest
-	(*SetInstanceMetadataRequest)(nil),    // 13: fleetgrpc.SetInstanceMetadataRequest
-	(*SetGroupLayoutRequest)(nil),         // 14: fleetgrpc.SetGroupLayoutRequest
-	(*DeleteGroupLayoutRequest)(nil),      // 15: fleetgrpc.DeleteGroupLayoutRequest
-	(*SetLastSeenVersionRequest)(nil),     // 16: fleetgrpc.SetLastSeenVersionRequest
-	(*GetConfigRequest)(nil),              // 17: fleetgrpc.GetConfigRequest
-	(*SetConfigRequest)(nil),              // 18: fleetgrpc.SetConfigRequest
-	(*ExecIn)(nil),                        // 19: fleetgrpc.ExecIn
-	(*ResolveExecCommandRequest)(nil),     // 20: fleetgrpc.ResolveExecCommandRequest
-	(*ResolveLogsCommandRequest)(nil),     // 21: fleetgrpc.ResolveLogsCommandRequest
-	(*LogsRequest)(nil),                   // 22: fleetgrpc.LogsRequest
-	(*PortForwardRequest)(nil),            // 23: fleetgrpc.PortForwardRequest
-	(*GetCoderTemplateParamsRequest)(nil), // 24: fleetgrpc.GetCoderTemplateParamsRequest
-	(*GetBrowserConfigRequest)(nil),       // 25: fleetgrpc.GetBrowserConfigRequest
-	(*PrepareBrowserRequest)(nil),         // 26: fleetgrpc.PrepareBrowserRequest
-	(*HelloReply)(nil),                    // 27: fleetgrpc.HelloReply
-	(*ShutdownReply)(nil),                 // 28: fleetgrpc.ShutdownReply
-	(*FleetTUIConnectedReply)(nil),        // 29: fleetgrpc.FleetTUIConnectedReply
-	(*GetStateReply)(nil),                 // 30: fleetgrpc.GetStateReply
-	(*Event)(nil),                         // 31: fleetgrpc.Event
-	(*JobEvent)(nil),                      // 32: fleetgrpc.JobEvent
-	(*MutationReply)(nil),                 // 33: fleetgrpc.MutationReply
-	(*GetConfigReply)(nil),                // 34: fleetgrpc.GetConfigReply
-	(*SetConfigReply)(nil),                // 35: fleetgrpc.SetConfigReply
-	(*ExecOut)(nil),                       // 36: fleetgrpc.ExecOut
-	(*ResolveExecCommandReply)(nil),       // 37: fleetgrpc.ResolveExecCommandReply
-	(*ResolveLogsCommandReply)(nil),       // 38: fleetgrpc.ResolveLogsCommandReply
-	(*LogLine)(nil),                       // 39: fleetgrpc.LogLine
-	(*PortForwardReply)(nil),              // 40: fleetgrpc.PortForwardReply
-	(*GetCoderTemplateParamsReply)(nil),   // 41: fleetgrpc.GetCoderTemplateParamsReply
-	(*GetBrowserConfigReply)(nil),         // 42: fleetgrpc.GetBrowserConfigReply
-	(*PrepareBrowserReply)(nil),           // 43: fleetgrpc.PrepareBrowserReply
+	(*DeleteBuildkitCacheRequest)(nil),    // 13: fleetgrpc.DeleteBuildkitCacheRequest
+	(*SetInstanceMetadataRequest)(nil),    // 14: fleetgrpc.SetInstanceMetadataRequest
+	(*SetGroupLayoutRequest)(nil),         // 15: fleetgrpc.SetGroupLayoutRequest
+	(*DeleteGroupLayoutRequest)(nil),      // 16: fleetgrpc.DeleteGroupLayoutRequest
+	(*SetLastSeenVersionRequest)(nil),     // 17: fleetgrpc.SetLastSeenVersionRequest
+	(*GetConfigRequest)(nil),              // 18: fleetgrpc.GetConfigRequest
+	(*SetConfigRequest)(nil),              // 19: fleetgrpc.SetConfigRequest
+	(*ExecIn)(nil),                        // 20: fleetgrpc.ExecIn
+	(*ResolveExecCommandRequest)(nil),     // 21: fleetgrpc.ResolveExecCommandRequest
+	(*ResolveLogsCommandRequest)(nil),     // 22: fleetgrpc.ResolveLogsCommandRequest
+	(*LogsRequest)(nil),                   // 23: fleetgrpc.LogsRequest
+	(*PortForwardRequest)(nil),            // 24: fleetgrpc.PortForwardRequest
+	(*GetCoderTemplateParamsRequest)(nil), // 25: fleetgrpc.GetCoderTemplateParamsRequest
+	(*GetBrowserConfigRequest)(nil),       // 26: fleetgrpc.GetBrowserConfigRequest
+	(*PrepareBrowserRequest)(nil),         // 27: fleetgrpc.PrepareBrowserRequest
+	(*HelloReply)(nil),                    // 28: fleetgrpc.HelloReply
+	(*ShutdownReply)(nil),                 // 29: fleetgrpc.ShutdownReply
+	(*FleetTUIConnectedReply)(nil),        // 30: fleetgrpc.FleetTUIConnectedReply
+	(*GetStateReply)(nil),                 // 31: fleetgrpc.GetStateReply
+	(*Event)(nil),                         // 32: fleetgrpc.Event
+	(*JobEvent)(nil),                      // 33: fleetgrpc.JobEvent
+	(*MutationReply)(nil),                 // 34: fleetgrpc.MutationReply
+	(*DeleteBuildkitCacheReply)(nil),      // 35: fleetgrpc.DeleteBuildkitCacheReply
+	(*GetConfigReply)(nil),                // 36: fleetgrpc.GetConfigReply
+	(*SetConfigReply)(nil),                // 37: fleetgrpc.SetConfigReply
+	(*ExecOut)(nil),                       // 38: fleetgrpc.ExecOut
+	(*ResolveExecCommandReply)(nil),       // 39: fleetgrpc.ResolveExecCommandReply
+	(*ResolveLogsCommandReply)(nil),       // 40: fleetgrpc.ResolveLogsCommandReply
+	(*LogLine)(nil),                       // 41: fleetgrpc.LogLine
+	(*PortForwardReply)(nil),              // 42: fleetgrpc.PortForwardReply
+	(*GetCoderTemplateParamsReply)(nil),   // 43: fleetgrpc.GetCoderTemplateParamsReply
+	(*GetBrowserConfigReply)(nil),         // 44: fleetgrpc.GetBrowserConfigReply
+	(*PrepareBrowserReply)(nil),           // 45: fleetgrpc.PrepareBrowserReply
 }
 var file_service_proto_depIdxs = []int32{
 	0,  // 0: fleetgrpc.FleetService.Hello:input_type -> fleetgrpc.HelloRequest
@@ -116,49 +119,51 @@ var file_service_proto_depIdxs = []int32{
 	10, // 10: fleetgrpc.FleetService.CreateFleet:input_type -> fleetgrpc.CreateFleetRequest
 	11, // 11: fleetgrpc.FleetService.DestroyFleet:input_type -> fleetgrpc.DestroyFleetRequest
 	12, // 12: fleetgrpc.FleetService.SetFleetSettings:input_type -> fleetgrpc.SetFleetSettingsRequest
-	13, // 13: fleetgrpc.FleetService.SetInstanceMetadata:input_type -> fleetgrpc.SetInstanceMetadataRequest
-	14, // 14: fleetgrpc.FleetService.SetGroupLayout:input_type -> fleetgrpc.SetGroupLayoutRequest
-	15, // 15: fleetgrpc.FleetService.DeleteGroupLayout:input_type -> fleetgrpc.DeleteGroupLayoutRequest
-	16, // 16: fleetgrpc.FleetService.SetLastSeenVersion:input_type -> fleetgrpc.SetLastSeenVersionRequest
-	17, // 17: fleetgrpc.FleetService.GetConfig:input_type -> fleetgrpc.GetConfigRequest
-	18, // 18: fleetgrpc.FleetService.SetConfig:input_type -> fleetgrpc.SetConfigRequest
-	19, // 19: fleetgrpc.FleetService.Exec:input_type -> fleetgrpc.ExecIn
-	20, // 20: fleetgrpc.FleetService.ResolveExecCommand:input_type -> fleetgrpc.ResolveExecCommandRequest
-	21, // 21: fleetgrpc.FleetService.ResolveLogsCommand:input_type -> fleetgrpc.ResolveLogsCommandRequest
-	22, // 22: fleetgrpc.FleetService.Logs:input_type -> fleetgrpc.LogsRequest
-	23, // 23: fleetgrpc.FleetService.PortForward:input_type -> fleetgrpc.PortForwardRequest
-	24, // 24: fleetgrpc.FleetService.GetCoderTemplateParams:input_type -> fleetgrpc.GetCoderTemplateParamsRequest
-	25, // 25: fleetgrpc.FleetService.GetBrowserConfig:input_type -> fleetgrpc.GetBrowserConfigRequest
-	26, // 26: fleetgrpc.FleetService.PrepareBrowser:input_type -> fleetgrpc.PrepareBrowserRequest
-	27, // 27: fleetgrpc.FleetService.Hello:output_type -> fleetgrpc.HelloReply
-	28, // 28: fleetgrpc.FleetService.Shutdown:output_type -> fleetgrpc.ShutdownReply
-	29, // 29: fleetgrpc.FleetService.FleetTUIConnected:output_type -> fleetgrpc.FleetTUIConnectedReply
-	30, // 30: fleetgrpc.FleetService.GetState:output_type -> fleetgrpc.GetStateReply
-	31, // 31: fleetgrpc.FleetService.Watch:output_type -> fleetgrpc.Event
-	32, // 32: fleetgrpc.FleetService.CreateInstance:output_type -> fleetgrpc.JobEvent
-	32, // 33: fleetgrpc.FleetService.DestroyInstance:output_type -> fleetgrpc.JobEvent
-	32, // 34: fleetgrpc.FleetService.StartInstance:output_type -> fleetgrpc.JobEvent
-	32, // 35: fleetgrpc.FleetService.StopInstance:output_type -> fleetgrpc.JobEvent
-	32, // 36: fleetgrpc.FleetService.CloneInstance:output_type -> fleetgrpc.JobEvent
-	33, // 37: fleetgrpc.FleetService.CreateFleet:output_type -> fleetgrpc.MutationReply
-	33, // 38: fleetgrpc.FleetService.DestroyFleet:output_type -> fleetgrpc.MutationReply
-	33, // 39: fleetgrpc.FleetService.SetFleetSettings:output_type -> fleetgrpc.MutationReply
-	33, // 40: fleetgrpc.FleetService.SetInstanceMetadata:output_type -> fleetgrpc.MutationReply
-	33, // 41: fleetgrpc.FleetService.SetGroupLayout:output_type -> fleetgrpc.MutationReply
-	33, // 42: fleetgrpc.FleetService.DeleteGroupLayout:output_type -> fleetgrpc.MutationReply
-	33, // 43: fleetgrpc.FleetService.SetLastSeenVersion:output_type -> fleetgrpc.MutationReply
-	34, // 44: fleetgrpc.FleetService.GetConfig:output_type -> fleetgrpc.GetConfigReply
-	35, // 45: fleetgrpc.FleetService.SetConfig:output_type -> fleetgrpc.SetConfigReply
-	36, // 46: fleetgrpc.FleetService.Exec:output_type -> fleetgrpc.ExecOut
-	37, // 47: fleetgrpc.FleetService.ResolveExecCommand:output_type -> fleetgrpc.ResolveExecCommandReply
-	38, // 48: fleetgrpc.FleetService.ResolveLogsCommand:output_type -> fleetgrpc.ResolveLogsCommandReply
-	39, // 49: fleetgrpc.FleetService.Logs:output_type -> fleetgrpc.LogLine
-	40, // 50: fleetgrpc.FleetService.PortForward:output_type -> fleetgrpc.PortForwardReply
-	41, // 51: fleetgrpc.FleetService.GetCoderTemplateParams:output_type -> fleetgrpc.GetCoderTemplateParamsReply
-	42, // 52: fleetgrpc.FleetService.GetBrowserConfig:output_type -> fleetgrpc.GetBrowserConfigReply
-	43, // 53: fleetgrpc.FleetService.PrepareBrowser:output_type -> fleetgrpc.PrepareBrowserReply
-	27, // [27:54] is the sub-list for method output_type
-	0,  // [0:27] is the sub-list for method input_type
+	13, // 13: fleetgrpc.FleetService.DeleteBuildkitCache:input_type -> fleetgrpc.DeleteBuildkitCacheRequest
+	14, // 14: fleetgrpc.FleetService.SetInstanceMetadata:input_type -> fleetgrpc.SetInstanceMetadataRequest
+	15, // 15: fleetgrpc.FleetService.SetGroupLayout:input_type -> fleetgrpc.SetGroupLayoutRequest
+	16, // 16: fleetgrpc.FleetService.DeleteGroupLayout:input_type -> fleetgrpc.DeleteGroupLayoutRequest
+	17, // 17: fleetgrpc.FleetService.SetLastSeenVersion:input_type -> fleetgrpc.SetLastSeenVersionRequest
+	18, // 18: fleetgrpc.FleetService.GetConfig:input_type -> fleetgrpc.GetConfigRequest
+	19, // 19: fleetgrpc.FleetService.SetConfig:input_type -> fleetgrpc.SetConfigRequest
+	20, // 20: fleetgrpc.FleetService.Exec:input_type -> fleetgrpc.ExecIn
+	21, // 21: fleetgrpc.FleetService.ResolveExecCommand:input_type -> fleetgrpc.ResolveExecCommandRequest
+	22, // 22: fleetgrpc.FleetService.ResolveLogsCommand:input_type -> fleetgrpc.ResolveLogsCommandRequest
+	23, // 23: fleetgrpc.FleetService.Logs:input_type -> fleetgrpc.LogsRequest
+	24, // 24: fleetgrpc.FleetService.PortForward:input_type -> fleetgrpc.PortForwardRequest
+	25, // 25: fleetgrpc.FleetService.GetCoderTemplateParams:input_type -> fleetgrpc.GetCoderTemplateParamsRequest
+	26, // 26: fleetgrpc.FleetService.GetBrowserConfig:input_type -> fleetgrpc.GetBrowserConfigRequest
+	27, // 27: fleetgrpc.FleetService.PrepareBrowser:input_type -> fleetgrpc.PrepareBrowserRequest
+	28, // 28: fleetgrpc.FleetService.Hello:output_type -> fleetgrpc.HelloReply
+	29, // 29: fleetgrpc.FleetService.Shutdown:output_type -> fleetgrpc.ShutdownReply
+	30, // 30: fleetgrpc.FleetService.FleetTUIConnected:output_type -> fleetgrpc.FleetTUIConnectedReply
+	31, // 31: fleetgrpc.FleetService.GetState:output_type -> fleetgrpc.GetStateReply
+	32, // 32: fleetgrpc.FleetService.Watch:output_type -> fleetgrpc.Event
+	33, // 33: fleetgrpc.FleetService.CreateInstance:output_type -> fleetgrpc.JobEvent
+	33, // 34: fleetgrpc.FleetService.DestroyInstance:output_type -> fleetgrpc.JobEvent
+	33, // 35: fleetgrpc.FleetService.StartInstance:output_type -> fleetgrpc.JobEvent
+	33, // 36: fleetgrpc.FleetService.StopInstance:output_type -> fleetgrpc.JobEvent
+	33, // 37: fleetgrpc.FleetService.CloneInstance:output_type -> fleetgrpc.JobEvent
+	34, // 38: fleetgrpc.FleetService.CreateFleet:output_type -> fleetgrpc.MutationReply
+	34, // 39: fleetgrpc.FleetService.DestroyFleet:output_type -> fleetgrpc.MutationReply
+	34, // 40: fleetgrpc.FleetService.SetFleetSettings:output_type -> fleetgrpc.MutationReply
+	35, // 41: fleetgrpc.FleetService.DeleteBuildkitCache:output_type -> fleetgrpc.DeleteBuildkitCacheReply
+	34, // 42: fleetgrpc.FleetService.SetInstanceMetadata:output_type -> fleetgrpc.MutationReply
+	34, // 43: fleetgrpc.FleetService.SetGroupLayout:output_type -> fleetgrpc.MutationReply
+	34, // 44: fleetgrpc.FleetService.DeleteGroupLayout:output_type -> fleetgrpc.MutationReply
+	34, // 45: fleetgrpc.FleetService.SetLastSeenVersion:output_type -> fleetgrpc.MutationReply
+	36, // 46: fleetgrpc.FleetService.GetConfig:output_type -> fleetgrpc.GetConfigReply
+	37, // 47: fleetgrpc.FleetService.SetConfig:output_type -> fleetgrpc.SetConfigReply
+	38, // 48: fleetgrpc.FleetService.Exec:output_type -> fleetgrpc.ExecOut
+	39, // 49: fleetgrpc.FleetService.ResolveExecCommand:output_type -> fleetgrpc.ResolveExecCommandReply
+	40, // 50: fleetgrpc.FleetService.ResolveLogsCommand:output_type -> fleetgrpc.ResolveLogsCommandReply
+	41, // 51: fleetgrpc.FleetService.Logs:output_type -> fleetgrpc.LogLine
+	42, // 52: fleetgrpc.FleetService.PortForward:output_type -> fleetgrpc.PortForwardReply
+	43, // 53: fleetgrpc.FleetService.GetCoderTemplateParams:output_type -> fleetgrpc.GetCoderTemplateParamsReply
+	44, // 54: fleetgrpc.FleetService.GetBrowserConfig:output_type -> fleetgrpc.GetBrowserConfigReply
+	45, // 55: fleetgrpc.FleetService.PrepareBrowser:output_type -> fleetgrpc.PrepareBrowserReply
+	28, // [28:56] is the sub-list for method output_type
+	0,  // [0:28] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/fleetgrpc/service.proto
+++ b/fleetgrpc/service.proto
@@ -50,6 +50,11 @@ service FleetService {
   rpc CreateFleet(CreateFleetRequest) returns (MutationReply);
   rpc DestroyFleet(DestroyFleetRequest) returns (MutationReply);
   rpc SetFleetSettings(SetFleetSettingsRequest) returns (MutationReply);
+
+  // DeleteBuildkitCache wipes a fleet's shared build cache and restarts the
+  // (empty) buildkit server. A synchronous host-docker action — clients use a
+  // longer deadline and show progress.
+  rpc DeleteBuildkitCache(DeleteBuildkitCacheRequest) returns (DeleteBuildkitCacheReply);
   rpc SetInstanceMetadata(SetInstanceMetadataRequest) returns (MutationReply);
   rpc SetGroupLayout(SetGroupLayoutRequest) returns (MutationReply);
   rpc DeleteGroupLayout(DeleteGroupLayoutRequest) returns (MutationReply);

--- a/fleetgrpc/service_grpc.pb.go
+++ b/fleetgrpc/service_grpc.pb.go
@@ -32,6 +32,7 @@ const (
 	FleetService_CreateFleet_FullMethodName            = "/fleetgrpc.FleetService/CreateFleet"
 	FleetService_DestroyFleet_FullMethodName           = "/fleetgrpc.FleetService/DestroyFleet"
 	FleetService_SetFleetSettings_FullMethodName       = "/fleetgrpc.FleetService/SetFleetSettings"
+	FleetService_DeleteBuildkitCache_FullMethodName    = "/fleetgrpc.FleetService/DeleteBuildkitCache"
 	FleetService_SetInstanceMetadata_FullMethodName    = "/fleetgrpc.FleetService/SetInstanceMetadata"
 	FleetService_SetGroupLayout_FullMethodName         = "/fleetgrpc.FleetService/SetGroupLayout"
 	FleetService_DeleteGroupLayout_FullMethodName      = "/fleetgrpc.FleetService/DeleteGroupLayout"
@@ -83,6 +84,10 @@ type FleetServiceClient interface {
 	CreateFleet(ctx context.Context, in *CreateFleetRequest, opts ...grpc.CallOption) (*MutationReply, error)
 	DestroyFleet(ctx context.Context, in *DestroyFleetRequest, opts ...grpc.CallOption) (*MutationReply, error)
 	SetFleetSettings(ctx context.Context, in *SetFleetSettingsRequest, opts ...grpc.CallOption) (*MutationReply, error)
+	// DeleteBuildkitCache wipes a fleet's shared build cache and restarts the
+	// (empty) buildkit server. A synchronous host-docker action — clients use a
+	// longer deadline and show progress.
+	DeleteBuildkitCache(ctx context.Context, in *DeleteBuildkitCacheRequest, opts ...grpc.CallOption) (*DeleteBuildkitCacheReply, error)
 	SetInstanceMetadata(ctx context.Context, in *SetInstanceMetadataRequest, opts ...grpc.CallOption) (*MutationReply, error)
 	SetGroupLayout(ctx context.Context, in *SetGroupLayoutRequest, opts ...grpc.CallOption) (*MutationReply, error)
 	DeleteGroupLayout(ctx context.Context, in *DeleteGroupLayoutRequest, opts ...grpc.CallOption) (*MutationReply, error)
@@ -295,6 +300,16 @@ func (c *fleetServiceClient) SetFleetSettings(ctx context.Context, in *SetFleetS
 	return out, nil
 }
 
+func (c *fleetServiceClient) DeleteBuildkitCache(ctx context.Context, in *DeleteBuildkitCacheRequest, opts ...grpc.CallOption) (*DeleteBuildkitCacheReply, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteBuildkitCacheReply)
+	err := c.cc.Invoke(ctx, FleetService_DeleteBuildkitCache_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *fleetServiceClient) SetInstanceMetadata(ctx context.Context, in *SetInstanceMetadataRequest, opts ...grpc.CallOption) (*MutationReply, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(MutationReply)
@@ -482,6 +497,10 @@ type FleetServiceServer interface {
 	CreateFleet(context.Context, *CreateFleetRequest) (*MutationReply, error)
 	DestroyFleet(context.Context, *DestroyFleetRequest) (*MutationReply, error)
 	SetFleetSettings(context.Context, *SetFleetSettingsRequest) (*MutationReply, error)
+	// DeleteBuildkitCache wipes a fleet's shared build cache and restarts the
+	// (empty) buildkit server. A synchronous host-docker action — clients use a
+	// longer deadline and show progress.
+	DeleteBuildkitCache(context.Context, *DeleteBuildkitCacheRequest) (*DeleteBuildkitCacheReply, error)
 	SetInstanceMetadata(context.Context, *SetInstanceMetadataRequest) (*MutationReply, error)
 	SetGroupLayout(context.Context, *SetGroupLayoutRequest) (*MutationReply, error)
 	DeleteGroupLayout(context.Context, *DeleteGroupLayoutRequest) (*MutationReply, error)
@@ -548,6 +567,9 @@ func (UnimplementedFleetServiceServer) DestroyFleet(context.Context, *DestroyFle
 }
 func (UnimplementedFleetServiceServer) SetFleetSettings(context.Context, *SetFleetSettingsRequest) (*MutationReply, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SetFleetSettings not implemented")
+}
+func (UnimplementedFleetServiceServer) DeleteBuildkitCache(context.Context, *DeleteBuildkitCacheRequest) (*DeleteBuildkitCacheReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteBuildkitCache not implemented")
 }
 func (UnimplementedFleetServiceServer) SetInstanceMetadata(context.Context, *SetInstanceMetadataRequest) (*MutationReply, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SetInstanceMetadata not implemented")
@@ -800,6 +822,24 @@ func _FleetService_SetFleetSettings_Handler(srv interface{}, ctx context.Context
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(FleetServiceServer).SetFleetSettings(ctx, req.(*SetFleetSettingsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _FleetService_DeleteBuildkitCache_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteBuildkitCacheRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FleetServiceServer).DeleteBuildkitCache(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: FleetService_DeleteBuildkitCache_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FleetServiceServer).DeleteBuildkitCache(ctx, req.(*DeleteBuildkitCacheRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1072,6 +1112,10 @@ var FleetService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetFleetSettings",
 			Handler:    _FleetService_SetFleetSettings_Handler,
+		},
+		{
+			MethodName: "DeleteBuildkitCache",
+			Handler:    _FleetService_DeleteBuildkitCache_Handler,
 		},
 		{
 			MethodName: "SetInstanceMetadata",

--- a/internal/buildkit/buildkit.go
+++ b/internal/buildkit/buildkit.go
@@ -267,6 +267,54 @@ func StopSharedServer(fleetName string) error {
 	return nil
 }
 
+// DeleteCache wipes a fleet's shared build cache and restarts the server empty:
+// it stops/removes the buildkit container, deletes the .buildkit directory
+// (including buildkitd's root-owned cache), then re-ensures the server so it
+// comes back with a fresh cache. Serialized per fleet and idempotent.
+//
+// The stop+remove happen under the per-fleet lock so a concurrent instance
+// create can't start a server we're about to wipe; the re-ensure runs after the
+// lock is released (EnsureSharedServer takes it again).
+func DeleteCache(fleetName string) error {
+	if err := func() error {
+		lock := fleetLock(fleetName)
+		lock.Lock()
+		defer lock.Unlock()
+		name := ContainerName(fleetName)
+		if out, err := runDocker("rm", "-f", name); err != nil && !strings.Contains(out, "No such container") {
+			return fmt.Errorf("stop buildkit server: %w (%s)", err, out)
+		}
+		return removeSharedDir(fleetName)
+	}(); err != nil {
+		return err
+	}
+	flog.Info("buildkit cache cleared", "fleet", fleetName)
+	if _, err := EnsureSharedServer(fleetName); err != nil {
+		return fmt.Errorf("restart buildkit server after cache clear: %w", err)
+	}
+	return nil
+}
+
+// removeSharedDir deletes a fleet's .buildkit directory. A plain os.RemoveAll
+// works when nothing root-owned is present; buildkitd's cache (written as root
+// in the privileged container) defeats a user-context rm, so on failure it
+// falls back to a throwaway root container that removes the dir.
+func removeSharedDir(fleetName string) error {
+	dir, err := SharedDir(fleetName)
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dir); err == nil {
+		return nil
+	}
+	parent := filepath.Dir(dir)
+	base := filepath.Base(dir)
+	if out, err := runDocker("run", "--rm", "--entrypoint", "rm", "-v", parent+":/work", image, "-rf", "/work/"+base); err != nil {
+		return fmt.Errorf("remove buildkit dir %s: %w (%s)", dir, err, out)
+	}
+	return nil
+}
+
 // inspectState reports whether a container exists and whether it is running.
 // `docker inspect` exits non-zero for a missing container, which we map to
 // exists=false.

--- a/internal/buildkit/buildkit.go
+++ b/internal/buildkit/buildkit.go
@@ -337,9 +337,12 @@ func clearSharedDir(fleetName string) error {
 		return nil
 	}
 	// Root-owned cache → clear the contents (NOT the dir) via a throwaway root
-	// container, preserving the .buildkit inode for instance bind mounts.
-	if out, err := runDocker("run", "--rm", "--entrypoint", "sh", "-v", dir+":/work", image,
-		"-c", "rm -rf /work/* /work/.[!.]* /work/..?* 2>/dev/null; true"); err != nil {
+	// container, preserving the .buildkit inode for instance bind mounts. `find
+	// -exec rm` (vs a shell glob) avoids "no match" noise AND propagates a real
+	// failure as a non-zero exit, so a partial wipe is reported rather than
+	// masked.
+	if out, err := runDocker("run", "--rm", "--entrypoint", "find", "-v", dir+":/work", image,
+		"/work", "-mindepth", "1", "-maxdepth", "1", "-exec", "rm", "-rf", "{}", ";"); err != nil {
 		return fmt.Errorf("clear buildkit dir %s: %w (%s)", dir, err, out)
 	}
 	return nil

--- a/internal/buildkit/buildkit.go
+++ b/internal/buildkit/buildkit.go
@@ -276,22 +276,30 @@ func StopSharedServer(fleetName string) error {
 // create can't start a server we're about to wipe; the re-ensure runs after the
 // lock is released (EnsureSharedServer takes it again).
 func DeleteCache(fleetName string) error {
-	if err := func() error {
+	var wipeErr error
+	func() {
 		lock := fleetLock(fleetName)
 		lock.Lock()
 		defer lock.Unlock()
 		name := ContainerName(fleetName)
 		if out, err := runDocker("rm", "-f", name); err != nil && !strings.Contains(out, "No such container") {
-			return fmt.Errorf("stop buildkit server: %w (%s)", err, out)
+			wipeErr = fmt.Errorf("stop buildkit server: %w (%s)", err, out)
+			return
 		}
-		return removeSharedDir(fleetName)
-	}(); err != nil {
-		return err
+		wipeErr = removeSharedDir(fleetName)
+	}()
+
+	// Always bring the server back, even if the wipe partially failed: the
+	// container was already removed above, so skipping the restart would leave
+	// the fleet with no build server at all.
+	_, ensureErr := EnsureSharedServer(fleetName)
+	if wipeErr != nil {
+		return fmt.Errorf("clear buildkit cache: %w", wipeErr)
+	}
+	if ensureErr != nil {
+		return fmt.Errorf("restart buildkit server after cache clear: %w", ensureErr)
 	}
 	flog.Info("buildkit cache cleared", "fleet", fleetName)
-	if _, err := EnsureSharedServer(fleetName); err != nil {
-		return fmt.Errorf("restart buildkit server after cache clear: %w", err)
-	}
 	return nil
 }
 

--- a/internal/buildkit/buildkit.go
+++ b/internal/buildkit/buildkit.go
@@ -268,13 +268,18 @@ func StopSharedServer(fleetName string) error {
 }
 
 // DeleteCache wipes a fleet's shared build cache and restarts the server empty:
-// it stops/removes the buildkit container, deletes the .buildkit directory
-// (including buildkitd's root-owned cache), then re-ensures the server so it
-// comes back with a fresh cache. Serialized per fleet and idempotent.
+// it stops/removes the buildkit container, clears the .buildkit directory's
+// CONTENTS (including buildkitd's root-owned cache), then re-ensures the server
+// so it comes back with a fresh cache. Serialized per fleet and idempotent.
 //
-// The stop+remove happen under the per-fleet lock so a concurrent instance
-// create can't start a server we're about to wipe; the re-ensure runs after the
-// lock is released (EnsureSharedServer takes it again).
+// It deliberately keeps the .buildkit DIRECTORY itself (only its contents go):
+// running instances bind-mount that directory, and removing+recreating it would
+// orphan their mounts — the new socket would live in a different inode invisible
+// inside the instance, leaving its buildx builder "inactive".
+//
+// The stop+clear happen under the per-fleet lock so a concurrent instance create
+// can't start a server we're about to wipe; the re-ensure runs after the lock is
+// released (EnsureSharedServer takes it again).
 func DeleteCache(fleetName string) error {
 	var wipeErr error
 	func() {
@@ -286,7 +291,7 @@ func DeleteCache(fleetName string) error {
 			wipeErr = fmt.Errorf("stop buildkit server: %w (%s)", err, out)
 			return
 		}
-		wipeErr = removeSharedDir(fleetName)
+		wipeErr = clearSharedDir(fleetName)
 	}()
 
 	// Always bring the server back, even if the wipe partially failed: the
@@ -303,22 +308,39 @@ func DeleteCache(fleetName string) error {
 	return nil
 }
 
-// removeSharedDir deletes a fleet's .buildkit directory. A plain os.RemoveAll
-// works when nothing root-owned is present; buildkitd's cache (written as root
-// in the privileged container) defeats a user-context rm, so on failure it
-// falls back to a throwaway root container that removes the dir.
-func removeSharedDir(fleetName string) error {
+// clearSharedDir wipes the CONTENTS of a fleet's .buildkit directory but keeps
+// the directory itself, so running instances' bind mounts of it stay valid (see
+// DeleteCache). A plain per-entry os.RemoveAll works when nothing root-owned is
+// present; buildkitd's cache (written as root in the privileged container)
+// defeats a user-context rm, so on failure it falls back to a throwaway root
+// container that clears the contents (never the dir).
+func clearSharedDir(fleetName string) error {
 	dir, err := SharedDir(fleetName)
 	if err != nil {
 		return err
 	}
-	if err := os.RemoveAll(dir); err == nil {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	cleared := true
+	for _, e := range entries {
+		if err := os.RemoveAll(filepath.Join(dir, e.Name())); err != nil {
+			cleared = false
+			break
+		}
+	}
+	if cleared {
 		return nil
 	}
-	parent := filepath.Dir(dir)
-	base := filepath.Base(dir)
-	if out, err := runDocker("run", "--rm", "--entrypoint", "rm", "-v", parent+":/work", image, "-rf", "/work/"+base); err != nil {
-		return fmt.Errorf("remove buildkit dir %s: %w (%s)", dir, err, out)
+	// Root-owned cache → clear the contents (NOT the dir) via a throwaway root
+	// container, preserving the .buildkit inode for instance bind mounts.
+	if out, err := runDocker("run", "--rm", "--entrypoint", "sh", "-v", dir+":/work", image,
+		"-c", "rm -rf /work/* /work/.[!.]* /work/..?* 2>/dev/null; true"); err != nil {
+		return fmt.Errorf("clear buildkit dir %s: %w (%s)", dir, err, out)
 	}
 	return nil
 }

--- a/internal/buildkit/buildkit_test.go
+++ b/internal/buildkit/buildkit_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -259,6 +260,10 @@ func TestDeleteCacheWipesAndRestarts(t *testing.T) {
 	if err := os.WriteFile(marker, []byte("stale"), 0o644); err != nil {
 		t.Fatalf("seed marker: %v", err)
 	}
+	// Capture the .buildkit directory inode: it MUST survive the wipe, or running
+	// instances' bind mounts of it would be orphaned (the new socket would be
+	// invisible inside the instance).
+	beforeIno := inodeOf(t, dir)
 
 	if err := DeleteCache("alpha"); err != nil {
 		t.Fatalf("DeleteCache: %v", err)
@@ -273,10 +278,26 @@ func TestDeleteCacheWipesAndRestarts(t *testing.T) {
 	if _, err := os.Stat(marker); !os.IsNotExist(err) {
 		t.Fatalf("stale cache blob not removed: %v", err)
 	}
-	// The server is restarted, so the dir is recreated (empty).
 	if _, err := os.Stat(dir); err != nil {
-		t.Fatalf("buildkit dir should be recreated after restart: %v", err)
+		t.Fatalf("buildkit dir should still exist after wipe: %v", err)
 	}
+	if afterIno := inodeOf(t, dir); afterIno != beforeIno {
+		t.Fatalf("buildkit dir inode changed (%d -> %d): would orphan instance bind mounts", beforeIno, afterIno)
+	}
+}
+
+// inodeOf returns the inode number of path (Linux/Unix).
+func inodeOf(t *testing.T, path string) uint64 {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Skip("inode check unsupported on this platform")
+	}
+	return st.Ino
 }
 
 func TestStopSharedServer(t *testing.T) {

--- a/internal/buildkit/buildkit_test.go
+++ b/internal/buildkit/buildkit_test.go
@@ -3,6 +3,7 @@ package buildkit
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -234,6 +235,47 @@ func TestEnsureSharedServerConcurrentRunsOnce(t *testing.T) {
 	defer mu.Unlock()
 	if runCount != 1 {
 		t.Fatalf("docker run issued %d times, want exactly 1", runCount)
+	}
+}
+
+func TestDeleteCacheWipesAndRestarts(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	var calls [][]string
+	stubDocker(t, func(args []string) (string, error) {
+		calls = append(calls, args)
+		if args[0] == "inspect" {
+			return "", fmt.Errorf("No such object") // absent → restart docker-runs
+		}
+		return "", nil
+	})
+	stubWaitForSocket(t, nil)
+
+	// Seed a cache dir with a marker blob to prove it gets wiped.
+	dir := state.BuildkitDir("alpha")
+	if err := os.MkdirAll(filepath.Join(dir, "cache"), 0o777); err != nil {
+		t.Fatalf("seed cache dir: %v", err)
+	}
+	marker := filepath.Join(dir, "cache", "old-blob")
+	if err := os.WriteFile(marker, []byte("stale"), 0o644); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+
+	if err := DeleteCache("alpha"); err != nil {
+		t.Fatalf("DeleteCache: %v", err)
+	}
+
+	if !hasCall(calls, "rm") {
+		t.Fatalf("expected docker rm (stop), calls=%v", calls)
+	}
+	if !hasCall(calls, "run") {
+		t.Fatalf("expected docker run (restart), calls=%v", calls)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("stale cache blob not removed: %v", err)
+	}
+	// The server is restarted, so the dir is recreated (empty).
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("buildkit dir should be recreated after restart: %v", err)
 	}
 }
 

--- a/internal/server/buildkit.go
+++ b/internal/server/buildkit.go
@@ -21,10 +21,26 @@ var deleteBuildkitCache = buildkit.DeleteCache
 // server. Synchronous: it returns only once the cache is gone and the server is
 // back (or an error). The client uses a longer deadline for this call.
 func (s *service) DeleteBuildkitCache(_ context.Context, req *fleetgrpc.DeleteBuildkitCacheRequest) (*fleetgrpc.DeleteBuildkitCacheReply, error) {
-	if req.GetFleet() == "" {
+	fleetName := req.GetFleet()
+	if fleetName == "" {
 		return nil, status.Error(codes.InvalidArgument, "fleet is required")
 	}
-	if err := deleteBuildkitCache(req.GetFleet()); err != nil {
+	// Guard: only wipe for a fleet that actually has the buildkit server enabled.
+	// Otherwise DeleteCache's restart step would spin up a server the fleet never
+	// asked for. (The TUI only shows the button when enabled; this protects
+	// direct/stale callers.)
+	st, err := state.Load()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "load state: %v", err)
+	}
+	f, ok := st.Fleets[fleetName]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "fleet %q not found", fleetName)
+	}
+	if !f.Settings.BuildkitServer {
+		return nil, status.Errorf(codes.FailedPrecondition, "fleet %q does not have the buildkit server enabled", fleetName)
+	}
+	if err := deleteBuildkitCache(fleetName); err != nil {
 		return nil, status.Errorf(codes.Internal, "delete buildkit cache: %v", err)
 	}
 	return &fleetgrpc.DeleteBuildkitCacheReply{}, nil

--- a/internal/server/buildkit.go
+++ b/internal/server/buildkit.go
@@ -3,12 +3,32 @@ package server
 import (
 	"context"
 
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/buildkit"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+// deleteBuildkitCache is the cache-wipe seam (a package var so the RPC handler
+// can be tested without docker).
+var deleteBuildkitCache = buildkit.DeleteCache
+
+// DeleteBuildkitCache wipes a fleet's shared build cache and restarts the empty
+// server. Synchronous: it returns only once the cache is gone and the server is
+// back (or an error). The client uses a longer deadline for this call.
+func (s *service) DeleteBuildkitCache(_ context.Context, req *fleetgrpc.DeleteBuildkitCacheRequest) (*fleetgrpc.DeleteBuildkitCacheReply, error) {
+	if req.GetFleet() == "" {
+		return nil, status.Error(codes.InvalidArgument, "fleet is required")
+	}
+	if err := deleteBuildkitCache(req.GetFleet()); err != nil {
+		return nil, status.Errorf(codes.Internal, "delete buildkit cache: %v", err)
+	}
+	return &fleetgrpc.DeleteBuildkitCacheReply{}, nil
+}
 
 // ensureBuildkitServer is the re-ensure seam (a package var so the TUI-connect
 // sweep can be exercised in tests without docker). Mirrors stopBuildkitServer in

--- a/internal/server/buildkit_cache_test.go
+++ b/internal/server/buildkit_cache_test.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestDeleteBuildkitCacheRPC verifies the handler delegates to the cache-wipe
+// seam and validates its input.
+func TestDeleteBuildkitCacheRPC(t *testing.T) {
+	var gotFleet string
+	orig := deleteBuildkitCache
+	deleteBuildkitCache = func(fleet string) error { gotFleet = fleet; return nil }
+	t.Cleanup(func() { deleteBuildkitCache = orig })
+
+	svc := newService()
+	if _, err := svc.DeleteBuildkitCache(context.Background(), &fleetgrpc.DeleteBuildkitCacheRequest{Fleet: "alpha"}); err != nil {
+		t.Fatalf("DeleteBuildkitCache: %v", err)
+	}
+	if gotFleet != "alpha" {
+		t.Fatalf("seam called with %q, want alpha", gotFleet)
+	}
+
+	// Empty fleet -> InvalidArgument, seam not called.
+	gotFleet = ""
+	if _, err := svc.DeleteBuildkitCache(context.Background(), &fleetgrpc.DeleteBuildkitCacheRequest{}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("empty fleet: want InvalidArgument, got %v", err)
+	}
+	if gotFleet != "" {
+		t.Fatalf("seam should not run for an empty fleet")
+	}
+}

--- a/internal/server/buildkit_cache_test.go
+++ b/internal/server/buildkit_cache_test.go
@@ -5,32 +5,57 @@ import (
 	"testing"
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-// TestDeleteBuildkitCacheRPC verifies the handler delegates to the cache-wipe
-// seam and validates its input.
+// TestDeleteBuildkitCacheRPC verifies the handler validates its input + the
+// fleet's buildkit state, then delegates to the cache-wipe seam.
 func TestDeleteBuildkitCacheRPC(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Settings: fleet.FleetSettings{BuildkitServer: true}},
+		"beta":  {Name: "beta"}, // buildkit disabled
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
 	var gotFleet string
 	orig := deleteBuildkitCache
 	deleteBuildkitCache = func(fleet string) error { gotFleet = fleet; return nil }
 	t.Cleanup(func() { deleteBuildkitCache = orig })
 
 	svc := newService()
-	if _, err := svc.DeleteBuildkitCache(context.Background(), &fleetgrpc.DeleteBuildkitCacheRequest{Fleet: "alpha"}); err != nil {
-		t.Fatalf("DeleteBuildkitCache: %v", err)
+	ctx := context.Background()
+
+	// Happy path: enabled fleet → seam runs.
+	if _, err := svc.DeleteBuildkitCache(ctx, &fleetgrpc.DeleteBuildkitCacheRequest{Fleet: "alpha"}); err != nil {
+		t.Fatalf("DeleteBuildkitCache(alpha): %v", err)
 	}
 	if gotFleet != "alpha" {
 		t.Fatalf("seam called with %q, want alpha", gotFleet)
 	}
 
-	// Empty fleet -> InvalidArgument, seam not called.
+	// Empty fleet → InvalidArgument, seam not called.
 	gotFleet = ""
-	if _, err := svc.DeleteBuildkitCache(context.Background(), &fleetgrpc.DeleteBuildkitCacheRequest{}); status.Code(err) != codes.InvalidArgument {
+	if _, err := svc.DeleteBuildkitCache(ctx, &fleetgrpc.DeleteBuildkitCacheRequest{}); status.Code(err) != codes.InvalidArgument {
 		t.Fatalf("empty fleet: want InvalidArgument, got %v", err)
 	}
+
+	// Unknown fleet → NotFound, seam not called.
+	if _, err := svc.DeleteBuildkitCache(ctx, &fleetgrpc.DeleteBuildkitCacheRequest{Fleet: "ghost"}); status.Code(err) != codes.NotFound {
+		t.Fatalf("unknown fleet: want NotFound, got %v", err)
+	}
+
+	// Fleet without buildkit enabled → FailedPrecondition (must NOT spin up a
+	// server via the restart step).
+	if _, err := svc.DeleteBuildkitCache(ctx, &fleetgrpc.DeleteBuildkitCacheRequest{Fleet: "beta"}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("disabled fleet: want FailedPrecondition, got %v", err)
+	}
+
 	if gotFleet != "" {
-		t.Fatalf("seam should not run for an empty fleet")
+		t.Fatalf("seam should not run for invalid/disabled fleets, ran for %q", gotFleet)
 	}
 }

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -205,6 +205,25 @@ var destroyFleetRemote = func(name string) error {
 	})
 }
 
+// deleteCacheTimeout bounds the buildkit cache-wipe RPC. It is longer than the
+// ordinary mutationTimeout because the server stops the container, removes the
+// cache, and restarts the server (which waits for the new socket) — seconds of
+// work, not the sub-second a normal mutation takes.
+const deleteCacheTimeout = 60 * time.Second
+
+// deleteBuildkitCacheRemote asks the server to wipe a fleet's shared build cache
+// and restart the (empty) buildkit server. Uses its own longer deadline.
+var deleteBuildkitCacheRemote = func(fleetName string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), deleteCacheTimeout)
+	defer cancel()
+	conn, err := dialMutation(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = conn.Service().DeleteBuildkitCache(ctx, &fleetgrpc.DeleteBuildkitCacheRequest{Fleet: fleetName})
+	return err
+}
+
 // notifyTUIConnectedRemote tells the server a TUI has opened so it can run its
 // once-per-open state reconciliation (e.g. re-ensuring configured buildkit
 // servers). Fire-and-forget: the server returns immediately and does the work

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -205,11 +205,12 @@ var destroyFleetRemote = func(name string) error {
 	})
 }
 
-// deleteCacheTimeout bounds the buildkit cache-wipe RPC. It is longer than the
-// ordinary mutationTimeout because the server stops the container, removes the
-// cache, and restarts the server (which waits for the new socket) — seconds of
-// work, not the sub-second a normal mutation takes.
-const deleteCacheTimeout = 60 * time.Second
+// deleteCacheTimeout bounds the buildkit cache-wipe RPC. It is much longer than
+// the ordinary mutationTimeout because the server stops the container, removes
+// the cache, and restarts the server — which on first run may pull the
+// moby/buildkit image and then waits up to ~15s for the new socket. 120s keeps
+// the common case from timing out before the server reports success.
+const deleteCacheTimeout = 120 * time.Second
 
 // deleteBuildkitCacheRemote asks the server to wipe a fleet's shared build cache
 // and restart the (empty) buildkit server. Uses its own longer deadline.

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -1056,11 +1056,46 @@ const (
 	editFleetRowClaude = iota
 	editFleetRowCodex
 	editFleetRowGh
-	editFleetRowBuildkit
 	editFleetRowHomeDir
 	editFleetRowPreferFleetLaunch
+	editFleetRowCaching  // collapsible section header
+	editFleetRowBuildkit // child of Caching; only navigable when expanded
 	editFleetRowCount
 )
+
+// visibleEditFleetRows returns the edit-fleet dialog's navigable rows in display
+// order. The Buildkit row only appears while the Caching section is expanded.
+func (fleetPage *fleetPage) visibleEditFleetRows() []int {
+	rows := []int{
+		editFleetRowClaude,
+		editFleetRowCodex,
+		editFleetRowGh,
+		editFleetRowHomeDir,
+		editFleetRowPreferFleetLaunch,
+		editFleetRowCaching,
+	}
+	if fleetPage.dialogCachingExpanded {
+		rows = append(rows, editFleetRowBuildkit)
+	}
+	return rows
+}
+
+// moveEditFleetRow moves the dialog cursor by delta within the visible rows,
+// wrapping, and resets the per-row sub-state (button focus / delete confirm).
+func (fleetPage *fleetPage) moveEditFleetRow(delta int) {
+	rows := fleetPage.visibleEditFleetRows()
+	idx := 0
+	for i, r := range rows {
+		if r == fleetPage.dialogRow {
+			idx = i
+			break
+		}
+	}
+	fleetPage.dialogRow = rows[(idx+delta+len(rows))%len(rows)]
+	fleetPage.dialogBuildkitButtonFocused = false
+	fleetPage.dialogDeleteCacheConfirm = false
+	fleetPage.syncEditFleetFocus()
+}
 
 // homedirDetectedMsg is delivered when an asynchronous home-directory
 // detection cmd completes. The fleetName lets the receiver discard
@@ -1125,6 +1160,10 @@ func (fleetPage *fleetPage) openEditFleetDialog(m *model) tea.Cmd {
 	fleetPage.dialogRow = editFleetRowClaude
 	fleetPage.dialogDetecting = false
 	fleetPage.dialogFieldActive = false
+	fleetPage.dialogCachingExpanded = false
+	fleetPage.dialogBuildkitButtonFocused = false
+	fleetPage.dialogDeleteCacheConfirm = false
+	fleetPage.dialogDeletingCache = false
 
 	fleetPage.homedirInput.SetValue(f.Settings.HomeDir)
 	fleetPage.homedirInput.Blur()
@@ -1174,23 +1213,26 @@ func (fleetPage *fleetPage) updateEditFleet(m *model, msg tea.Msg) tea.Cmd {
 
 	switch keyMsg.String() {
 	case "up", "k":
-		fleetPage.dialogRow = (fleetPage.dialogRow - 1 + editFleetRowCount) % editFleetRowCount
-		fleetPage.syncEditFleetFocus()
+		fleetPage.moveEditFleetRow(-1)
 		return nil
 
 	case "down", "j", "tab":
-		fleetPage.dialogRow = (fleetPage.dialogRow + 1) % editFleetRowCount
-		fleetPage.syncEditFleetFocus()
+		fleetPage.moveEditFleetRow(1)
 		return nil
 
 	case "esc", "q", "Q", "ctrl+c":
+		// An armed delete-cache confirm is cancelled first, not the dialog.
+		if fleetPage.dialogDeleteCacheConfirm {
+			fleetPage.dialogDeleteCacheConfirm = false
+			return nil
+		}
 		fleetPage.closeEditFleet(m)
 		return nil
 	}
 
 	// Row-specific actions.
 	switch fleetPage.dialogRow {
-	case editFleetRowClaude, editFleetRowCodex, editFleetRowGh, editFleetRowBuildkit, editFleetRowPreferFleetLaunch:
+	case editFleetRowClaude, editFleetRowCodex, editFleetRowGh, editFleetRowPreferFleetLaunch:
 		// space/x and h/l/enter all toggle (instant-save), matching the
 		// settings page.
 		switch keyMsg.String() {
@@ -1198,6 +1240,18 @@ func (fleetPage *fleetPage) updateEditFleet(m *model, msg tea.Msg) tea.Cmd {
 			return fleetPage.toggleEditFleetRow(m)
 		}
 		return nil
+	case editFleetRowCaching:
+		switch keyMsg.String() {
+		case " ", "enter":
+			fleetPage.dialogCachingExpanded = !fleetPage.dialogCachingExpanded
+		case "right", "l":
+			fleetPage.dialogCachingExpanded = true
+		case "left", "h":
+			fleetPage.dialogCachingExpanded = false
+		}
+		return nil
+	case editFleetRowBuildkit:
+		return fleetPage.updateBuildkitRow(m, keyMsg)
 	case editFleetRowHomeDir:
 		switch keyMsg.String() {
 		case "enter", " ":
@@ -1213,6 +1267,75 @@ func (fleetPage *fleetPage) updateEditFleet(m *model, msg tea.Msg) tea.Cmd {
 			fleetPage.homedirInput, inputCmd = fleetPage.homedirInput.Update(msg)
 			return tea.Batch(blinkCmd, inputCmd)
 		}
+	}
+	return nil
+}
+
+// updateBuildkitRow handles the Buildkit server row inside the expanded Caching
+// section: space/x toggles the setting (instant-save); when enabled, →/l focuses
+// the [Delete cache] button and ←/h returns to the toggle; Enter on the button
+// arms an inline confirm, and a second Enter performs the wipe asynchronously.
+func (fleetPage *fleetPage) updateBuildkitRow(m *model, keyMsg tea.KeyMsg) tea.Cmd {
+	// Ignore mutating keys while a wipe is in flight (navigation already ran).
+	if fleetPage.dialogDeletingCache {
+		return nil
+	}
+	switch keyMsg.String() {
+	case " ", "x":
+		cmd := fleetPage.toggleEditFleetRow(m)
+		if !fleetPage.dialogBuildkitServer {
+			// No server → no button; drop any button focus / armed confirm.
+			fleetPage.dialogBuildkitButtonFocused = false
+			fleetPage.dialogDeleteCacheConfirm = false
+		}
+		return cmd
+	case "right", "l":
+		if fleetPage.dialogBuildkitServer {
+			fleetPage.dialogBuildkitButtonFocused = true
+		}
+		return nil
+	case "left", "h":
+		fleetPage.dialogBuildkitButtonFocused = false
+		fleetPage.dialogDeleteCacheConfirm = false
+		return nil
+	case "enter":
+		if fleetPage.dialogBuildkitButtonFocused && fleetPage.dialogBuildkitServer {
+			if !fleetPage.dialogDeleteCacheConfirm {
+				fleetPage.dialogDeleteCacheConfirm = true // first Enter: arm confirm
+				return nil
+			}
+			fleetPage.dialogDeleteCacheConfirm = false // second Enter: do it
+			fleetPage.dialogDeletingCache = true
+			return deleteCacheCmd(fleetPage.dialogFleet)
+		}
+		// Toggle focused → toggle the setting.
+		return fleetPage.toggleEditFleetRow(m)
+	}
+	return nil
+}
+
+// deleteCacheDoneMsg reports the outcome of a buildkit cache wipe.
+type deleteCacheDoneMsg struct {
+	fleet string
+	err   error
+}
+
+// deleteCacheCmd runs the cache-wipe RPC off the UI loop and reports the result.
+func deleteCacheCmd(fleetName string) tea.Cmd {
+	return func() tea.Msg {
+		return deleteCacheDoneMsg{fleet: fleetName, err: deleteBuildkitCacheRemote(fleetName)}
+	}
+}
+
+// handleDeleteCacheDone clears the in-flight flag and surfaces the outcome.
+func (fleetPage *fleetPage) handleDeleteCacheDone(m *model, msg deleteCacheDoneMsg) tea.Cmd {
+	if fleetPage.dialogFleet == msg.fleet {
+		fleetPage.dialogDeletingCache = false
+	}
+	if msg.err != nil {
+		m.message = fmt.Sprintf("Delete cache failed: %v", msg.err)
+	} else {
+		m.message = "Build cache cleared"
 	}
 	return nil
 }
@@ -1390,6 +1513,8 @@ func (fleetPage *fleetPage) restoreHomedir(m *model) {
 // commit on close — every change was persisted as it was made.
 func (fleetPage *fleetPage) closeEditFleet(_ *model) {
 	fleetPage.mode = viewNormal
+	fleetPage.dialogDeleteCacheConfirm = false
+	fleetPage.dialogBuildkitButtonFocused = false
 	fleetPage.blurDialogFields()
 }
 

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -1241,10 +1241,17 @@ func (fleetPage *fleetPage) toggleEditFleetRow(m *model) tea.Cmd {
 		fleetPage.dialogBuildkitServer = !fleetPage.dialogBuildkitServer
 		revert = func() { fleetPage.dialogBuildkitServer = !fleetPage.dialogBuildkitServer }
 	case editFleetRowPreferFleetLaunch:
+		prevSet := fleetPage.dialogPreferFleetLaunchSet
 		fleetPage.dialogPreferFleetLaunch = !fleetPage.dialogPreferFleetLaunch
 		// The user explicitly chose a value, so it must now persist.
 		fleetPage.dialogPreferFleetLaunchSet = true
-		revert = func() { fleetPage.dialogPreferFleetLaunch = !fleetPage.dialogPreferFleetLaunch }
+		// Revert BOTH the value and the set-flag on save failure — otherwise a
+		// failed toggle would leave dialogPreferFleetLaunchSet=true and a later
+		// unrelated save would collapse a "never asked" (nil) tri-state.
+		revert = func() {
+			fleetPage.dialogPreferFleetLaunch = !fleetPage.dialogPreferFleetLaunch
+			fleetPage.dialogPreferFleetLaunchSet = prevSet
+		}
 	default:
 		return nil
 	}

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -1121,6 +1121,7 @@ func (fleetPage *fleetPage) openEditFleetDialog(m *model) tea.Cmd {
 	fleetPage.dialogGhMount = f.Settings.GhMount
 	fleetPage.dialogBuildkitServer = f.Settings.BuildkitServer
 	fleetPage.dialogPreferFleetLaunch = f.Settings.PreferFleetLaunchEnabled()
+	fleetPage.dialogPreferFleetLaunchSet = f.Settings.PreferFleetLaunchSet()
 	fleetPage.dialogRow = editFleetRowClaude
 	fleetPage.dialogDetecting = false
 	fleetPage.dialogFieldActive = false
@@ -1134,27 +1135,33 @@ func (fleetPage *fleetPage) openEditFleetDialog(m *model) tea.Cmd {
 	return nil
 }
 
-// updateEditFleet handles the edit-fleet dialog: arrow-key navigation
-// between rows, space/x toggling the mount checkboxes, character keys
-// editing the home-dir text input, enter committing, esc cancelling.
+// updateEditFleet handles the edit-fleet dialog. The dialog is INSTANT-SAVE
+// (like the settings page): every toggle and every committed home-dir edit
+// persists immediately, so there is no explicit "save" key — esc/q just closes,
+// and a per-change RPC failure is reverted in place.
 func (fleetPage *fleetPage) updateEditFleet(m *model, msg tea.Msg) tea.Cmd {
 	keyMsg, ok := msg.(tea.KeyMsg)
 	if !ok {
 		return nil
 	}
 
+	// Home-dir text-editing sub-mode.
 	if fleetPage.dialogFieldActive {
 		switch keyMsg.String() {
 		case "enter":
-			return fleetPage.saveFleetEdits(m)
+			// Commit the typed value (instant-save) and leave editing.
+			cmd := fleetPage.commitHomedir(m)
+			fleetPage.dialogFieldActive = false
+			fleetPage.syncEditFleetFocus()
+			return cmd
 		case "esc":
+			// Discard the uncommitted edit; restore the persisted value.
+			fleetPage.restoreHomedir(m)
 			fleetPage.dialogFieldActive = false
 			fleetPage.syncEditFleetFocus()
 			return nil
 		case "ctrl+c":
-			fleetPage.mode = viewNormal
-			fleetPage.blurDialogFields()
-			m.message = "Cancelled"
+			fleetPage.closeEditFleet(m)
 			return nil
 		}
 		if fleetPage.dialogRow == editFleetRowHomeDir {
@@ -1162,47 +1169,38 @@ func (fleetPage *fleetPage) updateEditFleet(m *model, msg tea.Msg) tea.Cmd {
 			fleetPage.homedirInput, cmd = fleetPage.homedirInput.Update(msg)
 			return cmd
 		}
+		return nil
 	}
 
 	switch keyMsg.String() {
-	case "enter":
-		if fleetPage.dialogRow == editFleetRowHomeDir {
-			fleetPage.dialogFieldActive = true
-			fleetPage.syncEditFleetFocus()
-			return fleetPage.homedirInput.Cursor.BlinkCmd()
-		}
-		return fleetPage.saveFleetEdits(m)
-
 	case "up", "k":
-		fleetPage.dialogFieldActive = false
 		fleetPage.dialogRow = (fleetPage.dialogRow - 1 + editFleetRowCount) % editFleetRowCount
 		fleetPage.syncEditFleetFocus()
 		return nil
 
 	case "down", "j", "tab":
-		fleetPage.dialogFieldActive = false
 		fleetPage.dialogRow = (fleetPage.dialogRow + 1) % editFleetRowCount
 		fleetPage.syncEditFleetFocus()
 		return nil
 
 	case "esc", "q", "Q", "ctrl+c":
-		fleetPage.mode = viewNormal
-		fleetPage.blurDialogFields()
-		m.message = "Cancelled"
+		fleetPage.closeEditFleet(m)
 		return nil
 	}
 
-	// Toggle / character input is row-specific.
+	// Row-specific actions.
 	switch fleetPage.dialogRow {
 	case editFleetRowClaude, editFleetRowCodex, editFleetRowGh, editFleetRowBuildkit, editFleetRowPreferFleetLaunch:
+		// space/x and h/l/enter all toggle (instant-save), matching the
+		// settings page.
 		switch keyMsg.String() {
-		case " ", "left", "right", "h", "l", "x":
+		case " ", "left", "right", "h", "l", "x", "enter":
 			return fleetPage.toggleEditFleetRow(m)
 		}
 		return nil
 	case editFleetRowHomeDir:
 		switch keyMsg.String() {
-		case " ":
+		case "enter", " ":
 			fleetPage.dialogFieldActive = true
 			fleetPage.syncEditFleetFocus()
 			return fleetPage.homedirInput.Cursor.BlinkCmd()
@@ -1219,40 +1217,51 @@ func (fleetPage *fleetPage) updateEditFleet(m *model, msg tea.Msg) tea.Cmd {
 	return nil
 }
 
-// toggleEditFleetRow flips the boolean for the currently focused
-// checkbox row. When a mount is being turned on it may also kick off
-// auto-detection of the container's home directory so the user does
-// not have to type it themselves.
+// toggleEditFleetRow flips the boolean for the currently focused checkbox row
+// and persists it immediately (reverting the flip if the save fails). When a
+// home-dir mount is turned on it may also kick off auto-detection of the
+// container's home directory.
 func (fleetPage *fleetPage) toggleEditFleetRow(m *model) tea.Cmd {
 	turnedOn := false
+	var revert func()
 	switch fleetPage.dialogRow {
 	case editFleetRowClaude:
 		fleetPage.dialogClaudeMount = !fleetPage.dialogClaudeMount
 		turnedOn = fleetPage.dialogClaudeMount
+		revert = func() { fleetPage.dialogClaudeMount = !fleetPage.dialogClaudeMount }
 	case editFleetRowCodex:
 		fleetPage.dialogCodexMount = !fleetPage.dialogCodexMount
 		turnedOn = fleetPage.dialogCodexMount
+		revert = func() { fleetPage.dialogCodexMount = !fleetPage.dialogCodexMount }
 	case editFleetRowGh:
 		fleetPage.dialogGhMount = !fleetPage.dialogGhMount
 		turnedOn = fleetPage.dialogGhMount
+		revert = func() { fleetPage.dialogGhMount = !fleetPage.dialogGhMount }
 	case editFleetRowBuildkit:
-		// Not a home-dir mount, so no detection to kick off — just flip it.
 		fleetPage.dialogBuildkitServer = !fleetPage.dialogBuildkitServer
-		return nil
+		revert = func() { fleetPage.dialogBuildkitServer = !fleetPage.dialogBuildkitServer }
 	case editFleetRowPreferFleetLaunch:
-		// Not a mount, so no home-dir detection to kick off — just flip it.
 		fleetPage.dialogPreferFleetLaunch = !fleetPage.dialogPreferFleetLaunch
+		// The user explicitly chose a value, so it must now persist.
+		fleetPage.dialogPreferFleetLaunchSet = true
+		revert = func() { fleetPage.dialogPreferFleetLaunch = !fleetPage.dialogPreferFleetLaunch }
+	default:
 		return nil
 	}
-	if !turnedOn {
+
+	if err := fleetPage.persistFleetSettings(m); err != nil {
+		if revert != nil {
+			revert()
+		}
+		m.message = fmt.Sprintf("Failed to save: %v", err)
 		return nil
 	}
-	f, ok := m.st.Fleets[fleetPage.dialogFleet]
-	if !ok {
-		return nil
-	}
-	if fleetPage.shouldKickHomedirDetect(f) {
-		return fleetPage.startHomedirDetect(f)
+
+	// On enabling a home-dir mount with no home dir recorded yet, auto-detect it.
+	if turnedOn {
+		if f, ok := m.st.Fleets[fleetPage.dialogFleet]; ok && fleetPage.shouldKickHomedirDetect(f) {
+			return fleetPage.startHomedirDetect(f)
+		}
 	}
 	return nil
 }
@@ -1281,26 +1290,31 @@ func (fleetPage *fleetPage) startHomedirDetect(f *fleet.Fleet) tea.Cmd {
 	return detectHomedirCmd(f.Name, f.Remote, "")
 }
 
-// handleHomedirDetected applies the result of an auto-detection. The
-// guard checks ensure stale results — from a fleet the user has since
-// closed, or arriving after the user has already typed a value —
-// never overwrite live state.
-func (fleetPage *fleetPage) handleHomedirDetected(msg homedirDetectedMsg) {
+// handleHomedirDetected applies the result of an auto-detection and (instant
+// save) persists the detected value. The guard checks ensure stale results —
+// from a fleet the user has since closed, or arriving after the user has
+// already typed a value — never overwrite live state.
+func (fleetPage *fleetPage) handleHomedirDetected(m *model, msg homedirDetectedMsg) tea.Cmd {
 	// Always clear the in-flight flag for *this* fleet so the spinner
 	// stops, even when the result is not applied.
 	if fleetPage.dialogFleet == msg.fleetName {
 		fleetPage.dialogDetecting = false
 	}
 	if msg.err != nil || msg.homeDir == "" {
-		return
+		return nil
 	}
 	if fleetPage.mode != viewEditFleet || fleetPage.dialogFleet != msg.fleetName {
-		return
+		return nil
 	}
 	if strings.TrimSpace(fleetPage.homedirInput.Value()) != "" {
-		return
+		return nil
 	}
 	fleetPage.homedirInput.SetValue(msg.homeDir)
+	if err := fleetPage.persistFleetSettings(m); err != nil {
+		fleetPage.restoreHomedir(m)
+		m.message = fmt.Sprintf("Failed to save: %v", err)
+	}
+	return nil
 }
 
 // syncEditFleetFocus moves the cursor blink to the home-dir input only
@@ -1314,31 +1328,62 @@ func (fleetPage *fleetPage) syncEditFleetFocus() {
 	}
 }
 
-// saveFleetEdits commits the dialog's mount toggles + home-dir to the
-// fleet's persisted settings and closes the dialog. Existing instances
-// are not retroactively re-mounted; the new settings apply to the next
-// instance provisioned on a supporting backend.
-func (fleetPage *fleetPage) saveFleetEdits(m *model) tea.Cmd {
+// persistFleetSettings writes the dialog's current state to the fleet record
+// and saves it through the server (instant-save). On RPC failure it reverts the
+// fleet record to its prior settings and returns the error so the caller can
+// undo its optimistic change too. Existing instances are not retroactively
+// re-mounted; settings apply to the next instance provisioned on a supporting
+// backend.
+//
+// PreferFleetLaunch is only written when the fleet already had a value or the
+// user toggled it this session (dialogPreferFleetLaunchSet) — so editing an
+// unrelated setting never collapses a "never asked" (nil) into explicit false.
+func (fleetPage *fleetPage) persistFleetSettings(m *model) error {
 	f, ok := m.st.Fleets[fleetPage.dialogFleet]
 	if !ok {
-		fleetPage.mode = viewNormal
-		fleetPage.blurDialogFields()
-		m.message = fmt.Sprintf("Fleet %s not found", fleetPage.dialogFleet)
-		return nil
+		return fmt.Errorf("fleet %s not found", fleetPage.dialogFleet)
 	}
+	prev := f.Settings
 	f.Settings.ClaudeCodeMount = fleetPage.dialogClaudeMount
 	f.Settings.CodexMount = fleetPage.dialogCodexMount
 	f.Settings.GhMount = fleetPage.dialogGhMount
 	f.Settings.BuildkitServer = fleetPage.dialogBuildkitServer
-	preferFleetLaunch := fleetPage.dialogPreferFleetLaunch
-	f.Settings.PreferFleetLaunch = &preferFleetLaunch
+	if fleetPage.dialogPreferFleetLaunchSet {
+		preferFleetLaunch := fleetPage.dialogPreferFleetLaunch
+		f.Settings.PreferFleetLaunch = &preferFleetLaunch
+	}
 	f.Settings.HomeDir = strings.TrimSpace(fleetPage.homedirInput.Value())
-	_ = setFleetSettingsRemote(fleetPage.dialogFleet, f.Settings)
 
+	if err := setFleetSettingsRemote(fleetPage.dialogFleet, f.Settings); err != nil {
+		f.Settings = prev
+		return err
+	}
+	return nil
+}
+
+// commitHomedir persists the current home-dir input value (instant-save),
+// restoring the input to the saved value if the save fails.
+func (fleetPage *fleetPage) commitHomedir(m *model) tea.Cmd {
+	if err := fleetPage.persistFleetSettings(m); err != nil {
+		fleetPage.restoreHomedir(m)
+		m.message = fmt.Sprintf("Failed to save: %v", err)
+	}
+	return nil
+}
+
+// restoreHomedir resets the home-dir input to the fleet's persisted value (used
+// to discard an uncommitted edit or undo a failed save).
+func (fleetPage *fleetPage) restoreHomedir(m *model) {
+	if f, ok := m.st.Fleets[fleetPage.dialogFleet]; ok {
+		fleetPage.homedirInput.SetValue(f.Settings.HomeDir)
+	}
+}
+
+// closeEditFleet closes the dialog. Instant-save means there is nothing to
+// commit on close — every change was persisted as it was made.
+func (fleetPage *fleetPage) closeEditFleet(_ *model) {
 	fleetPage.mode = viewNormal
 	fleetPage.blurDialogFields()
-	m.message = fmt.Sprintf("Updated %s settings", f.Name)
-	return nil
 }
 
 // ===========================================

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -1084,14 +1084,20 @@ func (fleetPage *fleetPage) visibleEditFleetRows() []int {
 // wrapping, and resets the per-row sub-state (button focus / delete confirm).
 func (fleetPage *fleetPage) moveEditFleetRow(delta int) {
 	rows := fleetPage.visibleEditFleetRows()
-	idx := 0
+	idx, found := 0, false
 	for i, r := range rows {
 		if r == fleetPage.dialogRow {
-			idx = i
+			idx, found = i, true
 			break
 		}
 	}
-	fleetPage.dialogRow = rows[(idx+delta+len(rows))%len(rows)]
+	if found {
+		fleetPage.dialogRow = rows[(idx+delta+len(rows))%len(rows)]
+	} else {
+		// The current row is no longer visible (e.g. its section collapsed under
+		// the cursor) — recover by landing on the first visible row.
+		fleetPage.dialogRow = rows[0]
+	}
 	fleetPage.dialogBuildkitButtonFocused = false
 	fleetPage.dialogDeleteCacheConfirm = false
 	fleetPage.syncEditFleetFocus()
@@ -1282,11 +1288,13 @@ func (fleetPage *fleetPage) updateBuildkitRow(m *model, keyMsg tea.KeyMsg) tea.C
 	}
 	switch keyMsg.String() {
 	case " ", "x":
+		// Toggling is a different action than confirming a delete, so always
+		// disarm the confirm.
+		fleetPage.dialogDeleteCacheConfirm = false
 		cmd := fleetPage.toggleEditFleetRow(m)
 		if !fleetPage.dialogBuildkitServer {
-			// No server → no button; drop any button focus / armed confirm.
+			// No server → no button; drop button focus too.
 			fleetPage.dialogBuildkitButtonFocused = false
-			fleetPage.dialogDeleteCacheConfirm = false
 		}
 		return cmd
 	case "right", "l":
@@ -1515,6 +1523,10 @@ func (fleetPage *fleetPage) closeEditFleet(_ *model) {
 	fleetPage.mode = viewNormal
 	fleetPage.dialogDeleteCacheConfirm = false
 	fleetPage.dialogBuildkitButtonFocused = false
+	// Clear the in-flight flag too: a wipe RPC may still be running, but its
+	// deleteCacheDoneMsg is matched on fleet name and only updates the message,
+	// so the dialog must not reopen showing a stale "Clearing…" spinner.
+	fleetPage.dialogDeletingCache = false
 	fleetPage.blurDialogFields()
 }
 

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -1712,7 +1712,7 @@ func (fleetPage *fleetPage) editFleetHint() string {
 	if fleetPage.dialogFieldActive {
 		return "[enter] Save  [esc] Discard edit"
 	}
-	return "[j/k] Select  [h/l/space] Toggle  [enter] Edit  [q/esc] Close · saved instantly"
+	return "[j/k] Select  [h/l/space] Toggle  [enter] Edit  [q/esc] Save & Close"
 }
 
 func (fleetPage *fleetPage) portForwardHint() string {

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -1771,8 +1771,11 @@ func (fleetPage *fleetPage) editFleetHint() string {
 			return "[space] Toggle  [l/→] Delete-cache button  [j/k] Select"
 		}
 		return "[space] Toggle  [j/k] Select  [q/esc] Save & Close"
+	case editFleetRowHomeDir:
+		return "[enter] Edit  [j/k] Select  [q/esc] Save & Close"
 	}
-	return "[j/k] Select  [h/l/space] Toggle  [enter] Edit  [q/esc] Save & Close"
+	// Flat checkbox rows: Enter/space/h/l all toggle (instant-save).
+	return "[j/k] Select  [space/enter/h/l] Toggle  [q/esc] Save & Close"
 }
 
 func (fleetPage *fleetPage) portForwardHint() string {

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -53,6 +53,12 @@ type fleetPage struct {
 	// instant-save path never collapses a "never asked" (nil) PreferFleetLaunch
 	// into an explicit false just because the user edited an unrelated setting.
 	dialogPreferFleetLaunchSet bool
+
+	// Caching section (edit-fleet dialog) state.
+	dialogCachingExpanded       bool // ▼ Caching expanded, revealing the Buildkit row
+	dialogBuildkitButtonFocused bool // horizontal sub-cursor: on the [Delete cache] button vs the toggle
+	dialogDeleteCacheConfirm    bool // inline confirm armed (first Enter on the button)
+	dialogDeletingCache         bool // a cache-wipe RPC is in flight
 	dialogDetecting         bool // true while a homedir auto-detect cmd is in flight
 
 	// dialogBrowserSwitching is true while the switch-browser dialog
@@ -205,6 +211,9 @@ func (fleetPage *fleetPage) Update(m *model, msg tea.Msg) tea.Cmd {
 
 	case homedirDetectedMsg:
 		return fleetPage.handleHomedirDetected(m, msg.(homedirDetectedMsg))
+
+	case deleteCacheDoneMsg:
+		return fleetPage.handleDeleteCacheDone(m, msg.(deleteCacheDoneMsg))
 
 	case devcontainerInspectedMsg:
 		return fleetPage.handleDevcontainerInspected(m, msg.(devcontainerInspectedMsg))
@@ -1425,65 +1434,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 
 	case viewEditFleet:
 		b.WriteString("\n")
-		rowMarker := func(r int) string {
-			if fleetPage.dialogRow == r {
-				return cursorStyle.Render("> ")
-			}
-			return "  "
-		}
-		checkbox := func(on bool) string {
-			if on {
-				return "[x]"
-			}
-			return "[ ]"
-		}
-
-		// Home-dir field: text input when focused, dim static text
-		// otherwise. Append a spinner + status when an auto-detect is
-		// running so the user knows the field will fill in soon (or
-		// can be safely typed over to discard the result).
-		var homedirField string
-		if fleetPage.dialogFieldActive && fleetPage.dialogRow == editFleetRowHomeDir {
-			homedirField = fleetPage.homedirInput.View()
-		} else {
-			value := fleetPage.homedirInput.Value()
-			if value == "" {
-				homedirField = dimStyle.Render("(unset — defaults to /home/vscode)")
-			} else {
-				homedirField = value
-			}
-		}
-		if fleetPage.dialogDetecting {
-			homedirField = homedirField + " " + m.spinner.View() + dimStyle.Render(" detecting home dir...")
-		}
-
-		dialog := fmt.Sprintf(
-			"%s\n\n  %s %s\n%s%s %s\n%s%s %s\n%s%s %s\n%s%s %s\n%s%s %s\n%s%s %s\n\n  %s\n\n%s",
-			dialogTitle.Render("Edit fleet"),
-			dialogLabel.Render("Fleet:    "),
-			fleetExpandedStyle.Render(fleetPage.dialogFleet),
-			rowMarker(editFleetRowClaude),
-			checkbox(fleetPage.dialogClaudeMount),
-			dialogLabel.Render("Claude Code mount"),
-			rowMarker(editFleetRowCodex),
-			checkbox(fleetPage.dialogCodexMount),
-			dialogLabel.Render("Codex mount"),
-			rowMarker(editFleetRowGh),
-			checkbox(fleetPage.dialogGhMount),
-			dialogLabel.Render("GitHub CLI mount"),
-			rowMarker(editFleetRowBuildkit),
-			checkbox(fleetPage.dialogBuildkitServer),
-			dialogLabel.Render("Buildkit server"),
-			rowMarker(editFleetRowHomeDir),
-			dialogLabel.Render("Home dir: "),
-			homedirField,
-			rowMarker(editFleetRowPreferFleetLaunch),
-			checkbox(fleetPage.dialogPreferFleetLaunch),
-			dialogLabel.Render("Prefer Fleet Launch"),
-			dimStyle.Render("Mounts apply on supported backends only"),
-			dialogHint.Render(fleetPage.editFleetHint()),
-		)
-		b.WriteString(dialogBox.Render(dialog))
+		b.WriteString(dialogBox.Render(fleetPage.renderEditFleet(m)))
 		b.WriteString("\n")
 
 	case viewTagInstance:
@@ -1708,9 +1659,116 @@ func (fleetPage *fleetPage) textDialogHint(action string) string {
 	return "[enter] Edit  [q/esc] Cancel"
 }
 
+// renderEditFleet builds the edit-fleet dialog body from the currently visible
+// rows. Instant-save means there is no explicit save row — toggles persist as
+// they're made and esc/q just closes.
+func (fleetPage *fleetPage) renderEditFleet(m *model) string {
+	marker := func(row int) string {
+		if fleetPage.dialogRow == row {
+			return cursorStyle.Render("> ")
+		}
+		return "  "
+	}
+	checkbox := func(on bool) string {
+		if on {
+			return "[x]"
+		}
+		return "[ ]"
+	}
+
+	var d strings.Builder
+	d.WriteString(dialogTitle.Render("Edit fleet"))
+	d.WriteString("\n\n")
+	d.WriteString("  " + dialogLabel.Render("Fleet:    ") + " " + fleetExpandedStyle.Render(fleetPage.dialogFleet) + "\n")
+
+	for _, row := range fleetPage.visibleEditFleetRows() {
+		switch row {
+		case editFleetRowClaude:
+			d.WriteString(marker(row) + checkbox(fleetPage.dialogClaudeMount) + " " + dialogLabel.Render("Claude Code mount"))
+		case editFleetRowCodex:
+			d.WriteString(marker(row) + checkbox(fleetPage.dialogCodexMount) + " " + dialogLabel.Render("Codex mount"))
+		case editFleetRowGh:
+			d.WriteString(marker(row) + checkbox(fleetPage.dialogGhMount) + " " + dialogLabel.Render("GitHub CLI mount"))
+		case editFleetRowHomeDir:
+			// Text input when focused, dim static text otherwise; append a
+			// spinner + status while an auto-detect runs.
+			var field string
+			if fleetPage.dialogFieldActive && fleetPage.dialogRow == editFleetRowHomeDir {
+				field = fleetPage.homedirInput.View()
+			} else if v := fleetPage.homedirInput.Value(); v == "" {
+				field = dimStyle.Render("(unset — defaults to /home/vscode)")
+			} else {
+				field = v
+			}
+			if fleetPage.dialogDetecting {
+				field += " " + m.spinner.View() + dimStyle.Render(" detecting home dir...")
+			}
+			d.WriteString(marker(row) + dialogLabel.Render("Home dir: ") + " " + field)
+		case editFleetRowPreferFleetLaunch:
+			d.WriteString(marker(row) + checkbox(fleetPage.dialogPreferFleetLaunch) + " " + dialogLabel.Render("Prefer Fleet Launch"))
+		case editFleetRowCaching:
+			arrow := "▶ "
+			if fleetPage.dialogCachingExpanded {
+				arrow = "▼ "
+			}
+			d.WriteString(marker(row) + dialogLabel.Render(arrow+"Caching"))
+		case editFleetRowBuildkit:
+			// Indented one level under the Caching header.
+			line := marker(row) + "  " + checkbox(fleetPage.dialogBuildkitServer) + " " + dialogLabel.Render("Buildkit server")
+			if fleetPage.dialogBuildkitServer {
+				line += "   " + fleetPage.renderDeleteCacheButton(m)
+			}
+			d.WriteString(line)
+		}
+		d.WriteString("\n")
+	}
+
+	d.WriteString("\n  " + dimStyle.Render("Mounts apply on supported backends only") + "\n\n")
+	d.WriteString(dialogHint.Render(fleetPage.editFleetHint()))
+	return d.String()
+}
+
+// renderDeleteCacheButton renders the [Delete cache] button shown next to an
+// enabled Buildkit server. It reflects the in-flight / inline-confirm state and
+// is highlighted when the horizontal sub-cursor is on it.
+func (fleetPage *fleetPage) renderDeleteCacheButton(m *model) string {
+	var label string
+	switch {
+	case fleetPage.dialogDeletingCache:
+		label = m.spinner.View() + " Clearing…"
+	case fleetPage.dialogDeleteCacheConfirm:
+		label = "Delete cache? enter=yes"
+	default:
+		label = "Delete cache"
+	}
+	text := "[ " + label + " ]"
+	if fleetPage.dialogBuildkitButtonFocused {
+		return selectedStyle.Render(text)
+	}
+	return dimStyle.Render(text)
+}
+
 func (fleetPage *fleetPage) editFleetHint() string {
 	if fleetPage.dialogFieldActive {
 		return "[enter] Save  [esc] Discard edit"
+	}
+	switch fleetPage.dialogRow {
+	case editFleetRowCaching:
+		if fleetPage.dialogCachingExpanded {
+			return "[h/←] Collapse  [j/k] Select  [q/esc] Save & Close"
+		}
+		return "[l/→/space] Expand  [j/k] Select  [q/esc] Save & Close"
+	case editFleetRowBuildkit:
+		if fleetPage.dialogBuildkitButtonFocused {
+			if fleetPage.dialogDeleteCacheConfirm {
+				return "[enter] Confirm wipe  [esc] Cancel"
+			}
+			return "[enter] Delete cache  [h/←] Back"
+		}
+		if fleetPage.dialogBuildkitServer {
+			return "[space] Toggle  [l/→] Delete-cache button  [j/k] Select"
+		}
+		return "[space] Toggle  [j/k] Select  [q/esc] Save & Close"
 	}
 	return "[j/k] Select  [h/l/space] Toggle  [enter] Edit  [q/esc] Save & Close"
 }

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -47,6 +47,12 @@ type fleetPage struct {
 	dialogGhMount           bool
 	dialogBuildkitServer    bool
 	dialogPreferFleetLaunch bool
+	// dialogPreferFleetLaunchSet tracks whether PreferFleetLaunch should be
+	// persisted as an explicit value. It starts true only if the fleet already
+	// had a value, and flips true when the user toggles that row — so the
+	// instant-save path never collapses a "never asked" (nil) PreferFleetLaunch
+	// into an explicit false just because the user edited an unrelated setting.
+	dialogPreferFleetLaunchSet bool
 	dialogDetecting         bool // true while a homedir auto-detect cmd is in flight
 
 	// dialogBrowserSwitching is true while the switch-browser dialog
@@ -198,8 +204,7 @@ func (fleetPage *fleetPage) Update(m *model, msg tea.Msg) tea.Cmd {
 		return nil
 
 	case homedirDetectedMsg:
-		fleetPage.handleHomedirDetected(msg.(homedirDetectedMsg))
-		return nil
+		return fleetPage.handleHomedirDetected(m, msg.(homedirDetectedMsg))
 
 	case devcontainerInspectedMsg:
 		return fleetPage.handleDevcontainerInspected(m, msg.(devcontainerInspectedMsg))
@@ -1705,9 +1710,9 @@ func (fleetPage *fleetPage) textDialogHint(action string) string {
 
 func (fleetPage *fleetPage) editFleetHint() string {
 	if fleetPage.dialogFieldActive {
-		return "[enter] Save  [esc] Done editing  [ctrl+c] Cancel"
+		return "[enter] Save  [esc] Discard edit"
 	}
-	return "[j/k] Select  [h/l/space] Toggle  [enter] Edit/Save  [q/esc] Cancel"
+	return "[j/k] Select  [h/l/space] Toggle  [enter] Edit  [q/esc] Close · saved instantly"
 }
 
 func (fleetPage *fleetPage) portForwardHint() string {

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -1737,7 +1737,9 @@ func (fleetPage *fleetPage) renderDeleteCacheButton(m *model) string {
 	case fleetPage.dialogDeletingCache:
 		label = m.spinner.View() + " Clearing…"
 	case fleetPage.dialogDeleteCacheConfirm:
-		label = "Delete cache? enter=yes"
+		// Kept short so the row fits the 46-col dialog; the footer hint spells
+		// out enter=confirm / esc=cancel.
+		label = "Delete cache?"
 	default:
 		label = "Delete cache"
 	}
@@ -1761,9 +1763,9 @@ func (fleetPage *fleetPage) editFleetHint() string {
 	case editFleetRowBuildkit:
 		if fleetPage.dialogBuildkitButtonFocused {
 			if fleetPage.dialogDeleteCacheConfirm {
-				return "[enter] Confirm wipe  [esc] Cancel"
+				return "[enter] Confirm delete  [esc] Cancel"
 			}
-			return "[enter] Delete cache  [h/←] Back"
+			return "[enter] Delete cache  [h/←] Back  [esc] Close"
 		}
 		if fleetPage.dialogBuildkitServer {
 			return "[space] Toggle  [l/→] Delete-cache button  [j/k] Select"

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 
@@ -635,8 +636,29 @@ func TestEditFleetSavesPreferFleetLaunch(t *testing.T) {
 	}
 }
 
-// TestEditFleetSavesBuildkitServer verifies the "Buildkit server"
-// checkbox toggles and persists to FleetSettings on submit, and that
+// navigateToBuildkitRow opens (assumes already open) the dialog's Caching
+// section and lands the cursor on the Buildkit row.
+func navigateToBuildkitRow(t *testing.T, fp *fleetPage, m *model) {
+	t.Helper()
+	guard := 0
+	for fp.dialogRow != editFleetRowCaching {
+		fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyDown})
+		if guard++; guard > 20 {
+			t.Fatal("never reached Caching header")
+		}
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}}) // expand
+	if !fp.dialogCachingExpanded {
+		t.Fatal("Caching section should expand on l")
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyDown}) // into Buildkit row
+	if fp.dialogRow != editFleetRowBuildkit {
+		t.Fatalf("dialogRow = %d, want buildkit row", fp.dialogRow)
+	}
+}
+
+// TestEditFleetSavesBuildkitServer verifies the "Buildkit server" checkbox
+// (inside the Caching section) toggles and persists instantly, and that
 // toggling it does NOT kick off home-dir detection (it is not a mount).
 func TestEditFleetSavesBuildkitServer(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
@@ -655,9 +677,7 @@ func TestEditFleetSavesBuildkitServer(t *testing.T) {
 		t.Fatalf("expected BuildkitServer off by default")
 	}
 
-	for fp.dialogRow != editFleetRowBuildkit {
-		fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyDown})
-	}
+	navigateToBuildkitRow(t, fp, m)
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace})
 	if !fp.dialogBuildkitServer {
 		t.Fatalf("toggle did not set dialogBuildkitServer")
@@ -669,6 +689,135 @@ func TestEditFleetSavesBuildkitServer(t *testing.T) {
 	// Instant-save: persisted on toggle, no submit step.
 	if !f.Settings.BuildkitServer {
 		t.Fatalf("Settings.BuildkitServer = %v, want true (instant-save)", f.Settings.BuildkitServer)
+	}
+}
+
+// TestEditFleetCachingExpandCollapse verifies the Caching section starts
+// collapsed (hiding the Buildkit row) and expands/collapses with l/h.
+func TestEditFleetCachingExpandCollapse(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
+	f := &fleet.Fleet{Name: "alpha"}
+	fp := newFleetPage()
+	fp.rows = []row{{kind: rowFleetHeader, fleetName: "alpha"}}
+	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}}, fleetPage: fp}
+
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	if fp.dialogCachingExpanded {
+		t.Fatal("Caching should start collapsed")
+	}
+	if slices.Contains(fp.visibleEditFleetRows(), editFleetRowBuildkit) {
+		t.Fatal("Buildkit row should be hidden while Caching is collapsed")
+	}
+	for fp.dialogRow != editFleetRowCaching {
+		fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if !fp.dialogCachingExpanded || !slices.Contains(fp.visibleEditFleetRows(), editFleetRowBuildkit) {
+		t.Fatal("l should expand Caching and reveal the Buildkit row")
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	if fp.dialogCachingExpanded {
+		t.Fatal("h should collapse Caching")
+	}
+}
+
+// TestEditFleetDeleteCacheButtonHiddenWhenOff verifies the Delete-cache button
+// is not reachable while Buildkit is disabled.
+func TestEditFleetDeleteCacheButtonHiddenWhenOff(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
+	f := &fleet.Fleet{Name: "alpha"}
+	fp := newFleetPage()
+	fp.rows = []row{{kind: rowFleetHeader, fleetName: "alpha"}}
+	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}}, fleetPage: fp}
+
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	navigateToBuildkitRow(t, fp, m) // buildkit is OFF
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if fp.dialogBuildkitButtonFocused {
+		t.Fatal("l must not focus the delete-cache button when Buildkit is off")
+	}
+}
+
+// TestEditFleetDeleteCacheButtonFlow drives the full button interaction:
+// focus → arm confirm → wipe (async) → done.
+func TestEditFleetDeleteCacheButtonFlow(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
+
+	var deleted string
+	origDel := deleteBuildkitCacheRemote
+	deleteBuildkitCacheRemote = func(fleetName string) error { deleted = fleetName; return nil }
+	t.Cleanup(func() { deleteBuildkitCacheRemote = origDel })
+
+	f := &fleet.Fleet{Name: "alpha"}
+	fp := newFleetPage()
+	fp.rows = []row{{kind: rowFleetHeader, fleetName: "alpha"}}
+	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}}, fleetPage: fp}
+
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	navigateToBuildkitRow(t, fp, m)
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace}) // enable buildkit → button appears
+	if !fp.dialogBuildkitServer {
+		t.Fatal("buildkit not enabled")
+	}
+
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}}) // focus button
+	if !fp.dialogBuildkitButtonFocused {
+		t.Fatal("l should focus the delete-cache button")
+	}
+
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter}) // arm inline confirm
+	if !fp.dialogDeleteCacheConfirm || fp.dialogDeletingCache {
+		t.Fatalf("first enter should only arm confirm; confirm=%v deleting=%v", fp.dialogDeleteCacheConfirm, fp.dialogDeletingCache)
+	}
+
+	cmd := fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter}) // confirm → wipe
+	if fp.dialogDeleteCacheConfirm {
+		t.Fatal("confirm should clear once the wipe starts")
+	}
+	if !fp.dialogDeletingCache {
+		t.Fatal("deletingCache should be set while the wipe runs")
+	}
+	if cmd == nil {
+		t.Fatal("expected a delete-cache command")
+	}
+	done, ok := cmd().(deleteCacheDoneMsg)
+	if !ok {
+		t.Fatal("delete cmd did not return deleteCacheDoneMsg")
+	}
+	if deleted != "alpha" {
+		t.Fatalf("delete RPC called for %q, want alpha", deleted)
+	}
+	fp.handleDeleteCacheDone(m, done)
+	if fp.dialogDeletingCache {
+		t.Fatal("deletingCache should clear after the wipe completes")
+	}
+}
+
+// TestEditFleetDeleteCacheConfirmEscCancels verifies esc cancels an armed
+// confirm without closing the dialog or wiping.
+func TestEditFleetDeleteCacheConfirmEscCancels(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
+	f := &fleet.Fleet{Name: "alpha"}
+	fp := newFleetPage()
+	fp.rows = []row{{kind: rowFleetHeader, fleetName: "alpha"}}
+	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}}, fleetPage: fp}
+
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	navigateToBuildkitRow(t, fp, m)
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace})                    // enable
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}}) // focus button
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter})                    // arm confirm
+
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEsc}) // cancel confirm
+	if fp.dialogDeleteCacheConfirm {
+		t.Fatal("esc should cancel the armed confirm")
+	}
+	if fp.mode != viewEditFleet {
+		t.Fatal("esc on an armed confirm should NOT close the dialog")
 	}
 }
 
@@ -1116,6 +1265,7 @@ func TestEditFleetDialogVimKeysAndActiveHomedir(t *testing.T) {
 		fleetPage: fp,
 	}
 
+	// j moves down through the flat rows; l toggles the focused checkbox.
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	if fp.dialogRow != editFleetRowCodex {
 		t.Fatalf("dialogRow = %d, want codex row", fp.dialogRow)
@@ -1133,22 +1283,15 @@ func TestEditFleetDialogVimKeysAndActiveHomedir(t *testing.T) {
 		t.Fatal("l should toggle selected gh row")
 	}
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-	if fp.dialogRow != editFleetRowBuildkit {
-		t.Fatalf("dialogRow = %d, want buildkit row", fp.dialogRow)
-	}
-	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
-	if !fp.dialogBuildkitServer {
-		t.Fatal("l should toggle selected buildkit row")
-	}
-	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	if fp.dialogRow != editFleetRowHomeDir {
 		t.Fatalf("dialogRow = %d, want home-dir row", fp.dialogRow)
 	}
+
+	// Enter activates the home-dir field; typing routes into it; esc discards.
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if !fp.dialogFieldActive {
 		t.Fatal("enter on home-dir row should activate text field")
 	}
-
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
 	if got := fp.homedirInput.Value(); got != "k" {
 		t.Fatalf("active home-dir input = %q, want k", got)
@@ -1156,12 +1299,12 @@ func TestEditFleetDialogVimKeysAndActiveHomedir(t *testing.T) {
 	if fp.dialogRow != editFleetRowHomeDir {
 		t.Fatalf("dialogRow moved while home-dir active: got %d", fp.dialogRow)
 	}
-
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEsc})
-	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
-	if fp.dialogRow != editFleetRowBuildkit {
-		t.Fatalf("dialogRow = %d, want buildkit row after inactive k", fp.dialogRow)
+	if fp.dialogFieldActive {
+		t.Fatal("esc should leave the home-dir field")
 	}
+
+	// k now navigates UP (field inactive): home-dir → gh → codex.
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
 	if fp.dialogRow != editFleetRowGh {
 		t.Fatalf("dialogRow = %d, want gh row after inactive k", fp.dialogRow)

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -796,6 +796,25 @@ func TestEditFleetDeleteCacheButtonFlow(t *testing.T) {
 	}
 }
 
+// TestEditFleetDeleteCacheError surfaces the failure path: a failed wipe clears
+// the in-flight flag and reports the error to the user.
+func TestEditFleetDeleteCacheError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	fp := newFleetPage()
+	fp.dialogFleet = "alpha"
+	fp.dialogDeletingCache = true
+	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{"alpha": {Name: "alpha"}}}, fleetPage: fp}
+
+	fp.handleDeleteCacheDone(m, deleteCacheDoneMsg{fleet: "alpha", err: errors.New("docker daemon unavailable")})
+
+	if fp.dialogDeletingCache {
+		t.Fatal("deletingCache should clear even on error")
+	}
+	if !strings.Contains(m.message, "docker daemon unavailable") {
+		t.Fatalf("message = %q, want it to surface the error", m.message)
+	}
+}
+
 // TestEditFleetDeleteCacheConfirmEscCancels verifies esc cancels an armed
 // confirm without closing the dialog or wiping.
 func TestEditFleetDeleteCacheConfirmEscCancels(t *testing.T) {

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -539,11 +539,22 @@ func TestEditInstanceRejectsEmptyName(t *testing.T) {
 	}
 }
 
-// TestEditFleetTogglesAndSavesSettings verifies that pressing 'e' on a
-// fleet header opens the edit-fleet dialog, that space toggles a row's
-// boolean, and that enter persists the new settings to the fleet.
+// stubFleetSettingsSave makes the instant-save RPC a no-op for tests: the dialog
+// mutates m.st in-memory before calling it, so a nil return means "saved" with
+// no real RPC and no revert.
+func stubFleetSettingsSave(t *testing.T) {
+	t.Helper()
+	orig := setFleetSettingsRemote
+	setFleetSettingsRemote = func(string, fleet.FleetSettings) error { return nil }
+	t.Cleanup(func() { setFleetSettingsRemote = orig })
+}
+
+// TestEditFleetTogglesAndSavesSettings verifies that pressing 'e' on a fleet
+// header opens the edit-fleet dialog and that toggling a row's boolean persists
+// it IMMEDIATELY (instant-save), with esc just closing the already-saved dialog.
 func TestEditFleetTogglesAndSavesSettings(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
 
 	f := &fleet.Fleet{Name: "alpha", Instances: []*fleet.Instance{}}
 	fp := newFleetPage()
@@ -568,7 +579,8 @@ func TestEditFleetTogglesAndSavesSettings(t *testing.T) {
 		t.Fatalf("expected mounts off by default; got claude=%v codex=%v", fp.dialogClaudeMount, fp.dialogCodexMount)
 	}
 
-	// Toggle Claude (cursor starts on row 0), move down, toggle Codex.
+	// Toggle Claude (cursor starts on row 0), move down, toggle Codex — each
+	// toggle saves instantly.
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace})
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyDown})
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace})
@@ -576,22 +588,23 @@ func TestEditFleetTogglesAndSavesSettings(t *testing.T) {
 	if !fp.dialogClaudeMount || !fp.dialogCodexMount {
 		t.Fatalf("after toggles: claude=%v codex=%v, want both true", fp.dialogClaudeMount, fp.dialogCodexMount)
 	}
-
-	// Submit.
-	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter})
-
-	if fp.mode != viewNormal {
-		t.Fatalf("mode after enter = %v, want viewNormal", fp.mode)
-	}
+	// Instant-save: already persisted, no submit needed.
 	if !f.Settings.ClaudeCodeMount || !f.Settings.CodexMount {
-		t.Fatalf("settings not persisted: %+v", f.Settings)
+		t.Fatalf("settings not persisted instantly: %+v", f.Settings)
+	}
+
+	// Esc just closes the (already-saved) dialog.
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEsc})
+	if fp.mode != viewNormal {
+		t.Fatalf("mode after esc = %v, want viewNormal", fp.mode)
 	}
 }
 
 // TestEditFleetSavesPreferFleetLaunch verifies the "Prefer Fleet Launch"
-// checkbox toggles and persists to FleetSettings on submit.
+// checkbox toggles and persists to FleetSettings instantly.
 func TestEditFleetSavesPreferFleetLaunch(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
 
 	f := &fleet.Fleet{Name: "alpha"}
 	fp := newFleetPage()
@@ -606,7 +619,8 @@ func TestEditFleetSavesPreferFleetLaunch(t *testing.T) {
 		t.Fatalf("expected PreferFleetLaunch off by default")
 	}
 
-	// Navigate to the Prefer Fleet Launch row (last row) and toggle it.
+	// Navigate to the Prefer Fleet Launch row (last row) and toggle it — this
+	// saves instantly.
 	for fp.dialogRow != editFleetRowPreferFleetLaunch {
 		fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyDown})
 	}
@@ -615,10 +629,8 @@ func TestEditFleetSavesPreferFleetLaunch(t *testing.T) {
 		t.Fatalf("toggle did not set dialogPreferFleetLaunch")
 	}
 
-	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter})
-
 	if !f.Settings.PreferFleetLaunchEnabled() {
-		t.Fatalf("Settings.PreferFleetLaunch = %v, want enabled", f.Settings.PreferFleetLaunch)
+		t.Fatalf("Settings.PreferFleetLaunch = %v, want enabled (instant-save)", f.Settings.PreferFleetLaunch)
 	}
 }
 
@@ -627,6 +639,7 @@ func TestEditFleetSavesPreferFleetLaunch(t *testing.T) {
 // toggling it does NOT kick off home-dir detection (it is not a mount).
 func TestEditFleetSavesBuildkitServer(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
 
 	f := &fleet.Fleet{Name: "alpha"}
 	fp := newFleetPage()
@@ -652,11 +665,9 @@ func TestEditFleetSavesBuildkitServer(t *testing.T) {
 	if fp.dialogDetecting {
 		t.Fatalf("buildkit toggle should not kick off home-dir detection")
 	}
-
-	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter})
-
+	// Instant-save: persisted on toggle, no submit step.
 	if !f.Settings.BuildkitServer {
-		t.Fatalf("Settings.BuildkitServer = %v, want true", f.Settings.BuildkitServer)
+		t.Fatalf("Settings.BuildkitServer = %v, want true (instant-save)", f.Settings.BuildkitServer)
 	}
 }
 
@@ -665,6 +676,7 @@ func TestEditFleetSavesBuildkitServer(t *testing.T) {
 // not typed anything, the home-dir input is populated.
 func TestEditFleetHomedirDetectedFillsEmptyInput(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
 
 	f := &fleet.Fleet{Name: "alpha", Remote: "git@example.com:org/repo.git"}
 	fp := newFleetPage()
@@ -680,7 +692,7 @@ func TestEditFleetHomedirDetectedFillsEmptyInput(t *testing.T) {
 		t.Fatalf("expected dialogDetecting to be true after toggle-on")
 	}
 
-	fp.handleHomedirDetected(homedirDetectedMsg{fleetName: "alpha", homeDir: "/home/node"})
+	fp.handleHomedirDetected(m, homedirDetectedMsg{fleetName: "alpha", homeDir: "/home/node"})
 
 	if fp.dialogDetecting {
 		t.Fatalf("dialogDetecting still true after result arrived")
@@ -695,6 +707,7 @@ func TestEditFleetHomedirDetectedFillsEmptyInput(t *testing.T) {
 // something into the home-dir field.
 func TestEditFleetHomedirDetectedRespectsUserInput(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
 
 	f := &fleet.Fleet{Name: "alpha", Remote: "git@example.com:org/repo.git"}
 	fp := newFleetPage()
@@ -708,7 +721,7 @@ func TestEditFleetHomedirDetectedRespectsUserInput(t *testing.T) {
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace}) // toggle Claude → kicks detect
 	fp.homedirInput.SetValue("/custom/path")              // simulate user typing while detect runs
 
-	fp.handleHomedirDetected(homedirDetectedMsg{fleetName: "alpha", homeDir: "/home/node"})
+	fp.handleHomedirDetected(m, homedirDetectedMsg{fleetName: "alpha", homeDir: "/home/node"})
 
 	if got := fp.homedirInput.Value(); got != "/custom/path" {
 		t.Fatalf("homedirInput = %q, want unchanged %q", got, "/custom/path")
@@ -721,6 +734,7 @@ func TestEditFleetHomedirDetectedRespectsUserInput(t *testing.T) {
 // has cross-talk.
 func TestEditFleetHomedirDetectedIgnoresStaleFleet(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
 
 	f := &fleet.Fleet{Name: "alpha", Remote: "git@example.com:org/repo.git"}
 	fp := newFleetPage()
@@ -735,7 +749,7 @@ func TestEditFleetHomedirDetectedIgnoresStaleFleet(t *testing.T) {
 
 	// Result for a different fleet — must be ignored, and must not
 	// clear our in-flight flag.
-	fp.handleHomedirDetected(homedirDetectedMsg{fleetName: "beta", homeDir: "/wrong"})
+	fp.handleHomedirDetected(m, homedirDetectedMsg{fleetName: "beta", homeDir: "/wrong"})
 
 	if got := fp.homedirInput.Value(); got != "" {
 		t.Fatalf("homedirInput = %q, want empty", got)
@@ -745,10 +759,12 @@ func TestEditFleetHomedirDetectedIgnoresStaleFleet(t *testing.T) {
 	}
 }
 
-// TestEditFleetSavesHomedir verifies the home-dir text field is
-// persisted to FleetSettings when the user submits the dialog.
+// TestEditFleetSavesHomedir verifies the home-dir text field is persisted to
+// FleetSettings when the user commits the edit (Enter within the field), under
+// the instant-save model.
 func TestEditFleetSavesHomedir(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
 
 	f := &fleet.Fleet{Name: "alpha", Remote: "git@example.com:org/repo.git"}
 	fp := newFleetPage()
@@ -759,18 +775,30 @@ func TestEditFleetSavesHomedir(t *testing.T) {
 	}
 
 	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	// Navigate to the Home dir row and open the field.
+	for fp.dialogRow != editFleetRowHomeDir {
+		fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter}) // activate field
+	if !fp.dialogFieldActive {
+		t.Fatal("expected home-dir field active after enter")
+	}
 	fp.homedirInput.SetValue("/opt/agent")
-	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter})
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter}) // commit → instant-save
 
+	if fp.dialogFieldActive {
+		t.Fatal("field should be inactive after commit")
+	}
 	if f.Settings.HomeDir != "/opt/agent" {
 		t.Fatalf("Settings.HomeDir = %q, want %q", f.Settings.HomeDir, "/opt/agent")
 	}
 }
 
-// TestEditFleetEscDiscardsChanges verifies that pressing esc abandons
-// pending toggles without modifying the fleet's saved settings.
-func TestEditFleetEscDiscardsChanges(t *testing.T) {
+// TestEditFleetEscKeepsInstantSaves verifies the instant-save contract: a toggle
+// persists immediately, and esc just closes the dialog WITHOUT discarding it.
+func TestEditFleetEscKeepsInstantSaves(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
 
 	f := &fleet.Fleet{Name: "alpha", Instances: []*fleet.Instance{}}
 	fp := newFleetPage()
@@ -783,14 +811,14 @@ func TestEditFleetEscDiscardsChanges(t *testing.T) {
 	}
 
 	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
-	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace}) // toggle claude on
-	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEsc})
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace}) // toggle claude on → saved now
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEsc})   // just closes
 
 	if fp.mode != viewNormal {
 		t.Fatalf("mode after esc = %v, want viewNormal", fp.mode)
 	}
-	if f.Settings.ClaudeCodeMount {
-		t.Fatalf("ClaudeCodeMount = true, expected esc to discard the toggle")
+	if !f.Settings.ClaudeCodeMount {
+		t.Fatalf("ClaudeCodeMount = false; instant-save toggle must persist through esc")
 	}
 }
 
@@ -974,6 +1002,7 @@ func TestAddInstanceDialogVimKeysRespectActiveField(t *testing.T) {
 func TestEditFleetDialogVimKeysAndActiveHomedir(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
+	stubFleetSettingsSave(t)
 	f := &fleet.Fleet{Name: "alpha", Instances: []*fleet.Instance{}}
 	fp := newFleetPage()
 	fp.mode = viewEditFleet

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -819,6 +820,108 @@ func TestEditFleetEscKeepsInstantSaves(t *testing.T) {
 	}
 	if !f.Settings.ClaudeCodeMount {
 		t.Fatalf("ClaudeCodeMount = false; instant-save toggle must persist through esc")
+	}
+}
+
+// TestEditFleetPreservesPFLNilOnUnrelatedEdit verifies instant-save does NOT
+// collapse a "never asked" (nil) PreferFleetLaunch into an explicit value when
+// the user edits an unrelated setting.
+func TestEditFleetPreservesPFLNilOnUnrelatedEdit(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
+
+	f := &fleet.Fleet{Name: "alpha"} // PreferFleetLaunch nil (never asked)
+	fp := newFleetPage()
+	fp.rows = []row{{kind: rowFleetHeader, fleetName: "alpha"}}
+	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}}, fleetPage: fp}
+
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace}) // toggle Claude (unrelated)
+
+	if !f.Settings.ClaudeCodeMount {
+		t.Fatal("claude mount not persisted")
+	}
+	if f.Settings.PreferFleetLaunch != nil {
+		t.Fatalf("PreferFleetLaunch collapsed to %v on unrelated edit; want nil", *f.Settings.PreferFleetLaunch)
+	}
+}
+
+// TestEditFleetPFLSetFlagRevertedOnSaveFailure guards the tri-state invariant
+// across a FAILED PreferFleetLaunch toggle: the set-flag must revert so a later
+// unrelated (successful) save does not collapse the nil tri-state.
+func TestEditFleetPFLSetFlagRevertedOnSaveFailure(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	failNext := false
+	orig := setFleetSettingsRemote
+	setFleetSettingsRemote = func(string, fleet.FleetSettings) error {
+		if failNext {
+			return errors.New("simulated save failure")
+		}
+		return nil
+	}
+	t.Cleanup(func() { setFleetSettingsRemote = orig })
+
+	f := &fleet.Fleet{Name: "alpha"} // PreferFleetLaunch nil
+	fp := newFleetPage()
+	fp.rows = []row{{kind: rowFleetHeader, fleetName: "alpha"}}
+	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}}, fleetPage: fp}
+
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	for fp.dialogRow != editFleetRowPreferFleetLaunch {
+		fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+
+	// Toggle PFL with a save that fails — must revert both the value and the flag.
+	failNext = true
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace})
+	failNext = false
+	if fp.dialogPreferFleetLaunch {
+		t.Fatal("dialogPreferFleetLaunch should revert after a failed save")
+	}
+	if fp.dialogPreferFleetLaunchSet {
+		t.Fatal("dialogPreferFleetLaunchSet should revert to false after a failed save")
+	}
+
+	// An unrelated, successful edit must still leave the nil tri-state intact.
+	fp.dialogRow = editFleetRowClaude
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace})
+	if !f.Settings.ClaudeCodeMount {
+		t.Fatal("claude mount not persisted")
+	}
+	if f.Settings.PreferFleetLaunch != nil {
+		t.Fatalf("PreferFleetLaunch collapsed to %v after a failed PFL toggle; want nil", *f.Settings.PreferFleetLaunch)
+	}
+}
+
+// TestEditFleetHomedirEscDiscards verifies that esc inside the home-dir field
+// discards the uncommitted edit and restores the saved value (instant-save only
+// commits on Enter).
+func TestEditFleetHomedirEscDiscards(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
+
+	f := &fleet.Fleet{Name: "alpha", Settings: fleet.FleetSettings{HomeDir: "/home/node"}}
+	fp := newFleetPage()
+	fp.rows = []row{{kind: rowFleetHeader, fleetName: "alpha"}}
+	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}}, fleetPage: fp}
+
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	for fp.dialogRow != editFleetRowHomeDir {
+		fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter}) // activate field
+	fp.homedirInput.SetValue("/opt/agent")                // uncommitted edit
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEsc})   // discard
+
+	if fp.dialogFieldActive {
+		t.Fatal("field should be inactive after esc")
+	}
+	if got := fp.homedirInput.Value(); got != "/home/node" {
+		t.Fatalf("home-dir input = %q after esc-discard, want restored %q", got, "/home/node")
+	}
+	if f.Settings.HomeDir != "/home/node" {
+		t.Fatalf("Settings.HomeDir = %q, want unchanged %q", f.Settings.HomeDir, "/home/node")
 	}
 }
 


### PR DESCRIPTION
## Summary

Two related changes to the **Edit Fleet** dialog:

1. **Instant-save** — the dialog now saves on every change, matching the settings page. No explicit save step; `esc`/`q` just closes.
2. **Caching section** — the `Buildkit server` toggle moved under a collapsible `▼ Caching` section, and an enabled server shows a `[ Delete cache ]` button (reached with `→`/`l`) that wipes the shared cache and restarts the server.

```
  Edit fleet

  Fleet:     my-fleet
  [ ] Claude Code mount
  [ ] Codex mount
  [ ] GitHub CLI mount
  Home dir:  (unset — defaults to /home/vscode)
  [ ] Prefer Fleet Launch
> ▼ Caching
      [x] Buildkit server   [ Delete cache ]
```

## Instant-save (`dbd84f1`, `c17b763`, `cd49aea`)
- Each toggle persists immediately (optimistic mutate + `SetFleetSettings`, reverted on RPC failure). Home dir commits on `Enter`, discards on `Esc`.
- Fixes a tri-state bug surfaced by review: a failed `PreferFleetLaunch` toggle no longer leaves the "set" flag stuck, which could collapse a "never asked" (nil) value into explicit `false` on a later unrelated save.

## Caching + Delete-cache (`359a0dc`, `5b93afc`, `ca1d9b7`, `9a14fdf`)
- New `DeleteBuildkitCache` RPC + `buildkit.DeleteCache`: stop container → clear the cache → restart empty. The handler validates the fleet has buildkit enabled (so a stray call can't spin up an unwanted server), and always restarts even if the wipe partially fails.
- Collapsible section with dynamic navigation (Buildkit only navigable when expanded); the Delete-cache button has an inline confirm (first `Enter` arms, second wipes, `esc` cancels), a `Clearing…` spinner, and context-aware footer hints.
- **Key fix:** the wipe clears the `.buildkit` directory's *contents* but keeps the directory itself. Removing+recreating it changed the inode and orphaned running instances' bind mounts (new socket invisible inside the instance → builder "inactive"). A test asserts the inode is preserved.

## Tests
Instant-save (toggle/persist, esc-keeps-saves, homedir commit/discard, PFL nil-preservation + revert-on-failure); Caching (expand/collapse gating, button focus/confirm/wipe/done flow, esc-cancels-confirm, error path); server `DeleteCache` (wipe + restart, inode preserved) and RPC validation (empty/unknown/disabled).

Local gate green: `go vet`, `golangci-lint` (0 issues), full `go test`, `-race` on tui/buildkit/server. Both prior buildkit features (per-fleet server, TUI-connect reconcile) reviewed adversarially; all confirmed findings fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)