### PR TITLE
feat(mcp): fleet gateway server (#97)

### DIFF
--- a/internal/cli/gateway.go
+++ b/internal/cli/gateway.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"github.com/BenjaminBenetti/fleet-man/internal/gateway"
+	"github.com/spf13/cobra"
+)
+
+// newGatewayCmd runs the fleet gateway: the remote, operator-hosted relay that
+// fleetd registers with to expose its MCP server to the internet (see
+// internal/gateway). Unlike `fleet server` this is meant to be run directly by an
+// operator on a public host, so it is NOT hidden.
+//
+// internal/cli normally must not import server-side packages (the depguard
+// boundary), but internal/gateway is a self-contained server module with no
+// fleetd internals, and this file is its thin entrypoint — mirroring how
+// server.go is the lone entrypoint for internal/server.
+func newGatewayCmd() *cobra.Command {
+	var cfg gateway.Config
+
+	cmd := &cobra.Command{
+		Use:   "gateway",
+		Short: "Run the fleet gateway (remote MCP relay)",
+		Long: "Run the fleet gateway: a public, operator-hosted server that relays remote\n" +
+			"MCP traffic to fleet daemons over a reverse tunnel. fleet daemons dial in on\n" +
+			"the control address; MCP agents connect over HTTPS at <public-url>/mcp/<id>.\n\n" +
+			"Requires a TLS certificate (use a publicly-trusted cert, e.g. from Let's\n" +
+			"Encrypt, so fleet daemons can verify it).",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return gateway.Serve(cmd.Context(), cfg)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVar(&cfg.ControlAddr, "control-addr", ":8443", "address fleet daemons dial in on (TLS)")
+	f.StringVar(&cfg.PublicAddr, "public-addr", ":443", "address MCP agents connect to (HTTPS)")
+	f.StringVar(&cfg.PublicURL, "public-url", "", "external base URL agents use, e.g. https://gw.example.com (required)")
+	f.StringVar(&cfg.TLSCert, "tls-cert", "", "path to the TLS certificate, PEM (required)")
+	f.StringVar(&cfg.TLSKey, "tls-key", "", "path to the TLS private key, PEM (required)")
+	f.IntVar(&cfg.MaxSessions, "max-sessions", 0, "max concurrent tunnels (0 = default 1024)")
+
+	return cmd
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -54,6 +54,7 @@ func NewRootCmd() *cobra.Command {
 		newLaunchCmd(),
 		newVersionCmd(),
 		newServerCmd(),
+		newGatewayCmd(),
 	)
 
 	return root

--- a/internal/gateway/control.go
+++ b/internal/gateway/control.go
@@ -54,7 +54,7 @@ func (s *Server) handleControl(ctx context.Context, conn net.Conn) {
 		return
 	}
 
-	sess, reply, err := s.reg.claim(req)
+	sess, reply, isNew, err := s.reg.claim(req)
 	if err != nil {
 		// Best-effort tell the client why, then drop.
 		_ = tunnel.WriteFrame(conn, tunnel.RegisterReply{Error: err.Error()})
@@ -62,7 +62,12 @@ func (s *Server) handleControl(ctx context.Context, conn net.Conn) {
 		_ = conn.Close()
 		return
 	}
+	// On any failure before bind, free a freshly-reserved slot so it doesn't count
+	// against the cap (a no-op for a reclaimed, already-bound session).
 	if err := tunnel.WriteFrame(conn, reply); err != nil {
+		if isNew {
+			s.reg.release(sess)
+		}
 		s.log.Warn("gateway: write register reply", "remote", remote, "err", err)
 		_ = conn.Close()
 		return
@@ -72,6 +77,9 @@ func (s *Server) handleControl(ctx context.Context, conn net.Conn) {
 
 	ym, err := tunnel.ServerSession(conn, s.yamuxLog())
 	if err != nil {
+		if isNew {
+			s.reg.release(sess)
+		}
 		s.log.Warn("gateway: yamux server", "remote", remote, "err", err)
 		_ = conn.Close()
 		return

--- a/internal/gateway/control.go
+++ b/internal/gateway/control.go
@@ -1,0 +1,96 @@
+package gateway
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/tunnel"
+)
+
+// control.go runs the control listener: the TLS endpoint fleetd dials to register
+// a tunnel. Each accepted connection performs the internal/tunnel handshake on
+// the raw conn, then becomes a yamux session the gateway opens streams on.
+
+// serveControl accepts control connections until ctx is cancelled. sem bounds the
+// number of in-flight control goroutines: a connection that can't acquire a slot
+// is shed (closed) immediately, so a flood of slow/never-registering clients
+// can't grow goroutines without bound or block the accept loop.
+func (s *Server) serveControl(ctx context.Context, ln net.Listener, sem chan struct{}) {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return // listener closed on shutdown
+			}
+			s.log.Warn("gateway: control accept", "err", err)
+			continue
+		}
+		select {
+		case sem <- struct{}{}:
+			go func(conn net.Conn) {
+				defer func() { <-sem }()
+				s.handleControl(ctx, conn)
+			}(conn)
+		default:
+			s.log.Warn("gateway: control connection shed (too many in flight)", "remote", conn.RemoteAddr().String())
+			_ = conn.Close()
+		}
+	}
+}
+
+// handleControl performs the register handshake on conn, attaches the resulting
+// yamux session to the registry, and keeps the connection alive until the tunnel
+// closes (fleetd gone) or the gateway shuts down.
+func (s *Server) handleControl(ctx context.Context, conn net.Conn) {
+	remote := conn.RemoteAddr().String()
+
+	// Bound the pre-yamux handshake with a deadline.
+	_ = conn.SetDeadline(time.Now().Add(controlHandshakeTimeout))
+	var req tunnel.RegisterRequest
+	if err := tunnel.ReadFrame(conn, &req); err != nil {
+		s.log.Warn("gateway: read register", "remote", remote, "err", err)
+		_ = conn.Close()
+		return
+	}
+
+	sess, reply, err := s.reg.claim(req)
+	if err != nil {
+		// Best-effort tell the client why, then drop.
+		_ = tunnel.WriteFrame(conn, tunnel.RegisterReply{Error: err.Error()})
+		s.log.Warn("gateway: claim rejected", "remote", remote, "err", err)
+		_ = conn.Close()
+		return
+	}
+	if err := tunnel.WriteFrame(conn, reply); err != nil {
+		s.log.Warn("gateway: write register reply", "remote", remote, "err", err)
+		_ = conn.Close()
+		return
+	}
+	// Clear the handshake deadline; yamux manages its own keepalive/timeouts.
+	_ = conn.SetDeadline(time.Time{})
+
+	ym, err := tunnel.ServerSession(conn, s.yamuxLog())
+	if err != nil {
+		s.log.Warn("gateway: yamux server", "remote", remote, "err", err)
+		_ = conn.Close()
+		return
+	}
+	s.reg.bind(sess, ym)
+	s.log.Info("gateway: tunnel registered", "remote", remote, "public_url", sess.publicURL)
+
+	// Keep serving until the tunnel closes (peer gone, detected by yamux
+	// keepalive) or the gateway shuts down.
+	select {
+	case <-ym.CloseChan():
+	case <-ctx.Done():
+		_ = ym.Close()
+	}
+	// Don't evict here: the session (and its public URL) is kept reserved for a
+	// grace TTL so a reconnect with the secret recovers the same URL. The reaper
+	// frees it once the TTL elapses with no reconnect. If a reconnect already
+	// replaced the tunnel, the session points at the new (live) one and the
+	// reaper leaves it alone.
+	_ = conn.Close()
+	s.log.Info("gateway: tunnel closed", "remote", remote, "public_url", sess.publicURL)
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -1,0 +1,195 @@
+// Package gateway is the fleet gateway: a standalone, operator-run, remote-hosted
+// server that relays remote MCP traffic to a user's fleetd over a reverse tunnel.
+// It is run via `fleet gateway` and is the public, internet-facing entrypoint of
+// the remote-MCP feature.
+//
+// It is deliberately ISOLATED from the fleet daemon: it imports only the shared
+// wire protocol (internal/tunnel) and the standard library — never internal/server,
+// internal/state, internal/flog, or any other fleetd internal. The gateway has no
+// access to ~/.fleet and holds no fleet state; it only routes bytes.
+//
+// # Two listeners
+//
+//   - Control (TLS): fleetd dials in here and performs the internal/tunnel
+//     handshake, then the connection becomes a yamux session the gateway opens
+//     streams on. This is NOT an HTTP endpoint.
+//   - Public (HTTPS): remote MCP agents connect here at https://<host>/mcp/<id>.
+//     Each request is reverse-proxied down the matching tunnel.
+//
+// # Security
+//
+// By design there is NO registration auth: anyone may open a tunnel. Isolation
+// comes from the unguessable 256-bit public id in the URL, and the real access
+// boundary remains the MCP bearer token, which the gateway forwards untouched to
+// fleetd's loopback MCP server. The reclaim credential (the tunnel "secret") is
+// kept out of the public URL so URL holders cannot hijack a tunnel.
+package gateway
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	defaultControlAddr = ":8443"
+	defaultPublicAddr  = ":443"
+	defaultMaxSessions = 1024
+
+	// controlHandshakeTimeout bounds the pre-yamux register exchange so a stalled
+	// or non-fleetd client can't tie up a control conn indefinitely.
+	controlHandshakeTimeout = 15 * time.Second
+	// reapInterval is how often closed tunnels are swept from the registry.
+	reapInterval = 15 * time.Second
+	// sessionTTL is how long a disconnected session keeps its URL reserved so a
+	// reconnecting fleetd (with its secret) recovers the same URL. After this
+	// elapses with no reconnect, the reaper frees the URL.
+	sessionTTL = 10 * time.Minute
+	// maxPendingHandshakes is the headroom (beyond MaxSessions) of in-flight
+	// control connections allowed at once. Because the gateway requires no auth,
+	// this bounds a slow-accept flood: once the cap is hit, new control
+	// connections are shed (closed) rather than each spawning a goroutine that
+	// lingers for the handshake timeout.
+	maxPendingHandshakes = 256
+	// shutdownTimeout bounds the public server drain on shutdown.
+	shutdownTimeout = 5 * time.Second
+)
+
+// Config configures a gateway. PublicURL, TLSCert, and TLSKey are required.
+type Config struct {
+	ControlAddr string // address fleetd dials in on (TLS). Default ":8443".
+	PublicAddr  string // address agents hit (HTTPS). Default ":443".
+	PublicURL   string // external base URL agents use, e.g. "https://gw.example.com". Required.
+	TLSCert     string // path to the TLS certificate (PEM). Required.
+	TLSKey      string // path to the TLS private key (PEM). Required.
+	MaxSessions int    // cap on concurrent tunnels. Default 1024.
+}
+
+// Server is a configured gateway. Build with New, then Run.
+type Server struct {
+	cfg       Config
+	reg       *registry
+	tlsConfig *tls.Config
+	log       *slog.Logger
+}
+
+// New validates cfg, loads the TLS keypair, and returns a ready Server.
+func New(cfg Config) (*Server, error) {
+	if strings.TrimSpace(cfg.PublicURL) == "" {
+		return nil, errors.New("gateway: --public-url is required (e.g. https://gw.example.com)")
+	}
+	if cfg.TLSCert == "" || cfg.TLSKey == "" {
+		return nil, errors.New("gateway: --tls-cert and --tls-key are required")
+	}
+	cert, err := tls.LoadX509KeyPair(cfg.TLSCert, cfg.TLSKey)
+	if err != nil {
+		return nil, fmt.Errorf("gateway: load TLS keypair: %w", err)
+	}
+	if cfg.ControlAddr == "" {
+		cfg.ControlAddr = defaultControlAddr
+	}
+	if cfg.PublicAddr == "" {
+		cfg.PublicAddr = defaultPublicAddr
+	}
+	if cfg.MaxSessions <= 0 {
+		cfg.MaxSessions = defaultMaxSessions
+	}
+	cfg.PublicURL = strings.TrimRight(cfg.PublicURL, "/")
+
+	return &Server{
+		cfg:       cfg,
+		reg:       newRegistry(cfg.PublicURL, cfg.MaxSessions),
+		tlsConfig: &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12},
+		log:       slog.Default(),
+	}, nil
+}
+
+// Serve is the convenience entrypoint used by the CLI: New + Run.
+func Serve(ctx context.Context, cfg Config) error {
+	s, err := New(cfg)
+	if err != nil {
+		return err
+	}
+	return s.Run(ctx)
+}
+
+// Run binds both listeners (up front, so a bind error surfaces immediately) and
+// serves until ctx is cancelled (SIGINT/SIGTERM) or a listener fails fatally.
+func (s *Server) Run(ctx context.Context) error {
+	controlLn, err := tls.Listen("tcp", s.cfg.ControlAddr, s.tlsConfig)
+	if err != nil {
+		return fmt.Errorf("gateway: listen control %s: %w", s.cfg.ControlAddr, err)
+	}
+	publicLn, err := tls.Listen("tcp", s.cfg.PublicAddr, s.tlsConfig)
+	if err != nil {
+		_ = controlLn.Close()
+		return fmt.Errorf("gateway: listen public %s: %w", s.cfg.PublicAddr, err)
+	}
+	return s.serve(ctx, controlLn, publicLn)
+}
+
+// serve runs the accept loops, reaper, and public HTTP server over already-bound
+// listeners until ctx is cancelled or the public server fails. Split from Run so
+// tests can supply ephemeral listeners.
+func (s *Server) serve(ctx context.Context, controlLn, publicLn net.Listener) error {
+	defer controlLn.Close()
+
+	publicSrv := &http.Server{
+		Handler:           s.publicHandler(),
+		ReadHeaderTimeout: 10 * time.Second, // bound header reads (slowloris); body/SSE unbounded
+	}
+
+	// Bound concurrent control goroutines (established sessions + in-flight
+	// handshakes) so the no-auth control port can't be flooded into unbounded
+	// goroutine growth. Sized so MaxSessions established tunnels plus a handshake
+	// headroom always fit; excess connections are shed in serveControl.
+	controlSem := make(chan struct{}, s.cfg.MaxSessions+maxPendingHandshakes)
+	go s.serveControl(ctx, controlLn, controlSem)
+	go s.runReaper(ctx)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- publicSrv.Serve(publicLn) }()
+
+	s.log.Info("fleet gateway started",
+		"control", s.cfg.ControlAddr, "public", s.cfg.PublicAddr, "public_url", s.cfg.PublicURL)
+
+	select {
+	case <-ctx.Done():
+		sctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		_ = publicSrv.Shutdown(sctx)
+		_ = controlLn.Close()
+		s.log.Info("fleet gateway stopped")
+		return nil
+	case err := <-errCh:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return fmt.Errorf("gateway: public server: %w", err)
+	}
+}
+
+// runReaper periodically sweeps closed tunnels from the registry.
+func (s *Server) runReaper(ctx context.Context) {
+	t := time.NewTicker(reapInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.reg.reap(time.Now(), sessionTTL)
+		}
+	}
+}
+
+// yamuxLog returns the writer yamux logs its internals to. Discarded — the
+// gateway logs the events it cares about (register/close) itself.
+func (s *Server) yamuxLog() io.Writer { return io.Discard }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -58,6 +58,10 @@ const (
 	// connections are shed (closed) rather than each spawning a goroutine that
 	// lingers for the handshake timeout.
 	maxPendingHandshakes = 256
+	// reservationGrace bounds how long a claimed-but-never-bound session slot may
+	// linger before the reaper frees it. Longer than controlHandshakeTimeout so an
+	// in-progress handshake is never reaped; a backstop to explicit release.
+	reservationGrace = 2 * controlHandshakeTimeout
 	// shutdownTimeout bounds the public server drain on shutdown.
 	shutdownTimeout = 5 * time.Second
 )

