### PR TITLE
feat(mcp): fleetd remote-MCP gateway tunnel client (#97)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/gin-gonic/gin v1.12.0
+	github.com/hashicorp/yamux v0.1.2
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/muesli/termenv v0.16.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+
 github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
+github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/internal/fleetpaths/paths.go
+++ b/internal/fleetpaths/paths.go
@@ -86,6 +86,16 @@ func McpEnvPath() string {
 	return filepath.Join(Dir(), "mcp.env")
 }
 
+// GatewaySessionPath holds the sticky remote-MCP gateway session for this
+// daemon: the gateway-assigned session id + public URL + the gateway URL it was
+// issued for. fleetd writes it (0600) on a successful registration and reads it
+// on reconnect to request the SAME public URL. Like the other ~/.fleet discovery
+// files it is host-local and per-user; it embeds no secret (the session id is a
+// public capability the gateway minted, not an auth token).
+func GatewaySessionPath() string {
+	return filepath.Join(Dir(), "gateway_session.json")
+}
+
 // WorkspacesDir is the base directory for instance workspace clones. Mirrors
 // internal/state.WorkspacesDir; lives here too so client code (which must not
 // import internal/state) can derive workspace paths.

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -41,6 +41,15 @@ func (s *service) SetConfig(_ context.Context, req *fleetgrpc.SetConfigRequest) 
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "reload config: %v", err)
 	}
+
+	// Converge the remote-MCP tunnel to the saved settings. Reconcile is
+	// non-blocking (it just records desired state and nudges the supervisor), so
+	// calling it while muWrite is held cannot deadlock. nil during tests that use
+	// newService() without a serve loop.
+	if s.remote != nil {
+		s.remote.Reconcile(saved.RemoteMcpSettings.Enabled, saved.RemoteMcpSettings.GatewayURL)
+	}
+
 	return &fleetgrpc.SetConfigReply{Config: configToProto(saved)}, nil
 }
 

--- a/internal/server/remote/dial.go
+++ b/internal/server/remote/dial.go
@@ -1,0 +1,51 @@
+package remote
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/url"
+)
+
+// dial.go opens the outbound control connection to the gateway. fleetd is behind
+// NAT/firewall, so it always DIALS — the gateway never connects in.
+
+// gatewayAddress resolves a user-entered gateway URL to the TCP address to dial
+// and the TLS server name to verify. The URL must be https; the port defaults to
+// 443 when not given. It is split out (and pure) so the URL handling is unit
+// testable without a network.
+func gatewayAddress(gatewayURL string) (addr, serverName string, err error) {
+	u, err := url.Parse(gatewayURL)
+	if err != nil {
+		return "", "", fmt.Errorf("parse gateway url: %w", err)
+	}
+	if u.Scheme != "https" {
+		return "", "", fmt.Errorf("gateway url must be https, got %q", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return "", "", fmt.Errorf("gateway url has no host: %q", gatewayURL)
+	}
+	port := u.Port()
+	if port == "" {
+		port = "443"
+	}
+	return net.JoinHostPort(host, port), host, nil
+}
+
+// dialTLS is the production transport seam (Manager.dial): a TLS dial to the
+// gateway verified against the system roots. Tests override Manager.dial to
+// reach an in-process gateway with a test CA.
+func dialTLS(ctx context.Context, gatewayURL string) (net.Conn, error) {
+	addr, serverName, err := gatewayAddress(gatewayURL)
+	if err != nil {
+		return nil, err
+	}
+	d := &tls.Dialer{Config: &tls.Config{ServerName: serverName, MinVersion: tls.VersionTLS12}}
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("dial gateway %s: %w", addr, err)
+	}
+	return conn, nil
+}

--- a/internal/server/remote/manager.go
+++ b/internal/server/remote/manager.go
@@ -104,11 +104,24 @@ func (m *Manager) Run(ctx context.Context) {
 			return
 		}
 
+		// Read the desired config AND install this attempt's cancel under ONE
+		// lock. They must be atomic: if they were separate, a Reconcile landing
+		// between them (the window is widened by the publish() below) would see no
+		// cancel installed and let the attempt run on with stale settings — even
+		// serving after a disable. With one lock, a Reconcile either precedes it
+		// (we read its fresh desired) or follows it (it sees our cancel and aborts
+		// this attempt).
+		attemptCtx, cancel := context.WithCancel(ctx)
 		m.mu.Lock()
 		d := m.desired
