### PR TITLE
feat(mcp): add fleet_session_list tool to enumerate tmux sessions (#104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ An MCP client config (`mcp.json`) can then reference them directly:
 Tools mirror the non-interactive CLI: `fleet_list`, `fleet_status`,
 `fleet_version`, `fleet_logs`, `fleet_up`, `fleet_start`, `fleet_stop`,
 `fleet_down`, `fleet_destroy_fleet`, `fleet_clone`, `fleet_exec`, and the tmux
-session tools `fleet_session_spawn` / `fleet_session_exec` / `fleet_session_read`.
+session tools `fleet_session_spawn` / `fleet_session_exec` / `fleet_session_read` /
+`fleet_session_list`.
 Interactive, open-ended commands (`fleet shell`, log following) are intentionally
 not exposed.
 

--- a/internal/server/convert_runtime.go
+++ b/internal/server/convert_runtime.go
@@ -85,7 +85,10 @@ func parseTmuxSessionsProto(output string) []*fleetgrpc.TmuxSession {
 			s.Windows = int32(w)
 		}
 		if len(parts) >= 3 {
-			s.Attached = parts[2] == "1"
+			// session_attached is the client count, not a 0/1 flag; any positive
+			// count means a client is attached.
+			a, _ := strconv.Atoi(parts[2])
+			s.Attached = a > 0
 		}
 		sessions = append(sessions, s)
 	}

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetpaths"
@@ -115,6 +116,7 @@ func TestNewMCPServerRegistersAllTools(t *testing.T) {
 		"fleet_up", "fleet_start", "fleet_stop", "fleet_down",
 		"fleet_destroy_fleet", "fleet_clone",
 		"fleet_exec", "fleet_session_spawn", "fleet_session_exec", "fleet_session_read",
+		"fleet_session_list",
 	}
 	for _, name := range want {
 		if !got[name] {
@@ -191,6 +193,74 @@ func TestMCPToolErrors(t *testing.T) {
 	}
 	if !res.IsError {
 		t.Fatalf("want input-validation tool error for missing instance, got %q", toolText(res))
+	}
+}
+
+// TestParseMCPSessions covers the tmux list-sessions parser: field mapping,
+// the attached flag, epoch->RFC3339 rendering, colon-bearing names (name is the
+// trailing field), and skipping of blank/short/garbage lines.
+func TestParseMCPSessions(t *testing.T) {
+	const created = 1700000000
+	wantCreated := time.Unix(created, 0).UTC().Format(time.RFC3339)
+	output := strings.Join([]string{
+		"3:1:" + strconv.Itoa(created) + ":hello-world-test~i-spy", // 1 client -> attached
+		"4:10:" + strconv.Itoa(created) + ":multi-client",          // 10 clients -> attached
+		"1:0:" + strconv.Itoa(created) + ":plain",                  // detached
+		"2:0:0:zero-created",                                       // created 0 -> omitted
+		"1:0:notanint:bad-created",                                 // unparseable created -> omitted
+		"5:1:" + strconv.Itoa(created) + ":has:colons:in:name",     // ':' kept in name
+		"",                             // blank -> skipped
+		"  ",                           // whitespace -> skipped
+		"1:0:" + strconv.Itoa(created), // too few fields -> skipped
+	}, "\n")
+
+	got := parseMCPSessions(output)
+	want := []FleetSession{
+		{Session: "hello-world-test~i-spy", Windows: 3, CreatedAt: wantCreated, Attached: true},
+		{Session: "multi-client", Windows: 4, CreatedAt: wantCreated, Attached: true},
+		{Session: "plain", Windows: 1, CreatedAt: wantCreated, Attached: false},
+		{Session: "zero-created", Windows: 2, CreatedAt: "", Attached: false},
+		{Session: "bad-created", Windows: 1, CreatedAt: "", Attached: false},
+		{Session: "has:colons:in:name", Windows: 5, CreatedAt: wantCreated, Attached: true},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("parsed %d sessions, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("session[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+
+	// Empty input yields a non-nil empty slice (JSON-marshals to [], not null) —
+	// the "no sessions => empty array" acceptance criterion.
+	empty := parseMCPSessions("")
+	if empty == nil || len(empty) != 0 {
+		t.Fatalf("empty input: want non-nil empty slice, got %#v", empty)
+	}
+}
+
+// TestMCPSessionListNotRunning asserts fleet_session_list rejects a stopped
+// instance with a clear "not running" tool error rather than shelling in.
+func TestMCPSessionListNotRunning(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Instances: []*fleet.Instance{
+			{Name: "i1", Status: fleet.StatusStopped, Backend: fleet.BackendDevcontainer},
+		}},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	cs := mcpConnect(t, newService())
+
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "fleet_session_list", Arguments: map[string]any{"fleet": "alpha", "instance": "i1"},
+	})
+	if err != nil {
+		t.Fatalf("transport error: %v", err)
+	}
+	if !res.IsError || !strings.Contains(toolText(res), "not running") {
+		t.Fatalf("want 'not running' tool error, got IsError=%v text=%q", res.IsError, toolText(res))
 	}
 }
 

--- a/internal/server/mcp_tools.go
+++ b/internal/server/mcp_tools.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os/exec"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -93,6 +94,10 @@ func registerMCPTools(srv *mcp.Server, s *service) {
 		Name:        "fleet_session_read",
 		Description: "Capture the current screen contents of a tmux session inside an instance.",
 	}, s.mcpSessionRead)
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "fleet_session_list",
+		Description: "List the tmux sessions inside a running instance (name, window count, creation time, attached). Returns an empty list when the instance has no sessions.",
+	}, s.mcpSessionList)
 }
 
 // --- shared shapes ---