--- a/internal/gateway/gateway_e2e_test.go
+++ b/internal/gateway/gateway_e2e_test.go
@@ -1,0 +1,269 @@
+package gateway
+
+import (
+	"bufio"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/big"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/tunnel"
+)
+
+// genTestTLS returns a self-signed cert valid for 127.0.0.1 + a pool trusting it.
+func genTestTLS(t *testing.T) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "fleet-test-gateway"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:              []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, _ := x509.MarshalECPrivateKey(priv)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("keypair: %v", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(certPEM) {
+		t.Fatal("append cert")
+	}
+	return cert, pool
+}
+
+// startTestGateway builds a Server with the given cert and starts it on ephemeral
+// control + public TLS listeners, returning their addresses.
+func startTestGateway(t *testing.T, cert tls.Certificate, publicBase string) (*Server, string, string) {
+	t.Helper()
+	tlsCfg := &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}
+	s := &Server{
+		cfg:       Config{PublicURL: publicBase, MaxSessions: 64},
+		reg:       newRegistry(publicBase, 64),
+		tlsConfig: tlsCfg,
+		log:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	controlLn, err := tls.Listen("tcp", "127.0.0.1:0", tlsCfg)
+	if err != nil {
+		t.Fatalf("control listen: %v", err)
+	}
+	publicLn, err := tls.Listen("tcp", "127.0.0.1:0", tlsCfg)
+	if err != nil {
+		t.Fatalf("public listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = s.serve(ctx, controlLn, publicLn) }()
+	return s, controlLn.Addr().String(), publicLn.Addr().String()
+}
+
+// fleetdMCPHandler is fleetd's stand-in MCP server: it serves a few routes so the
+// test can assert routing, auth passthrough, and SSE streaming.
+func fleetdMCPHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) { _, _ = io.WriteString(w, "root") })
+	mux.HandleFunc("/echo", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, r.Header.Get("Authorization"))
+	})
+	mux.HandleFunc("/sse", func(w http.ResponseWriter, r *http.Request) {
+		n := 0
+		fmt.Sscanf(r.URL.Query().Get("n"), "%d", &n)
+		fl, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "no flusher", 500)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(w, "data: %d\n\n", i)
+			fl.Flush()
+		}
+	})
+	return mux
+}
+
+// dialFleetd simulates a fleet daemon: it dials the control endpoint, performs
+// the tunnel handshake, and serves fleetdMCPHandler over the resulting yamux
+// session (exactly as fleetd's serveProxy does, but with a test handler). It
+// returns the gateway's reply. cleanup is registered on t.
+func dialFleetd(t *testing.T, controlAddr string, pool *x509.CertPool, sessionID string) tunnel.RegisterReply {
+	t.Helper()
+	conn, err := tls.Dial("tcp", controlAddr, &tls.Config{RootCAs: pool, ServerName: "127.0.0.1"})
+	if err != nil {
+		t.Fatalf("dial control: %v", err)
+	}
+	if err := tunnel.WriteFrame(conn, tunnel.RegisterRequest{SessionID: sessionID, ClientVersion: "vtest"}); err != nil {
+		t.Fatalf("write register: %v", err)
+	}
+	var reply tunnel.RegisterReply
+	if err := tunnel.ReadFrame(conn, &reply); err != nil {
+		t.Fatalf("read reply: %v", err)
+	}
+	if reply.Error != "" {
+		t.Fatalf("gateway refused: %s", reply.Error)
+	}
+	sess, err := tunnel.ClientSession(conn, io.Discard)
+	if err != nil {
+		t.Fatalf("client session: %v", err)
+	}
+	srv := &http.Server{Handler: fleetdMCPHandler()}
+	go func() { _ = srv.Serve(sess) }()
+	t.Cleanup(func() {
+		_ = srv.Close()
+		_ = sess.Close()
+		_ = conn.Close()
+	})
+	return reply
+}
+
+// publicIDOf extracts the <id> from a https://host/mcp/<id> public URL.
+func publicIDOf(t *testing.T, publicURL string) string {
+	t.Helper()
+	u, err := url.Parse(publicURL)
+	if err != nil {
+		t.Fatalf("parse public url: %v", err)
+	}
+	return strings.TrimPrefix(u.Path, "/mcp/")
+}
+
+func httpsClient(pool *x509.CertPool) *http.Client {
+	return &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: pool, ServerName: "127.0.0.1"},
+	}}
+}
+
+func waitRegistered(t *testing.T, s *Server, publicID string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if s.reg.lookup(publicID) != nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("session never registered")
+}
+
+func TestGatewayEndToEnd(t *testing.T) {
+	cert, pool := genTestTLS(t)
+	s, controlAddr, publicAddr := startTestGateway(t, cert, "https://gw.example.com")
+
+	reply := dialFleetd(t, controlAddr, pool, "")
+	id := publicIDOf(t, reply.PublicURL)
+	if strings.Contains(reply.PublicURL, reply.SessionID) {
+		t.Fatal("public URL must not contain the reclaim secret")
+	}
+	waitRegistered(t, s, id)
+
+	client := httpsClient(pool)
+	base := "https://" + publicAddr + "/mcp/" + id
+
+	// Exact endpoint maps to fleetd root.
+	if body := getBody(t, client, base, ""); body != "root" {
+		t.Fatalf("/mcp/<id> -> %q, want root", body)
+	}
+	// Subpath + Authorization passthrough.
+	req, _ := http.NewRequest(http.MethodGet, base+"/echo", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("echo: %v", err)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if string(b) != "Bearer secret-token" {
+		t.Fatalf("auth not forwarded through tunnel: %q", b)
+	}
+
+	// SSE streams end to end.
+	sseResp, err := client.Get(base + "/sse?n=5")
+	if err != nil {
+		t.Fatalf("sse: %v", err)
+	}
+	defer sseResp.Body.Close()
+	events := 0
+	sc := bufio.NewScanner(sseResp.Body)
+	for sc.Scan() {
+		if strings.HasPrefix(sc.Text(), "data: ") {
+			events++
+		}
+	}
+	if events != 5 {
+		t.Fatalf("got %d SSE events through the gateway, want 5", events)
+	}
+}
+
+func TestGatewayUnknownSession404(t *testing.T) {
+	cert, pool := genTestTLS(t)
+	_, _, publicAddr := startTestGateway(t, cert, "https://gw.example.com")
+	client := httpsClient(pool)
+	resp, err := client.Get("https://" + publicAddr + "/mcp/deadbeefdeadbeef")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("unknown session -> %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestGatewayStickyReconnect(t *testing.T) {
+	cert, pool := genTestTLS(t)
+	s, controlAddr, _ := startTestGateway(t, cert, "https://gw.example.com")
+
+	reply1 := dialFleetd(t, controlAddr, pool, "")
+	waitRegistered(t, s, publicIDOf(t, reply1.PublicURL))
+
+	// Reconnect presenting the secret -> the SAME public URL (sticky).
+	reply2 := dialFleetd(t, controlAddr, pool, reply1.SessionID)
+	if reply2.PublicURL != reply1.PublicURL {
+		t.Fatalf("sticky reconnect: got %q, want %q", reply2.PublicURL, reply1.PublicURL)
+	}
+	if reply2.SessionID != reply1.SessionID {
+		t.Fatalf("sticky reconnect: secret changed %q -> %q", reply1.SessionID, reply2.SessionID)
+	}
+}
+
+func getBody(t *testing.T, c *http.Client, url, auth string) string {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("get %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return string(b)
+}

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -1,0 +1,70 @@
+package gateway
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+)
+
+// proxy.go serves the public HTTPS endpoint. Agents connect to
+// https://<host>/mcp/<publicID>[/...]; each request is reverse-proxied down the
+// matching tunnel to fleetd's loopback MCP server. The gateway is a transparent
+// pipe — it forwards the Authorization header (the MCP bearer token) untouched,
+// so the loopback server's auth stays the real boundary.
+
+// publicHandler builds the router for the public listener.
+func (s *Server) publicHandler() http.Handler {
+	mux := http.NewServeMux()
+	// Exact endpoint and any subpath both route to the same handler. The MCP
+	// Streamable HTTP transport uses the single configured URL (POST/GET/DELETE),
+	// so the exact form is the common case; the subpath form is for completeness.
+	mux.HandleFunc("/mcp/{id}", s.handleMCP)
+	mux.HandleFunc("/mcp/{id}/{rest...}", s.handleMCP)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok\n")
+	})
+	return mux
+}
+
+// handleMCP reverse-proxies one request to fleetd over its tunnel.
+func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	sess := s.reg.lookup(id)
+	if sess == nil {
+		http.Error(w, "unknown or expired session", http.StatusNotFound)
+		return
+	}
+
+	// Strip the /mcp/<id> prefix: fleetd's MCP server is mounted at root, so the
+	// public /mcp/<id> maps to "/" (plus any subpath).
+	target := "/" + r.PathValue("rest")
+
+	rp := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = "http"
+			req.URL.Host = "tunnel" // ignored: the transport dials the yamux stream
+			req.URL.Path = target
+			// Blank the Host so fleetd presents the loopback target to its MCP
+			// server (matching the loopback proxy on the fleetd side).
+			req.Host = ""
+		},
+		Transport: &http.Transport{
+			// One fresh yamux stream per request; no pooling of tunnel streams.
+			DisableKeepAlives: true,
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return sess.open()
+			},
+		},
+		// Flush each write immediately so SSE (text/event-stream) responses stream
+		// through instead of buffering.
+		FlushInterval: -1,
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, _ error) {
+			// A tunnel that just dropped / is mid-reconnect: report a clean 502.
+			http.Error(w, "tunnel unavailable", http.StatusBadGateway)
+		},
+	}
+	rp.ServeHTTP(w, r)
+}