+		m.attemptCancel = cancel
 		m.mu.Unlock()
 
 		if !d.enabled || d.gatewayURL == "" {
+			cancel()
+			m.mu.Lock()
+			m.attemptCancel = nil
+			m.mu.Unlock()
 			m.publish(statusDisabled())
 			if !m.wait(ctx) {
 				return
@@ -118,11 +131,6 @@ func (m *Manager) Run(ctx context.Context) {
 		}
 
 		m.publish(statusConnecting())
-		attemptCtx, cancel := context.WithCancel(ctx)
-		m.mu.Lock()
-		m.attemptCancel = cancel
-		m.mu.Unlock()
-
 		registered, err := m.connectAndServe(attemptCtx, d.gatewayURL)
 		cancel()
 
@@ -169,6 +177,12 @@ func (m *Manager) connectAndServe(ctx context.Context, gatewayURL string) (regis
 		return false, err
 	}
 	defer conn.Close()
+	// Close the conn on ctx cancel so the attempt aborts promptly at ANY stage:
+	// the handshake (which is bounded by conn deadlines, not ctx) as well as the
+	// serve loop (closing the conn under yamux makes serveProxy return).
+	// Idempotent with the defers and with session.Close below.
+	stopOnCancel := context.AfterFunc(ctx, func() { _ = conn.Close() })
+	defer stopOnCancel()
 
 	// Control handshake on the raw conn (before yamux), bounded by a deadline so
 	// a silent gateway can't hang the attempt.
@@ -197,11 +211,8 @@ func (m *Manager) connectAndServe(ctx context.Context, gatewayURL string) (regis
 		return registered, fmt.Errorf("yamux client: %w", err)
 	}
 	defer session.Close()
-	// Closing the session on ctx cancel unblocks serveProxy promptly (shutdown or
-	// a Reconcile-driven teardown).
-	stop := context.AfterFunc(ctx, func() { _ = session.Close() })
-	defer stop()
-
+	// serveProxy unblocks when the session/conn closes — on a peer drop, or when
+	// stopOnCancel closes the conn on ctx cancel (shutdown or Reconcile teardown).
 	return registered, serveProxy(session, m.mcpPort)
 }
 

--- a/internal/server/remote/manager.go
+++ b/internal/server/remote/manager.go
@@ -1,0 +1,250 @@
+// Package remote drives fleetd's side of the remote-MCP reverse tunnel: it dials
+// the user-configured fleet gateway, registers (sticky session id), and serves
+// the gateway's inbound MCP requests by reverse-proxying them to the loopback MCP
+// server. It is server-only (imported solely by internal/server) and additive —
+// the local MCP server in mcp.go is untouched; tunneled requests hit the same
+// loopback listener and the same bearer-token auth as local clients.
+//
+// The Manager is a single supervisor goroutine. Config changes arrive via
+// Reconcile (non-blocking, safe to call under the service's config lock) and the
+// loop reacts: connect when enabled, tear down when disabled, reconnect on drop
+// with jittered exponential backoff. Every state transition is published as a
+// fleetgrpc.RemoteMcpStatus so the TUI's settings page reflects it live.
+package remote
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/tunnel"
+)
+
+const (
+	// initialBackoff and maxBackoff bound the reconnect schedule. Full jitter is
+	// applied per sleep, and the schedule resets after an established connection.
+	initialBackoff = 500 * time.Millisecond
+	maxBackoff     = 60 * time.Second
+	// handshakeTimeout bounds the pre-yamux control exchange so a silent gateway
+	// can't wedge an attempt forever. yamux manages its own timeouts after.
+	handshakeTimeout = 15 * time.Second
+)
+
+// desiredState is the latest config the manager should converge to.
+type desiredState struct {
+	enabled    bool
+	gatewayURL string
+}
+
+// Manager supervises the outbound tunnel. Construct with NewManager and drive
+// with Run (once) + Reconcile (on every config change).
+type Manager struct {
+	mcpPort       int
+	clientVersion string
+	publish       func(*fleetgrpc.RemoteMcpStatus)
+	logOut        io.Writer
+
+	// dial is the transport seam (TLS in production); tests override it to reach
+	// an in-process gateway.
+	dial func(ctx context.Context, gatewayURL string) (net.Conn, error)
+
+	mu            sync.Mutex
+	desired       desiredState
+	attemptCancel context.CancelFunc // cancels the in-flight connect attempt, if any
+	wake          chan struct{}      // size-1 nudge: Reconcile wakes the loop
+}
+
+// NewManager builds a Manager that reverse-proxies to the loopback MCP server on
+// mcpPort and reports status via publish (which must be safe to call from the
+// manager's goroutine — typically a hub.post). A zero mcpPort means the local
+// MCP server is not running, in which case the manager reports an error while
+// enabled rather than connecting.
+func NewManager(mcpPort int, clientVersion string, publish func(*fleetgrpc.RemoteMcpStatus)) *Manager {
+	return &Manager{
+		mcpPort:       mcpPort,
+		clientVersion: clientVersion,
+		publish:       publish,
+		logOut:        io.Discard,
+		dial:          dialTLS,
+		wake:          make(chan struct{}, 1),
+	}
+}
+
+// Reconcile records the desired config and nudges the supervisor. It is
+// NON-BLOCKING: it sets state, cancels any in-flight attempt so it re-evaluates,
+// and signals the loop — so it is safe to call while holding other locks (e.g.
+// the service's config-write lock in SetConfig).
+func (m *Manager) Reconcile(enabled bool, gatewayURL string) {
+	m.mu.Lock()
+	m.desired = desiredState{enabled: enabled, gatewayURL: strings.TrimSpace(gatewayURL)}
+	cancel := m.attemptCancel
+	m.mu.Unlock()
+	if cancel != nil {
+		cancel() // interrupt the current attempt so it picks up the new desired state
+	}
+	select {
+	case m.wake <- struct{}{}:
+	default:
+	}
+}
+
+// Run is the supervisor loop. It blocks until ctx is cancelled (daemon
+// shutdown), so callers start it on a goroutine. Exactly one attempt is ever in
+// flight, so there is no reconnection storm.
+func (m *Manager) Run(ctx context.Context) {
+	backoff := initialBackoff
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		m.mu.Lock()
+		d := m.desired
+		m.mu.Unlock()
+
+		if !d.enabled || d.gatewayURL == "" {
+			m.publish(statusDisabled())
+			if !m.wait(ctx) {
+				return
+			}
+			backoff = initialBackoff
+			continue
+		}
+
+		m.publish(statusConnecting())
+		attemptCtx, cancel := context.WithCancel(ctx)
+		m.mu.Lock()
+		m.attemptCancel = cancel
+		m.mu.Unlock()
+
+		registered, err := m.connectAndServe(attemptCtx, d.gatewayURL)
+		cancel()
+
+		m.mu.Lock()
+		m.attemptCancel = nil
+		changed := m.desired != d
+		m.mu.Unlock()
+
+		if ctx.Err() != nil {
+			return
+		}
+		if changed {
+			// Desired config changed mid-attempt (Reconcile). Re-evaluate now
+			// with no backoff and no spurious error.
+			backoff = initialBackoff
+			continue
+		}
+		if registered {
+			// An established tunnel dropped (gateway restart / network). Reconnect
+			// promptly; the next iteration republishes CONNECTING.
+			backoff = initialBackoff
+		} else {
+			// Never connected this attempt — surface the failure while we back off.
+			m.publish(statusError(err))
+		}
+		if !m.sleep(ctx, jitter(backoff)) {
+			return
+		}
+		backoff = nextBackoff(backoff)
+	}
+}
+
+// connectAndServe runs one full attempt: dial, register, then serve the tunnel
+// until it drops or attemptCtx is cancelled. registered reports whether the
+// gateway accepted the registration (used to reset the backoff for an
+// established-then-dropped connection).
+func (m *Manager) connectAndServe(ctx context.Context, gatewayURL string) (registered bool, err error) {
+	if m.mcpPort == 0 {
+		return false, fmt.Errorf("local MCP server is not running")
+	}
+
+	conn, err := m.dial(ctx, gatewayURL)
+	if err != nil {
+		return false, err
+	}
+	defer conn.Close()
+
+	// Control handshake on the raw conn (before yamux), bounded by a deadline so
+	// a silent gateway can't hang the attempt.
+	_ = conn.SetDeadline(time.Now().Add(handshakeTimeout))
+	prev := loadSession(gatewayURL)
+	req := tunnel.RegisterRequest{SessionID: prev.SessionID, ClientVersion: m.clientVersion}
+	if err := tunnel.WriteFrame(conn, req); err != nil {
+		return false, fmt.Errorf("register write: %w", err)
+	}
+	var reply tunnel.RegisterReply
+	if err := tunnel.ReadFrame(conn, &reply); err != nil {
+		return false, fmt.Errorf("register read: %w", err)
+	}
+	_ = conn.SetDeadline(time.Time{}) // clear; yamux manages its own timeouts
+	if reply.Error != "" {
+		return false, fmt.Errorf("gateway refused registration: %s", reply.Error)
+	}
+
+	// Registered. Persist the sticky session and report the public URL.
+	registered = true
+	_ = saveSession(sessionFile{SessionID: reply.SessionID, PublicURL: reply.PublicURL, GatewayURL: gatewayURL})
+	m.publish(statusConnected(reply.PublicURL))
+
+	session, err := tunnel.ClientSession(conn, m.logOut)
+	if err != nil {
+		return registered, fmt.Errorf("yamux client: %w", err)
+	}
+	defer session.Close()
+	// Closing the session on ctx cancel unblocks serveProxy promptly (shutdown or
+	// a Reconcile-driven teardown).
+	stop := context.AfterFunc(ctx, func() { _ = session.Close() })
+	defer stop()
+
+	return registered, serveProxy(session, m.mcpPort)
+}
+
+// wait blocks until a Reconcile nudge arrives or ctx is cancelled. It returns
+// false only on cancellation.
+func (m *Manager) wait(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-m.wake:
+		return true
+	}
+}
+
+// sleep waits for d, a Reconcile nudge, or cancellation. It returns false only
+// on cancellation (a nudge or timeout both mean "proceed").
+func (m *Manager) sleep(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-m.wake:
+		return true
+	case <-t.C:
+		return true
+	}
+}
+
+// nextBackoff doubles d up to maxBackoff.
+func nextBackoff(d time.Duration) time.Duration {
+	d *= 2
+	if d > maxBackoff {
+		return maxBackoff
+	}
+	return d
+}
+
+// jitter applies full jitter: a uniformly random duration in [0, d]. Spreads out
+// reconnect attempts so many fleetds don't thunder a recovering gateway.
+func jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int64N(int64(d) + 1))
+}