@@ -543,6 +548,72 @@ func (s *service) mcpSessionRead(ctx context.Context, _ *mcp.CallToolRequest, in
 		return nil, FleetSessionReadOutput{}, fmt.Errorf("read session %q: %w: %s", in.Session, err, strings.TrimSpace(out))
 	}
 	return nil, FleetSessionReadOutput{Content: out}, nil
+}
+
+// fleetSessionListFormat lists every tmux session, one per line, as
+// `windows:attached:created:name`. session_name is placed LAST so a name
+// containing the ':' delimiter (tmux allows it) can't shift the fixed leading
+// fields — parseMCPSessions caps the split at 4 and keeps the remainder as the
+// name. `2>/dev/null` drops tmux's "no server running" stderr; the caller appends
+// `|| true` so that exit-1 (no sessions) collapses to empty output, not an error.
+const fleetSessionListFormat = `tmux list-sessions -F "#{session_windows}:#{session_attached}:#{session_created}:#{session_name}" 2>/dev/null`
+
+// FleetSession is the JSON-friendly view of one tmux session.
+type FleetSession struct {
+	Session   string `json:"session"`
+	Windows   int    `json:"windows"`
+	CreatedAt string `json:"created_at,omitempty"`
+	Attached  bool   `json:"attached"`
+}
+
+type FleetSessionListOutput struct {
+	Sessions []FleetSession `json:"sessions"`
+}
+
+// mcpSessionList enumerates the tmux sessions inside a running instance. A
+// running instance with no sessions yields an empty list (not an error); a
+// not-running instance is rejected up front by runningInstance.
+func (s *service) mcpSessionList(ctx context.Context, _ *mcp.CallToolRequest, in FleetInstanceInput) (*mcp.CallToolResult, FleetSessionListOutput, error) {
+	inst, err := s.runningInstance(in.Fleet, in.Instance)
+	if err != nil {
+		return nil, FleetSessionListOutput{}, err
+	}
+	cctx, cancel := mergeCtx(s.bgCtx, ctx)
+	defer cancel()
+	// `|| true` makes "no tmux server" (exit 1) a successful empty read; a genuine
+	// exec failure (e.g. the container vanished) still surfaces as a tool error.
+	out, err := runContainerShell(cctx, inst, fleetSessionListFormat+" || true")
+	if err != nil {
+		return nil, FleetSessionListOutput{}, fmt.Errorf("list sessions in %s/%s: %w: %s", in.Fleet, in.Instance, err, strings.TrimSpace(out))
+	}
+	return nil, FleetSessionListOutput{Sessions: parseMCPSessions(out)}, nil
+}
+
+// parseMCPSessions parses fleetSessionListFormat output into the MCP session
+// list. Blank/short lines are skipped; created (a Unix epoch) is rendered as
+// RFC3339 UTC to match the other MCP timestamps, or omitted if unparseable.
+func parseMCPSessions(output string) []FleetSession {
+	sessions := []FleetSession{}
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 4)
+		if len(parts) < 4 || parts[3] == "" {
+			continue
+		}
+		windows, _ := strconv.Atoi(parts[0])
+		// session_attached is the CLIENT COUNT, not a 0/1 flag: any positive count
+		// means a client is attached; blank/unparseable counts as detached.
+		attached, _ := strconv.Atoi(parts[1])
+		sess := FleetSession{Session: parts[3], Windows: windows, Attached: attached > 0}
+		if created, err := strconv.ParseInt(parts[2], 10, 64); err == nil && created > 0 {
+			sess.CreatedAt = time.Unix(created, 0).UTC().Format(time.RFC3339)
+		}
+		sessions = append(sessions, sess)
+	}
+	return sessions
 }
 
 // --- helpers ---

