### PR TITLE
fix(client): create ~/.fleet on fresh install before spawning server

### DIFF
--- a/internal/fleetclient/spawn.go
+++ b/internal/fleetclient/spawn.go
@@ -92,6 +92,13 @@ func pingOK(ep Endpoint) bool {
 // acquireSpawnLock takes the spawn lock, waiting (bounded) for another client
 // that is mid-spawn. The returned *os.File must stay open to hold the lock.
 func acquireSpawnLock(ctx context.Context) (*os.File, error) {
+	// Ensure ~/.fleet exists first: on a machine that has never run fleet the
+	// directory is absent, and O_CREATE below makes the lock file but not its
+	// parent — so without this the first command on a fresh install fails with
+	// ENOENT before it can spawn the server.
+	if _, err := fleetpaths.EnsureDir(); err != nil {
+		return nil, fmt.Errorf("create fleet dir: %w", err)
+	}
 	f, err := os.OpenFile(fleetpaths.SpawnLockPath(), os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, err

--- a/internal/fleetpaths/paths.go
+++ b/internal/fleetpaths/paths.go
@@ -19,6 +19,21 @@ func Dir() string {
 	return filepath.Join(os.Getenv("HOME"), ".fleet")
 }
 
+// EnsureDir creates ~/.fleet if it does not exist, returning its path. The
+// server's Serve does the same on startup, but the CLIENT needs the directory
+// to exist BEFORE that — it opens the spawn lock file there to serialize the
+// very spawn that would start the server. O_CREATE makes the lock file, not its
+// parent, so on a machine that has never run fleet (no ~/.fleet yet) the client
+// would otherwise fail with ENOENT before it could spawn the server at all.
+// 0700 matches the perms Serve uses.
+func EnsureDir() (string, error) {
+	dir := Dir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
 // SocketPath is the unix domain socket the fleet server listens on and clients
 // dial. Host-local and per-user.
 func SocketPath() string {


### PR DESCRIPTION
## Problem

On a machine that has **never run fleet** (no `~/.fleet` directory), the beta server build fails to start: every CLI command fails to run and the TUI exits immediately. Creating `~/.fleet` by hand works around it.

## Root cause

The client auto-spawns the server, but first opens a spawn-lock file at `~/.fleet/spawn.lock` to serialize racing spawns:

```go
f, err := os.OpenFile(fleetpaths.SpawnLockPath(), os.O_CREATE|os.O_RDWR, 0o600)
```

`O_CREATE` creates the lock *file* but **not** its missing parent directory, so on a fresh install this fails with ENOENT (`acquire spawn lock: … no such file or directory`). The client dies before it can spawn the server. The server's `Serve` *does* `MkdirAll(~/.fleet)`, but that code never runs because the client can't get far enough to launch it — which is exactly why creating the directory manually fixes it.

## Fix

- Add `fleetpaths.EnsureDir()` (`MkdirAll` at `0700`, matching `Serve`) to the shared, dependency-free `fleetpaths` leaf package.
- Call it in `acquireSpawnLock` before opening the lock. This covers both the normal spawn path (`ensureServerLocal`) and the version-restart path (`restartServer`), since both go through `acquireSpawnLock`.

## Verification

Built the binary and ran `fleet ls` under a temp `HOME` with no `~/.fleet`:

- Before: fails with ENOENT on the spawn lock.
- After: exits 0, spawns the server, and `~/.fleet` is created with its sockets/locks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)