--- a/internal/server/remote/manager_test.go
+++ b/internal/server/remote/manager_test.go
@@ -337,6 +337,90 @@ func waitForReg(t *testing.T, ch <-chan string, timeout time.Duration) string {
 	}
 }
 
+// TestManagerReconcileDisableConverges hammers Reconcile with interleaved
+// enable/disable toggles (exercising the desired/attemptCancel race the code
+// review flagged) and asserts the manager settles on UNSPECIFIED — i.e. a
+// disable is never left running a stale tunnel.
+func TestManagerReconcileDisableConverges(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cert, pool := genTestTLS(t)
+	mcp := newFakeMCP()
+	defer mcp.srv.Close()
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{Certificates: []tls.Certificate{cert}})
+	if err != nil {
+		t.Fatalf("tls listen: %v", err)
+	}
+	defer ln.Close()
+
+	gwDone := make(chan struct{})
+	defer close(gwDone)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close()
+				var req tunnel.RegisterRequest
+				if err := tunnel.ReadFrame(conn, &req); err != nil {
+					return
+				}
+				if err := tunnel.WriteFrame(conn, tunnel.RegisterReply{SessionID: "s", PublicURL: "https://gw/mcp/s"}); err != nil {
+					return
+				}
+				sess, err := tunnel.ServerSession(conn, io.Discard)
+				if err != nil {
+					return
+				}
+				defer sess.Close()
+				<-gwDone
+			}(conn)
+		}
+	}()
+
+	m, statusCh := newManagerForTest(mcp.port(t), ln.Addr().String(), pool)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.Run(ctx)
+
+	for i := 0; i < 30; i++ {
+		m.Reconcile(true, "https://gw.example.com")
+		m.Reconcile(false, "https://gw.example.com")
+	}
+
+	// After the toggles settle, the LAST state observed must be UNSPECIFIED —
+	// the manager must not be left connected/connecting with the feature off.
+	last := drainUntilIdle(statusCh, 400*time.Millisecond, 5*time.Second)
+	if last != fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_UNSPECIFIED {
+		t.Fatalf("after disable toggles, settled on %v, want UNSPECIFIED", last)
+	}
+}
+
+// drainUntilIdle reads statuses until none arrive for `idle` (or `total`
+// elapses), returning the last state seen.
+func drainUntilIdle(ch <-chan *fleetgrpc.RemoteMcpStatus, idle, total time.Duration) fleetgrpc.RemoteMcpConn {
+	last := fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_UNSPECIFIED
+	idleTimer := time.NewTimer(idle)
+	defer idleTimer.Stop()
+	deadline := time.After(total)
+	for {
+		select {
+		case st := <-ch:
+			last = st.GetState()
+			if !idleTimer.Stop() {
+				<-idleTimer.C
+			}
+			idleTimer.Reset(idle)
+		case <-idleTimer.C:
+			return last
+		case <-deadline:
+			return last
+		}
+	}
+}
+
 // TestManagerErrorsWhenMcpDown reports an error (not a crash) when enabled but
 // the local MCP server isn't running (mcpPort == 0).
 func TestManagerErrorsWhenMcpDown(t *testing.T) {

--- a/internal/server/remote/manager_test.go
+++ b/internal/server/remote/manager_test.go
@@ -1,0 +1,355 @@
+package remote
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetpaths"
+	"github.com/BenjaminBenetti/fleet-man/internal/tunnel"
+)
+
+// --- unit tests ------------------------------------------------------------
+
+func TestGatewayAddress(t *testing.T) {
+	cases := []struct {
+		url, wantAddr, wantSNI string
+		wantErr                bool
+	}{
+		{url: "https://gw.example.com", wantAddr: "gw.example.com:443", wantSNI: "gw.example.com"},
+		{url: "https://gw.example.com:8443", wantAddr: "gw.example.com:8443", wantSNI: "gw.example.com"},
+		{url: "http://gw.example.com", wantErr: true},  // must be https
+		{url: "ftp://gw.example.com", wantErr: true},   // must be https
+		{url: "https://", wantErr: true},               // no host
+		{url: "://bad", wantErr: true},                 // unparseable
+	}
+	for _, c := range cases {
+		addr, sni, err := gatewayAddress(c.url)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("%q: want error, got addr=%q", c.url, addr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%q: unexpected error %v", c.url, err)
+			continue
+		}
+		if addr != c.wantAddr || sni != c.wantSNI {
+			t.Errorf("%q: got (%q,%q), want (%q,%q)", c.url, addr, sni, c.wantAddr, c.wantSNI)
+		}
+	}
+}
+
+func TestNextBackoffCaps(t *testing.T) {
+	d := initialBackoff
+	for i := 0; i < 20; i++ {
+		d = nextBackoff(d)
+	}
+	if d != maxBackoff {
+		t.Fatalf("backoff should saturate at %v, got %v", maxBackoff, d)
+	}
+}
+
+func TestJitterBounds(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		j := jitter(time.Second)
+		if j < 0 || j > time.Second {
+			t.Fatalf("jitter out of [0,1s]: %v", j)
+		}
+	}
+	if jitter(0) != 0 {
+		t.Fatal("jitter(0) must be 0")
+	}
+}
+
+func TestSessionFileRoundTripAndStale(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if _, err := fleetpaths.EnsureDir(); err != nil {
+		t.Fatalf("ensure dir: %v", err)
+	}
+
+	in := sessionFile{SessionID: "sid1", PublicURL: "https://gw/mcp/sid1", GatewayURL: "https://gw"}
+	if err := saveSession(in); err != nil {
+		t.Fatalf("saveSession: %v", err)
+	}
+	// Same gateway URL -> returned.
+	if got := loadSession("https://gw"); got != in {
+		t.Fatalf("loadSession same gw: got %+v want %+v", got, in)
+	}
+	// Different gateway URL -> stale, ignored (zero value).
+	if got := loadSession("https://other"); got != (sessionFile{}) {
+		t.Fatalf("loadSession different gw should be zero, got %+v", got)
+	}
+	// Missing file -> zero value.
+	_ = os.Remove(filepath.Join(fleetpaths.Dir(), "gateway_session.json"))
+	if got := loadSession("https://gw"); got != (sessionFile{}) {
+		t.Fatalf("loadSession missing should be zero, got %+v", got)
+	}
+}
+
+// --- end-to-end over a real in-test TLS gateway ---------------------------
+
+// genTestTLS returns a self-signed cert valid for 127.0.0.1 plus a pool that
+// trusts it (the leaf is its own CA).
+func genTestTLS(t *testing.T) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "fleet-test-gateway"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:              []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("x509 keypair: %v", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(certPEM) {
+		t.Fatal("append cert to pool")
+	}
+	return cert, pool
+}
+
+func waitForState(t *testing.T, ch <-chan *fleetgrpc.RemoteMcpStatus, want fleetgrpc.RemoteMcpConn, timeout time.Duration) *fleetgrpc.RemoteMcpStatus {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case st := <-ch:
+			if st.GetState() == want {
+				return st
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for state %v", want)
+			return nil
+		}
+	}
+}
+
+// newManagerForTest builds a Manager whose dial reaches addr over TLS trusting
+// pool, with status pushed to the returned channel.
+func newManagerForTest(mcpPort int, addr string, pool *x509.CertPool) (*Manager, <-chan *fleetgrpc.RemoteMcpStatus) {
+	statusCh := make(chan *fleetgrpc.RemoteMcpStatus, 64)
+	m := NewManager(mcpPort, "vtest", func(st *fleetgrpc.RemoteMcpStatus) { statusCh <- st })
+	m.dial = func(ctx context.Context, _ string) (net.Conn, error) {
+		d := &tls.Dialer{Config: &tls.Config{RootCAs: pool, ServerName: "127.0.0.1"}}
+		return d.DialContext(ctx, "tcp", addr)
+	}
+	return m, statusCh
+}
+
+// TestManagerConnectsServesAndDisables drives the full lifecycle against a real
+// TLS gateway: CONNECTING -> CONNECTED (with the gateway's public URL), the
+// session is persisted, the tunnel actually serves a request, and disabling
+// tears it down to UNSPECIFIED.
+func TestManagerConnectsServesAndDisables(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cert, pool := genTestTLS(t)
+	mcp := newFakeMCP()
+	defer mcp.srv.Close()
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{Certificates: []tls.Certificate{cert}})
+	if err != nil {
+		t.Fatalf("tls listen: %v", err)
+	}
+	defer ln.Close()
+
+	served := make(chan string, 1) // the auth header the tunnel delivered to the MCP server
+	gwDone := make(chan struct{})
+	defer close(gwDone)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var req tunnel.RegisterRequest
+		if err := tunnel.ReadFrame(conn, &req); err != nil {
+			return
+		}
+		_ = tunnel.WriteFrame(conn, tunnel.RegisterReply{SessionID: "sess-A", PublicURL: "https://gw/mcp/sess-A"})
+		sess, err := tunnel.ServerSession(conn, io.Discard)
+		if err != nil {
+			return
+		}
+		defer sess.Close()
+		// Prove the tunnel serves: issue a request back down it to the loopback MCP.
+		hc := gatewayHTTPClient(sess)
+		hreq, _ := http.NewRequest(http.MethodGet, "http://tunnel/echo", nil)
+		hreq.Header.Set("Authorization", "Bearer e2e")
+		if resp, err := hc.Do(hreq); err == nil {
+			b, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			served <- string(b)
+		} else {
+			served <- "ERR:" + err.Error()
+		}
+		<-gwDone
+	}()
+
+	m, statusCh := newManagerForTest(mcp.port(t), ln.Addr().String(), pool)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.Run(ctx)
+
+	m.Reconcile(true, "https://gw.example.com")
+
+	connected := waitForState(t, statusCh, fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED, 5*time.Second)
+	if connected.GetPublicUrl() != "https://gw/mcp/sess-A" {
+		t.Fatalf("public url = %q, want https://gw/mcp/sess-A", connected.GetPublicUrl())
+	}
+
+	// The tunnel actually carried a request, auth header intact.
+	select {
+	case got := <-served:
+		if got != "Bearer e2e" {
+			t.Fatalf("tunnel served auth = %q, want %q", got, "Bearer e2e")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("gateway never served a request over the tunnel")
+	}
+
+	// Sticky session persisted for reconnect.
+	if s := loadSession("https://gw.example.com"); s.SessionID != "sess-A" || s.PublicURL != "https://gw/mcp/sess-A" {
+		t.Fatalf("session not persisted: %+v", s)
+	}
+
+	// Disable -> tears down to UNSPECIFIED.
+	m.Reconcile(false, "https://gw.example.com")
+	waitForState(t, statusCh, fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_UNSPECIFIED, 5*time.Second)
+}
+
+// TestManagerStickyReconnect verifies that after an established connection drops,
+// the manager reconnects supplying the previously-assigned session id so the
+// gateway can hand back the SAME public URL.
+func TestManagerStickyReconnect(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cert, pool := genTestTLS(t)
+	mcp := newFakeMCP()
+	defer mcp.srv.Close()
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{Certificates: []tls.Certificate{cert}})
+	if err != nil {
+		t.Fatalf("tls listen: %v", err)
+	}
+	defer ln.Close()
+
+	regIDs := make(chan string, 8)
+	var conns atomic.Int32
+	gwDone := make(chan struct{})
+	defer close(gwDone)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close()
+				var req tunnel.RegisterRequest
+				if err := tunnel.ReadFrame(conn, &req); err != nil {
+					return
+				}
+				n := conns.Add(1)
+				regIDs <- req.SessionID
+				sid := req.SessionID
+				if sid == "" {
+					sid = "sticky-1"
+				}
+				if err := tunnel.WriteFrame(conn, tunnel.RegisterReply{SessionID: sid, PublicURL: "https://gw/mcp/" + sid}); err != nil {
+					return
+				}
+				if n == 1 {
+					return // drop immediately to force a sticky reconnect
+				}
+				sess, err := tunnel.ServerSession(conn, io.Discard)
+				if err != nil {
+					return
+				}
+				defer sess.Close()
+				<-gwDone
+			}(conn)
+		}
+	}()
+
+	m, statusCh := newManagerForTest(mcp.port(t), ln.Addr().String(), pool)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.Run(ctx)
+	m.Reconcile(true, "https://gw.example.com")
+
+	// First registration: no prior session id.
+	if got := waitForReg(t, regIDs, 5*time.Second); got != "" {
+		t.Fatalf("first registration session id = %q, want empty", got)
+	}
+	// Second registration (after the forced drop): the sticky id.
+	if got := waitForReg(t, regIDs, 5*time.Second); got != "sticky-1" {
+		t.Fatalf("reconnect registration session id = %q, want sticky-1", got)
+	}
+	// And it lands CONNECTED on the kept connection.
+	waitForState(t, statusCh, fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED, 5*time.Second)
+}
+
+func waitForReg(t *testing.T, ch <-chan string, timeout time.Duration) string {
+	t.Helper()
+	select {
+	case id := <-ch:
+		return id
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for a registration")
+		return ""
+	}
+}
+
+// TestManagerErrorsWhenMcpDown reports an error (not a crash) when enabled but
+// the local MCP server isn't running (mcpPort == 0).
+func TestManagerErrorsWhenMcpDown(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	statusCh := make(chan *fleetgrpc.RemoteMcpStatus, 64)
+	m := NewManager(0, "vtest", func(st *fleetgrpc.RemoteMcpStatus) { statusCh <- st })
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.Run(ctx)
+	m.Reconcile(true, "https://gw.example.com")
+
+	st := waitForState(t, statusCh, fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_ERROR, 5*time.Second)
+	if st.GetError() == "" {
+		t.Fatal("error status should carry a message")
+	}
+}