--- a/internal/server/runtime_test.go
+++ b/internal/server/runtime_test.go
@@ -50,10 +50,10 @@ func TestApplyRuntimeMergesFields(t *testing.T) {
 }
 
 func TestParseTmuxSessionsProto(t *testing.T) {
-	out := "main:2:1\nbg:1:0\n\nbad\n"
+	out := "main:2:1\nbg:1:0\nmulti:3:2\n\nbad\n"
 	sessions := parseTmuxSessionsProto(out)
-	if len(sessions) != 3 {
-		t.Fatalf("want 3 sessions (main, bg, bad), got %d", len(sessions))
+	if len(sessions) != 4 {
+		t.Fatalf("want 4 sessions (main, bg, multi, bad), got %d", len(sessions))
 	}
 	if sessions[0].GetName() != "main" || sessions[0].GetWindows() != 2 || !sessions[0].GetAttached() {
 		t.Fatalf("main parsed wrong: %+v", sessions[0])
@@ -61,7 +61,11 @@ func TestParseTmuxSessionsProto(t *testing.T) {
 	if sessions[1].GetAttached() {
 		t.Fatalf("bg should be unattached: %+v", sessions[1])
 	}
-	if sessions[2].GetName() != "bad" || sessions[2].GetWindows() != 0 {
-		t.Fatalf("bad (name-only) parsed wrong: %+v", sessions[2])
+	// session_attached is a client count: 2 attached clients -> attached.
+	if !sessions[2].GetAttached() || sessions[2].GetWindows() != 3 {
+		t.Fatalf("multi (2 clients) should be attached: %+v", sessions[2])
+	}
+	if sessions[3].GetName() != "bad" || sessions[3].GetWindows() != 0 {
+		t.Fatalf("bad (name-only) parsed wrong: %+v", sessions[3])
 	}
 }


### PR DESCRIPTION
Adds an MCP tool fleet_session_list(fleet, instance) that lists the tmux sessions inside a running instance, returning {session, windows, created_at, attached} per session. This closes the discovery gap: the existing session tools (spawn/exec/read) all required a known session name, leaving a raw `tmux ls` exec as the only way to find sessions.

- On-demand, dedicated tool (not folded into fleet_list) so fleet_list stays a cheap daemon-state read and isn't coupled to a per-container tmux exec.
- No tmux server (no sessions) returns an empty list, not an error (`2>/dev/null || true`); a not-running instance returns a clear error via runningInstance. session_name is placed last in the -F format so a name containing ':' can't shift the fixed fields.

Drive-by fix: session_attached is tmux's CLIENT COUNT, not a 0/1 flag, so the pre-existing parseTmuxSessionsProto (which feeds the TUI's attached indicator) mis-reported any session with 2+ clients as detached. Both parsers now treat any positive count as attached.