### PR TITLE
feat(mcp): remote MCP end-to-end test + operator docs (#97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,84 @@ session tools `fleet_session_spawn` / `fleet_session_exec` / `fleet_session_read
 Interactive, open-ended commands (`fleet shell`, log following) are intentionally
 not exposed.
 
+## Remote MCP
+
+By default the MCP server is loopback-only. To let a **remote** agent drive your
+fleet, you can expose it through a **fleet gateway** — a small public relay you
+(or someone) runs. Your daemon dials *out* to the gateway (so it works behind
+NAT/firewalls) and the gateway routes inbound MCP requests back down that tunnel:
+
+```
+agent ──HTTPS──▶ fleet gateway ──reverse tunnel──▶ your fleetd ──▶ local MCP server
+```
+
+### Enable it (in the TUI)
+
+In **Settings → Fleet Remote (MCP)**:
+
+1. Set **Gateway URL** to the gateway's **control** endpoint, e.g.
+   `https://gateway.example.com:8443` (this is where the daemon dials out — the
+   gateway's `--control-addr`, default port `8443`; it is *not* the public
+   address agents use).
+2. Flip **Enabled** on.
+
+Once connected, the read-only **Public MCP URL** appears (e.g.
+`https://gateway.example.com/mcp/<id>`) — that is the address external tools use.
+The line shows the live connection state (connecting / connected / error).
+
+### Use it from a remote agent
+
+Point the remote MCP client at the Public MCP URL, with the **same bearer token**
+your daemon uses (from `~/.fleet/mcp.token`):
+
+```json
+{
+  "mcpServers": {
+    "fleet-remote": {
+      "type": "http",
+      "url": "https://gateway.example.com/mcp/<id>",
+      "headers": { "Authorization": "Bearer <token from ~/.fleet/mcp.token>" }
+    }
+  }
+}
+```
+
+### Running a gateway
+
+The gateway is the same binary: `fleet gateway`. It needs a **publicly-trusted**
+TLS certificate (e.g. from Let's Encrypt) so daemons can verify it against the
+system roots.
+
+```bash
+fleet gateway \
+  --public-url https://gateway.example.com \
+  --tls-cert /etc/fleet/tls/fullchain.pem \
+  --tls-key  /etc/fleet/tls/privkey.pem
+```
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--public-url` | (required) | External base URL agents use; session URLs are `<public-url>/mcp/<id>` |
+| `--tls-cert` / `--tls-key` | (required) | TLS certificate + key (PEM) |
+| `--public-addr` | `:443` | Address agents connect to (HTTPS) |
+| `--control-addr` | `:8443` | Address daemons dial in on (TLS) — this is what **Gateway URL** points at |
+| `--max-sessions` | `1024` | Cap on concurrent tunnels |
+
+Both ports must be reachable; expose `--public-addr` to agents and `--control-addr`
+to your daemons. A `GET /healthz` on the public listener returns `ok`.
+
+### Security model
+
+- **No gateway authentication.** Anyone can open a tunnel; the gateway just routes
+  bytes. Isolation comes from the **unguessable 256-bit id** in the public URL.
+- **The bearer token is the real access boundary.** The gateway forwards the
+  `Authorization` header untouched to your loopback MCP server, whose existing
+  token check gates every request. Treat the Public MCP URL as a capability, but
+  **the token is the secret** — share both only with agents you trust.
+- The id in the URL is *not* the reconnect credential: the daemon holds a separate
+  secret (never placed in the URL), so a URL holder cannot hijack your tunnel.
+- All gateway traffic is TLS; the daemon verifies the gateway's certificate.
+
 ## Requirements
 
 - Linux, including Ubuntu on WSL2

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -136,13 +136,16 @@ func (s *Server) Run(ctx context.Context) error {
 		_ = controlLn.Close()
 		return fmt.Errorf("gateway: listen public %s: %w", s.cfg.PublicAddr, err)
 	}
-	return s.serve(ctx, controlLn, publicLn)
+	return s.ServeListeners(ctx, controlLn, publicLn)
 }
 
-// serve runs the accept loops, reaper, and public HTTP server over already-bound
-// listeners until ctx is cancelled or the public server fails. Split from Run so
-// tests can supply ephemeral listeners.
-func (s *Server) serve(ctx context.Context, controlLn, publicLn net.Listener) error {
+// ServeListeners runs the accept loops, reaper, and public HTTP server over
+// already-bound listeners until ctx is cancelled or the public server fails. Run
+// is the usual entrypoint (it binds from Config); this is exposed for embedding
+// the gateway on caller-supplied listeners (e.g. socket activation) and for
+// integration tests that need ephemeral ports. The listeners must already carry
+// TLS (Run wraps them with the configured cert).
+func (s *Server) ServeListeners(ctx context.Context, controlLn, publicLn net.Listener) error {
 	defer controlLn.Close()
 
 	publicSrv := &http.Server{

--- a/internal/gateway/gateway_e2e_test.go
+++ b/internal/gateway/gateway_e2e_test.go
@@ -82,7 +82,7 @@ func startTestGateway(t *testing.T, cert tls.Certificate, publicBase string) (*S
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	go func() { _ = s.serve(ctx, controlLn, publicLn) }()
+	go func() { _ = s.ServeListeners(ctx, controlLn, publicLn) }()
 	return s, controlLn.Addr().String(), publicLn.Addr().String()
 }
 

--- a/internal/server/mcp_remote_e2e_test.go
+++ b/internal/server/mcp_remote_e2e_test.go
@@ -1,0 +1,240 @@
+package server
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetpaths"
+	"github.com/BenjaminBenetti/fleet-man/internal/gateway"
+	"github.com/BenjaminBenetti/fleet-man/internal/server/remote"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// mcp_remote_e2e_test.go is the full-stack integration test for the remote-MCP
+// feature: a REAL fleetd MCP server (loopback, bearer-gated, real fleet tools) is
+// exposed through a REAL gateway by a REAL remote.Manager tunnel, and driven by a
+// REAL MCP SDK client over HTTPS at the gateway-minted public URL. It is the
+// authoritative check that an agent can actually reach the fleet through the
+// gateway — in particular that the MCP SDK's default DNS-rebinding protection
+// does not reject tunneled requests.
+
+// genTestTLSFiles writes a self-signed cert (valid for 127.0.0.1) to temp files
+// and returns a pool that trusts it plus the cert/key paths.
+func genTestTLSFiles(t *testing.T) (pool *x509.CertPool, certPath, keyPath string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "fleet-e2e"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:              []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, _ := x509.MarshalECPrivateKey(priv)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	pool = x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(certPEM) {
+		t.Fatal("append cert")
+	}
+	return pool, certPath, keyPath
+}
+
+// bearerRT adds an Authorization: Bearer header to every request.
+type bearerRT struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (b bearerRT) RoundTrip(r *http.Request) (*http.Response, error) {
+	r = r.Clone(r.Context())
+	r.Header.Set("Authorization", "Bearer "+b.token)
+	return b.base.RoundTrip(r)
+}
+
+// remoteMCPStack stands up the full real stack and returns the gateway-minted
+// public MCP URL, the gateway's public base URL, the MCP bearer token, and a
+// cert pool trusting the gateway.
+func remoteMCPStack(t *testing.T) (publicMCPURL, publicBase, token string, pool *x509.CertPool) {
+	t.Helper()
+	isolateFleetDir(t)
+	if err := os.MkdirAll(fleetpaths.Dir(), 0o700); err != nil {
+		t.Fatalf("mkdir fleet dir: %v", err)
+	}
+
+	// Real fleetd MCP server: loopback, bearer-gated, real fleet tools.
+	svc := newService()
+	mcpHTTP, mcpPort := startMCPServer(svc)
+	if mcpHTTP == nil {
+		t.Fatal("MCP server failed to start")
+	}
+	t.Cleanup(func() { _ = mcpHTTP.Close() })
+	var err error
+	token, err = loadOrCreateMCPToken()
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+
+	// Real gateway on ephemeral TLS listeners.
+	var certPath, keyPath string
+	pool, certPath, keyPath = genTestTLSFiles(t)
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		t.Fatalf("load keypair: %v", err)
+	}
+	serverTLS := &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}
+	controlLn, err := tls.Listen("tcp", "127.0.0.1:0", serverTLS)
+	if err != nil {
+		t.Fatalf("control listen: %v", err)
+	}
+	t.Cleanup(func() { _ = controlLn.Close() })
+	publicLn, err := tls.Listen("tcp", "127.0.0.1:0", serverTLS)
+	if err != nil {
+		t.Fatalf("public listen: %v", err)
+	}
+	t.Cleanup(func() { _ = publicLn.Close() })
+	publicBase = "https://" + publicLn.Addr().String()
+
+	gw, err := gateway.New(gateway.Config{PublicURL: publicBase, TLSCert: certPath, TLSKey: keyPath})
+	if err != nil {
+		t.Fatalf("gateway.New: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = gw.ServeListeners(ctx, controlLn, publicLn) }()
+
+	// Real fleetd tunnel manager, dialing the test gateway's control listener.
+	statusCh := make(chan *fleetgrpc.RemoteMcpStatus, 64)
+	controlAddr := controlLn.Addr().String()
+	mgr := remote.NewManager(mcpPort, "e2e",
+		func(st *fleetgrpc.RemoteMcpStatus) { statusCh <- st },
+		remote.WithDialFunc(func(dctx context.Context, _ string) (net.Conn, error) {
+			d := &tls.Dialer{Config: &tls.Config{RootCAs: pool, ServerName: "127.0.0.1"}}
+			return d.DialContext(dctx, "tcp", controlAddr)
+		}),
+	)
+	go mgr.Run(ctx)
+	mgr.Reconcile(true, "https://gw.example.com")
+
+	// Wait for CONNECTED and the gateway-assigned public URL.
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case st := <-statusCh:
+			if st.GetState() == fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED {
+				if st.GetPublicUrl() == "" {
+					t.Fatal("CONNECTED status missing public URL")
+				}
+				return st.GetPublicUrl(), publicBase, token, pool
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for the tunnel to connect")
+		}
+	}
+}
+
+// TestRemoteMCPEndToEnd drives a real MCP client through the full chain
+// (HTTPS -> gateway -> reverse tunnel -> fleetd -> loopback MCP server) and calls
+// a real tool. A success here proves the DNS-rebinding/Host handling is correct
+// and the bearer token is forwarded untouched.
+func TestRemoteMCPEndToEnd(t *testing.T) {
+	publicMCPURL, _, token, pool := remoteMCPStack(t)
+
+	httpClient := &http.Client{Transport: bearerRT{
+		token: token,
+		base:  &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool, ServerName: "127.0.0.1"}},
+	}}
+	transport := &mcp.StreamableClientTransport{Endpoint: publicMCPURL, HTTPClient: httpClient}
+	client := mcp.NewClient(&mcp.Implementation{Name: "fleet-e2e", Version: "1"}, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cs, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatalf("MCP connect through the tunnel failed (DNS-rebinding/Host or auth?): %v", err)
+	}
+	defer cs.Close()
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "fleet_version"})
+	if err != nil {
+		t.Fatalf("CallTool fleet_version through the tunnel: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("fleet_version returned a tool error: %s", toolText(res))
+	}
+	if toolText(res) == "" {
+		t.Fatal("fleet_version returned empty content through the tunnel")
+	}
+}
+
+// TestRemoteMCPRejectsBadToken confirms the MCP bearer token remains the access
+// boundary end to end: a request with no/!wrong token is rejected (401), even
+// though it reached fleetd through the tunnel.
+func TestRemoteMCPRejectsBadToken(t *testing.T) {
+	publicMCPURL, _, _, pool := remoteMCPStack(t)
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool, ServerName: "127.0.0.1"}}}
+
+	req, _ := http.NewRequest(http.MethodGet, publicMCPURL, nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("bad token through the tunnel -> %d, want 401", resp.StatusCode)
+	}
+}
+
+// TestRemoteMCPUnknownSession404 confirms the gateway 404s an unknown public id.
+func TestRemoteMCPUnknownSession404(t *testing.T) {
+	_, publicBase, _, pool := remoteMCPStack(t)
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool, ServerName: "127.0.0.1"}}}
+
+	resp, err := client.Get(publicBase + "/mcp/" + strings.Repeat("a", 64))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("unknown session -> %d, want 404", resp.StatusCode)
+	}
+}

--- a/internal/server/remote/manager.go
+++ b/internal/server/remote/manager.go
@@ -60,13 +60,24 @@ type Manager struct {
 	wake          chan struct{}      // size-1 nudge: Reconcile wakes the loop
 }
 
+// Option customizes a Manager. The production daemon uses none; the transport
+// seam (WithDialFunc) exists for tests and for future custom transports.
+type Option func(*Manager)
+
+// WithDialFunc overrides how the Manager opens the control connection to the
+// gateway (the default is a TLS dial verified against the system roots). Used by
+// integration tests to reach an in-process gateway with a test CA.
+func WithDialFunc(dial func(ctx context.Context, gatewayURL string) (net.Conn, error)) Option {
+	return func(m *Manager) { m.dial = dial }
+}
+
 // NewManager builds a Manager that reverse-proxies to the loopback MCP server on
 // mcpPort and reports status via publish (which must be safe to call from the
 // manager's goroutine — typically a hub.post). A zero mcpPort means the local
 // MCP server is not running, in which case the manager reports an error while
 // enabled rather than connecting.
-func NewManager(mcpPort int, clientVersion string, publish func(*fleetgrpc.RemoteMcpStatus)) *Manager {
-	return &Manager{
+func NewManager(mcpPort int, clientVersion string, publish func(*fleetgrpc.RemoteMcpStatus), opts ...Option) *Manager {
+	m := &Manager{
 		mcpPort:       mcpPort,
 		clientVersion: clientVersion,
 		publish:       publish,
@@ -74,6 +85,10 @@ func NewManager(mcpPort int, clientVersion string, publish func(*fleetgrpc.Remot
 		dial:          dialTLS,
 		wake:          make(chan struct{}, 1),
 	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
 }
 
 // Reconcile records the desired config and nudges the supervisor. It is

--- a/internal/server/remote/proxy.go
+++ b/internal/server/remote/proxy.go
@@ -31,14 +31,19 @@ func serveProxy(session *yamux.Session, mcpPort int) error {
 	// FlushInterval -1 flushes each write immediately, which SSE (text/event-stream)
 	// requires — otherwise events buffer and the stream stalls.
 	rp.FlushInterval = -1
-	// Present the loopback target as the Host so the local MCP server sees a
-	// same-origin request rather than the gateway's public host. The Authorization
-	// header is deliberately left untouched so the MCP bearer token reaches the
-	// loopback server's auth middleware — that token stays the real access gate.
+	// Set the Host to the loopback MCP target. This is REQUIRED, not cosmetic: the
+	// MCP SDK enables DNS-rebinding protection by default and returns 403 when the
+	// server is bound to loopback but the request's Host is not loopback — and an
+	// EMPTY Host counts as non-loopback (util.IsLoopback("")==false). A tunneled
+	// request would otherwise arrive with no meaningful Host and be rejected.
+	// Using the loopback target satisfies the check while still rejecting a
+	// genuinely foreign Host. The Authorization header is left untouched so the
+	// MCP bearer token reaches the loopback server's auth — that stays the real
+	// access gate.
 	orig := rp.Director
 	rp.Director = func(req *http.Request) {
 		orig(req)
-		req.Host = ""
+		req.Host = target.Host
 	}
 	// Peer resets / closed streams are normal tunnel churn, not server faults;
 	// discard the proxy's per-request error spam.


### PR DESCRIPTION
## What

PR 4 — the **finale** of Fleet remote MCP (#97): a full-stack integration test that proves an agent can actually reach a fleet through the gateway, plus operator/user docs. With this, the feature is complete and **Closes #97**.

Builds on the three merged pieces: config + Watch plumbing (#108), the fleetd reverse-tunnel client (#109), and the gateway server (#110).

## The end-to-end test

`internal/server/mcp_remote_e2e_test.go` stands up the **entire real stack** and drives it with a **real MCP SDK client**:

- fleetd's **real loopback MCP server** (`startMCPServer` — bearer-gated, the actual `fleet_*` tools)
- a **real `fleet gateway`** (`gateway.New` + `ServeListeners`) on ephemeral TLS listeners
- a **real `remote.Manager`** tunnel dialing the gateway's control endpoint
- a **real go-sdk `StreamableClientTransport`** client connecting to the gateway-minted public URL with the bearer token

It then:
- calls **`fleet_version` end to end** (`HTTPS → gateway → reverse tunnel → fleetd → loopback MCP`) and asserts a real result,
- asserts a **wrong bearer token → 401** (the token is still the boundary, even over the tunnel),
- asserts an **unknown session id → 404**.

Passes under `-race`. (I confirmed it genuinely traverses the tunnel — not a stub.)

## DNS-rebinding hardening

While building the E2E I dug into the **make-or-break risk** flagged earlier: the MCP SDK enables **DNS-rebinding protection by default** and returns **403** for a loopback server whose request `Host` isn't loopback — and an *empty* `Host` counts as non-loopback (`util.IsLoopback("") == false`).

Both proxies blanked `req.Host`. I verified empirically (revert + re-run) that the prior code **already worked**, because `httputil.ReverseProxy`/`http.Transport` falls back to `req.URL.Host` (the loopback target) when `req.Host` is empty — so the MCP server saw a loopback `Host`. To not depend on that subtle fallback, `serveProxy` now sets `req.Host` to the loopback target **explicitly**, with a comment. **This is a robustness/clarity change, not a fix for broken behavior** — and the new E2E is the regression guard.

(A browser-style `Origin` is *not* a problem: the SDK's `CrossOriginProtection` is nil by default, so Origin is not checked. `Authorization` is forwarded untouched throughout.)

## Small, justified test seams

Two minimal additions make the faithful E2E possible (both generally useful, not test-only hacks):

- `remote.WithDialFunc(...)` — a transport `Option` on `NewManager` (the production call site is unchanged) so a test can point the manager at an in-process gateway with a test CA.
- `gateway.Server.ServeListeners(ctx, controlLn, publicLn)` — the exported form of the gateway's serve loop, for running on caller-supplied listeners (embedding / socket activation / ephemeral test ports). `Run` calls it.

## Docs

A **"Remote MCP"** section in the README: enabling it in the TUI (with the key clarification that **Gateway URL is the gateway's *control* endpoint**, default `:8443`, distinct from the public address), running `fleet gateway` (flags + TLS/ACME), wiring the public URL + bearer token into a remote agent's `mcp.json`, and the security model.

## Reviewer notes

- No new dependencies (the MCP SDK was already present). `make test` + `make proto-check` pass.
- An adversarial multi-agent review (host/DNS-rebinding correctness, test fidelity, docs accuracy) returned **no confirmed findings**.

Closes #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