--- a/internal/server/remote/proxy.go
+++ b/internal/server/remote/proxy.go
@@ -1,0 +1,51 @@
+package remote
+
+import (
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+
+	"github.com/hashicorp/yamux"
+)
+
+// proxy.go is the data path. fleetd treats the yamux session as a net.Listener
+// and runs a stdlib http.Server over it: every stream the gateway opens (one per
+// inbound MCP request) is Accept()ed as a net.Conn, the HTTP request is read off
+// it, and an httputil.ReverseProxy streams it to the loopback MCP server and the
+// response back. Reusing http.Server + ReverseProxy means SSE flushing and
+// chunked streaming are handled by the same stdlib path the local MCP server
+// already uses — correct by construction, and per-stream isolation guarantees
+// concurrent requests never interleave.
+
+// serveProxy serves the yamux session until it errors (peer gone, or the caller
+// closes the session to unblock it). It always returns a non-nil error — the
+// listener (session) only stops by failing — which the caller uses to decide
+// whether to reconnect.
+func serveProxy(session *yamux.Session, mcpPort int) error {
+	target := &url.URL{Scheme: "http", Host: net.JoinHostPort("127.0.0.1", strconv.Itoa(mcpPort))}
+	rp := httputil.NewSingleHostReverseProxy(target)
+	// FlushInterval -1 flushes each write immediately, which SSE (text/event-stream)
+	// requires — otherwise events buffer and the stream stalls.
+	rp.FlushInterval = -1
+	// Present the loopback target as the Host so the local MCP server sees a
+	// same-origin request rather than the gateway's public host. The Authorization
+	// header is deliberately left untouched so the MCP bearer token reaches the
+	// loopback server's auth middleware — that token stays the real access gate.
+	orig := rp.Director
+	rp.Director = func(req *http.Request) {
+		orig(req)
+		req.Host = ""
+	}
+	// Peer resets / closed streams are normal tunnel churn, not server faults;
+	// discard the proxy's per-request error spam.
+	rp.ErrorLog = log.New(io.Discard, "", 0)
+
+	srv := &http.Server{Handler: rp}
+	// http.Server.Serve returns the listener's error when Accept fails; for a
+	// yamux session that is the session-closed/peer-gone error we want to surface.
+	return srv.Serve(session)
+}

