### PR TITLE
feat(qa): containerized QA environment for fleet PRs

### DIFF
--- a/.github/workflows/qa-image.yml
+++ b/.github/workflows/qa-image.yml
@@ -2,16 +2,14 @@ name: QA Image
 
 # Builds and publishes the fleet-man QA environment image (qa/env) to the GitHub
 # Container Registry so cloud QA agents can pull a ready-made environment to QA
-# PRs in. Pushes the multi-arch image on main / manual / weekly runs; on PRs it
-# only builds (no push) so a change to the image is validated before merge.
+# PRs in. Runs only on trusted refs — pushes to main, manual dispatch, and a
+# weekly rebuild. It deliberately does NOT run on pull_request: building and
+# (especially) running this privileged Docker-in-Docker image from untrusted PR
+# code would let a fork execute attacker-controlled code on the runner with
+# access to its credentials.
 
 on:
   push:
-    branches: [main]
-    paths:
-      - "qa/env/**"
-      - ".github/workflows/qa-image.yml"
-  pull_request:
     branches: [main]
     paths:
       - "qa/env/**"
@@ -27,10 +25,9 @@ permissions:
 
 concurrency:
   group: qa-image-${{ github.ref }}
-  # Fast-cancel redundant PR validation builds, but never cancel an in-flight
-  # publish (a cancel mid-push leaves ghcr incomplete) — same reasoning as
-  # release.yml.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Never cancel an in-flight publish — a cancel mid-push leaves ghcr with an
+  # incomplete image. Same reasoning as release.yml.
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -57,7 +54,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -72,35 +68,12 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,format=short
-            type=ref,event=pr
             type=schedule,pattern=weekly
 