--- a/internal/gateway/registry.go
+++ b/internal/gateway/registry.go
@@ -53,58 +53,74 @@ func newID() (string, error) {
 }
 
 // claim resolves a registration to a session and the reply to send back. On a
-// reclaim (req.SessionID is a known secret) it returns the existing session and
-// its original public URL. Otherwise it mints a fresh secret + public id. The
-// caller must bind() the live yamux session afterward; claim does NOT insert a
-// brand-new session into the routing maps (that happens at bind), so a half-open
-// registration never becomes routable or counts against the reaper.
-func (r *registry) claim(req tunnel.RegisterRequest) (*session, tunnel.RegisterReply, error) {
+// reclaim (req.SessionID is a known secret) it returns the existing session
+// (isNew=false) and its original public URL. Otherwise it RESERVES a fresh slot:
+// it checks the cap and inserts the new session into bySecret atomically (under
+// the registry lock), so the MaxSessions cap is a HARD limit even under a burst
+// of concurrent first-time registrations. The reserved session is not yet
+// routable (byPublic is populated at bind); the caller must bind() on a
+// successful handshake or release() the reservation on failure.
+func (r *registry) claim(req tunnel.RegisterRequest) (s *session, reply tunnel.RegisterReply, isNew bool, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if req.SessionID != "" {
-		if s, ok := r.bySecret[req.SessionID]; ok {
-			return s, tunnel.RegisterReply{SessionID: s.secret, PublicURL: s.publicURL}, nil
+		if existing, ok := r.bySecret[req.SessionID]; ok {
+			return existing, tunnel.RegisterReply{SessionID: existing.secret, PublicURL: existing.publicURL}, false, nil
 		}
 		// Unknown secret (e.g. the gateway restarted, or a stale file): fall
 		// through and mint a fresh session rather than failing.
 	}
 
 	if len(r.bySecret) >= r.max {
-		return nil, tunnel.RegisterReply{}, errAtCapacity
+		return nil, tunnel.RegisterReply{}, false, errAtCapacity
 	}
 
 	secret, err := newID()
 	if err != nil {
-		return nil, tunnel.RegisterReply{}, err
+		return nil, tunnel.RegisterReply{}, false, err
 	}
 	publicID, err := newID()
 	if err != nil {
-		return nil, tunnel.RegisterReply{}, err
+		return nil, tunnel.RegisterReply{}, false, err
 	}
-	s := &session{
+	s = &session{
 		secret:    secret,
 		publicID:  publicID,
 		publicURL: r.publicBase + "/mcp/" + publicID,
+		createdAt: time.Now(),
 	}
-	return s, tunnel.RegisterReply{SessionID: secret, PublicURL: s.publicURL}, nil
+	r.bySecret[secret] = s // reserve the slot now -> cap is a hard limit
+	return s, tunnel.RegisterReply{SessionID: secret, PublicURL: s.publicURL}, true, nil
 }
 
-// bind installs the live tunnel on s and makes it routable. It closes any tunnel
-// it replaced (a reconnect supersedes the old, now-dead connection). Setting the
-// yamux before inserting into the maps means a session is only ever routable with
-// a live tunnel attached.
+// bind installs the live tunnel on a claimed session and makes it routable. It
+// closes any tunnel it replaced (a reconnect supersedes the old, now-dead
+// connection). bySecret already holds the session (reserved at claim); bind adds
+// the byPublic route after the tunnel is live.
 func (r *registry) bind(s *session, ym *yamux.Session) {
 	old := s.setYamux(ym)
 
 	r.mu.Lock()
-	r.bySecret[s.secret] = s
 	r.byPublic[s.publicID] = s
 	r.mu.Unlock()
 
 	if old != nil && old != ym {
 		_ = old.Close()
 	}
+}
+
+// release frees a reservation whose handshake failed before bind. It only removes
+// a session that never got a live tunnel, so it is safe to call after a failed
+// re-handshake of an already-bound session (it is a no-op in that case).
+func (r *registry) release(s *session) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if s.currentYamux() != nil {
+		return // already bound (e.g. a reclaim) — keep it
+	}
+	delete(r.bySecret, s.secret)
+	delete(r.byPublic, s.publicID)
 }
 
 // lookup finds the session for a public id (nil if unknown).
@@ -122,10 +138,12 @@ func (r *registry) lookup(publicID string) *session {
 func (r *registry) reap(now time.Time, ttl time.Duration) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	for id, s := range r.byPublic {
+	// Iterate bySecret (the superset): it holds bound sessions AND unbound
+	// reservations, both of which reapable() can evict.
+	for secret, s := range r.bySecret {
 		if s.reapable(now, ttl) {
-			delete(r.byPublic, id)
-			delete(r.bySecret, s.secret)
+			delete(r.bySecret, secret)
+			delete(r.byPublic, s.publicID)
 		}
 	}
 }

--- a/internal/gateway/registry.go
+++ b/internal/gateway/registry.go
@@ -1,0 +1,131 @@
+package gateway
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/tunnel"
+	"github.com/hashicorp/yamux"
+)
+
+// registry tracks live tunnels. It is indexed two ways:
+//   - bySecret: keyed by the reclaim credential, for sticky reconnect.
+//   - byPublic: keyed by the public id (the thing in the URL), for routing
+//     inbound agent requests.
+//
+// Entries are inserted at bind() — i.e. only once a tunnel actually exists — so a
+// session in either map always has (or just had) a live yamux session; the
+// reaper evicts ones whose tunnel has closed.
+type registry struct {
+	mu         sync.Mutex
+	bySecret   map[string]*session
+	byPublic   map[string]*session
+	publicBase string // e.g. "https://gw.example.com" (no trailing slash)
+	max        int
+}
+
+// errAtCapacity is returned by claim when the session cap is reached. Since the
+// gateway intentionally requires no registration auth, this cap is the basic
+// guard against unbounded session creation.
+var errAtCapacity = errors.New("gateway at capacity")
+
+func newRegistry(publicBase string, max int) *registry {
+	return &registry{
+		bySecret:   make(map[string]*session),
+		byPublic:   make(map[string]*session),
+		publicBase: publicBase,
+		max:        max,
+	}
+}
+
+// newID returns a 256-bit cryptographically-random hex id. Used for both the
+// secret reclaim credential and the public id; 256 bits makes the public id
+// unguessable (it is the capability that isolates each fleetd).
+func newID() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// claim resolves a registration to a session and the reply to send back. On a
+// reclaim (req.SessionID is a known secret) it returns the existing session and
+// its original public URL. Otherwise it mints a fresh secret + public id. The
+// caller must bind() the live yamux session afterward; claim does NOT insert a
+// brand-new session into the routing maps (that happens at bind), so a half-open
+// registration never becomes routable or counts against the reaper.
+func (r *registry) claim(req tunnel.RegisterRequest) (*session, tunnel.RegisterReply, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if req.SessionID != "" {
+		if s, ok := r.bySecret[req.SessionID]; ok {
+			return s, tunnel.RegisterReply{SessionID: s.secret, PublicURL: s.publicURL}, nil
+		}
+		// Unknown secret (e.g. the gateway restarted, or a stale file): fall
+		// through and mint a fresh session rather than failing.
+	}
+
+	if len(r.bySecret) >= r.max {
+		return nil, tunnel.RegisterReply{}, errAtCapacity
+	}
+
+	secret, err := newID()
+	if err != nil {
+		return nil, tunnel.RegisterReply{}, err
+	}
+	publicID, err := newID()
+	if err != nil {
+		return nil, tunnel.RegisterReply{}, err
+	}
+	s := &session{
+		secret:    secret,
+		publicID:  publicID,
+		publicURL: r.publicBase + "/mcp/" + publicID,
+	}
+	return s, tunnel.RegisterReply{SessionID: secret, PublicURL: s.publicURL}, nil
+}
+
+// bind installs the live tunnel on s and makes it routable. It closes any tunnel
+// it replaced (a reconnect supersedes the old, now-dead connection). Setting the
+// yamux before inserting into the maps means a session is only ever routable with
+// a live tunnel attached.
+func (r *registry) bind(s *session, ym *yamux.Session) {
+	old := s.setYamux(ym)
+
+	r.mu.Lock()
+	r.bySecret[s.secret] = s
+	r.byPublic[s.publicID] = s
+	r.mu.Unlock()
+
+	if old != nil && old != ym {
+		_ = old.Close()
+	}
+}
+
+// lookup finds the session for a public id (nil if unknown).
+func (r *registry) lookup(publicID string) *session {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.byPublic[publicID]
+}
+
+// reap evicts sessions whose tunnel has been closed past ttl. The grace window
+// is what makes sticky reconnect work across a brief drop: a disconnected
+// session keeps its URL reserved (its secret stays claimable) until ttl elapses
+// with no reconnect. A reconnect within the window reclaims the same URL; only
+// after the window is the URL freed.
+func (r *registry) reap(now time.Time, ttl time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for id, s := range r.byPublic {
+		if s.reapable(now, ttl) {
+			delete(r.byPublic, id)
+			delete(r.bySecret, s.secret)
+		}
+	}
+}

--- a/internal/gateway/registry_test.go
+++ b/internal/gateway/registry_test.go
@@ -36,11 +36,11 @@ func fakeTunnel(t *testing.T) *yamux.Session {
 func TestRegistryClaimMintsDistinctUnguessableIDs(t *testing.T) {
 	r := newRegistry("https://gw.example.com", 16)
 
-	s1, reply1, err := r.claim(tunnel.RegisterRequest{})
+	s1, reply1, _, err := r.claim(tunnel.RegisterRequest{})
 	if err != nil {
 		t.Fatalf("claim 1: %v", err)
 	}
-	s2, reply2, err := r.claim(tunnel.RegisterRequest{})
+	s2, reply2, _, err := r.claim(tunnel.RegisterRequest{})
 	if err != nil {
 		t.Fatalf("claim 2: %v", err)
 	}
@@ -68,28 +68,37 @@ func TestRegistryClaimMintsDistinctUnguessableIDs(t *testing.T) {
 func TestRegistryReclaimReturnsSameURL(t *testing.T) {
 	r := newRegistry("https://gw", 16)
 
-	s, reply, err := r.claim(tunnel.RegisterRequest{})
+	s, reply, isNew, err := r.claim(tunnel.RegisterRequest{})
 	if err != nil {
 		t.Fatalf("claim: %v", err)
+	}
+	if !isNew {
+		t.Fatal("a first-time claim must be reported as new")
 	}
 	r.bind(s, fakeTunnel(t))
 	if r.lookup(s.publicID) == nil {
 		t.Fatal("session should be routable after bind")
 	}
 
-	// Reconnect with the secret -> same session + same public URL.
-	s2, reply2, err := r.claim(tunnel.RegisterRequest{SessionID: reply.SessionID})
+	// Reconnect with the secret -> same session + same public URL, NOT new.
+	s2, reply2, isNew2, err := r.claim(tunnel.RegisterRequest{SessionID: reply.SessionID})
 	if err != nil {
 		t.Fatalf("reclaim: %v", err)
+	}
+	if isNew2 {
+		t.Fatal("a reclaim must not be reported as new")
 	}
 	if s2 != s || reply2.PublicURL != reply.PublicURL {
 		t.Fatalf("reclaim should return the same session and URL: %q vs %q", reply2.PublicURL, reply.PublicURL)
 	}
 
 	// An unknown secret mints a fresh session (does not error).
-	s3, reply3, err := r.claim(tunnel.RegisterRequest{SessionID: "not-a-real-secret"})
+	s3, reply3, isNew3, err := r.claim(tunnel.RegisterRequest{SessionID: "not-a-real-secret"})
 	if err != nil {
 		t.Fatalf("claim unknown: %v", err)
+	}
+	if !isNew3 {
+		t.Fatal("an unknown secret must mint a NEW session")
 	}
 	if s3 == s || reply3.PublicURL == reply.PublicURL {
 		t.Fatal("unknown secret should mint a fresh session")
@@ -98,11 +107,11 @@ func TestRegistryReclaimReturnsSameURL(t *testing.T) {
 
 func TestRegistryReclaimReplacesAndClosesOldTunnel(t *testing.T) {
 	r := newRegistry("https://gw", 16)
-	s, reply, _ := r.claim(tunnel.RegisterRequest{})
+	s, reply, _, _ := r.claim(tunnel.RegisterRequest{})
 	old := fakeTunnel(t)
 	r.bind(s, old)
 
-	s2, _, _ := r.claim(tunnel.RegisterRequest{SessionID: reply.SessionID})
+	s2, _, _, _ := r.claim(tunnel.RegisterRequest{SessionID: reply.SessionID})
 	newYm := fakeTunnel(t)
 	r.bind(s2, newYm)
 
@@ -116,14 +125,69 @@ func TestRegistryReclaimReplacesAndClosesOldTunnel(t *testing.T) {
 
 func TestRegistryCapacity(t *testing.T) {
 	r := newRegistry("https://gw", 1)
-	s, _, err := r.claim(tunnel.RegisterRequest{})
+	s, _, _, err := r.claim(tunnel.RegisterRequest{})
 	if err != nil {
 		t.Fatalf("claim 1: %v", err)
 	}
 	r.bind(s, fakeTunnel(t))
 
-	if _, _, err := r.claim(tunnel.RegisterRequest{}); err != errAtCapacity {
+	if _, _, _, err := r.claim(tunnel.RegisterRequest{}); err != errAtCapacity {
 		t.Fatalf("want errAtCapacity, got %v", err)
+	}
+}
+
+// TestRegistryCapacityIsHardAtClaim guards the DoS fix from PR review: the cap
+// must hold even for concurrent FIRST-TIME claims that haven't bound yet, because
+// the slot is reserved (in bySecret) at claim, not at bind.
+func TestRegistryCapacityIsHardAtClaim(t *testing.T) {
+	r := newRegistry("https://gw", 1)
+	if _, _, _, err := r.claim(tunnel.RegisterRequest{}); err != nil {
+		t.Fatalf("claim 1: %v", err)
+	}
+	// No bind() yet — the second claim must STILL be rejected.
+	if _, _, _, err := r.claim(tunnel.RegisterRequest{}); err != errAtCapacity {
+		t.Fatalf("cap must be enforced at claim (pre-bind), got %v", err)
+	}
+}
+
+// TestRegistryReleaseFreesReservation verifies a failed-handshake reservation is
+// freed (and frees the cap slot), while release is a no-op for a bound session.
+func TestRegistryReleaseFreesReservation(t *testing.T) {
+	r := newRegistry("https://gw", 1)
+	s, _, isNew, _ := r.claim(tunnel.RegisterRequest{})
+	if !isNew {
+		t.Fatal("want new")
+	}
+	r.release(s) // handshake failed before bind
+	// The slot is free again.
+	if _, _, _, err := r.claim(tunnel.RegisterRequest{}); err != nil {
+		t.Fatalf("slot should be free after release, got %v", err)
+	}
+
+	// release is a no-op once bound.
+	r2 := newRegistry("https://gw", 16)
+	bs, _, _, _ := r2.claim(tunnel.RegisterRequest{})
+	r2.bind(bs, fakeTunnel(t))
+	r2.release(bs)
+	if r2.lookup(bs.publicID) == nil {
+		t.Fatal("release must not remove a bound session")
+	}
+}
+
+// TestRegistryReapsAbandonedReservation verifies the reaper backstop frees a
+// reservation whose handshake never completed.
+func TestRegistryReapsAbandonedReservation(t *testing.T) {
+	r := newRegistry("https://gw", 16)
+	s, _, _, _ := r.claim(tunnel.RegisterRequest{}) // never bound, never released
+	// Within the reservation grace: kept.
+	r.reap(s.createdAt.Add(reservationGrace/2), sessionTTL)
+	if _, ok := r.bySecret[s.secret]; !ok {
+		t.Fatal("reservation must be kept within the grace window")
+	}
+	// Past it: reaped.
+	r.reap(s.createdAt.Add(2*reservationGrace), sessionTTL)
+	if _, ok := r.bySecret[s.secret]; ok {
+		t.Fatal("abandoned reservation must be reaped after the grace window")
 	}
 }
 
@@ -133,7 +197,7 @@ func TestRegistryReapHonorsGraceTTL(t *testing.T) {
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	// A LIVE session is never reaped.
-	live, _, _ := r.claim(tunnel.RegisterRequest{})
+	live, _, _, _ := r.claim(tunnel.RegisterRequest{})
 	r.bind(live, fakeTunnel(t))
 	r.reap(now, ttl)
 	if r.lookup(live.publicID) == nil {
@@ -141,7 +205,7 @@ func TestRegistryReapHonorsGraceTTL(t *testing.T) {
 	}
 
 	// A closed session is kept within the grace window, then evicted after it.
-	dead, _, _ := r.claim(tunnel.RegisterRequest{})
+	dead, _, _, _ := r.claim(tunnel.RegisterRequest{})
 	deadYm := fakeTunnel(t)
 	r.bind(dead, deadYm)
 	_ = deadYm.Close()

--- a/internal/gateway/registry_test.go
+++ b/internal/gateway/registry_test.go
@@ -1,0 +1,161 @@
+package gateway
+
+import (
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/tunnel"
+	"github.com/hashicorp/yamux"
+)
+
+// fakeTunnel returns a live yamux session (the gateway/server end) backed by an
+// in-memory pipe, so registry tests can bind real sessions without a network.
+func fakeTunnel(t *testing.T) *yamux.Session {
+	t.Helper()
+	c1, c2 := net.Pipe()
+	srv, err := tunnel.ServerSession(c1, io.Discard)
+	if err != nil {
+		t.Fatalf("server session: %v", err)
+	}
+	cli, err := tunnel.ClientSession(c2, io.Discard)
+	if err != nil {
+		t.Fatalf("client session: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = srv.Close()
+		_ = cli.Close()
+		_ = c1.Close()
+		_ = c2.Close()
+	})
+	return srv
+}
+
+func TestRegistryClaimMintsDistinctUnguessableIDs(t *testing.T) {
+	r := newRegistry("https://gw.example.com", 16)
+
+	s1, reply1, err := r.claim(tunnel.RegisterRequest{})
+	if err != nil {
+		t.Fatalf("claim 1: %v", err)
+	}
+	s2, reply2, err := r.claim(tunnel.RegisterRequest{})
+	if err != nil {
+		t.Fatalf("claim 2: %v", err)
+	}
+
+	if s1.secret == s2.secret || s1.publicID == s2.publicID {
+		t.Fatal("distinct claims must get distinct secret and public ids")
+	}
+	if len(s1.secret) != 64 || len(s1.publicID) != 64 {
+		t.Fatalf("ids should be 256-bit hex (64 chars): secret=%d public=%d", len(s1.secret), len(s1.publicID))
+	}
+	// The headline security property: the reclaim secret must NEVER appear in the
+	// public URL (which agents can see).
+	if strings.Contains(reply1.PublicURL, s1.secret) || strings.Contains(reply2.PublicURL, s2.secret) {
+		t.Fatal("public URL must not contain the reclaim secret")
+	}
+	if reply1.PublicURL != "https://gw.example.com/mcp/"+s1.publicID {
+		t.Fatalf("unexpected public url: %q", reply1.PublicURL)
+	}
+	// A fresh (unbound) claim is not yet routable.
+	if r.lookup(s1.publicID) != nil {
+		t.Fatal("session should not be routable before bind")
+	}
+}
+
+func TestRegistryReclaimReturnsSameURL(t *testing.T) {
+	r := newRegistry("https://gw", 16)
+
+	s, reply, err := r.claim(tunnel.RegisterRequest{})
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	r.bind(s, fakeTunnel(t))
+	if r.lookup(s.publicID) == nil {
+		t.Fatal("session should be routable after bind")
+	}
+
+	// Reconnect with the secret -> same session + same public URL.
+	s2, reply2, err := r.claim(tunnel.RegisterRequest{SessionID: reply.SessionID})
+	if err != nil {
+		t.Fatalf("reclaim: %v", err)
+	}
+	if s2 != s || reply2.PublicURL != reply.PublicURL {
+		t.Fatalf("reclaim should return the same session and URL: %q vs %q", reply2.PublicURL, reply.PublicURL)
+	}
+
+	// An unknown secret mints a fresh session (does not error).
+	s3, reply3, err := r.claim(tunnel.RegisterRequest{SessionID: "not-a-real-secret"})
+	if err != nil {
+		t.Fatalf("claim unknown: %v", err)
+	}
+	if s3 == s || reply3.PublicURL == reply.PublicURL {
+		t.Fatal("unknown secret should mint a fresh session")
+	}
+}
+
+func TestRegistryReclaimReplacesAndClosesOldTunnel(t *testing.T) {
+	r := newRegistry("https://gw", 16)
+	s, reply, _ := r.claim(tunnel.RegisterRequest{})
+	old := fakeTunnel(t)
+	r.bind(s, old)
+
+	s2, _, _ := r.claim(tunnel.RegisterRequest{SessionID: reply.SessionID})
+	newYm := fakeTunnel(t)
+	r.bind(s2, newYm)
+
+	if !old.IsClosed() {
+		t.Fatal("reclaim should close the superseded tunnel")
+	}
+	if s.currentYamux() != newYm {
+		t.Fatal("session should now point at the new tunnel")
+	}
+}
+
+func TestRegistryCapacity(t *testing.T) {
+	r := newRegistry("https://gw", 1)
+	s, _, err := r.claim(tunnel.RegisterRequest{})
+	if err != nil {
+		t.Fatalf("claim 1: %v", err)
+	}
+	r.bind(s, fakeTunnel(t))
+
+	if _, _, err := r.claim(tunnel.RegisterRequest{}); err != errAtCapacity {
+		t.Fatalf("want errAtCapacity, got %v", err)
+	}
+}
+
+func TestRegistryReapHonorsGraceTTL(t *testing.T) {
+	r := newRegistry("https://gw", 16)
+	const ttl = 5 * time.Minute
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// A LIVE session is never reaped.
+	live, _, _ := r.claim(tunnel.RegisterRequest{})
+	r.bind(live, fakeTunnel(t))
+	r.reap(now, ttl)
+	if r.lookup(live.publicID) == nil {
+		t.Fatal("a live session must not be reaped")
+	}
+
+	// A closed session is kept within the grace window, then evicted after it.
+	dead, _, _ := r.claim(tunnel.RegisterRequest{})
+	deadYm := fakeTunnel(t)
+	r.bind(dead, deadYm)
+	_ = deadYm.Close()
+
+	r.reap(now, ttl) // first observation: stamps closedAt, keeps it
+	if r.lookup(dead.publicID) == nil {
+		t.Fatal("a just-closed session must be kept within the grace window (for sticky reconnect)")
+	}
+	r.reap(now.Add(ttl/2), ttl) // still within grace
+	if r.lookup(dead.publicID) == nil {
+		t.Fatal("session must remain reserved within the grace window")
+	}
+	r.reap(now.Add(2*ttl), ttl) // past grace -> evicted
+	if r.lookup(dead.publicID) != nil {
+		t.Fatal("session must be reaped after the grace TTL")
+	}
+}

--- a/internal/gateway/session.go
+++ b/internal/gateway/session.go
@@ -1,0 +1,87 @@
+package gateway
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/yamux"
+)
+
+// errNoTunnel is returned by session.open when the session has no live tunnel
+// (e.g. fleetd is mid-reconnect). The public handler turns it into a 502.
+var errNoTunnel = errors.New("gateway: session has no live tunnel")
+
+// session is one registered fleetd: the reverse tunnel back to it plus its two
+// identifiers.
+//
+// CRITICAL split: `secret` is the reclaim credential — fleetd persists it and
+// sends it on reconnect to recover the same URL — and it is NEVER placed in the
+// public URL. `publicID` is what appears in publicURL and is therefore visible
+// to anyone the agent shares the URL with. Keeping them distinct means a holder
+// of the public URL cannot re-register (hijack) the tunnel, because that
+// requires the secret, which they never see.
+type session struct {
+	secret    string
+	publicID  string
+	publicURL string
+
+	mu sync.Mutex
+	ym *yamux.Session // current live tunnel; replaced on reconnect (older one closed)
+	// closedAt is when the current tunnel was first observed closed (zero while
+	// live). The session — and its public URL — is RESERVED for a grace TTL after
+	// this, so a fleetd that drops and reconnects (with its secret) recovers the
+	// same URL. The reaper frees it only once the TTL elapses with no reconnect.
+	closedAt time.Time
+}
+
+// setYamux installs ym as the live tunnel and returns the one it replaced (nil on
+// first bind). Installing a tunnel clears closedAt, so a reconnect un-expires the
+// session.
+func (s *session) setYamux(ym *yamux.Session) (old *yamux.Session) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	old, s.ym, s.closedAt = s.ym, ym, time.Time{}
+	return old
+}
+
+// currentYamux returns the live tunnel (nil if none / not yet bound).
+func (s *session) currentYamux() *yamux.Session {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ym
+}
+
+// reapable reports whether the session should be evicted: its tunnel is closed
+// AND has stayed closed past ttl. It lazily stamps closedAt on the first
+// observation of a closed tunnel, so the grace clock starts even if nothing else
+// noticed the disconnect.
+func (s *session) reapable(now time.Time, ttl time.Duration) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.ym == nil {
+		return true // never bound (defensive; bound sessions always have a tunnel)
+	}
+	if !s.ym.IsClosed() {
+		return false
+	}
+	if s.closedAt.IsZero() {
+		s.closedAt = now
+		return false
+	}
+	return now.Sub(s.closedAt) > ttl
+}
+
+// open dials a fresh multiplexed stream to fleetd over the live tunnel. Each
+// inbound public request gets its own stream, so SSE and concurrent requests
+// never interleave.
+func (s *session) open() (net.Conn, error) {
+	s.mu.Lock()
+	ym := s.ym
+	s.mu.Unlock()
+	if ym == nil {
+		return nil, errNoTunnel
+	}
+	return ym.Open()
+}

--- a/internal/gateway/session.go
+++ b/internal/gateway/session.go
@@ -27,8 +27,12 @@ type session struct {
 	publicID  string
 	publicURL string
 
+	// createdAt is when the session slot was reserved (at claim). Used by the
+	// reaper to evict a reservation whose handshake never completed (never bound).
+	createdAt time.Time
+
 	mu sync.Mutex
-	ym *yamux.Session // current live tunnel; replaced on reconnect (older one closed)
+	ym *yamux.Session // current live tunnel; nil until bind; replaced on reconnect
 	// closedAt is when the current tunnel was first observed closed (zero while
 	// live). The session — and its public URL — is RESERVED for a grace TTL after
 	// this, so a fleetd that drops and reconnects (with its secret) recovers the
@@ -53,15 +57,18 @@ func (s *session) currentYamux() *yamux.Session {
 	return s.ym
 }
 
-// reapable reports whether the session should be evicted: its tunnel is closed
-// AND has stayed closed past ttl. It lazily stamps closedAt on the first
-// observation of a closed tunnel, so the grace clock starts even if nothing else
-// noticed the disconnect.
+// reapable reports whether the session should be evicted. A bound session is
+// reaped once its tunnel has stayed closed past ttl (lazily stamping closedAt on
+// first observation, so the grace clock starts even if nothing else noticed the
+// disconnect). An UNBOUND reservation — claimed but whose handshake never reached
+// bind — is reaped once it is older than reservationGrace; this is only a backstop
+// (handshake failures release their reservation explicitly), but it guarantees a
+// slot can never be reserved forever.
 func (s *session) reapable(now time.Time, ttl time.Duration) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.ym == nil {
-		return true // never bound (defensive; bound sessions always have a tunnel)
+		return now.Sub(s.createdAt) > reservationGrace
 	}
 	if !s.ym.IsClosed() {
 		return false


### PR DESCRIPTION
## What

PR 3 of **Fleet remote MCP** (#97): the **standalone fleet gateway server** — the public, operator-run relay that fleet daemons (the PR 2 client, #109) dial *out* to, and that remote MCP agents reach over HTTPS at `https://<gw>/mcp/<id>`. Run via **`fleet gateway`**.

With this, the full path is wired end to end: `agent ──HTTPS──► gateway ──reverse tunnel──► fleetd ──loopback──► MCP server`.

## Isolated module (as requested)

`internal/gateway` is a **fully isolated module**: it imports only the shared wire protocol (`internal/tunnel`) and the stdlib + yamux — **never** `internal/server`, `internal/state`, `internal/flog`, or any other fleetd internal. Its sole importer is the thin `cli/gateway.go` entrypoint (mirroring how `cli/server.go` fronts `internal/server`). The gateway holds no fleet state and has no `~/.fleet` access — it only routes bytes.

```
internal/gateway/
  gateway.go    Config · Server · New · Run/serve · reaper
  control.go    control TLS listener: tunnel handshake → yamux → register
  proxy.go      public HTTPS: /mcp/{id} → ReverseProxy over a yamux stream
  registry.go   session registry: claim/reclaim, bind, lookup, reap
  session.go    one tunnel: secret/publicID, yamux, grace-TTL reap state
internal/cli/gateway.go   the `fleet gateway` subcommand
```

## How it works

- **Two TLS listeners:** *control* (fleetd dials in; the `internal/tunnel` handshake then yamux — not HTTP) and *public* (HTTPS; agents). Per inbound agent request the public reverse proxy opens a **fresh yamux stream** to the matching fleetd (`FlushInterval=-1` for SSE), strips the `/mcp/<id>` prefix, and forwards `Authorization` untouched.
- **Sticky reconnect:** a disconnected session keeps its URL **reserved for a grace TTL (10m)** so a fleetd that drops and reconnects (with its secret) recovers the *same* URL; the reaper frees it only after the TTL.

## Security

No registration auth, by design — but with a **secret/public split** that closes the obvious hole: the registry mints **two** ids — a **secret reclaim credential** (`RegisterReply.SessionID`, persisted by fleetd, sent on reconnect) and a separate **public id** that appears in the URL. The secret is **never** in the public URL, so a holder of the URL can use the MCP server (with the bearer token) but **cannot hijack/reclaim** the tunnel. The 256-bit public id is the capability; the MCP bearer token (forwarded untouched) stays the real access boundary. No protocol change was needed — the gateway owns the split.

DoS guards for the unauthenticated control port: a `MaxSessions` cap (default 1024) and a **bounded-concurrency accept loop** that sheds excess in-flight connections (rather than spawning an unbounded number of handshake goroutines).

## Tests (pass under `-race`)

- **Registry:** claim/reclaim, capacity cap, **secret-never-in-URL**, and the **reap grace-TTL** (a just-disconnected session is kept within the window, evicted after it).
- **End-to-end** over real TLS control + public listeners with a simulated fleetd (`tunnel.ClientSession` serving an HTTP handler): routing `/mcp/<id>` → fleetd root + subpaths, **Authorization passthrough**, **SSE streaming through the tunnel**, **404** for unknown sessions, and **sticky reconnect** returns the same URL.

`make test` (depguard import-boundary lint + all unit tests) passes.

## Reviewer notes

- An adversarial multi-agent review (registry/concurrency, proxy/routing, security/isolation) returned **no confirmed findings**; the load-shedding guard above came from its one optional suggestion.
- **Known PR 4 follow-up:** real MCP clients may send an `Origin` header; the go-sdk MCP server's DNS-rebinding protection (if any) needs an end-to-end check, and docs (running a gateway, ACME/cert setup) land there.

Part of #97. Next: PR 4 — end-to-end integration + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
