### PR TITLE
feat(mcp): remote-MCP gateway settings + Watch status plumbing (#97)

### DIFF
--- a/fleetgrpc/config.pb.go
+++ b/fleetgrpc/config.pb.go
@@ -447,6 +447,66 @@ func (x *BrowserSettings) GetAutoSwitch() bool {
 	return false
 }
 
+// RemoteMcpSettings mirrors internal/state.RemoteMcpSettings — the user's intent
+// to expose this daemon's local MCP server to the internet through a remote fleet
+// gateway. These are the ONLY two persisted fields: enabled and gateway_url.
+//
+// The COMPUTED "Public MCP URL" the gateway assigns on connect is deliberately
+// NOT in Config — it is runtime state owned by the server and pushed to the TUI
+// via the Watch RemoteMcpStatus event (watch.proto). Keeping it out of Config is
+// what prevents the SetConfig-replaces-everything contract from clobbering it.
+type RemoteMcpSettings struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Enabled       bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	GatewayUrl    string                 `protobuf:"bytes,2,opt,name=gateway_url,json=gatewayUrl,proto3" json:"gateway_url,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RemoteMcpSettings) Reset() {
+	*x = RemoteMcpSettings{}
+	mi := &file_config_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RemoteMcpSettings) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RemoteMcpSettings) ProtoMessage() {}
+
+func (x *RemoteMcpSettings) ProtoReflect() protoreflect.Message {
+	mi := &file_config_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RemoteMcpSettings.ProtoReflect.Descriptor instead.
+func (*RemoteMcpSettings) Descriptor() ([]byte, []int) {
+	return file_config_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *RemoteMcpSettings) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *RemoteMcpSettings) GetGatewayUrl() string {
+	if x != nil {
+		return x.GatewayUrl
+	}
+	return ""
+}
+
 type Config struct {
 	state      protoimpl.MessageState `protogen:"open.v1"`
 	General    *GeneralSettings       `protobuf:"bytes,1,opt,name=general,proto3" json:"general,omitempty"`
@@ -457,14 +517,15 @@ type Config struct {
 	Browser    *BrowserSettings       `protobuf:"bytes,6,opt,name=browser,proto3" json:"browser,omitempty"`
 	// Feeds CreateInstanceRequest's UNSPECIFIED-backend resolution. UNSPECIFIED
 	// means "no default recorded" (-> DEVCONTAINER).
-	DefaultBackend BackendType `protobuf:"varint,7,opt,name=default_backend,json=defaultBackend,proto3,enum=fleetgrpc.BackendType" json:"default_backend,omitempty"`
+	DefaultBackend BackendType        `protobuf:"varint,7,opt,name=default_backend,json=defaultBackend,proto3,enum=fleetgrpc.BackendType" json:"default_backend,omitempty"`
+	RemoteMcp      *RemoteMcpSettings `protobuf:"bytes,8,opt,name=remote_mcp,json=remoteMcp,proto3" json:"remote_mcp,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
 
 func (x *Config) Reset() {
 	*x = Config{}
-	mi := &file_config_proto_msgTypes[7]
+	mi := &file_config_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -476,7 +537,7 @@ func (x *Config) String() string {
 func (*Config) ProtoMessage() {}
 
 func (x *Config) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[7]
+	mi := &file_config_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -489,7 +550,7 @@ func (x *Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Config.ProtoReflect.Descriptor instead.
 func (*Config) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{7}
+	return file_config_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *Config) GetGeneral() *GeneralSettings {
@@ -541,6 +602,13 @@ func (x *Config) GetDefaultBackend() BackendType {
 	return BackendType_BACKEND_TYPE_UNSPECIFIED
 }
 
+func (x *Config) GetRemoteMcp() *RemoteMcpSettings {
+	if x != nil {
+		return x.RemoteMcp
+	}
+	return nil
+}
+
 type GetConfigRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -549,7 +617,7 @@ type GetConfigRequest struct {
 
 func (x *GetConfigRequest) Reset() {
 	*x = GetConfigRequest{}
-	mi := &file_config_proto_msgTypes[8]
+	mi := &file_config_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -561,7 +629,7 @@ func (x *GetConfigRequest) String() string {
 func (*GetConfigRequest) ProtoMessage() {}
 
 func (x *GetConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[8]
+	mi := &file_config_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -574,7 +642,7 @@ func (x *GetConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetConfigRequest) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{8}
+	return file_config_proto_rawDescGZIP(), []int{9}
 }
 
 type GetConfigReply struct {
@@ -586,7 +654,7 @@ type GetConfigReply struct {
 
 func (x *GetConfigReply) Reset() {
 	*x = GetConfigReply{}
-	mi := &file_config_proto_msgTypes[9]
+	mi := &file_config_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -598,7 +666,7 @@ func (x *GetConfigReply) String() string {
 func (*GetConfigReply) ProtoMessage() {}
 
 func (x *GetConfigReply) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[9]
+	mi := &file_config_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -611,7 +679,7 @@ func (x *GetConfigReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetConfigReply.ProtoReflect.Descriptor instead.
 func (*GetConfigReply) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{9}
+	return file_config_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *GetConfigReply) GetConfig() *Config {
@@ -632,7 +700,7 @@ type SetConfigRequest struct {
 
 func (x *SetConfigRequest) Reset() {
 	*x = SetConfigRequest{}
-	mi := &file_config_proto_msgTypes[10]
+	mi := &file_config_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -644,7 +712,7 @@ func (x *SetConfigRequest) String() string {
 func (*SetConfigRequest) ProtoMessage() {}
 
 func (x *SetConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[10]
+	mi := &file_config_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -657,7 +725,7 @@ func (x *SetConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetConfigRequest.ProtoReflect.Descriptor instead.
 func (*SetConfigRequest) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{10}
+	return file_config_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *SetConfigRequest) GetConfig() *Config {
@@ -676,7 +744,7 @@ type SetConfigReply struct {
 
 func (x *SetConfigReply) Reset() {
 	*x = SetConfigReply{}
-	mi := &file_config_proto_msgTypes[11]
+	mi := &file_config_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -688,7 +756,7 @@ func (x *SetConfigReply) String() string {
 func (*SetConfigReply) ProtoMessage() {}
 
 func (x *SetConfigReply) ProtoReflect() protoreflect.Message {
-	mi := &file_config_proto_msgTypes[11]
+	mi := &file_config_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -701,7 +769,7 @@ func (x *SetConfigReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetConfigReply.ProtoReflect.Descriptor instead.
 func (*SetConfigReply) Descriptor() ([]byte, []int) {
-	return file_config_proto_rawDescGZIP(), []int{11}
+	return file_config_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *SetConfigReply) GetConfig() *Config {
@@ -761,7 +829,11 @@ const file_config_proto_rawDesc = "" +
 	"\vauto_switch\x18\x02 \x01(\bH\x01R\n" +
 	"autoSwitch\x88\x01\x01B\x1e\n" +
 	"\x1c_multiple_browsers_per_fleetB\x0e\n" +
-	"\f_auto_switch\"\x93\x03\n" +
+	"\f_auto_switch\"N\n" +
+	"\x11RemoteMcpSettings\x12\x18\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x1f\n" +
+	"\vgateway_url\x18\x02 \x01(\tR\n" +
+	"gatewayUrl\"\xd0\x03\n" +
 	"\x06Config\x124\n" +
 	"\ageneral\x18\x01 \x01(\v2\x1a.fleetgrpc.GeneralSettingsR\ageneral\x12.\n" +
 	"\x05agent\x18\x02 \x01(\v2\x18.fleetgrpc.AgentSettingsR\x05agent\x127\n" +
@@ -771,7 +843,9 @@ const file_config_proto_rawDesc = "" +
 	"codespaces\x18\x05 \x01(\v2\x1d.fleetgrpc.CodespacesSettingsR\n" +
 	"codespaces\x124\n" +
 	"\abrowser\x18\x06 \x01(\v2\x1a.fleetgrpc.BrowserSettingsR\abrowser\x12?\n" +
-	"\x0fdefault_backend\x18\a \x01(\x0e2\x16.fleetgrpc.BackendTypeR\x0edefaultBackendJ\x04\b\b\x10\x15\"\x12\n" +
+	"\x0fdefault_backend\x18\a \x01(\x0e2\x16.fleetgrpc.BackendTypeR\x0edefaultBackend\x12;\n" +
+	"\n" +
+	"remote_mcp\x18\b \x01(\v2\x1c.fleetgrpc.RemoteMcpSettingsR\tremoteMcpJ\x04\b\t\x10\x15\"\x12\n" +
 	"\x10GetConfigRequest\";\n" +
 	"\x0eGetConfigReply\x12)\n" +
 	"\x06config\x18\x01 \x01(\v2\x11.fleetgrpc.ConfigR\x06config\"=\n" +
@@ -792,7 +866,7 @@ func file_config_proto_rawDescGZIP() []byte {
 	return file_config_proto_rawDescData
 }
 
-var file_config_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_config_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_config_proto_goTypes = []any{
 	(*GeneralSettings)(nil),    // 0: fleetgrpc.GeneralSettings
 	(*AgentSettings)(nil),      // 1: fleetgrpc.AgentSettings
@@ -801,12 +875,13 @@ var file_config_proto_goTypes = []any{
 	(*CoderSettings)(nil),      // 4: fleetgrpc.CoderSettings
 	(*CodespacesSettings)(nil), // 5: fleetgrpc.CodespacesSettings
 	(*BrowserSettings)(nil),    // 6: fleetgrpc.BrowserSettings
-	(*Config)(nil),             // 7: fleetgrpc.Config
-	(*GetConfigRequest)(nil),   // 8: fleetgrpc.GetConfigRequest
-	(*GetConfigReply)(nil),     // 9: fleetgrpc.GetConfigReply
-	(*SetConfigRequest)(nil),   // 10: fleetgrpc.SetConfigRequest
-	(*SetConfigReply)(nil),     // 11: fleetgrpc.SetConfigReply
-	(BackendType)(0),           // 12: fleetgrpc.BackendType
+	(*RemoteMcpSettings)(nil),  // 7: fleetgrpc.RemoteMcpSettings
+	(*Config)(nil),             // 8: fleetgrpc.Config
+	(*GetConfigRequest)(nil),   // 9: fleetgrpc.GetConfigRequest
+	(*GetConfigReply)(nil),     // 10: fleetgrpc.GetConfigReply
+	(*SetConfigRequest)(nil),   // 11: fleetgrpc.SetConfigRequest
+	(*SetConfigReply)(nil),     // 12: fleetgrpc.SetConfigReply
+	(BackendType)(0),           // 13: fleetgrpc.BackendType
 }
 var file_config_proto_depIdxs = []int32{
 	3,  // 0: fleetgrpc.CoderSettings.parameters:type_name -> fleetgrpc.CoderParameter
@@ -816,15 +891,16 @@ var file_config_proto_depIdxs = []int32{
 	4,  // 4: fleetgrpc.Config.coder:type_name -> fleetgrpc.CoderSettings
 	5,  // 5: fleetgrpc.Config.codespaces:type_name -> fleetgrpc.CodespacesSettings
 	6,  // 6: fleetgrpc.Config.browser:type_name -> fleetgrpc.BrowserSettings
-	12, // 7: fleetgrpc.Config.default_backend:type_name -> fleetgrpc.BackendType
-	7,  // 8: fleetgrpc.GetConfigReply.config:type_name -> fleetgrpc.Config
-	7,  // 9: fleetgrpc.SetConfigRequest.config:type_name -> fleetgrpc.Config
-	7,  // 10: fleetgrpc.SetConfigReply.config:type_name -> fleetgrpc.Config
-	11, // [11:11] is the sub-list for method output_type
-	11, // [11:11] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	13, // 7: fleetgrpc.Config.default_backend:type_name -> fleetgrpc.BackendType
+	7,  // 8: fleetgrpc.Config.remote_mcp:type_name -> fleetgrpc.RemoteMcpSettings
+	8,  // 9: fleetgrpc.GetConfigReply.config:type_name -> fleetgrpc.Config
+	8,  // 10: fleetgrpc.SetConfigRequest.config:type_name -> fleetgrpc.Config
+	8,  // 11: fleetgrpc.SetConfigReply.config:type_name -> fleetgrpc.Config
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_config_proto_init() }
@@ -845,7 +921,7 @@ func file_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_config_proto_rawDesc), len(file_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   12,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/fleetgrpc/config.proto
+++ b/fleetgrpc/config.proto
@@ -74,6 +74,19 @@ message BrowserSettings {
   optional bool auto_switch = 2;
 }
 
+// RemoteMcpSettings mirrors internal/state.RemoteMcpSettings — the user's intent
+// to expose this daemon's local MCP server to the internet through a remote fleet
+// gateway. These are the ONLY two persisted fields: enabled and gateway_url.
+//
+// The COMPUTED "Public MCP URL" the gateway assigns on connect is deliberately
+// NOT in Config — it is runtime state owned by the server and pushed to the TUI
+// via the Watch RemoteMcpStatus event (watch.proto). Keeping it out of Config is
+// what prevents the SetConfig-replaces-everything contract from clobbering it.
+message RemoteMcpSettings {
+  bool enabled = 1;
+  string gateway_url = 2;
+}
+
 message Config {
   GeneralSettings general = 1;
   AgentSettings agent = 2;
@@ -84,8 +97,9 @@ message Config {
   // Feeds CreateInstanceRequest's UNSPECIFIED-backend resolution. UNSPECIFIED
   // means "no default recorded" (-> DEVCONTAINER).
   BackendType default_backend = 7;
+  RemoteMcpSettings remote_mcp = 8;
 
-  reserved 8 to 20;
+  reserved 9 to 20;
 }
 
 message GetConfigRequest {}

--- a/fleetgrpc/watch.pb.go
+++ b/fleetgrpc/watch.pb.go
@@ -21,6 +21,59 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// RemoteMcpConn is the connection state of the outbound MCP gateway tunnel.
+type RemoteMcpConn int32
+
+const (
+	RemoteMcpConn_REMOTE_MCP_CONN_UNSPECIFIED RemoteMcpConn = 0 // feature off / not connected (the default)
+	RemoteMcpConn_REMOTE_MCP_CONN_CONNECTING  RemoteMcpConn = 1 // enabled, dialing/registering with the gateway
+	RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED   RemoteMcpConn = 2 // tunnel up; public_url is live
+	RemoteMcpConn_REMOTE_MCP_CONN_ERROR       RemoteMcpConn = 3 // enabled but the last attempt failed; error is set
+)
+
+// Enum value maps for RemoteMcpConn.
+var (
+	RemoteMcpConn_name = map[int32]string{
+		0: "REMOTE_MCP_CONN_UNSPECIFIED",
+		1: "REMOTE_MCP_CONN_CONNECTING",
+		2: "REMOTE_MCP_CONN_CONNECTED",
+		3: "REMOTE_MCP_CONN_ERROR",
+	}
+	RemoteMcpConn_value = map[string]int32{
+		"REMOTE_MCP_CONN_UNSPECIFIED": 0,
+		"REMOTE_MCP_CONN_CONNECTING":  1,
+		"REMOTE_MCP_CONN_CONNECTED":   2,
+		"REMOTE_MCP_CONN_ERROR":       3,
+	}
+)
+
+func (x RemoteMcpConn) Enum() *RemoteMcpConn {
+	p := new(RemoteMcpConn)
+	*p = x
+	return p
+}
+
+func (x RemoteMcpConn) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RemoteMcpConn) Descriptor() protoreflect.EnumDescriptor {
+	return file_watch_proto_enumTypes[0].Descriptor()
+}
+
+func (RemoteMcpConn) Type() protoreflect.EnumType {
+	return &file_watch_proto_enumTypes[0]
+}
+
+func (x RemoteMcpConn) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RemoteMcpConn.Descriptor instead.
+func (RemoteMcpConn) EnumDescriptor() ([]byte, []int) {
+	return file_watch_proto_rawDescGZIP(), []int{0}
+}
+
 // WatchRequest opens a subscription.
 //
 // include_initial_state: emit one StateChanged snapshot, one RuntimeChanged
@@ -117,6 +170,12 @@ func (x *WatchRequest) GetReattachJobIds() []string {
 // a browser.open envelope from inside a container; the SERVER owns the control
 // socket and resolves the URL, the CLIENT execs its local browser — the correct
 // split for the remote-TUI goal.
+//
+// RemoteMcpStatus carries the live state of the outbound MCP gateway tunnel,
+// including the gateway-assigned Public MCP URL. It is a server-owned, push-only
+// COMPUTED value (never a Config field), so the settings page renders whatever
+// the latest pushed status says without any SetConfig read-back. Conflatable
+// (newest status wins) and cached by the hub for the initial snapshot.
 type Event struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Kind:
@@ -128,6 +187,7 @@ type Event struct {
 	//	*Event_JobDone
 	//	*Event_BrowserOpen
 	//	*Event_RuntimeChanged
+	//	*Event_RemoteMcpStatus
 	Kind          isEvent_Kind `protobuf_oneof:"kind"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -233,6 +293,15 @@ func (x *Event) GetRuntimeChanged() *RuntimeChanged {
 	return nil
 }
 
+func (x *Event) GetRemoteMcpStatus() *RemoteMcpStatus {
+	if x != nil {
+		if x, ok := x.Kind.(*Event_RemoteMcpStatus); ok {
+			return x.RemoteMcpStatus
+		}
+	}
+	return nil
+}
+
 type isEvent_Kind interface {
 	isEvent_Kind()
 }
@@ -265,6 +334,10 @@ type Event_RuntimeChanged struct {
 	RuntimeChanged *RuntimeChanged `protobuf:"bytes,7,opt,name=runtime_changed,json=runtimeChanged,proto3,oneof"`
 }
 
+type Event_RemoteMcpStatus struct {
+	RemoteMcpStatus *RemoteMcpStatus `protobuf:"bytes,8,opt,name=remote_mcp_status,json=remoteMcpStatus,proto3,oneof"`
+}
+
 func (*Event_StateChanged) isEvent_Kind() {}
 
 func (*Event_JobStarted) isEvent_Kind() {}
@@ -279,6 +352,73 @@ func (*Event_BrowserOpen) isEvent_Kind() {}
 
 func (*Event_RuntimeChanged) isEvent_Kind() {}
 
+func (*Event_RemoteMcpStatus) isEvent_Kind() {}
+
+// RemoteMcpStatus is the computed status the settings page shows after the user
+// enables remote MCP. public_url is the gateway-assigned Public MCP URL (only
+// meaningful when state is CONNECTED); error carries the last failure (when
+// state is ERROR). The tunnel itself lands in a later PR — for now this only
+// ever reports DISABLED, but the full push path is wired end to end.
+type RemoteMcpStatus struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	State         RemoteMcpConn          `protobuf:"varint,1,opt,name=state,proto3,enum=fleetgrpc.RemoteMcpConn" json:"state,omitempty"`
+	PublicUrl     string                 `protobuf:"bytes,2,opt,name=public_url,json=publicUrl,proto3" json:"public_url,omitempty"`
+	Error         string                 `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RemoteMcpStatus) Reset() {
+	*x = RemoteMcpStatus{}
+	mi := &file_watch_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RemoteMcpStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RemoteMcpStatus) ProtoMessage() {}
+
+func (x *RemoteMcpStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_watch_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RemoteMcpStatus.ProtoReflect.Descriptor instead.
+func (*RemoteMcpStatus) Descriptor() ([]byte, []int) {
+	return file_watch_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *RemoteMcpStatus) GetState() RemoteMcpConn {
+	if x != nil {
+		return x.State
+	}
+	return RemoteMcpConn_REMOTE_MCP_CONN_UNSPECIFIED
+}
+
+func (x *RemoteMcpStatus) GetPublicUrl() string {
+	if x != nil {
+		return x.PublicUrl
+	}
+	return ""
+}
+
+func (x *RemoteMcpStatus) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
 // StateChanged is pushed whenever the authoritative PERSISTED model mutates. It
 // carries the full State (simple, race-free for a small model) so the client
 // never reconciles partial deltas — directly replacing state.Load reloads.
@@ -291,7 +431,7 @@ type StateChanged struct {
 
 func (x *StateChanged) Reset() {
 	*x = StateChanged{}
-	mi := &file_watch_proto_msgTypes[2]
+	mi := &file_watch_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -303,7 +443,7 @@ func (x *StateChanged) String() string {
 func (*StateChanged) ProtoMessage() {}
 
 func (x *StateChanged) ProtoReflect() protoreflect.Message {
-	mi := &file_watch_proto_msgTypes[2]
+	mi := &file_watch_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -316,7 +456,7 @@ func (x *StateChanged) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StateChanged.ProtoReflect.Descriptor instead.
 func (*StateChanged) Descriptor() ([]byte, []int) {
-	return file_watch_proto_rawDescGZIP(), []int{2}
+	return file_watch_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *StateChanged) GetState() *State {
@@ -339,7 +479,7 @@ type RuntimeChanged struct {
 
 func (x *RuntimeChanged) Reset() {
 	*x = RuntimeChanged{}
-	mi := &file_watch_proto_msgTypes[3]
+	mi := &file_watch_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -351,7 +491,7 @@ func (x *RuntimeChanged) String() string {
 func (*RuntimeChanged) ProtoMessage() {}
 
 func (x *RuntimeChanged) ProtoReflect() protoreflect.Message {
-	mi := &file_watch_proto_msgTypes[3]
+	mi := &file_watch_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -364,7 +504,7 @@ func (x *RuntimeChanged) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuntimeChanged.ProtoReflect.Descriptor instead.
 func (*RuntimeChanged) Descriptor() ([]byte, []int) {
-	return file_watch_proto_rawDescGZIP(), []int{3}
+	return file_watch_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *RuntimeChanged) GetRuntime() []*InstanceRuntime {
@@ -390,7 +530,7 @@ type BrowserOpen struct {
 
 func (x *BrowserOpen) Reset() {
 	*x = BrowserOpen{}
-	mi := &file_watch_proto_msgTypes[4]
+	mi := &file_watch_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -402,7 +542,7 @@ func (x *BrowserOpen) String() string {
 func (*BrowserOpen) ProtoMessage() {}
 
 func (x *BrowserOpen) ProtoReflect() protoreflect.Message {
-	mi := &file_watch_proto_msgTypes[4]
+	mi := &file_watch_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -415,7 +555,7 @@ func (x *BrowserOpen) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BrowserOpen.ProtoReflect.Descriptor instead.
 func (*BrowserOpen) Descriptor() ([]byte, []int) {
-	return file_watch_proto_rawDescGZIP(), []int{4}
+	return file_watch_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *BrowserOpen) GetUrl() string {
@@ -455,7 +595,7 @@ const file_watch_proto_rawDesc = "" +
 	"\fWatchRequest\x122\n" +
 	"\x15include_initial_state\x18\x01 \x01(\bR\x13includeInitialState\x12+\n" +
 	"\x11subscribe_runtime\x18\x02 \x01(\bR\x10subscribeRuntime\x12(\n" +
-	"\x10reattach_job_ids\x18\x03 \x03(\tR\x0ereattachJobIds\"\xa8\x03\n" +
+	"\x10reattach_job_ids\x18\x03 \x03(\tR\x0ereattachJobIds\"\xf2\x03\n" +
 	"\x05Event\x12>\n" +
 	"\rstate_changed\x18\x01 \x01(\v2\x17.fleetgrpc.StateChangedH\x00R\fstateChanged\x128\n" +
 	"\vjob_started\x18\x02 \x01(\v2\x15.fleetgrpc.JobStartedH\x00R\n" +
@@ -464,8 +604,14 @@ const file_watch_proto_rawDesc = "" +
 	"\ajob_log\x18\x04 \x01(\v2\x11.fleetgrpc.JobLogH\x00R\x06jobLog\x12/\n" +
 	"\bjob_done\x18\x05 \x01(\v2\x12.fleetgrpc.JobDoneH\x00R\ajobDone\x12;\n" +
 	"\fbrowser_open\x18\x06 \x01(\v2\x16.fleetgrpc.BrowserOpenH\x00R\vbrowserOpen\x12D\n" +
-	"\x0fruntime_changed\x18\a \x01(\v2\x19.fleetgrpc.RuntimeChangedH\x00R\x0eruntimeChangedB\x06\n" +
-	"\x04kind\"6\n" +
+	"\x0fruntime_changed\x18\a \x01(\v2\x19.fleetgrpc.RuntimeChangedH\x00R\x0eruntimeChanged\x12H\n" +
+	"\x11remote_mcp_status\x18\b \x01(\v2\x1a.fleetgrpc.RemoteMcpStatusH\x00R\x0fremoteMcpStatusB\x06\n" +
+	"\x04kind\"v\n" +
+	"\x0fRemoteMcpStatus\x12.\n" +
+	"\x05state\x18\x01 \x01(\x0e2\x18.fleetgrpc.RemoteMcpConnR\x05state\x12\x1d\n" +
+	"\n" +
+	"public_url\x18\x02 \x01(\tR\tpublicUrl\x12\x14\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\"6\n" +
 	"\fStateChanged\x12&\n" +
 	"\x05state\x18\x01 \x01(\v2\x10.fleetgrpc.StateR\x05state\"F\n" +
 	"\x0eRuntimeChanged\x124\n" +
@@ -475,7 +621,12 @@ const file_watch_proto_rawDesc = "" +
 	"\bdata_dir\x18\x02 \x01(\tH\x00R\adataDir\x88\x01\x01\x12\x14\n" +
 	"\x05fleet\x18\x03 \x01(\tR\x05fleet\x12\x1a\n" +
 	"\binstance\x18\x04 \x01(\tR\binstanceB\v\n" +
-	"\t_data_dirB:Z8github.com/BenjaminBenetti/fleet-man/fleetgrpc;fleetgrpcb\x06proto3"
+	"\t_data_dir*\x8a\x01\n" +
+	"\rRemoteMcpConn\x12\x1f\n" +
+	"\x1bREMOTE_MCP_CONN_UNSPECIFIED\x10\x00\x12\x1e\n" +
+	"\x1aREMOTE_MCP_CONN_CONNECTING\x10\x01\x12\x1d\n" +
+	"\x19REMOTE_MCP_CONN_CONNECTED\x10\x02\x12\x19\n" +
+	"\x15REMOTE_MCP_CONN_ERROR\x10\x03B:Z8github.com/BenjaminBenetti/fleet-man/fleetgrpc;fleetgrpcb\x06proto3"
 
 var (
 	file_watch_proto_rawDescOnce sync.Once
@@ -489,35 +640,40 @@ func file_watch_proto_rawDescGZIP() []byte {
 	return file_watch_proto_rawDescData
 }
 
-var file_watch_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_watch_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_watch_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_watch_proto_goTypes = []any{
-	(*WatchRequest)(nil),    // 0: fleetgrpc.WatchRequest
-	(*Event)(nil),           // 1: fleetgrpc.Event
-	(*StateChanged)(nil),    // 2: fleetgrpc.StateChanged
-	(*RuntimeChanged)(nil),  // 3: fleetgrpc.RuntimeChanged
-	(*BrowserOpen)(nil),     // 4: fleetgrpc.BrowserOpen
-	(*JobStarted)(nil),      // 5: fleetgrpc.JobStarted
-	(*JobProgress)(nil),     // 6: fleetgrpc.JobProgress
-	(*JobLog)(nil),          // 7: fleetgrpc.JobLog
-	(*JobDone)(nil),         // 8: fleetgrpc.JobDone
-	(*State)(nil),           // 9: fleetgrpc.State
-	(*InstanceRuntime)(nil), // 10: fleetgrpc.InstanceRuntime
+	(RemoteMcpConn)(0),      // 0: fleetgrpc.RemoteMcpConn
+	(*WatchRequest)(nil),    // 1: fleetgrpc.WatchRequest
+	(*Event)(nil),           // 2: fleetgrpc.Event
+	(*RemoteMcpStatus)(nil), // 3: fleetgrpc.RemoteMcpStatus
+	(*StateChanged)(nil),    // 4: fleetgrpc.StateChanged
+	(*RuntimeChanged)(nil),  // 5: fleetgrpc.RuntimeChanged
+	(*BrowserOpen)(nil),     // 6: fleetgrpc.BrowserOpen
+	(*JobStarted)(nil),      // 7: fleetgrpc.JobStarted
+	(*JobProgress)(nil),     // 8: fleetgrpc.JobProgress
+	(*JobLog)(nil),          // 9: fleetgrpc.JobLog
+	(*JobDone)(nil),         // 10: fleetgrpc.JobDone
+	(*State)(nil),           // 11: fleetgrpc.State
+	(*InstanceRuntime)(nil), // 12: fleetgrpc.InstanceRuntime
 }
 var file_watch_proto_depIdxs = []int32{
-	2,  // 0: fleetgrpc.Event.state_changed:type_name -> fleetgrpc.StateChanged
-	5,  // 1: fleetgrpc.Event.job_started:type_name -> fleetgrpc.JobStarted
-	6,  // 2: fleetgrpc.Event.job_progress:type_name -> fleetgrpc.JobProgress
-	7,  // 3: fleetgrpc.Event.job_log:type_name -> fleetgrpc.JobLog
-	8,  // 4: fleetgrpc.Event.job_done:type_name -> fleetgrpc.JobDone
-	4,  // 5: fleetgrpc.Event.browser_open:type_name -> fleetgrpc.BrowserOpen
-	3,  // 6: fleetgrpc.Event.runtime_changed:type_name -> fleetgrpc.RuntimeChanged
-	9,  // 7: fleetgrpc.StateChanged.state:type_name -> fleetgrpc.State
-	10, // 8: fleetgrpc.RuntimeChanged.runtime:type_name -> fleetgrpc.InstanceRuntime
-	9,  // [9:9] is the sub-list for method output_type
-	9,  // [9:9] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	4,  // 0: fleetgrpc.Event.state_changed:type_name -> fleetgrpc.StateChanged
+	7,  // 1: fleetgrpc.Event.job_started:type_name -> fleetgrpc.JobStarted
+	8,  // 2: fleetgrpc.Event.job_progress:type_name -> fleetgrpc.JobProgress
+	9,  // 3: fleetgrpc.Event.job_log:type_name -> fleetgrpc.JobLog
+	10, // 4: fleetgrpc.Event.job_done:type_name -> fleetgrpc.JobDone
+	6,  // 5: fleetgrpc.Event.browser_open:type_name -> fleetgrpc.BrowserOpen
+	5,  // 6: fleetgrpc.Event.runtime_changed:type_name -> fleetgrpc.RuntimeChanged
+	3,  // 7: fleetgrpc.Event.remote_mcp_status:type_name -> fleetgrpc.RemoteMcpStatus
+	0,  // 8: fleetgrpc.RemoteMcpStatus.state:type_name -> fleetgrpc.RemoteMcpConn
+	11, // 9: fleetgrpc.StateChanged.state:type_name -> fleetgrpc.State
+	12, // 10: fleetgrpc.RuntimeChanged.runtime:type_name -> fleetgrpc.InstanceRuntime
+	11, // [11:11] is the sub-list for method output_type
+	11, // [11:11] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_watch_proto_init() }
@@ -536,20 +692,22 @@ func file_watch_proto_init() {
 		(*Event_JobDone)(nil),
 		(*Event_BrowserOpen)(nil),
 		(*Event_RuntimeChanged)(nil),
+		(*Event_RemoteMcpStatus)(nil),
 	}
-	file_watch_proto_msgTypes[4].OneofWrappers = []any{}
+	file_watch_proto_msgTypes[5].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_watch_proto_rawDesc), len(file_watch_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   5,
+			NumEnums:      1,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_watch_proto_goTypes,
 		DependencyIndexes: file_watch_proto_depIdxs,
+		EnumInfos:         file_watch_proto_enumTypes,
 		MessageInfos:      file_watch_proto_msgTypes,
 	}.Build()
 	File_watch_proto = out.File

--- a/fleetgrpc/watch.proto
+++ b/fleetgrpc/watch.proto
@@ -56,6 +56,12 @@ message WatchRequest {
 // a browser.open envelope from inside a container; the SERVER owns the control
 // socket and resolves the URL, the CLIENT execs its local browser — the correct
 // split for the remote-TUI goal.
+//
+// RemoteMcpStatus carries the live state of the outbound MCP gateway tunnel,
+// including the gateway-assigned Public MCP URL. It is a server-owned, push-only
+// COMPUTED value (never a Config field), so the settings page renders whatever
+// the latest pushed status says without any SetConfig read-back. Conflatable
+// (newest status wins) and cached by the hub for the initial snapshot.
 message Event {
   oneof kind {
     StateChanged state_changed = 1;
@@ -65,7 +71,27 @@ message Event {
     JobDone job_done = 5;
     BrowserOpen browser_open = 6;
     RuntimeChanged runtime_changed = 7;
+    RemoteMcpStatus remote_mcp_status = 8;
   }
+}
+
+// RemoteMcpConn is the connection state of the outbound MCP gateway tunnel.
+enum RemoteMcpConn {
+  REMOTE_MCP_CONN_UNSPECIFIED = 0; // feature off / not connected (the default)
+  REMOTE_MCP_CONN_CONNECTING = 1; // enabled, dialing/registering with the gateway
+  REMOTE_MCP_CONN_CONNECTED = 2; // tunnel up; public_url is live
+  REMOTE_MCP_CONN_ERROR = 3; // enabled but the last attempt failed; error is set
+}
+
+// RemoteMcpStatus is the computed status the settings page shows after the user
+// enables remote MCP. public_url is the gateway-assigned Public MCP URL (only
+// meaningful when state is CONNECTED); error carries the last failure (when
+// state is ERROR). The tunnel itself lands in a later PR — for now this only
+// ever reports DISABLED, but the full push path is wired end to end.
+message RemoteMcpStatus {
+  RemoteMcpConn state = 1;
+  string public_url = 2;
+  string error = 3;
 }
 
 // StateChanged is pushed whenever the authoritative PERSISTED model mutates. It

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -58,6 +58,10 @@ func configToProto(c *state.Config) *fleetgrpc.Config {
 		Coder:          &fleetgrpc.CoderSettings{},
 		Codespaces:     &fleetgrpc.CodespacesSettings{},
 		Browser:        &fleetgrpc.BrowserSettings{},
+		RemoteMcp: &fleetgrpc.RemoteMcpSettings{
+			Enabled:    c.RemoteMcpSettings.Enabled,
+			GatewayUrl: c.RemoteMcpSettings.GatewayURL,
+		},
 		DefaultBackend: backendToProto(fleet.BackendType(c.DefaultBackend)),
 	}
 
@@ -179,6 +183,11 @@ func protoConfigToLegacy(pc *fleetgrpc.Config) *state.Config {
 			v := b.GetAutoSwitch()
 			c.BrowserSettings.AutoSwitch = &v
 		}
+	}
+
+	if rm := pc.GetRemoteMcp(); rm != nil {
+		c.RemoteMcpSettings.Enabled = rm.GetEnabled()
+		c.RemoteMcpSettings.GatewayURL = rm.GetGatewayUrl()
 	}
 
 	c.DefaultBackend = backendProtoToString(pc.GetDefaultBackend())

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -97,3 +97,43 @@ func TestSetConfigRoundTripsFullConfig(t *testing.T) {
 		t.Fatalf("disk config lost rich coder params: %+v", loaded.CoderSettings.Parameters)
 	}
 }
+
+// TestSetConfigRoundTripsRemoteMcp guards the remote-MCP settings: enabled and
+// gateway_url must survive a SetConfig -> GetConfig round-trip and land on disk.
+// (The computed Public MCP URL is deliberately NOT a Config field — it travels
+// over the Watch RemoteMcpStatus event — so there is nothing to round-trip for
+// it here.)
+func TestSetConfigRoundTripsRemoteMcp(t *testing.T) {
+	isolateFleetDir(t)
+	svc := newService()
+	ctx := context.Background()
+
+	in := &fleetgrpc.Config{
+		Agent:     &fleetgrpc.AgentSettings{ToolSelection: "claude"},
+		RemoteMcp: &fleetgrpc.RemoteMcpSettings{Enabled: true, GatewayUrl: "https://gateway.example.com"},
+	}
+	if _, err := svc.SetConfig(ctx, &fleetgrpc.SetConfigRequest{Config: in}); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+
+	reply, err := svc.GetConfig(ctx, &fleetgrpc.GetConfigRequest{})
+	if err != nil {
+		t.Fatalf("GetConfig: %v", err)
+	}
+	rm := reply.GetConfig().GetRemoteMcp()
+	if !rm.GetEnabled() {
+		t.Fatalf("enabled lost on round-trip")
+	}
+	if rm.GetGatewayUrl() != "https://gateway.example.com" {
+		t.Fatalf("gateway_url mismatch: %q", rm.GetGatewayUrl())
+	}
+
+	// And the bytes on disk match what the legacy SaveConfig writes.
+	loaded, err := state.LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !loaded.RemoteMcpSettings.Enabled || loaded.RemoteMcpSettings.GatewayURL != "https://gateway.example.com" {
+		t.Fatalf("disk config lost remote-mcp settings: %+v", loaded.RemoteMcpSettings)
+	}
+}

--- a/internal/server/hub.go
+++ b/internal/server/hub.go
@@ -29,6 +29,12 @@ type hub struct {
 	subs    map[*subscriber]struct{}
 	agent   *agentTracker // stateful agent-activity detection (owned by the loop)
 
+	// remoteMcp is the latest outbound-MCP-gateway tunnel status (owned by the
+	// loop). It is a computed, server-owned value pushed to clients via the Watch
+	// RemoteMcpStatus event and cached here so a newly-attached subscriber gets
+	// the current status in its initial snapshot. Defaults to DISABLED.
+	remoteMcp *fleetgrpc.RemoteMcpStatus
+
 	// runtimeWanted is true while at least one subscriber asked for runtime;
 	// the runtime pollers read it lock-free to gate their expensive work.
 	runtimeWanted atomic.Bool
@@ -58,6 +64,7 @@ func newHub() *hub {
 		subs:        make(map[*subscriber]struct{}),
 		agent:       newAgentTracker(),
 		runtimeEdge: make(chan struct{}, 1),
+		remoteMcp:   &fleetgrpc.RemoteMcpStatus{}, // state == UNSPECIFIED (not connected)
 	}
 }
 
@@ -173,6 +180,23 @@ func (h *hub) broadcastBrowserOpen(ev *fleetgrpc.BrowserOpen) {
 	}
 }
 
+// broadcastRemoteMcpStatus caches the latest outbound-MCP-tunnel status and fans
+// it out to every subscriber. Conflatable (newest status wins, like setState),
+// so a no-op transition is dropped and a slow consumer only ever sees the
+// current status. Runs on the hub loop.
+func (h *hub) broadcastRemoteMcpStatus(st *fleetgrpc.RemoteMcpStatus) {
+	if st == nil {
+		return
+	}
+	if proto.Equal(h.remoteMcp, st) {
+		return
+	}
+	h.remoteMcp = st
+	for sub := range h.subs {
+		sub.enqueueRemoteMcp(st)
+	}
+}
+
 func runtimeKey(fleetName, instance string) string { return fleetName + "/" + instance }
 
 // subscriber is one Watch stream's conflating buffer. pendingState keeps the
@@ -191,6 +215,9 @@ type subscriber struct {
 	// Unlike state/runtime these are discrete (each open matters), so they are
 	// NOT conflated — they accumulate until drained.
 	pendingBrowserOpen []*fleetgrpc.BrowserOpen
+	// pendingRemoteMcp is the newest outbound-MCP-tunnel status (conflated like
+	// pendingState — only the current status matters).
+	pendingRemoteMcp *fleetgrpc.RemoteMcpStatus
 
 	notify chan struct{}
 }
@@ -233,9 +260,16 @@ func (s *subscriber) enqueueBrowserOpen(ev *fleetgrpc.BrowserOpen) {
 	s.signal()
 }
 
-// drain takes the pending state + runtime + browser-opens out of the buffer for
-// sending.
-func (s *subscriber) drain() (*fleetgrpc.State, []*fleetgrpc.InstanceRuntime, []*fleetgrpc.BrowserOpen) {
+func (s *subscriber) enqueueRemoteMcp(st *fleetgrpc.RemoteMcpStatus) {
+	s.mu.Lock()
+	s.pendingRemoteMcp = st
+	s.mu.Unlock()
+	s.signal()
+}
+
+// drain takes the pending state + runtime + browser-opens + remote-MCP status
+// out of the buffer for sending.
+func (s *subscriber) drain() (*fleetgrpc.State, []*fleetgrpc.InstanceRuntime, []*fleetgrpc.BrowserOpen, *fleetgrpc.RemoteMcpStatus) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	st := s.pendingState
@@ -250,5 +284,7 @@ func (s *subscriber) drain() (*fleetgrpc.State, []*fleetgrpc.InstanceRuntime, []
 	}
 	bo := s.pendingBrowserOpen
 	s.pendingBrowserOpen = nil
-	return st, rt, bo
+	rm := s.pendingRemoteMcp
+	s.pendingRemoteMcp = nil
+	return st, rt, bo, rm
 }

--- a/internal/server/hub_test.go
+++ b/internal/server/hub_test.go
@@ -26,11 +26,11 @@ func TestSubscriberStateConflation(t *testing.T) {
 	s.enqueueState(&fleetgrpc.State{LastSeenVersion: proto.String("v1")})
 	s.enqueueState(&fleetgrpc.State{LastSeenVersion: proto.String("v2")})
 
-	st, _, _ := s.drain()
+	st, _, _, _ := s.drain()
 	if st.GetLastSeenVersion() != "v2" {
 		t.Fatalf("conflation: want newest v2, got %q", st.GetLastSeenVersion())
 	}
-	if again, _, _ := s.drain(); again != nil {
+	if again, _, _, _ := s.drain(); again != nil {
 		t.Fatalf("want nil state after drain, got %v", again)
 	}
 }
@@ -43,7 +43,7 @@ func TestSubscriberRuntimeConflationByKey(t *testing.T) {
 	// A different instance survives independently.
 	s.enqueueRuntime([]*fleetgrpc.InstanceRuntime{{Fleet: "f", Instance: "j", LiveStatus: fleetgrpc.LiveContainerStatus_LIVE_CONTAINER_STATUS_RUNNING}})
 
-	_, rt, _ := s.drain()
+	_, rt, _, _ := s.drain()
 	if len(rt) != 2 {
 		t.Fatalf("want 2 keyed entries, got %d", len(rt))
 	}
@@ -74,13 +74,13 @@ func TestHubSetStateBroadcastsAndDedups(t *testing.T) {
 	h.post(func(h *hub) { h.setState(&fleetgrpc.State{LastSeenVersion: proto.String("v1")}) })
 	drainSync(t, h)
 
-	st, _, _ := sub.drain()
+	st, _, _, _ := sub.drain()
 	if st.GetLastSeenVersion() != "v1" {
 		t.Fatalf("want broadcast v1, got %q", st.GetLastSeenVersion())
 	}
 	// After draining the single broadcast, the dedup'd second setState left
 	// nothing pending.
-	if again, _, _ := sub.drain(); again != nil {
+	if again, _, _, _ := sub.drain(); again != nil {
 		t.Fatalf("dedup: want no second broadcast, got %v", again)
 	}
 }
@@ -106,12 +106,72 @@ func TestHubBackpressureDoesNotBlock(t *testing.T) {
 	}
 	drainSync(t, h)
 
-	st, _, _ := fast.drain()
+	st, _, _, _ := fast.drain()
 	if st == nil {
 		t.Fatal("fast subscriber received nothing")
 	}
 	if st.GetLastSeenVersion() != "v199" {
 		t.Fatalf("fast subscriber: want newest v199, got %q", st.GetLastSeenVersion())
+	}
+}
+
+func TestSubscriberRemoteMcpConflation(t *testing.T) {
+	s := newSubscriber(false)
+	s.enqueueRemoteMcp(&fleetgrpc.RemoteMcpStatus{State: fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTING})
+	s.enqueueRemoteMcp(&fleetgrpc.RemoteMcpStatus{
+		State:     fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
+		PublicUrl: "https://gw/mcp/abc",
+	})
+
+	_, _, _, rm := s.drain()
+	if rm.GetState() != fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED || rm.GetPublicUrl() != "https://gw/mcp/abc" {
+		t.Fatalf("conflation: want newest CONNECTED+url, got %v", rm)
+	}
+	if _, _, _, again := s.drain(); again != nil {
+		t.Fatalf("want nil remote-mcp status after drain, got %v", again)
+	}
+}
+
+func TestHubRemoteMcpStatusBroadcastsAndDedups(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h := newHub()
+	go h.run(ctx)
+
+	sub := newSubscriber(false)
+	if !h.post(func(h *hub) { h.addSub(sub) }) {
+		t.Fatal("addSub post failed")
+	}
+	status := &fleetgrpc.RemoteMcpStatus{
+		State:     fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
+		PublicUrl: "https://gw/mcp/xyz",
+	}
+	h.post(func(h *hub) { h.broadcastRemoteMcpStatus(status) })
+	// An identical status must NOT re-broadcast (proto.Equal dedup).
+	h.post(func(h *hub) {
+		h.broadcastRemoteMcpStatus(&fleetgrpc.RemoteMcpStatus{
+			State:     fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
+			PublicUrl: "https://gw/mcp/xyz",
+		})
+	})
+	drainSync(t, h)
+
+	_, _, _, rm := sub.drain()
+	if rm.GetPublicUrl() != "https://gw/mcp/xyz" {
+		t.Fatalf("want broadcast status, got %v", rm)
+	}
+	if _, _, _, again := sub.drain(); again != nil {
+		t.Fatalf("dedup: want no second broadcast, got %v", again)
+	}
+
+	// The hub caches the latest status for the initial snapshot of a future
+	// subscriber.
+	var cached *fleetgrpc.RemoteMcpStatus
+	synced := make(chan struct{})
+	h.post(func(h *hub) { cached = h.remoteMcp; close(synced) })
+	<-synced
+	if cached.GetPublicUrl() != "https://gw/mcp/xyz" {
+		t.Fatalf("hub did not cache latest status: %v", cached)
 	}
 }
 

--- a/internal/server/watch.go
+++ b/internal/server/watch.go
@@ -33,6 +33,11 @@ func (s *service) Watch(req *fleetgrpc.WatchRequest, stream grpc.ServerStreaming
 				}
 				sub.enqueueRuntime(items)
 			}
+			// The current remote-MCP tunnel status, so the settings page shows
+			// the right state the moment it attaches (not gated on runtime).
+			if h.remoteMcp != nil {
+				sub.enqueueRemoteMcp(h.remoteMcp)
+			}
 		}
 		close(registered)
 	})
@@ -56,7 +61,7 @@ func (s *service) Watch(req *fleetgrpc.WatchRequest, stream grpc.ServerStreaming
 			// complete.
 			return nil
 		case <-sub.notify:
-			st, rt, bo := sub.drain()
+			st, rt, bo, rm := sub.drain()
 			if st != nil {
 				ev := &fleetgrpc.Event{Kind: &fleetgrpc.Event_StateChanged{StateChanged: &fleetgrpc.StateChanged{State: st}}}
 				if err := stream.Send(ev); err != nil {
@@ -71,6 +76,12 @@ func (s *service) Watch(req *fleetgrpc.WatchRequest, stream grpc.ServerStreaming
 			}
 			for _, b := range bo {
 				ev := &fleetgrpc.Event{Kind: &fleetgrpc.Event_BrowserOpen{BrowserOpen: b}}
+				if err := stream.Send(ev); err != nil {
+					return err
+				}
+			}
+			if rm != nil {
+				ev := &fleetgrpc.Event{Kind: &fleetgrpc.Event_RemoteMcpStatus{RemoteMcpStatus: rm}}
 				if err := stream.Send(ev); err != nil {
 					return err
 				}

--- a/internal/server/watch_grpc_test.go
+++ b/internal/server/watch_grpc_test.go
@@ -118,3 +118,63 @@ func TestWatchPushesOnStateChange(t *testing.T) {
 		t.Fatalf("want pushed state v9, got %q", got)
 	}
 }
+
+// TestWatchStreamsRemoteMcpStatus validates the computed-field-over-Watch design:
+// the gateway-assigned Public MCP URL is delivered as a RemoteMcpStatus event
+// (never a Config field), and a subscriber with include_initial_state receives
+// the hub's cached status up front.
+func TestWatchStreamsRemoteMcpStatus(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	svc := newService()
+	go svc.hub.run(ctx)
+
+	// Seed the hub's cached tunnel status (what the tunnel manager will push in
+	// a later PR).
+	want := &fleetgrpc.RemoteMcpStatus{
+		State:     fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
+		PublicUrl: "https://gw.example.com/mcp/deadbeef",
+	}
+	synced := make(chan struct{})
+	svc.hub.post(func(h *hub) { h.broadcastRemoteMcpStatus(want); close(synced) })
+	<-synced
+
+	lis := bufconn.Listen(1 << 20)
+	gs := grpc.NewServer()
+	fleetgrpc.RegisterFleetServiceServer(gs, svc)
+	go func() { _ = gs.Serve(lis) }()
+	defer gs.Stop()
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) { return lis.DialContext(ctx) }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	streamCtx, streamCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer streamCancel()
+	stream, err := fleetgrpc.NewFleetServiceClient(conn).Watch(streamCtx, &fleetgrpc.WatchRequest{IncludeInitialState: true})
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	// The initial snapshot may interleave StateChanged with the status; read
+	// until the RemoteMcpStatus event arrives.
+	for {
+		ev, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv before RemoteMcpStatus: %v", err)
+		}
+		if rm := ev.GetRemoteMcpStatus(); rm != nil {
+			if rm.GetState() != fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED || rm.GetPublicUrl() != want.GetPublicUrl() {
+				t.Fatalf("remote-mcp status mismatch: %v", rm)
+			}
+			return
+		}
+	}
+}

--- a/internal/state/config.go
+++ b/internal/state/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	CoderSettings      CoderSettings      `json:"coder_settings"`
 	CodespacesSettings CodespacesSettings `json:"codespaces_settings"`
 	BrowserSettings    BrowserSettings    `json:"browser_settings"`
+	RemoteMcpSettings  RemoteMcpSettings  `json:"remote_mcp_settings"`
 	DefaultBackend     string             `json:"default_backend,omitempty"` // "devcontainer", "coder", or "codespaces"
 }
 
@@ -44,6 +45,8 @@ func (c *Config) applyDefaults() {
 
 	c.CoderSettings.Template = strings.TrimSpace(c.CoderSettings.Template)
 	c.CoderSettings.Preset = strings.TrimSpace(c.CoderSettings.Preset)
+
+	c.RemoteMcpSettings.GatewayURL = strings.TrimSpace(c.RemoteMcpSettings.GatewayURL)
 }
 
 // ConfigPath returns the path to the config file.

--- a/internal/state/config_test.go
+++ b/internal/state/config_test.go
@@ -231,6 +231,39 @@ func TestSaveConfigRoundTripAutoInstall(t *testing.T) {
 	}
 }
 
+func TestSaveConfigRoundTripRemoteMcp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	want := &Config{
+		AgentSettings:     AgentSettings{ToolSelection: AgentToolClaude},
+		RemoteMcpSettings: RemoteMcpSettings{Enabled: true, GatewayURL: "https://gateway.example.com"},
+	}
+
+	if err := SaveConfig(want); err != nil {
+		t.Fatalf("SaveConfig() error = %v", err)
+	}
+
+	got, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	if !got.RemoteMcpSettings.Enabled {
+		t.Fatal("RemoteMcpSettings.Enabled = false, want true")
+	}
+	if got.RemoteMcpSettings.GatewayURL != "https://gateway.example.com" {
+		t.Fatalf("GatewayURL = %q, want %q", got.RemoteMcpSettings.GatewayURL, "https://gateway.example.com")
+	}
+}
+
+func TestApplyDefaultsTrimsRemoteMcpGatewayURL(t *testing.T) {
+	c := &Config{RemoteMcpSettings: RemoteMcpSettings{GatewayURL: "  https://gateway.example.com\n"}}
+	c.applyDefaults()
+	if c.RemoteMcpSettings.GatewayURL != "https://gateway.example.com" {
+		t.Fatalf("GatewayURL not trimmed: %q", c.RemoteMcpSettings.GatewayURL)
+	}
+}
+
 func TestTmuxVimKeysDefaultsToTrue(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/state/remote_mcp_settings.go
+++ b/internal/state/remote_mcp_settings.go
@@ -1,0 +1,24 @@
+package state
+
+// RemoteMcpSettings holds the user's intent to expose this daemon's local MCP
+// server to the internet through a remote fleet gateway, so remote agents can
+// drive the fleet. The local MCP server itself (internal/server/mcp.go) is
+// unchanged and stays loopback-only; the gateway tunnel (a later PR) dials OUT
+// to GatewayURL and reverse-proxies inbound requests back to it.
+//
+// Only two fields are persisted here. The gateway-assigned "Public MCP URL" is
+// deliberately NOT stored: it is runtime state the server computes after it
+// connects and pushes to the TUI over the Watch stream (fleetgrpc.RemoteMcpStatus).
+// Keeping it out of Config is what stops SetConfig — which replaces the whole
+// Config — from clobbering it.
+type RemoteMcpSettings struct {
+	// Enabled turns the remote-MCP gateway tunnel on. Plain bool (default
+	// off), matching the create-time *Mount flags: false == "never set" ==
+	// disabled.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// GatewayURL is the fleet gateway to register with (e.g.
+	// "https://gateway.example.com"). Empty while Enabled means "enabled but
+	// not yet configured"; the tunnel manager treats that as a no-op.
+	GatewayURL string `json:"gateway_url,omitempty"`
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -38,6 +38,11 @@ type model struct {
 	pstate  *fleetgrpc.State
 	runtime map[string]*fleetgrpc.InstanceRuntime
 
+	// remoteMcpStatus is the latest outbound-MCP-gateway tunnel status pushed by
+	// the server over Watch (connection state + the computed Public MCP URL). The
+	// settings page renders it read-only; nil means "no status received yet".
+	remoteMcpStatus *fleetgrpc.RemoteMcpStatus
+
 	// Page routing
 	currentPage Page
 	fleetPage   *fleetPage // persistent — has running state accessed by background message handlers
@@ -623,6 +628,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.url != "" && msg.fleet != "" && msg.instance != "" {
 			return m, tea.Batch(spinCmd, m.openControlBrowserCmd(msg.fleet+"/"+msg.instance, msg.url))
 		}
+		return m, spinCmd
+
+	case remoteMcpStatusMsg:
+		// The server pushed the current remote-MCP tunnel status (connection
+		// state + computed Public MCP URL). Cache it for the settings page to
+		// render; a redraw picks it up on the next frame.
+		m.remoteMcpStatus = msg.status
 		return m, spinCmd
 
 	case watchErrMsg, watchClosedMsg:

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -340,6 +340,10 @@ func configToProto(c *configutil.Config) *fleetgrpc.Config {
 		Coder:          &fleetgrpc.CoderSettings{},
 		Codespaces:     &fleetgrpc.CodespacesSettings{},
 		Browser:        &fleetgrpc.BrowserSettings{},
+		RemoteMcp: &fleetgrpc.RemoteMcpSettings{
+			Enabled:    c.RemoteMcpSettings.Enabled,
+			GatewayUrl: c.RemoteMcpSettings.GatewayURL,
+		},
 		DefaultBackend: backendStringToProto(c.DefaultBackend),
 	}
 
@@ -616,6 +620,10 @@ func protoConfigToLegacy(pc *fleetgrpc.Config) *configutil.Config {
 			v := b.GetAutoSwitch()
 			c.BrowserSettings.AutoSwitch = &v
 		}
+	}
+	if rm := pc.GetRemoteMcp(); rm != nil {
+		c.RemoteMcpSettings.Enabled = rm.GetEnabled()
+		c.RemoteMcpSettings.GatewayURL = rm.GetGatewayUrl()
 	}
 	c.DefaultBackend = backendProtoToString(pc.GetDefaultBackend())
 	return c

--- a/internal/tui/client_test.go
+++ b/internal/tui/client_test.go
@@ -61,6 +61,25 @@ func TestConfigToProtoEncodesFullConfig(t *testing.T) {
 	}
 }
 
+// TestRemoteMcpConfigRoundTripClient checks the remote-MCP settings survive both
+// client converters, guarding against drift from the server's mappers.
+func TestRemoteMcpConfigRoundTripClient(t *testing.T) {
+	c := &state.Config{
+		AgentSettings:     state.AgentSettings{ToolSelection: state.AgentToolClaude},
+		RemoteMcpSettings: state.RemoteMcpSettings{Enabled: true, GatewayURL: "https://gateway.example.com"},
+	}
+
+	pc := configToProto(c)
+	if !pc.GetRemoteMcp().GetEnabled() || pc.GetRemoteMcp().GetGatewayUrl() != "https://gateway.example.com" {
+		t.Fatalf("configToProto lost remote-mcp: %v", pc.GetRemoteMcp())
+	}
+
+	back := protoConfigToLegacy(pc)
+	if !back.RemoteMcpSettings.Enabled || back.RemoteMcpSettings.GatewayURL != "https://gateway.example.com" {
+		t.Fatalf("protoConfigToLegacy lost remote-mcp: %+v", back.RemoteMcpSettings)
+	}
+}
+
 // TestFleetSettingsToProtoPreservesTriState checks the PreferFleetLaunch
 // nil-vs-set distinction survives the client converter.
 func TestFleetSettingsToProtoPreservesTriState(t *testing.T) {

--- a/internal/tui/page_settings.go
+++ b/internal/tui/page_settings.go
@@ -979,7 +979,13 @@ func (settingsPage *settingsPage) viewSettings(m *model) string {
 		tail.WriteString(keybindingsDialogBox.Render(settingsPage.renderKeybindingsDialog()))
 		tail.WriteString("\n")
 	}
-	if currentItem >= settingsItemCoderParamBase && currentItem < settingsItemToolStatusBase {
+	// Only the coder PARAMETER rows (value fields, which can interpolate the
+	// variables below) get this hint. Coder params occupy
+	// [settingsItemCoderParamBase, settingsItemCodespacesMachine); the upper
+	// bound must be settingsItemCodespacesMachine, not settingsItemToolStatusBase,
+	// or the hint also (wrongly) shows on the codespaces/browser/remote-mcp rows
+	// that sit in the 500/600/700 blocks below it.
+	if currentItem >= settingsItemCoderParamBase && currentItem < settingsItemCodespacesMachine {
 		tail.WriteString(dimStyle.Render("  Variables: ${GIT_URL} = fleet repo URL, ${GIT_BRANCH} = git branch (blank = default), ${INSTANCE_NAME} = workspace name"))
 		tail.WriteString("\n")
 	}

--- a/internal/tui/page_settings.go
+++ b/internal/tui/page_settings.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
 	"github.com/BenjaminBenetti/fleet-man/internal/agent"
 	"github.com/BenjaminBenetti/fleet-man/internal/configutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/doctor"
@@ -35,6 +36,9 @@ const (
 
 	settingsItemBrowserMultiple   = 600 // browser settings start here
 	settingsItemBrowserAutoSwitch = 601
+
+	settingsItemRemoteMcpEnabled    = 700 // fleet remote (MCP) settings start here
+	settingsItemRemoteMcpGatewayURL = 701
 
 	settingsItemToolStatusBase = 1000 // tool status rows start here
 	settingsItemDoctor         = 2000 // doctor action row
@@ -166,6 +170,15 @@ var settingsSections = []settingsSection{
 				items = append(items, settingsItemBrowserAutoSwitch)
 			}
 			return items
+		},
+	},
+	{
+		Title: "Fleet Remote (MCP)",
+		Items: func(_ *configutil.Config) []int {
+			// The computed Public MCP URL is rendered inline as a read-only
+			// status line (not navigable), so only the two editable settings
+			// are listed here.
+			return []int{settingsItemRemoteMcpEnabled, settingsItemRemoteMcpGatewayURL}
 		},
 	},
 	{
@@ -324,6 +337,28 @@ func (settingsPage *settingsPage) toggleBrowserMultiple(m *model) {
 	m.message = fmt.Sprintf("Multiple browsers per fleet set to %s", label)
 }
 
+// toggleRemoteMcpEnabled flips the "Enabled" preference for exposing this
+// daemon's MCP server through a remote fleet gateway, and saves. Reverts on a
+// save failure, mirroring the other toggles.
+func (settingsPage *settingsPage) toggleRemoteMcpEnabled(m *model) {
+	if m.config == nil {
+		m.config = configutil.DefaultConfig()
+	}
+	current := m.config.RemoteMcpSettings.Enabled
+	next := !current
+	m.config.RemoteMcpSettings.Enabled = next
+	if err := setConfigRemote(m.config); err != nil {
+		m.config.RemoteMcpSettings.Enabled = current
+		m.message = fmt.Sprintf("Failed to save settings: %v", err)
+		return
+	}
+	label := "off"
+	if next {
+		label = "on"
+	}
+	m.message = fmt.Sprintf("Remote MCP set to %s", label)
+}
+
 // toggleAutoInstall toggles the dotfiles auto-install setting.
 func (settingsPage *settingsPage) toggleAutoInstall(m *model) {
 	if m.config == nil {
@@ -401,6 +436,34 @@ func (settingsPage *settingsPage) codespacesMachineLabel(m *model) string {
 	return name
 }
 
+// remoteMcpStatusValue renders the read-only Public MCP URL / connection-state
+// line from the latest status the server pushed over Watch. The tunnel itself
+// lands in a later PR, so today this resolves to "not connected" once enabled;
+// the CONNECTING/CONNECTED/ERROR rendering is wired and ready for it.
+func remoteMcpStatusValue(m *model) string {
+	st := m.remoteMcpStatus
+	if st == nil {
+		return dimStyle.Render("(not connected)")
+	}
+	switch st.GetState() {
+	case fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED:
+		if url := st.GetPublicUrl(); url != "" {
+			return statusRunningStyle.Render("connected") + "  " + url
+		}
+		return statusRunningStyle.Render("connected")
+	case fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTING:
+		return m.spinner.View() + " connecting…"
+	case fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_ERROR:
+		msg := st.GetError()
+		if msg == "" {
+			msg = "connection failed"
+		}
+		return statusCreatingStyle.Render("error") + "  " + dimStyle.Render(msg)
+	default: // UNSPECIFIED / not yet connected
+		return dimStyle.Render("(not connected)")
+	}
+}
+
 // ===========================================
 // Update Handlers
 // ===========================================
@@ -453,6 +516,8 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 				settingsPage.toggleBrowserMultiple(m)
 			} else if item == settingsItemBrowserAutoSwitch {
 				settingsPage.toggleBrowserAutoSwitch(m)
+			} else if item == settingsItemRemoteMcpEnabled {
+				settingsPage.toggleRemoteMcpEnabled(m)
 			} else if item == settingsItemCoderPreset {
 				settingsPage.cycleCoderPreset(m, -1)
 			} else if item == settingsItemCodespacesMachine {
@@ -472,6 +537,8 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 				settingsPage.toggleBrowserMultiple(m)
 			} else if item == settingsItemBrowserAutoSwitch {
 				settingsPage.toggleBrowserAutoSwitch(m)
+			} else if item == settingsItemRemoteMcpEnabled {
+				settingsPage.toggleRemoteMcpEnabled(m)
 			} else if item == settingsItemCoderPreset {
 				settingsPage.cycleCoderPreset(m, 1)
 			} else if item == settingsItemCodespacesMachine {
@@ -499,6 +566,10 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 			}
 			if item == settingsItemBrowserAutoSwitch {
 				settingsPage.toggleBrowserAutoSwitch(m)
+				return nil
+			}
+			if item == settingsItemRemoteMcpEnabled {
+				settingsPage.toggleRemoteMcpEnabled(m)
 				return nil
 			}
 			if item == settingsItemCoderPreset {
@@ -564,6 +635,9 @@ func (settingsPage *settingsPage) enterSettingsEditing(m *model) tea.Cmd {
 	case item == settingsItemCoderTemplate:
 		current = m.config.CoderSettings.Template
 		settingsPage.input.Placeholder = "template-name"
+	case item == settingsItemRemoteMcpGatewayURL:
+		current = m.config.RemoteMcpSettings.GatewayURL
+		settingsPage.input.Placeholder = "https://gateway.example.com"
 	case item >= settingsItemCoderParamBase && item < settingsItemCodespacesMachine:
 		idx := item - settingsItemCoderParamBase
 		if idx < len(m.config.CoderSettings.Parameters) {
@@ -607,6 +681,8 @@ func (settingsPage *settingsPage) updateSettingsEditing(m *model, msg tea.Msg) t
 				m.config.DotfilesSettings.RepoURL = value
 			case item == settingsItemDotfilesScript:
 				m.config.DotfilesSettings.InstallScript = value
+			case item == settingsItemRemoteMcpGatewayURL:
+				m.config.RemoteMcpSettings.GatewayURL = value
 			case item == settingsItemCoderTemplate:
 				oldTemplate := m.config.CoderSettings.Template
 				m.config.CoderSettings.Template = value
@@ -836,6 +912,31 @@ func (settingsPage *settingsPage) viewSettings(m *model) string {
 				// (%-18s) + value-separator (1).
 				autoSwitchValue += "\n" + strings.Repeat(" ", 21) + dimStyle.Render("Do not prompt when switching the browser to another instance")
 				recordRow(settingsItemBrowserAutoSwitch, settingsPage.renderSettingsRow(m, currentItem == settingsItemBrowserAutoSwitch, "Auto Switch", autoSwitchValue))
+			}
+
+		case "Fleet Remote (MCP)":
+			enabledValue := "[ off ]"
+			if config.RemoteMcpSettings.Enabled {
+				enabledValue = "[ on ]"
+			}
+			// Append a dim sub-line describing what the toggle does.
+			enabledValue += "\n" + strings.Repeat(" ", 21) + dimStyle.Render("Expose this fleet's MCP server to the internet via a fleet gateway")
+			recordRow(settingsItemRemoteMcpEnabled, settingsPage.renderSettingsRow(m, currentItem == settingsItemRemoteMcpEnabled, "Enabled", enabledValue))
+			listContent.WriteString("\n")
+
+			gatewayValue := config.RemoteMcpSettings.GatewayURL
+			if gatewayValue == "" && !(settingsPage.editing && currentItem == settingsItemRemoteMcpGatewayURL) {
+				gatewayValue = dimStyle.Render("(not set)")
+			}
+			recordRow(settingsItemRemoteMcpGatewayURL, settingsPage.renderSettingsRow(m, currentItem == settingsItemRemoteMcpGatewayURL, "Gateway URL", gatewayValue))
+
+			// The computed Public MCP URL is read-only (not navigable): it is the
+			// gateway-assigned address, delivered over Watch, that external tools
+			// use to reach this fleet. Only shown once the feature is enabled.
+			if config.RemoteMcpSettings.Enabled {
+				listContent.WriteString("\n")
+				row := settingsPage.renderSettingsRow(m, false, "Public MCP URL", remoteMcpStatusValue(m))
+				listContent.WriteString(lipgloss.NewStyle().Width(contentWidth).Render(row))
 			}
 
 		case "Tool Status":

--- a/internal/tui/page_settings_test.go
+++ b/internal/tui/page_settings_test.go
@@ -47,6 +47,30 @@ func TestSettingsSectionIncludesRemoteMcp(t *testing.T) {
 	}
 }
 
+// TestCoderVariablesHintScopedToCoderParams guards the footer hint range: the
+// "${GIT_URL}" coder-variables hint must show only on coder PARAMETER rows, not
+// on the codespaces/browser/remote-mcp rows that sit in the numeric blocks below
+// the coder-param range.
+func TestCoderVariablesHintScopedToCoderParams(t *testing.T) {
+	sp := newSettingsPage()
+	cfg := state.DefaultConfig()
+	cfg.RemoteMcpSettings.Enabled = true
+	cfg.CoderSettings.Parameters = []state.CoderParameter{{Name: "p1", Value: "v1"}}
+	m := &model{config: cfg, toolStatus: allToolsFound(), spinner: spinner.New()}
+
+	// Cursor on the Remote MCP gateway-URL row: NO coder-variables hint.
+	sp.cursor = settingsPositionOf(sp, m, settingsItemRemoteMcpGatewayURL)
+	if out := sp.viewSettings(m); strings.Contains(out, "${GIT_URL}") {
+		t.Fatal("coder-variables hint wrongly shown on a remote-mcp row")
+	}
+
+	// Cursor on a coder parameter row: hint IS shown.
+	sp.cursor = settingsPositionOf(sp, m, settingsItemCoderParamBase)
+	if out := sp.viewSettings(m); !strings.Contains(out, "${GIT_URL}") {
+		t.Fatal("coder-variables hint missing on a coder parameter row")
+	}
+}
+
 // TestRemoteMcpStatusValueRendersStates exercises the read-only status line for
 // each tunnel state the server can push.
 func TestRemoteMcpStatusValueRendersStates(t *testing.T) {

--- a/internal/tui/page_settings_test.go
+++ b/internal/tui/page_settings_test.go
@@ -1,0 +1,154 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestSettingsSectionIncludesRemoteMcp confirms the new "Fleet Remote (MCP)"
+// section is navigable (its two editable items appear) and that the read-only
+// Public MCP URL line renders once the feature is enabled.
+func TestSettingsSectionIncludesRemoteMcp(t *testing.T) {
+	sp := newSettingsPage()
+	cfg := state.DefaultConfig()
+	cfg.RemoteMcpSettings.Enabled = true
+	m := &model{
+		config:     cfg,
+		toolStatus: allToolsFound(),
+		spinner:    spinner.New(),
+	}
+
+	items := sp.visibleItems(m)
+	hasEnabled, hasURL := false, false
+	for _, id := range items {
+		switch id {
+		case settingsItemRemoteMcpEnabled:
+			hasEnabled = true
+		case settingsItemRemoteMcpGatewayURL:
+			hasURL = true
+		}
+	}
+	if !hasEnabled || !hasURL {
+		t.Fatalf("remote-mcp items missing from settings nav: enabled=%v url=%v", hasEnabled, hasURL)
+	}
+
+	out := sp.viewSettings(m)
+	if !strings.Contains(out, "Fleet Remote (MCP)") {
+		t.Fatal("settings view missing the Fleet Remote (MCP) section header")
+	}
+	if !strings.Contains(out, "Public MCP URL") {
+		t.Fatal("settings view missing the computed Public MCP URL row when enabled")
+	}
+}
+
+// TestRemoteMcpStatusValueRendersStates exercises the read-only status line for
+// each tunnel state the server can push.
+func TestRemoteMcpStatusValueRendersStates(t *testing.T) {
+	m := &model{spinner: spinner.New()}
+
+	// No status yet.
+	if got := remoteMcpStatusValue(m); !strings.Contains(got, "not connected") {
+		t.Fatalf("nil status: want 'not connected', got %q", got)
+	}
+
+	m.remoteMcpStatus = &fleetgrpc.RemoteMcpStatus{
+		State:     fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
+		PublicUrl: "https://gw.example.com/mcp/abc123",
+	}
+	got := remoteMcpStatusValue(m)
+	if !strings.Contains(got, "connected") || !strings.Contains(got, "https://gw.example.com/mcp/abc123") {
+		t.Fatalf("connected: want 'connected' + url, got %q", got)
+	}
+
+	m.remoteMcpStatus = &fleetgrpc.RemoteMcpStatus{State: fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTING}
+	if got := remoteMcpStatusValue(m); !strings.Contains(got, "connecting") {
+		t.Fatalf("connecting: want 'connecting', got %q", got)
+	}
+
+	m.remoteMcpStatus = &fleetgrpc.RemoteMcpStatus{
+		State: fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_ERROR,
+		Error: "dial tcp: refused",
+	}
+	if got := remoteMcpStatusValue(m); !strings.Contains(got, "error") || !strings.Contains(got, "dial tcp: refused") {
+		t.Fatalf("error: want 'error' + message, got %q", got)
+	}
+}
+
+// TestToggleRemoteMcpEnabledPersists confirms pressing enter on the Enabled row
+// flips the setting and persists it through the setConfigRemote seam.
+func TestToggleRemoteMcpEnabledPersists(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	origSetConfig := setConfigRemote
+	setConfigRemote = func(c *state.Config) error { return state.SaveConfig(c) }
+	defer func() { setConfigRemote = origSetConfig }()
+
+	sp := newSettingsPage()
+	m := &model{
+		config:      state.DefaultConfig(),
+		toolStatus:  allToolsFound(),
+		currentPage: sp,
+		fleetPage:   newFleetPage(),
+		spinner:     spinner.New(),
+	}
+	sp.cursor = settingsPositionOf(sp, m, settingsItemRemoteMcpEnabled)
+
+	sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if !m.config.RemoteMcpSettings.Enabled {
+		t.Fatal("enabled should be true after toggle")
+	}
+	loaded, err := state.LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !loaded.RemoteMcpSettings.Enabled {
+		t.Fatal("toggle did not persist to disk")
+	}
+}
+
+// TestRemoteMcpGatewayURLEditPersists confirms editing the Gateway URL field
+// saves the value.
+func TestRemoteMcpGatewayURLEditPersists(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	origSetConfig := setConfigRemote
+	setConfigRemote = func(c *state.Config) error { return state.SaveConfig(c) }
+	defer func() { setConfigRemote = origSetConfig }()
+
+	si := textinput.New()
+	si.CharLimit = 256
+	sp := &settingsPage{editing: true, input: si}
+	m := &model{
+		config:      state.DefaultConfig(),
+		toolStatus:  allToolsFound(),
+		currentPage: sp,
+		fleetPage:   newFleetPage(),
+		spinner:     spinner.New(),
+	}
+	sp.cursor = settingsPositionOf(sp, m, settingsItemRemoteMcpGatewayURL)
+	sp.input.SetValue("https://gateway.example.com")
+	sp.input.Focus()
+
+	sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if sp.editing {
+		t.Fatal("editing should be false after enter")
+	}
+	if m.config.RemoteMcpSettings.GatewayURL != "https://gateway.example.com" {
+		t.Fatalf("GatewayURL = %q", m.config.RemoteMcpSettings.GatewayURL)
+	}
+	loaded, err := state.LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if loaded.RemoteMcpSettings.GatewayURL != "https://gateway.example.com" {
+		t.Fatalf("persisted GatewayURL = %q", loaded.RemoteMcpSettings.GatewayURL)
+	}
+}

--- a/internal/tui/watch.go
+++ b/internal/tui/watch.go
@@ -27,6 +27,7 @@ type runtimeChangedMsg struct{ runtime []*fleetgrpc.InstanceRuntime }
 type watchBrowserOpenMsg struct {
 	url, dataDir, fleet, instance string
 }
+type remoteMcpStatusMsg struct{ status *fleetgrpc.RemoteMcpStatus }
 type watchErrMsg struct{ err error }
 type watchClosedMsg struct{ err error }
 
@@ -112,6 +113,8 @@ func watchOnce(ctx context.Context, program *tea.Program) bool {
 				fleet:    bo.GetFleet(),
 				instance: bo.GetInstance(),
 			})
+		case *fleetgrpc.Event_RemoteMcpStatus:
+			program.Send(remoteMcpStatusMsg{status: k.RemoteMcpStatus})
 		default:
 			// Job* events are not consumed by the TUI in P2.
 		}


### PR DESCRIPTION
## What

First slice of **Fleet remote MCP** (#97): the **config + status plumbing** that the rest of the feature builds on. This PR adds the settings and the end-to-end push path for the computed *Public MCP URL* — but **no tunnel and no gateway yet** (those land in follow-up PRs).

After this PR, the **Settings** page gains a "Fleet Remote (MCP)" section (Enabled toggle, Gateway URL, and a read-only Public MCP URL status line). The toggle/URL persist; the status line reads whatever the server pushes — which for now is always "(not connected)" because nothing connects yet.

## Why this shape

The feature splits cleanly into 4 reviewable PRs (config plumbing → fleetd tunnel client → `fleet gateway` server → e2e + docs). Landing the config/status contract first lets us validate the trickiest design decision — **how the computed Public MCP URL reaches the TUI** — before any tunnel risk lands.

The Public MCP URL is gateway-assigned runtime state known only to the daemon after it connects. It is delivered **only** via a new `RemoteMcpStatus` variant on the Watch `Event` oneof (a server→client push the TUI already consumes), and is deliberately **not** a `Config` field. That keeps the `SetConfig`-replaces-the-whole-Config contract from ever clobbering it.

## Changes

- **`config.proto` / `state.Config`**: new `RemoteMcpSettings { enabled, gateway_url }` (the only two persisted fields), mirrored field-for-field through the server + client config converters and trimmed in `applyDefaults`.
- **`watch.proto`**: new `RemoteMcpConn` enum + `RemoteMcpStatus { state, public_url, error }`, added as `Event.remote_mcp_status`.
- **hub / Watch (server)**: cache the latest tunnel status (with `proto.Equal` dedup), broadcast it to subscribers, and include the cached status in the initial snapshot. `drain()` now also returns the pending status.
- **TUI**: new "Fleet Remote (MCP)" settings section (Enabled toggle + Gateway URL edit + read-only Public MCP URL status line), fed by a new `remoteMcpStatusMsg` Watch handler and a `model.remoteMcpStatus` cache. The status line renders connecting / connected+URL / error / not-connected states (ready for the tunnel PR).

## Tests

- Config round-trips: `state` (Save/Load), server (`SetConfig`→`GetConfig` + on-disk), and client converters.
- Hub: status conflation + `proto.Equal` dedup + cache.
- End-to-end Watch delivery of `RemoteMcpStatus` over an in-process bufconn (the key design path).
- TUI: section presence, toggle persistence, gateway-URL edit, and per-state status rendering.

`make test` (depguard import-boundary lint + all unit tests) and `make proto-check` pass.

## Notes for reviewers

- **Import boundary** (depguard) is preserved — no client file imports a server-only package; the new `fleetgrpc` import in `page_settings.go` is the contract, which is allowed.
- Proto stubs were regenerated with `protoc-gen-go v1.36.10` to match the rest of the checked-in generated code, so only `config.pb.go` + `watch.pb.go` change (no incidental version-bump churn across the other stubs).

Part of #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