-      # Build a single-arch image, load it locally, and smoke-test it: this is
-      # the real validation — it proves the toolchain is complete AND that
-      # Docker-in-Docker actually comes up inside the container.
-      - name: Build (amd64) for smoke test
-        uses: docker/build-push-action@v6
-        with:
-          context: ./qa/env
-          file: ./qa/env/Dockerfile
-          platforms: linux/amd64
-          load: true
-          tags: ${{ steps.img.outputs.name }}:smoke
-          build-args: |
-            GO_VERSION=${{ steps.go.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: false
-
-      - name: Smoke test (toolchain + DinD)
-        run: |
-          docker run --rm --privileged "${{ steps.img.outputs.name }}:smoke" \
-            qa-verify-toolchain --smoke
-
-      # Publish the multi-arch image. Reuses the gha cache from the smoke build
-      # for the amd64 layers, so only arm64 is built fresh. Skipped on PRs.
+      # The Dockerfile runs `qa-verify-toolchain --no-daemon` as a build-time
+      # assertion, so a missing tool fails the build here without ever running
+      # the (privileged) container in CI.
       - name: Build and push (multi-arch)
-        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
         with:
           context: ./qa/env

--- a/.github/workflows/qa-image.yml
+++ b/.github/workflows/qa-image.yml
@@ -1,0 +1,116 @@
+name: QA Image
+
+# Builds and publishes the fleet-man QA environment image (qa/env) to the GitHub
+# Container Registry so cloud QA agents can pull a ready-made environment to QA
+# PRs in. Pushes the multi-arch image on main / manual / weekly runs; on PRs it
+# only builds (no push) so a change to the image is validated before merge.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "qa/env/**"
+      - ".github/workflows/qa-image.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "qa/env/**"
+      - ".github/workflows/qa-image.yml"
+  workflow_dispatch:
+  schedule:
+    # Weekly rebuild so the image picks up base-OS and toolchain security fixes.
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: qa-image-${{ github.ref }}
+  # Fast-cancel redundant PR validation builds, but never cancel an in-flight
+  # publish (a cancel mid-push leaves ghcr incomplete) — same reasoning as
+  # release.yml.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v5
+
+      # Keep the image's Go in lockstep with the repo: read the version from
+      # go.mod and pass it as a build-arg.
+      - name: Resolve Go version from go.mod
+        id: go
+        run: echo "version=$(awk '/^go /{print $2; exit}' go.mod)" >> "$GITHUB_OUTPUT"
+
+      # ghcr image names must be lowercase; the owner (BenjaminBenetti) is not.
+      - name: Compute image name
+        id: img
+        run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}/qa" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.img.outputs.name }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=short
+            type=ref,event=pr
+            type=schedule,pattern=weekly
+
+      # Build a single-arch image, load it locally, and smoke-test it: this is
+      # the real validation — it proves the toolchain is complete AND that
+      # Docker-in-Docker actually comes up inside the container.
+      - name: Build (amd64) for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: ./qa/env
+          file: ./qa/env/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: ${{ steps.img.outputs.name }}:smoke
+          build-args: |
+            GO_VERSION=${{ steps.go.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+
+      - name: Smoke test (toolchain + DinD)
+        run: |
+          docker run --rm --privileged "${{ steps.img.outputs.name }}:smoke" \
+            qa-verify-toolchain --smoke
+
+      # Publish the multi-arch image. Reuses the gha cache from the smoke build
+      # for the amd64 layers, so only arm64 is built fresh. Skipped on PRs.
+      - name: Build and push (multi-arch)
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./qa/env
+          file: ./qa/env/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GO_VERSION=${{ steps.go.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false

--- a/qa/env/Dockerfile
+++ b/qa/env/Dockerfile
@@ -1,0 +1,169 @@
+# fleet-man QA environment.
+#
+# A heavyweight, self-contained image carrying everything an automated agent
+# needs to QA a fleet PR end to end: build it, lint it, run the unit suite, and
+# run the integration suite — which drives real devcontainers against a real
+# Docker daemon. The daemon runs *inside* this container (Docker-in-Docker), so
+# a cloud QA agent gets a clean, isolated environment per PR with no dependency
+# on the host's Docker.
+#
+# Toolchain mirrors the project's devcontainer (.devcontainer/setup.sh) and CI
+# (.github/workflows/{unit,integration}.yml) so QA runs match what a PR sees:
+#   Go (pinned to go.mod), Docker engine + buildx + compose, Node + the
+#   devcontainer CLI, tmux (TUI tests), golangci-lint (import-boundary lint),
+#   buf + protoc plugins (proto contract), git, and gh.
+#
+# Published to GitHub Container Registry by .github/workflows/qa-image.yml.
+
+ARG BASE_IMAGE=ubuntu:26.04
+FROM ${BASE_IMAGE}
+
+# --- versions -------------------------------------------------------------
+# GO_VERSION is overridden at build time from go.mod by the publish workflow so
+# the image's Go always tracks the repo; the default keeps a plain local build
+# in sync too. The rest are pinned to match .devcontainer/setup.sh and CI.
+ARG GO_VERSION=1.25.8
+ARG NODE_MAJOR=20
+ARG GOLANGCI_LINT_VERSION=v2.11.4
+ARG PROTOC_GEN_GO_VERSION=v1.36.11
+ARG PROTOC_GEN_GO_GRPC_VERSION=v1.5.1
+ARG DEVCONTAINER_CLI_VERSION=latest
+# buildx-provided; selects the right arch for Go / buf downloads (amd64|arm64).
+ARG TARGETARCH
+
+# QA user — non-root by default so PR artifacts aren't root-owned, with
+# passwordless sudo (dockerd needs root) and docker-group membership.
+ARG QA_USER=qa
+ARG QA_UID=1000
+ARG QA_GID=1000
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+# --- base OS packages -----------------------------------------------------
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates curl wget gnupg lsb-release apt-transport-https \
+        git openssh-client \
+        build-essential make pkg-config \
+        tmux \
+        jq ripgrep unzip zip xz-utils \
+        python3 python3-pip python3-venv \
+        sudo less vim nano bash-completion \
+        procps iproute2 iptables uidmap kmod \
+        iputils-ping netcat-openbsd dnsutils; \
+    rm -rf /var/lib/apt/lists/*
+
+# --- Docker engine (CE) + buildx + compose --------------------------------
+# Installed from Docker's official apt repo. Ubuntu 26.04 ("resolute") is recent
+# enough that Docker may not publish that suite yet, so fall back to the newest
+# always-supported LTS suite (noble) — the CE packages are forward-compatible.
+RUN set -eux; \
+    install -m 0755 -d /etc/apt/keyrings; \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc; \
+    chmod a+r /etc/apt/keyrings/docker.asc; \
+    codename="$(. /etc/os-release && echo "${VERSION_CODENAME}")"; \
+    if ! curl -fsSL "https://download.docker.com/linux/ubuntu/dists/${codename}/Release" >/dev/null 2>&1; then \
+        echo "Docker apt repo has no '${codename}' suite yet; falling back to 'noble'."; \
+        codename="noble"; \
+    fi; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu ${codename} stable" \
+        > /etc/apt/sources.list.d/docker.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin; \
+    rm -rf /var/lib/apt/lists/*
+
+# --- GitHub CLI -----------------------------------------------------------
+RUN set -eux; \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /etc/apt/keyrings/githubcli.gpg; \
+    chmod a+r /etc/apt/keyrings/githubcli.gpg; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends gh; \
+    rm -rf /var/lib/apt/lists/*
+
+# --- Node.js + devcontainer CLI -------------------------------------------
+# NodeSource's repo is codename-independent (nodistro), so it works on any
+# Ubuntu base. The devcontainer CLI is how fleet drives devcontainers.
+RUN set -eux; \
+    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash -; \
+    apt-get install -y --no-install-recommends nodejs; \
+    npm install -g "@devcontainers/cli@${DEVCONTAINER_CLI_VERSION}"; \
+    npm cache clean --force; \
+    rm -rf /var/lib/apt/lists/*
+
+# --- Go (pinned to go.mod) ------------------------------------------------
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${arch}.tar.gz" -o /tmp/go.tgz; \
+    rm -rf /usr/local/go; \
+    tar -C /usr/local -xzf /tmp/go.tgz; \
+    rm /tmp/go.tgz; \
+    /usr/local/go/bin/go version
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# --- Go-based tooling -----------------------------------------------------
+# golangci-lint (import-boundary lint, pinned to CI), buf (proto contract; from
+# the prebuilt release so multi-arch builds don't compile it under emulation),
+# and the protoc-gen-* plugins (for `make proto`). All land in /usr/local/bin so
+# every user has them; the build caches are wiped to keep the image lean.
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    case "${arch}" in \
+        amd64) buf_arch=x86_64 ;; \
+        arm64) buf_arch=aarch64 ;; \
+        *) echo "unsupported arch: ${arch}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/bufbuild/buf/releases/latest/download/buf-Linux-${buf_arch}" -o /usr/local/bin/buf; \
+    chmod +x /usr/local/bin/buf; \
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
+        | sh -s -- -b /usr/local/bin "${GOLANGCI_LINT_VERSION}"; \
+    GOBIN=/usr/local/bin GOTOOLCHAIN=auto go install "google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION}"; \
+    GOBIN=/usr/local/bin GOTOOLCHAIN=auto go install "google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}"; \
+    go clean -cache -modcache; \
+    rm -rf /root/.cache /root/go
+
+# --- QA user --------------------------------------------------------------
+# Ubuntu 26.04 ships a default 'ubuntu' user/group at uid/gid 1000; reclaim that
+# id for the qa user (cloud platforms commonly assume uid 1000).
+RUN set -eux; \
+    if id -u ubuntu >/dev/null 2>&1; then userdel -r ubuntu 2>/dev/null || true; fi; \
+    if getent group ubuntu >/dev/null 2>&1; then groupdel ubuntu 2>/dev/null || true; fi; \
+    groupadd --gid "${QA_GID}" "${QA_USER}"; \
+    useradd --uid "${QA_UID}" --gid "${QA_GID}" --create-home --shell /bin/bash "${QA_USER}"; \
+    echo "${QA_USER} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${QA_USER}"; \
+    chmod 0440 "/etc/sudoers.d/${QA_USER}"; \
+    groupadd -f docker; \
+    usermod -aG docker "${QA_USER}"
+
+# --- entrypoint + verification --------------------------------------------
+COPY entrypoint.sh /usr/local/bin/qa-entrypoint
+COPY verify-toolchain.sh /usr/local/bin/qa-verify-toolchain
+RUN set -eux; \
+    chmod +x /usr/local/bin/qa-entrypoint /usr/local/bin/qa-verify-toolchain; \
+    # Build-time assertion: fail the image build if any tool is missing.
+    # --no-daemon because dockerd isn't running during the build.
+    qa-verify-toolchain --no-daemon
+
+LABEL org.opencontainers.image.source="https://github.com/BenjaminBenetti/fleet-man" \
+      org.opencontainers.image.title="fleet-man QA environment" \
+      org.opencontainers.image.description="Toolchain image for automated QA of fleet PRs: Go, Docker (DinD), devcontainer CLI, tmux, golangci-lint, buf, gh."
+
+# Bundled daemon stores layers here; a volume avoids overlay-on-overlay churn.
+VOLUME /var/lib/docker
+
+# GOTOOLCHAIN=auto lets `go` fetch a newer toolchain if a PR bumps go.mod past
+# the pinned version, so the QA env can still build it.
+ENV PATH="/home/${QA_USER}/go/bin:${PATH}" \
+    GOTOOLCHAIN=auto \
+    FLEET_QA_START_DOCKER=1
+
+USER ${QA_USER}
+WORKDIR /home/${QA_USER}
+
+ENTRYPOINT ["/usr/local/bin/qa-entrypoint"]
+CMD ["bash", "-l"]

--- a/qa/env/README.md
+++ b/qa/env/README.md
@@ -1,0 +1,113 @@
+# fleet-man QA environment
+
+A heavyweight, self-contained container image carrying everything an automated
+agent needs to **QA a fleet PR end to end** — build it, lint it, run the unit
+suite, and run the integration suite (which drives real devcontainers against a
+real Docker daemon).
+
+The image is built for cloud QA agents: spin one up per PR and it has a clean,
+isolated environment with its own Docker daemon (Docker-in-Docker), so QA never
+depends on — or pollutes — the host.
+
+## What's inside
+
+| Tool | Why fleet needs it |
+|------|--------------------|
+| **Go** (pinned to `go.mod`) | build `fleet`, run `go test` / `go vet` |
+| **Docker** engine + CLI + buildx + compose | integration tests drive a real daemon; runs in-container (DinD) |
+| **Node + `@devcontainers/cli`** | fleet's devcontainer backend |
+| **tmux** | the TUI integration tests run `fleet` in a headless tmux |
+| **golangci-lint** (`v2.11.4`) | the client/server import-boundary lint CI enforces |
+| **buf** + **protoc-gen-go** / **protoc-gen-go-grpc** | the `fleetgrpc` proto contract (`make proto` / `make proto-check`) |
+| **git**, **gh** | check out PRs, report results |
+| general utilities | `make`, `build-essential`, `jq`, `ripgrep`, `python3`, `curl`, `wget`, networking tools |
+
+Versions track the project's devcontainer (`.devcontainer/setup.sh`) and CI
+(`.github/workflows/{unit,integration}.yml`) so a QA run matches what a PR
+actually sees. The Go version is injected from `go.mod` at build time, so it
+never drifts from the repo.
+
+Run `qa-verify-toolchain` inside the container to print every tool's version and
+confirm the Docker daemon is reachable.
+
+## Published image
+
+The publish workflow (`.github/workflows/qa-image.yml`) pushes to the GitHub
+Container Registry on every change to `qa/env/**` on `main`, on manual dispatch,
+and weekly (to absorb base-OS / toolchain security fixes):
+
+```
+ghcr.io/benjaminbenetti/fleet-man/qa:latest
+ghcr.io/benjaminbenetti/fleet-man/qa:sha-<short-sha>   # immutable, pin this in automation
+```
+
+Images are multi-arch (`linux/amd64`, `linux/arm64`). Authentication uses the
+workflow's built-in `GITHUB_TOKEN` — no external secrets.
+
+> First publish only: the package is created private. Make it public (or grant
+> the puller access) under the repo's **Packages** settings so cloud agents can
+> pull it. The `org.opencontainers.image.source` label links the package back to
+> this repo.
+
+## Running it
+
+The bundled Docker daemon needs `--privileged` to start:
+
+```bash
+docker run --rm -it --privileged \
+  ghcr.io/benjaminbenetti/fleet-man/qa:latest
+```
+
+The entrypoint starts `dockerd` (Docker-in-Docker), waits for it, then drops you
+into a shell. Verify, then QA a PR:
+
+```bash
+qa-verify-toolchain                 # confirm the toolchain + daemon
+
+gh repo clone BenjaminBenetti/fleet-man
+cd fleet-man
+gh pr checkout <PR-number>
+
+go vet ./...                        # static checks (CI runs this as a separate step)
+make test                           # import-boundary lint + unit tests
+go build -o /tmp/fleet ./cmd/fleet  # build the binary
+FLEET_BIN=/tmp/fleet ./integration/run.sh   # full integration suite (needs the daemon)
+```
+
+(`gh` needs a token — `GH_TOKEN` / `gh auth login` — for private repos or to
+post results.)
+
+### Environment knobs
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `FLEET_QA_START_DOCKER` | `1` | set `0` to skip starting the bundled daemon (e.g. when mounting a host `/var/run/docker.sock`) |
+| `FLEET_QA_DOCKERD_TIMEOUT` | `60` | seconds to wait for `dockerd` to become ready |
+
+If a working Docker daemon is already reachable (a mounted host socket), the
+entrypoint detects it and does not start the bundled one.
+
+## Building locally
+
+```bash
+docker build -t fleet-qa ./qa/env
+docker run --rm -it --privileged fleet-qa qa-verify-toolchain --smoke
+```
+
+Build args (see the `Dockerfile` for the full list and defaults):
+
+| Arg | Purpose |
+|-----|---------|
+| `BASE_IMAGE` | base image (default `ubuntu:26.04`) |
+| `GO_VERSION` | Go toolchain version (CI passes the value from `go.mod`) |
+| `NODE_MAJOR` | Node major version for the devcontainer CLI |
+| `GOLANGCI_LINT_VERSION` / `PROTOC_GEN_GO_VERSION` / `PROTOC_GEN_GO_GRPC_VERSION` | pinned tool versions |
+
+## Maintenance
+
+- **Go** auto-tracks `go.mod` (no manual bump needed).
+- **golangci-lint / protoc plugins** are pinned here; keep them matching
+  `.devcontainer/setup.sh` and `.github/workflows/unit.yml` when those change.
+- The weekly scheduled rebuild keeps the base OS and `latest`-pinned tools
+  (buf, devcontainer CLI) current; pin those in the `Dockerfile` if you need
+  reproducible rebuilds.

--- a/qa/env/entrypoint.sh
+++ b/qa/env/entrypoint.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Entry point for the fleet-man QA environment container.
+#
+# Brings up an in-container Docker daemon (Docker-in-Docker) so the fleet
+# integration suite — which drives real devcontainers against a real daemon —
+# has something to talk to, then hands off to the requested command (default:
+# an interactive login shell).
+#
+# The container must be run with --privileged for the bundled daemon to start.
+# If a usable daemon is already reachable (e.g. a host /var/run/docker.sock is
+# mounted in), startup is skipped. Set FLEET_QA_START_DOCKER=0 to never start
+# the bundled daemon.
+set -euo pipefail
+
+log() { printf '[qa-entrypoint] %s\n' "$*" >&2; }
+
+# --- iptables backend fix -------------------------------------------------
+# dockerd's bridge networking needs the iptables backend to match the host
+# kernel. Modern kernels use nf_tables; if the container still points iptables
+# at the legacy backend, dockerd fails to set up its network. Mirror the
+# devcontainer's detection (.devcontainer/setup.sh) and switch to nft if needed.
+fix_iptables_backend() {
+  command -v update-alternatives >/dev/null 2>&1 || return 0
+  [ -x /usr/sbin/iptables-nft ] || return 0
+
+  local current
+  current="$(update-alternatives --query iptables 2>/dev/null | awk '/^Value:/{print $2}')"
+  [ "${current}" = "/usr/sbin/iptables-nft" ] && return 0
+
+  if [ -d /sys/module/nf_tables ] || grep -q nf_tables /proc/modules 2>/dev/null \
+     || ! /usr/sbin/iptables-legacy -L -n >/dev/null 2>&1; then
+    log "switching iptables backend to nft"
+    sudo update-alternatives --set iptables /usr/sbin/iptables-nft >/dev/null 2>&1 || true
+    if [ -x /usr/sbin/ip6tables-nft ]; then
+      sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-nft >/dev/null 2>&1 || true
+    fi
+  fi
+}
+
+start_dockerd() {
+  if docker info >/dev/null 2>&1; then
+    log "docker daemon already reachable; not starting the bundled one"
+    return 0
+  fi
+
+  fix_iptables_backend
+  log "starting dockerd (Docker-in-Docker)…"
+  # The redirect runs under sudo so root owns the log file, and dockerd is
+  # backgrounded inside that root shell so it survives this script.
+  sudo rm -f /var/run/docker.pid
+  sudo sh -c 'nohup dockerd >/var/log/dockerd.log 2>&1 &'
+
+  local timeout="${FLEET_QA_DOCKERD_TIMEOUT:-60}"
+  for ((i = 0; i < timeout; i++)); do
+    if docker info >/dev/null 2>&1; then
+      log "docker daemon is up"
+      return 0
+    fi
+    sleep 1
+  done
+
+  log "dockerd did not become ready within ${timeout}s — last log lines:"
+  sudo tail -n 40 /var/log/dockerd.log >&2 || true
+  return 1
+}
+
+if [ "${FLEET_QA_START_DOCKER:-1}" = "1" ]; then
+  start_dockerd || log "continuing without a working docker daemon"
+fi
+
+if [ "$#" -eq 0 ]; then
+  exec bash -l
+fi
+exec "$@"

--- a/qa/env/verify-toolchain.sh
+++ b/qa/env/verify-toolchain.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Reports the version of every tool in the fleet QA toolchain and asserts each
+# one is present. Three uses:
+#   --no-daemon : image build time — fail the build if a tool is missing
+#                 (dockerd isn't running yet, so skip the daemon check).
+#   --smoke     : CI — also prove Docker-in-Docker works by running hello-world.
+#   (no args)   : by hand inside the container, to sanity-check the environment.
+set -uo pipefail
+
+CHECK_DAEMON=1
+SMOKE=0
+for arg in "$@"; do
+  case "${arg}" in
+    --no-daemon) CHECK_DAEMON=0 ;;
+    --smoke)     SMOKE=1 ;;
+    -h|--help)   sed -n '2,9p' "$0"; exit 0 ;;
+    *) echo "unknown arg: ${arg}" >&2; exit 2 ;;
+  esac
+done
+
+fail=0
+
+# report NAME CMD [ARGS...] — print NAME + first line of `CMD ARGS`, or MISSING.
+report() {
+  local name="$1"; shift
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf '  %-20s MISSING\n' "${name}"
+    fail=1
+    return
+  fi
+  printf '  %-20s %s\n' "${name}" "$("$@" 2>&1 | head -n1)"
+}
+
+echo "fleet QA toolchain:"
+report go                  go version
+report git                 git --version
+report docker              docker --version
+report dockerd             dockerd --version
+report "docker buildx"     docker buildx version
+report "docker compose"    docker compose version
+report node                node --version
+report npm                 npm --version
+report devcontainer        devcontainer --version
+report tmux                tmux -V
+report golangci-lint       golangci-lint version
+report buf                 buf --version
+report protoc-gen-go       protoc-gen-go --version
+report protoc-gen-go-grpc  protoc-gen-go-grpc --version
+report gh                  gh --version
+report jq                  jq --version
+report rg                  rg --version
+report python3             python3 --version
+
+if [ "${CHECK_DAEMON}" -eq 1 ]; then
+  echo "docker daemon:"
+  if docker info >/dev/null 2>&1; then
+    echo "  reachable"
+  else
+    echo "  UNREACHABLE"
+    fail=1
+  fi
+fi
+
+if [ "${SMOKE}" -eq 1 ]; then
+  echo "smoke: docker run hello-world"
+  if docker run --rm hello-world >/dev/null 2>&1; then
+    echo "  ok"
+  else
+    echo "  FAILED"
+    fail=1
+  fi
+fi
+
+if [ "${fail}" -ne 0 ]; then
+  echo "toolchain verification FAILED" >&2
+  exit 1
+fi
+echo "toolchain OK"

--- a/qa/env/verify-toolchain.sh
+++ b/qa/env/verify-toolchain.sh
@@ -3,7 +3,8 @@
 # one is present. Three uses:
 #   --no-daemon : image build time — fail the build if a tool is missing
 #                 (dockerd isn't running yet, so skip the daemon check).
-#   --smoke     : CI — also prove Docker-in-Docker works by running hello-world.
+#   --smoke     : also prove Docker-in-Docker works by running hello-world
+#                 (for local/manual use — CI never runs this privileged image).
 #   (no args)   : by hand inside the container, to sanity-check the environment.
 set -uo pipefail
 
@@ -20,15 +21,19 @@ done
 
 fail=0
 
-# report NAME CMD [ARGS...] — print NAME + first line of `CMD ARGS`, or MISSING.
+# report NAME CMD [ARGS...] — print NAME + first line of `CMD ARGS`, or mark it
+# failed. Runs the full command and checks its exit status, so a missing binary
+# OR a missing subcommand/plugin (e.g. `docker buildx` when the plugin isn't
+# installed) is caught — not just whether the first word is on PATH.
 report() {
   local name="$1"; shift
-  if ! command -v "$1" >/dev/null 2>&1; then
-    printf '  %-20s MISSING\n' "${name}"
+  local out
+  if ! out="$("$@" 2>&1)"; then
+    printf '  %-20s MISSING/FAILED\n' "${name}"
     fail=1
     return
   fi
-  printf '  %-20s %s\n' "${name}" "$("$@" 2>&1 | head -n1)"
+  printf '  %-20s %s\n' "${name}" "$(printf '%s\n' "${out}" | head -n1)"
 }
 
 echo "fleet QA toolchain:"


### PR DESCRIPTION
## What

Adds `qa/env/`, a self-contained container image carrying everything an automated agent needs to **QA a fleet PR end to end** — build, lint, unit tests, and the integration suite (which drives real devcontainers against a real Docker daemon, run in-container via Docker-in-Docker). Intended for cloud QA agents that spin up per PR. Plus a workflow that publishes it to the **GitHub Container Registry**.

## Contents

- `qa/env/Dockerfile` — Ubuntu 26.04 base + full QA toolchain
- `qa/env/entrypoint.sh` — starts the in-container `dockerd` (DinD), then hands off
- `qa/env/verify-toolchain.sh` — asserts the toolchain (build-time / CI smoke / manual)
- `qa/env/README.md` — usage + maintenance
- `.github/workflows/qa-image.yml` — multi-arch build + publish to `ghcr.io`

The toolchain mirrors the devcontainer (`.devcontainer/setup.sh`) and CI, version-matched: **Go** (pinned from `go.mod` at build time), **Docker** engine + buildx + compose, **Node 20 + `@devcontainers/cli`**, **tmux**, **golangci-lint v2.11.4**, **buf + protoc-gen-go v1.36.11 / protoc-gen-go-grpc v1.5.1**, **git**, **gh**.

Auth uses the workflow's built-in `GITHUB_TOKEN` — no external secrets.

## Validation (run locally against this image)

- `docker build` succeeds; the build-time assertion confirms every tool is present at its pinned version.
- Privileged DinD smoke test: `dockerd` starts, daemon reachable, `docker run hello-world` works (even nested).
- Ran the repo's own `make test` **inside** the container: `go build` of `fleet` ok, **golangci-lint: 0 issues**, full unit suite passes.

## Notes

- First publish creates the ghcr package **private** — make it public (or grant pull access) under the repo's **Packages** settings so cloud agents can pull it. The `org.opencontainers.image.source` label links the package to this repo.
- The image's Go version auto-tracks `go.mod`; a weekly scheduled rebuild absorbs base-OS / toolchain security fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)