--- a/internal/server/remote/proxy_test.go
+++ b/internal/server/remote/proxy_test.go
@@ -1,0 +1,294 @@
+package remote
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/tunnel"
+)
+
+// tcpPair returns a connected pair of loopback TCP conns. Used instead of
+// net.Pipe for the proxy stress test because it has real socket buffering, which
+// better matches production and avoids net.Pipe's strict-synchrony quirks under
+// many concurrent multiplexed streams.
+func tcpPair(t *testing.T) (net.Conn, net.Conn) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	type res struct {
+		c   net.Conn
+		err error
+	}
+	ch := make(chan res, 1)
+	go func() {
+		c, err := ln.Accept()
+		ch <- res{c, err}
+	}()
+	client, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	got := <-ch
+	if got.err != nil {
+		t.Fatalf("accept: %v", got.err)
+	}
+	return client, got.c
+}
+
+// gatewayHTTPClient builds an http.Client whose transport dials a fresh yamux
+// stream per request (DisableKeepAlives), exactly as the real gateway's reverse
+// proxy will. The request URL host is irrelevant — the dialer ignores it.
+func gatewayHTTPClient(session interface {
+	Open() (net.Conn, error)
+}) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return session.Open()
+			},
+		},
+	}
+}
+
+// fakeMCP is a stand-in for the loopback MCP server. /sse streams numbered SSE
+// events (with a per-event delay) and records the Authorization header it saw,
+// keyed by the request's id; /echo returns the Authorization header in the body.
+type fakeMCP struct {
+	srv      *httptest.Server
+	mu       sync.Mutex
+	authByID map[string]string
+}
+
+func newFakeMCP() *fakeMCP {
+	f := &fakeMCP{authByID: map[string]string{}}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sse", func(w http.ResponseWriter, r *http.Request) {
+		id := r.URL.Query().Get("id")
+		n, _ := strconv.Atoi(r.URL.Query().Get("n"))
+		delayMS, _ := strconv.Atoi(r.URL.Query().Get("delay"))
+		f.mu.Lock()
+		f.authByID[id] = r.Header.Get("Authorization")
+		f.mu.Unlock()
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "no flusher", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(w, "data: %s-%d\n\n", id, i)
+			flusher.Flush()
+			if delayMS > 0 {
+				time.Sleep(time.Duration(delayMS) * time.Millisecond)
+			}
+		}
+	})
+	mux.HandleFunc("/echo", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, r.Header.Get("Authorization"))
+	})
+	f.srv = httptest.NewServer(mux)
+	return f
+}
+
+func (f *fakeMCP) port(t *testing.T) int {
+	t.Helper()
+	u, err := url.Parse(f.srv.URL)
+	if err != nil {
+		t.Fatalf("parse fake mcp url: %v", err)
+	}
+	p, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("port: %v", err)
+	}
+	return p
+}
+
+func (f *fakeMCP) authFor(id string) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.authByID[id]
+}
+
+// readSSEData reads "data: X" payloads from an SSE body in order.
+func readSSEData(t *testing.T, body io.Reader) []string {
+	t.Helper()
+	var out []string
+	sc := bufio.NewScanner(body)
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.HasPrefix(line, "data: ") {
+			out = append(out, strings.TrimPrefix(line, "data: "))
+		}
+	}
+	return out
+}
+
+// TestServeProxyConcurrentSSEAndAuth is the load-bearing transport test: many
+// SSE streams driven concurrently over ONE yamux session must each deliver their
+// events complete and IN ORDER (no cross-stream interleaving / corruption), and
+// the per-request Authorization header must reach the loopback server untouched.
+func TestServeProxyConcurrentSSEAndAuth(t *testing.T) {
+	mcp := newFakeMCP()
+	defer mcp.srv.Close()
+
+	fleetdConn, gatewayConn := tcpPair(t)
+	fleetdSession, err := tunnel.ClientSession(fleetdConn, io.Discard)
+	if err != nil {
+		t.Fatalf("client session: %v", err)
+	}
+	defer fleetdSession.Close()
+	gatewaySession, err := tunnel.ServerSession(gatewayConn, io.Discard)
+	if err != nil {
+		t.Fatalf("server session: %v", err)
+	}
+	defer gatewaySession.Close()
+
+	go func() { _ = serveProxy(fleetdSession, mcp.port(t)) }()
+
+	client := gatewayHTTPClient(gatewaySession)
+
+	const (
+		streams        = 24
+		eventsPerStream = 8
+	)
+	var wg sync.WaitGroup
+	errs := make(chan error, streams)
+	for g := 0; g < streams; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			id := fmt.Sprintf("s%d", g)
+			auth := fmt.Sprintf("Bearer token-%d", g)
+			req, _ := http.NewRequest(http.MethodGet,
+				fmt.Sprintf("http://tunnel/sse?id=%s&n=%d", id, eventsPerStream), nil)
+			req.Header.Set("Authorization", auth)
+			resp, err := client.Do(req)
+			if err != nil {
+				errs <- fmt.Errorf("%s: do: %w", id, err)
+				return
+			}
+			defer resp.Body.Close()
+			got := readSSEData(t, resp.Body)
+			if len(got) != eventsPerStream {
+				errs <- fmt.Errorf("%s: got %d events, want %d", id, len(got), eventsPerStream)
+				return
+			}
+			for i, ev := range got {
+				want := fmt.Sprintf("%s-%d", id, i)
+				if ev != want {
+					errs <- fmt.Errorf("%s: event %d = %q, want %q (interleave/order bug)", id, i, ev, want)
+					return
+				}
+			}
+			if seen := mcp.authFor(id); seen != auth {
+				errs <- fmt.Errorf("%s: auth = %q, want %q", id, seen, auth)
+				return
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+// TestServeProxyStreamsSSEIncrementally proves the proxy does NOT buffer the
+// whole response: with a per-event server delay, the first event must reach the
+// client well before the handler could have produced the last one.
+func TestServeProxyStreamsSSEIncrementally(t *testing.T) {
+	mcp := newFakeMCP()
+	defer mcp.srv.Close()
+
+	fleetdConn, gatewayConn := tcpPair(t)
+	fleetdSession, err := tunnel.ClientSession(fleetdConn, io.Discard)
+	if err != nil {
+		t.Fatalf("client session: %v", err)
+	}
+	defer fleetdSession.Close()
+	gatewaySession, err := tunnel.ServerSession(gatewayConn, io.Discard)
+	if err != nil {
+		t.Fatalf("server session: %v", err)
+	}
+	defer gatewaySession.Close()
+
+	go func() { _ = serveProxy(fleetdSession, mcp.port(t)) }()
+	client := gatewayHTTPClient(gatewaySession)
+
+	const (
+		n       = 10
+		delayMS = 40 // total handler time ~= 400ms
+	)
+	req, _ := http.NewRequest(http.MethodGet,
+		fmt.Sprintf("http://tunnel/sse?id=stream&n=%d&delay=%d", n, delayMS), nil)
+	start := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	sc := bufio.NewScanner(resp.Body)
+	var firstAt time.Duration
+	count := 0
+	for sc.Scan() {
+		if strings.HasPrefix(sc.Text(), "data: ") {
+			if count == 0 {
+				firstAt = time.Since(start)
+			}
+			count++
+		}
+	}
+	if count != n {
+		t.Fatalf("got %d events, want %d", count, n)
+	}
+	// If the proxy buffered the whole body, the first event would only arrive
+	// after the handler finished (~n*delay). It must arrive much sooner.
+	if firstAt > time.Duration(n*delayMS/2)*time.Millisecond {
+		t.Fatalf("first SSE event took %v — looks buffered, not streamed", firstAt)
+	}
+}
+
+// TestServeProxyForwardsAuthOnUnaryRequest checks a plain (non-SSE) request also
+// carries the Authorization header through.
+func TestServeProxyForwardsAuthOnUnaryRequest(t *testing.T) {
+	mcp := newFakeMCP()
+	defer mcp.srv.Close()
+
+	fleetdConn, gatewayConn := tcpPair(t)
+	fleetdSession, _ := tunnel.ClientSession(fleetdConn, io.Discard)
+	defer fleetdSession.Close()
+	gatewaySession, _ := tunnel.ServerSession(gatewayConn, io.Discard)
+	defer gatewaySession.Close()
+	go func() { _ = serveProxy(fleetdSession, mcp.port(t)) }()
+	client := gatewayHTTPClient(gatewaySession)
+
+	req, _ := http.NewRequest(http.MethodGet, "http://tunnel/echo", nil)
+	req.Header.Set("Authorization", "Bearer secret-xyz")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if string(b) != "Bearer secret-xyz" {
+		t.Fatalf("auth not forwarded: got %q", b)
+	}
+}

--- a/internal/server/remote/session.go
+++ b/internal/server/remote/session.go
@@ -1,0 +1,55 @@
+package remote
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetpaths"
+)
+
+// session.go persists the sticky gateway session so that, across reconnects and
+// daemon restarts, fleetd asks the gateway for the SAME public URL. The file
+// (~/.fleet/gateway_session.json, 0600) records the assigned session id, the
+// public URL, and the gateway URL it was issued for.
+
+type sessionFile struct {
+	SessionID  string `json:"session_id"`
+	PublicURL  string `json:"public_url"`
+	GatewayURL string `json:"gateway_url"`
+}
+
+// loadSession returns the persisted session IF it was issued for gatewayURL. A
+// stored session for a DIFFERENT gateway is stale (the id is meaningless to a
+// new gateway), so it is ignored and a fresh registration is requested. A
+// missing/unreadable/corrupt file yields a zero sessionFile (request a fresh id).
+func loadSession(gatewayURL string) sessionFile {
+	data, err := os.ReadFile(fleetpaths.GatewaySessionPath())
+	if err != nil {
+		return sessionFile{}
+	}
+	var s sessionFile
+	if err := json.Unmarshal(data, &s); err != nil {
+		return sessionFile{}
+	}
+	if s.GatewayURL != gatewayURL {
+		return sessionFile{}
+	}
+	return s
+}
+
+// saveSession persists s atomically-enough for a best-effort hint (0600 — it is
+// host-local and per-user, mirroring the other ~/.fleet discovery files). A
+// write failure is returned but is non-fatal to the tunnel: a lost file just
+// means the next reconnect gets a fresh URL.
+func saveSession(s sessionFile) error {
+	// ~/.fleet always exists by the time the daemon runs the manager (Serve
+	// MkdirAlls it first), but ensure it so the write can't fail on a fresh dir.
+	if _, err := fleetpaths.EnsureDir(); err != nil {
+		return err
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(fleetpaths.GatewaySessionPath(), data, 0o600)
+}

--- a/internal/server/remote/status.go
+++ b/internal/server/remote/status.go
@@ -1,0 +1,33 @@
+package remote
+
+import "github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+
+// status.go builds the fleetgrpc.RemoteMcpStatus values the manager publishes to
+// the hub (and thence to the TUI over Watch). The status is the ONLY channel for
+// the computed Public MCP URL — it is never persisted in Config.
+
+func statusDisabled() *fleetgrpc.RemoteMcpStatus {
+	return &fleetgrpc.RemoteMcpStatus{State: fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_UNSPECIFIED}
+}
+
+func statusConnecting() *fleetgrpc.RemoteMcpStatus {
+	return &fleetgrpc.RemoteMcpStatus{State: fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTING}
+}
+
+func statusConnected(publicURL string) *fleetgrpc.RemoteMcpStatus {
+	return &fleetgrpc.RemoteMcpStatus{
+		State:     fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
+		PublicUrl: publicURL,
+	}
+}
+
+func statusError(err error) *fleetgrpc.RemoteMcpStatus {
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+	return &fleetgrpc.RemoteMcpStatus{
+		State: fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_ERROR,
+		Error: msg,
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,6 +18,8 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetpaths"
 	"github.com/BenjaminBenetti/fleet-man/internal/flog"
+	"github.com/BenjaminBenetti/fleet-man/internal/server/remote"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	"github.com/BenjaminBenetti/fleet-man/internal/version"
 	"google.golang.org/grpc"
 )
@@ -119,6 +121,22 @@ func Serve(ctx context.Context) error {
 			// across restarts so configured MCP clients (mcp.json) keep working.
 			_ = os.Remove(fleetpaths.McpPortPath())
 		}()
+	}
+
+	// Remote-MCP gateway tunnel: an outbound, OPT-IN connection that exposes the
+	// loopback MCP server to the internet through a remote fleet gateway. Like MCP
+	// itself it is auxiliary — the supervisor stays idle until the config enables
+	// it, and a connect failure only affects remote access, never the local
+	// daemon. It publishes its status (incl. the gateway-assigned Public MCP URL)
+	// through the hub so the TUI settings page reflects it live.
+	svc.remote = remote.NewManager(mcpPort, versionOrDev(), func(st *fleetgrpc.RemoteMcpStatus) {
+		svc.hub.post(func(h *hub) { h.broadcastRemoteMcpStatus(st) })
+	})
+	go svc.remote.Run(hubCtx)
+	if cfg, err := state.LoadConfig(); err == nil {
+		svc.remote.Reconcile(cfg.RemoteMcpSettings.Enabled, cfg.RemoteMcpSettings.GatewayURL)
+	} else {
+		flog.Warn("remote mcp: load config", "err", err)
 	}
 
 	writeVersionFile()

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/server/remote"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	"github.com/BenjaminBenetti/fleet-man/internal/version"
 	"google.golang.org/grpc/codes"
@@ -25,6 +26,11 @@ type service struct {
 	startedAt time.Time
 	hub       *hub
 	jobs      *jobManager
+
+	// remote drives the outbound remote-MCP gateway tunnel. Set in server.go
+	// after the MCP listener binds (so it knows the loopback port); nil for tests
+	// that use newService() without a serve loop, so callers must nil-check.
+	remote *remote.Manager
 
 	// bgCtx is cancelled at server shutdown (set to the serve loop's hubCtx in
 	// server.go). Background work spawned by RPC handlers — e.g. the TUI-connect

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -1,0 +1,125 @@
+// Package tunnel defines the wire protocol shared by the two ends of the
+// remote-MCP reverse tunnel: the fleetd side (internal/server/remote), which
+// dials OUT to a gateway and serves inbound MCP requests, and the fleet gateway
+// (internal/gateway, a later PR), which accepts those dials and routes public
+// MCP traffic back down them.
+//
+// It is a small leaf package — it imports only the standard library and yamux —
+// so both server-side modules can share the exact frame definitions without
+// coupling to each other or to fleet internals.
+//
+// # Connection lifecycle
+//
+//  1. fleetd dials the gateway (TLS) and writes ONE RegisterRequest control
+//     frame on the raw conn; the gateway replies with ONE RegisterReply frame.
+//     This length-prefixed JSON handshake happens BEFORE yamux is layered on, so
+//     registration stays a simple typed exchange.
+//  2. Both sides then wrap the SAME conn in yamux (fleetd as client, gateway as
+//     server). The gateway opens one yamux stream per inbound MCP request; fleetd
+//     accepts each stream and serves it as a normal HTTP connection proxied to
+//     its loopback MCP server. One stream per request means SSE streams and
+//     concurrent calls never interleave.
+//
+// There is no authentication frame: the gateway authorizes nobody. The
+// unguessable public URL it mints per session is the capability that isolates
+// each fleetd, and the MCP bearer token (carried end to end in the Authorization
+// header) remains the real access boundary on the loopback server.
+package tunnel
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+
+	"github.com/hashicorp/yamux"
+)
+
+// RegisterRequest is the first frame fleetd writes after dialing the gateway.
+// SessionID is empty on a first registration and set to the previously-assigned
+// id on reconnect, so the gateway can hand back the SAME public URL (sticky).
+type RegisterRequest struct {
+	// SessionID, when non-empty, asks the gateway to re-use a prior session's
+	// public URL (sticky reconnect). Empty requests a fresh one.
+	SessionID string `json:"session_id,omitempty"`
+	// ClientVersion is the fleetd version, for the gateway's logs/diagnostics.
+	ClientVersion string `json:"client_version,omitempty"`
+}
+
+// RegisterReply is the gateway's response. On success Error is empty, SessionID
+// is the assigned (possibly reused) id, and PublicURL is the address external
+// MCP clients use. On failure Error explains why and the other fields are empty.
+type RegisterReply struct {
+	SessionID string `json:"session_id,omitempty"`
+	PublicURL string `json:"public_url,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+// MaxFrameSize caps a control frame so a malicious or garbled peer cannot make
+// the reader allocate unbounded memory. Control frames are tiny JSON objects.
+const MaxFrameSize = 64 << 10
+
+// ErrFrameTooLarge is returned when a frame exceeds MaxFrameSize.
+var ErrFrameTooLarge = errors.New("tunnel: control frame too large")
+
+// WriteFrame writes v as a length-prefixed JSON control frame: a 4-byte
+// big-endian length followed by the JSON bytes.
+func WriteFrame(w io.Writer, v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	if len(b) > MaxFrameSize {
+		return ErrFrameTooLarge
+	}
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(b)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err = w.Write(b)
+	return err
+}
+
+// ReadFrame reads a length-prefixed JSON control frame (written by WriteFrame)
+// into v. It rejects oversized length prefixes before allocating.
+func ReadFrame(r io.Reader, v any) error {
+	var hdr [4]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return err
+	}
+	n := binary.BigEndian.Uint32(hdr[:])
+	if n > MaxFrameSize {
+		return ErrFrameTooLarge
+	}
+	b := make([]byte, n)
+	if _, err := io.ReadFull(r, b); err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
+}
+
+// sessionConfig returns the shared yamux config. yamux keepalive (enabled by
+// default) keeps NAT mappings warm and detects a dead peer at the frame layer,
+// so neither side needs an application-level heartbeat. logOutput receives
+// yamux's internal logging; pass io.Discard to silence it.
+func sessionConfig(logOutput io.Writer) *yamux.Config {
+	cfg := yamux.DefaultConfig()
+	if logOutput != nil {
+		cfg.LogOutput = logOutput
+	}
+	return cfg
+}
+
+// ClientSession wraps the dialing side (fleetd) of an established control conn,
+// after the RegisterRequest/RegisterReply handshake has completed on it.
+func ClientSession(conn net.Conn, logOutput io.Writer) (*yamux.Session, error) {
+	return yamux.Client(conn, sessionConfig(logOutput))
+}
+
+// ServerSession wraps the accepting side (the gateway) of an established control
+// conn, after the handshake has completed on it.
+func ServerSession(conn net.Conn, logOutput io.Writer) (*yamux.Session, error) {
+	return yamux.Server(conn, sessionConfig(logOutput))
+}

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -1,0 +1,104 @@
+package tunnel
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestFrameRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	in := RegisterRequest{SessionID: "abc123", ClientVersion: "v1.2.3"}
+	if err := WriteFrame(&buf, in); err != nil {
+		t.Fatalf("WriteFrame: %v", err)
+	}
+	var out RegisterRequest
+	if err := ReadFrame(&buf, &out); err != nil {
+		t.Fatalf("ReadFrame: %v", err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch: got %+v want %+v", out, in)
+	}
+}
+
+func TestFrameReplyRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	in := RegisterReply{SessionID: "s1", PublicURL: "https://gw/mcp/s1"}
+	if err := WriteFrame(&buf, in); err != nil {
+		t.Fatalf("WriteFrame: %v", err)
+	}
+	var out RegisterReply
+	if err := ReadFrame(&buf, &out); err != nil {
+		t.Fatalf("ReadFrame: %v", err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch: got %+v want %+v", out, in)
+	}
+}
+
+// TestReadFrameRejectsOversizeHeader guards the allocation cap: a hostile length
+// prefix must be rejected before allocating, without reading the body.
+func TestReadFrameRejectsOversizeHeader(t *testing.T) {
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], MaxFrameSize+1)
+	r := io.MultiReader(bytes.NewReader(hdr[:]), strings.NewReader("ignored"))
+	var v RegisterReply
+	if err := ReadFrame(r, &v); err != ErrFrameTooLarge {
+		t.Fatalf("want ErrFrameTooLarge, got %v", err)
+	}
+}
+
+func TestWriteFrameRejectsOversizePayload(t *testing.T) {
+	big := RegisterReply{Error: strings.Repeat("x", MaxFrameSize+1)}
+	if err := WriteFrame(io.Discard, big); err != ErrFrameTooLarge {
+		t.Fatalf("want ErrFrameTooLarge, got %v", err)
+	}
+}
+
+// TestYamuxSessionOverPipe sanity-checks the session helpers: a client/server
+// pair over net.Pipe can open a stream and exchange bytes both directions.
+func TestYamuxSessionOverPipe(t *testing.T) {
+	c1, c2 := net.Pipe()
+	client, err := ClientSession(c1, io.Discard)
+	if err != nil {
+		t.Fatalf("ClientSession: %v", err)
+	}
+	defer client.Close()
+	server, err := ServerSession(c2, io.Discard)
+	if err != nil {
+		t.Fatalf("ServerSession: %v", err)
+	}
+	defer server.Close()
+
+	go func() {
+		stream, err := server.Accept()
+		if err != nil {
+			return
+		}
+		defer stream.Close()
+		b := make([]byte, 4)
+		if _, err := io.ReadFull(stream, b); err != nil {
+			return
+		}
+		_, _ = stream.Write(append(b, '!'))
+	}()
+
+	stream, err := client.Open()
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer stream.Close()
+	if _, err := stream.Write([]byte("ping")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got := make([]byte, 5)
+	if _, err := io.ReadFull(stream, got); err != nil {
+		t.Fatalf("ReadFull: %v", err)
+	}
+	if string(got) != "ping!" {
+		t.Fatalf("got %q want %q", got, "ping!")
+	}
+}


### PR DESCRIPTION
## What

PR 2 of **Fleet remote MCP** (#97): the **fleetd side of the reverse tunnel**. fleetd dials *out* to the configured gateway, registers, and serves the gateway's inbound MCP requests by reverse-proxying them to its loopback MCP server. The gateway server itself is the next PR — these tests stand up an in-process one.

Builds on PR 1 (#108), which added the settings + the Watch `RemoteMcpStatus` push path. The manager now actually drives that status (CONNECTING → CONNECTED + Public MCP URL → ERROR), so the Settings page goes live once a gateway exists.

## Transport — yamux (the design's load-bearing choice)

- **`internal/tunnel`** — a small, dependency-light shared protocol: a length-prefixed JSON `RegisterRequest`/`RegisterReply` handshake on the raw TLS conn, then **yamux over the same conn**. The gateway opens **one yamux stream per inbound request**, so fleetd serves each with a stdlib `http.Server` + `httputil.ReverseProxy` (`FlushInterval=-1`). This reuses the stdlib's exact SSE-flush path *per stream*: streaming is correct by construction and concurrent requests can't interleave. (Leaf package — yamux + stdlib only — so the gateway in PR 3 shares the exact frame definitions.)
- **`internal/server/remote`** — the `Manager`, a single supervisor goroutine: dial → register → serve → reconnect with **jittered exponential backoff** (500ms→60s). `Reconcile(enabled, url)` is **non-blocking** (sets desired state, cancels the in-flight attempt, nudges the loop), so `SetConfig` can call it while holding the config-write lock without deadlocking. **Sticky reconnect** persists `~/.fleet/gateway_session.json` so the gateway re-issues the same public URL across reconnects/restarts (a session stored for a different gateway URL is ignored).

## Security

No gateway auth (per the agreed model): the **unguessable, gateway-minted public URL is the capability**, and the **MCP bearer token is forwarded untouched** in `Authorization` so the loopback server's existing auth stays the real boundary — the proxy is a transparent pipe. yamux v0.1.2 is MPL-2.0 (one-way GPL-3.0 compatible).

## Tests (all pass under `-race`)

- **The critical transport test:** 24 concurrent SSE streams over **one** yamux session, asserting per-stream event **ordering + no interleaving + Authorization passthrough**, plus an **incremental-streaming proof** (the first event must arrive long before the handler could finish — i.e. not buffered).
- **End-to-end manager test** over a **real in-test TLS gateway**: connect → serve a request → disable-teardown; **sticky reconnect** (second registration carries the saved session id); and the `mcp-down` error path.
- Unit tests for the frame protocol (incl. oversize-frame rejection), `gatewayAddress` URL handling, backoff/jitter bounds, and the session-file round-trip / stale-on-different-gateway logic.

`make test` (depguard import-boundary lint + all unit tests) passes. No proto changes in this PR.

## Reviewer notes

- **Import boundary preserved:** `internal/server/remote` and `internal/tunnel` are server-side; only `internal/server` imports `remote`. depguard passes.
- The tunnel is **opt-in and auxiliary** — the supervisor stays idle until config enables it, and a connect failure only affects remote access, never the local daemon.
- An adversarial multi-agent review of the diff (concurrency/lifecycle, proxy/SSE, security) returned no findings.

Part of #97. Next: PR 3 — the `fleet gateway` server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
