### PR TITLE
fix(client): create ~/.fleet on fresh install before spawning server

### DIFF
--- a/internal/fleetclient/spawn.go
+++ b/internal/fleetclient/spawn.go
@@ -92,6 +92,13 @@ func pingOK(ep Endpoint) bool {
 // acquireSpawnLock takes the spawn lock, waiting (bounded) for another client
 // that is mid-spawn. The returned *os.File must stay open to hold the lock.
 func acquireSpawnLock(ctx context.Context) (*os.File, error) {
+	// Ensure ~/.fleet exists first: on a machine that has never run fleet the
+	// directory is absent, and O_CREATE below makes the lock file but not its
+	// parent — so without this the first command on a fresh install fails with
+	// ENOENT before it can spawn the server.
+	if _, err := fleetpaths.EnsureDir(); err != nil {
+		return nil, fmt.Errorf("create fleet dir: %w", err)
+	}
 	f, err := os.OpenFile(fleetpaths.SpawnLockPath(), os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, err

--- a/internal/fleetclient/spawn.go
+++ b/internal/fleetclient/spawn.go
@@ -2,6 +2,7 @@ package fleetclient
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -40,6 +41,16 @@ func ensureServerLocal(ctx context.Context, ep Endpoint) error {
 // startServerProcess fork-execs `fleet server` detached, so it outlives the
 // client that spawned it.
 func startServerProcess() error {
+	// Refuse to spawn from a Go test binary. We spawn by re-execing our own
+	// executable with "server"; under `go test` os.Executable() is the test
+	// binary, which ignores that arg and re-runs the whole suite — each new
+	// process auto-spawns again, a fork bomb that exhausts memory. A test that
+	// needs the server should start a real one or stub the dialing seam; it must
+	// never auto-spawn itself. (flag.Lookup("test.v") is non-nil only in a test
+	// binary, so this is a no-op in the real fleet binary.)
+	if flag.Lookup("test.v") != nil {
+		return fmt.Errorf("refusing to auto-spawn fleet server from a test binary")
+	}
 	self, err := os.Executable()
 	if err != nil {
 		return err

--- a/internal/fleetpaths/paths.go
+++ b/internal/fleetpaths/paths.go
@@ -19,6 +19,21 @@ func Dir() string {
 	return filepath.Join(os.Getenv("HOME"), ".fleet")
 }
 
+// EnsureDir creates ~/.fleet if it does not exist, returning its path. The
+// server's Serve does the same on startup, but the CLIENT needs the directory
+// to exist BEFORE that — it opens the spawn lock file there to serialize the
+// very spawn that would start the server. O_CREATE makes the lock file, not its
+// parent, so on a machine that has never run fleet (no ~/.fleet yet) the client
+// would otherwise fail with ENOENT before it could spawn the server at all.
+// 0700 matches the perms Serve uses.
+func EnsureDir() (string, error) {
+	dir := Dir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
 // SocketPath is the unix domain socket the fleet server listens on and clients
 // dial. Host-local and per-user.
 func SocketPath() string {

--- a/internal/tui/browser_test.go
+++ b/internal/tui/browser_test.go
@@ -40,6 +40,17 @@ func stubBrowserConfig(t *testing.T, initialURL string, hasLanding bool) {
 	t.Cleanup(func() { fetchBrowserConfig = orig })
 }
 
+// stubSetFleetSettings replaces the SetFleetSettings RPC seam with a no-op so
+// the chooser-dialog tests exercise only the in-memory setting flip. Without it,
+// chooseBrowserLaunch would call the real seam, which dials (and auto-spawns) a
+// fleet server — in a test binary that re-execs the suite and fork-bombs.
+func stubSetFleetSettings(t *testing.T) {
+	t.Helper()
+	orig := setFleetSettingsRemote
+	setFleetSettingsRemote = func(string, fleet.FleetSettings) error { return nil }
+	t.Cleanup(func() { setFleetSettingsRemote = orig })
+}
+
 // TestBeginBrowserOpenPromptsWhenUnset verifies the chooser dialog opens
 // (rather than launching) when the fleet has no saved preference and the
 // workspace configures both targets.
@@ -65,6 +76,7 @@ func TestBeginBrowserOpenPromptsWhenUnset(t *testing.T) {
 // and closes the dialog.
 func TestChooseBrowserLaunchPersists(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	stubSetFleetSettings(t)
 
 	for _, tc := range []struct {
 		key  string
@@ -103,6 +115,7 @@ func TestChooseBrowserLaunchPersists(t *testing.T) {
 func TestChooseBrowserLaunchCursorEnter(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	stubBrowserConfig(t, "https://example.com", true)
+	stubSetFleetSettings(t)
 	inst := &fleet.Instance{Name: "i1", Status: fleet.StatusRunning, WorkspaceDir: t.TempDir()}
 	f := &fleet.Fleet{Name: "alpha", Instances: []*fleet.Instance{inst}}
 	fp := newFleetPage()


### PR DESCRIPTION
On a machine that has never run fleet, ~/.fleet does not exist yet. The client auto-spawns the server, but first opens a spawn-lock file at ~/.fleet/spawn.lock to serialize racing spawns. os.OpenFile with O_CREATE makes the lock file but not its missing parent directory, so the call fails with ENOENT and the client dies before it can spawn the server — every CLI command fails and the TUI exits immediately. The server's Serve does MkdirAll(~/.fleet), but that code never runs because the client can't get far enough to launch it.

Add fleetpaths.EnsureDir() (MkdirAll at 0700, matching Serve) and call it in acquireSpawnLock before opening the lock. This covers both the normal spawn path (ensureServerLocal) and the version-restart path (restartServer), since both go through acquireSpawnLock.