### PR TITLE
feat(grpc): fleetd tunnel demux + token-gated gRPC server (#97)

### DIFF
--- a/internal/server/remote/chanlistener.go
+++ b/internal/server/remote/chanlistener.go
@@ -1,0 +1,67 @@
+package remote
+
+import (
+	"net"
+	"sync"
+)
+
+// chanlistener.go provides an in-memory net.Listener whose connections are PUSHED
+// in rather than accepted from an OS socket. The tunnel demux (serveTunnel)
+// classifies each yamux stream by its tag and pushes it into the right listener:
+// one feeds the loopback MCP http.Server, one feeds the daemon's tunnel-facing
+// gRPC server. Neither served server needs a real port or socket.
+
+// chanAddr is the placeholder address a ChanListener reports (used only for the
+// served server's logging/diagnostics).
+type chanAddr struct{}
+
+func (chanAddr) Network() string { return "fleet-tunnel" }
+func (chanAddr) String() string  { return "fleet-tunnel" }
+
+// ChanListener is a net.Listener fed by Push. It satisfies net.Listener so a
+// stdlib http.Server or a grpc.Server can Serve it.
+type ChanListener struct {
+	conns     chan net.Conn
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+// NewChanListener returns an open ChanListener.
+func NewChanListener() *ChanListener {
+	return &ChanListener{
+		conns: make(chan net.Conn),
+		done:  make(chan struct{}),
+	}
+}
+
+// Push hands c to a waiting Accept. If the listener is already closed it closes c
+// instead, so a late stream is never leaked.
+func (l *ChanListener) Push(c net.Conn) {
+	select {
+	case l.conns <- c:
+	case <-l.done:
+		_ = c.Close()
+	}
+}
+
+// Accept blocks until a connection is pushed or the listener is closed (after
+// which it returns net.ErrClosed, which http.Server/grpc.Server treat as a clean
+// stop).
+func (l *ChanListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.conns:
+		return c, nil
+	case <-l.done:
+		return nil, net.ErrClosed
+	}
+}
+
+// Close stops the listener; pending/future Accepts return net.ErrClosed and
+// pushed connections are closed. Idempotent.
+func (l *ChanListener) Close() error {
+	l.closeOnce.Do(func() { close(l.done) })
+	return nil
+}
+
+// Addr reports the placeholder tunnel address.
+func (l *ChanListener) Addr() net.Addr { return chanAddr{} }

--- a/internal/server/remote/chanlistener_test.go
+++ b/internal/server/remote/chanlistener_test.go
@@ -1,0 +1,55 @@
+package remote
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestChanListenerPushAccept(t *testing.T) {
+	l := NewChanListener()
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	go l.Push(c1)
+	got, err := l.Accept()
+	if err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	if got != c1 {
+		t.Fatal("Accept returned a different conn than was pushed")
+	}
+}
+
+func TestChanListenerCloseUnblocksAccept(t *testing.T) {
+	l := NewChanListener()
+	done := make(chan error, 1)
+	go func() { _, err := l.Accept(); done <- err }()
+	_ = l.Close()
+	select {
+	case err := <-done:
+		if err != net.ErrClosed {
+			t.Fatalf("Accept after Close = %v, want net.ErrClosed", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not unblock Accept")
+	}
+	// Close is idempotent.
+	if err := l.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+// TestChanListenerPushAfterCloseClosesConn ensures a stream pushed after Close is
+// not leaked.
+func TestChanListenerPushAfterCloseClosesConn(t *testing.T) {
+	l := NewChanListener()
+	_ = l.Close()
+	c1, c2 := net.Pipe()
+	defer c2.Close()
+	l.Push(c1) // should close c1
+	if _, err := c1.Read(make([]byte, 1)); err == nil {
+		t.Fatal("pushed-after-close conn should have been closed")
+	}
+}

--- a/internal/server/remote/manager.go
+++ b/internal/server/remote/manager.go
@@ -54,6 +54,11 @@ type Manager struct {
 	// an in-process gateway.
 	dial func(ctx context.Context, gatewayURL string) (net.Conn, error)
 
+	// grpcLis, when set, enables tunneling the daemon's gRPC server alongside MCP:
+	// the Manager advertises FeatureGRPC, and on a gateway that negotiates it,
+	// demuxes tagged streams (grpc streams are pushed here). nil = MCP only.
+	grpcLis *ChanListener
+
 	mu            sync.Mutex
 	desired       desiredState
 	attemptCancel context.CancelFunc // cancels the in-flight connect attempt, if any
@@ -69,6 +74,23 @@ type Option func(*Manager)
 // integration tests to reach an in-process gateway with a test CA.
 func WithDialFunc(dial func(ctx context.Context, gatewayURL string) (net.Conn, error)) Option {
 	return func(m *Manager) { m.dial = dial }
+}
+
+// WithGRPCListener enables tunneling the daemon's gRPC server alongside MCP. lis
+// is fed demuxed gRPC streams and is Served by a gRPC server in the daemon (with
+// the bearer-token auth interceptor). Without this option the Manager tunnels
+// only MCP.
+func WithGRPCListener(lis *ChanListener) Option {
+	return func(m *Manager) { m.grpcLis = lis }
+}
+
+// features lists the tunnel capabilities this Manager requests in its
+// RegisterRequest. Only advertises FeatureGRPC when a gRPC listener is wired.
+func (m *Manager) features() []string {
+	if m.grpcLis != nil {
+		return []string{tunnel.FeatureGRPC}
+	}
+	return nil
 }
 
 // NewManager builds a Manager that reverse-proxies to the loopback MCP server on
@@ -203,7 +225,7 @@ func (m *Manager) connectAndServe(ctx context.Context, gatewayURL string) (regis
 	// a silent gateway can't hang the attempt.
 	_ = conn.SetDeadline(time.Now().Add(handshakeTimeout))
 	prev := loadSession(gatewayURL)
-	req := tunnel.RegisterRequest{SessionID: prev.SessionID, ClientVersion: m.clientVersion}
+	req := tunnel.RegisterRequest{SessionID: prev.SessionID, ClientVersion: m.clientVersion, Features: m.features()}
 	if err := tunnel.WriteFrame(conn, req); err != nil {
 		return false, fmt.Errorf("register write: %w", err)
 	}
@@ -226,8 +248,13 @@ func (m *Manager) connectAndServe(ctx context.Context, gatewayURL string) (regis
 		return registered, fmt.Errorf("yamux client: %w", err)
 	}
 	defer session.Close()
-	// serveProxy unblocks when the session/conn closes — on a peer drop, or when
-	// stopOnCancel closes the conn on ctx cancel (shutdown or Reconcile teardown).
+	// The serve loop unblocks when the session/conn closes — on a peer drop, or
+	// when stopOnCancel closes the conn on ctx cancel (shutdown / Reconcile
+	// teardown). Use the demuxing path only when the gateway negotiated gRPC AND
+	// we have a gRPC listener; otherwise the streams are untagged (legacy MCP).
+	if m.grpcLis != nil && tunnel.HasFeature(reply.Features, tunnel.FeatureGRPC) {
+		return registered, serveTunnel(session, m.mcpPort, m.grpcLis)
+	}
 	return registered, serveProxy(session, m.mcpPort)
 }
 

--- a/internal/server/remote/proxy.go
+++ b/internal/server/remote/proxy.go
@@ -9,23 +9,25 @@ import (
 	"net/url"
 	"strconv"
 
+	"github.com/BenjaminBenetti/fleet-man/internal/tunnel"
 	"github.com/hashicorp/yamux"
 )
 
-// proxy.go is the data path. fleetd treats the yamux session as a net.Listener
-// and runs a stdlib http.Server over it: every stream the gateway opens (one per
-// inbound MCP request) is Accept()ed as a net.Conn, the HTTP request is read off
-// it, and an httputil.ReverseProxy streams it to the loopback MCP server and the
-// response back. Reusing http.Server + ReverseProxy means SSE flushing and
-// chunked streaming are handled by the same stdlib path the local MCP server
-// already uses — correct by construction, and per-stream isolation guarantees
-// concurrent requests never interleave.
+// proxy.go is the data path. fleetd treats the yamux session as a source of
+// streams and serves each one.
+//
+// Two modes, chosen per connection by what the gateway negotiated:
+//   - serveProxy (legacy / MCP-only gateway): every stream is an HTTP request,
+//     served by one http.Server over the whole session and reverse-proxied to the
+//     loopback MCP server.
+//   - serveTunnel (FeatureGRPC negotiated): every stream begins with a tag byte;
+//     fleetd reads it and dispatches — TagMCP streams go to the MCP http.Server,
+//     TagGRPC streams are spliced (as raw net.Conns) to the daemon's tunnel-facing
+//     gRPC server. One stream per request/connection means MCP requests, SSE, and
+//     native gRPC (incl. bidi) never interleave.
 
-// serveProxy serves the yamux session until it errors (peer gone, or the caller
-// closes the session to unblock it). It always returns a non-nil error — the
-// listener (session) only stops by failing — which the caller uses to decide
-// whether to reconnect.
-func serveProxy(session *yamux.Session, mcpPort int) error {
+// mcpReverseProxy builds the reverse proxy to the loopback MCP server.
+func mcpReverseProxy(mcpPort int) http.Handler {
 	target := &url.URL{Scheme: "http", Host: net.JoinHostPort("127.0.0.1", strconv.Itoa(mcpPort))}
 	rp := httputil.NewSingleHostReverseProxy(target)
 	// FlushInterval -1 flushes each write immediately, which SSE (text/event-stream)
@@ -33,24 +35,65 @@ func serveProxy(session *yamux.Session, mcpPort int) error {
 	rp.FlushInterval = -1
 	// Set the Host to the loopback MCP target. This is REQUIRED, not cosmetic: the
 	// MCP SDK enables DNS-rebinding protection by default and returns 403 when the
-	// server is bound to loopback but the request's Host is not loopback — and an
-	// EMPTY Host counts as non-loopback (util.IsLoopback("")==false). A tunneled
-	// request would otherwise arrive with no meaningful Host and be rejected.
-	// Using the loopback target satisfies the check while still rejecting a
-	// genuinely foreign Host. The Authorization header is left untouched so the
-	// MCP bearer token reaches the loopback server's auth — that stays the real
-	// access gate.
+	// server is bound to loopback but the request's Host is not loopback (an EMPTY
+	// Host counts as non-loopback). Using the loopback target satisfies the check
+	// while still rejecting a genuinely foreign Host. Authorization is left
+	// untouched so the MCP bearer token reaches the loopback server's auth gate.
 	orig := rp.Director
 	rp.Director = func(req *http.Request) {
 		orig(req)
 		req.Host = target.Host
 	}
-	// Peer resets / closed streams are normal tunnel churn, not server faults;
-	// discard the proxy's per-request error spam.
+	// Peer resets / closed streams are normal tunnel churn, not server faults.
 	rp.ErrorLog = log.New(io.Discard, "", 0)
+	return rp
+}
 
-	srv := &http.Server{Handler: rp}
-	// http.Server.Serve returns the listener's error when Accept fails; for a
-	// yamux session that is the session-closed/peer-gone error we want to surface.
+// serveProxy serves an MCP-only session: every stream is an HTTP request. It
+// returns when the session errors (peer gone, or the caller closes it).
+func serveProxy(session *yamux.Session, mcpPort int) error {
+	srv := &http.Server{Handler: mcpReverseProxy(mcpPort)}
 	return srv.Serve(session)
+}
+
+// serveTunnel serves a session whose streams are TAG-prefixed (FeatureGRPC
+// negotiated): it reads each stream's tag and routes it. MCP streams feed a local
+// http.Server; gRPC streams feed grpcLis (the daemon's tunnel-facing gRPC server,
+// which is shared across reconnects and NOT closed here). Returns when the
+// session errors.
+func serveTunnel(session *yamux.Session, mcpPort int, grpcLis *ChanListener) error {
+	mcpLis := NewChanListener()
+	mcpSrv := &http.Server{Handler: mcpReverseProxy(mcpPort)}
+	// Closing the server closes mcpLis (so its Accept unblocks) and drops the
+	// per-connection MCP requests; grpcLis is NOT closed — it outlives this
+	// connection so reconnects reuse the same gRPC server.
+	defer mcpSrv.Close()
+	go func() { _ = mcpSrv.Serve(mcpLis) }()
+
+	for {
+		stream, err := session.Accept()
+		if err != nil {
+			return err
+		}
+		go dispatchStream(stream, mcpLis, grpcLis)
+	}
+}
+
+// dispatchStream reads the leading tag byte and routes the (tag-stripped) stream
+// to the MCP or gRPC listener. An unreadable tag or unknown value closes the
+// stream without disturbing the others.
+func dispatchStream(stream net.Conn, mcpLis, grpcLis *ChanListener) {
+	tag, err := tunnel.ReadTag(stream)
+	if err != nil {
+		_ = stream.Close()
+		return
+	}
+	switch tag {
+	case tunnel.TagMCP:
+		mcpLis.Push(stream)
+	case tunnel.TagGRPC:
+		grpcLis.Push(stream)
+	default:
+		_ = stream.Close()
+	}
 }

--- a/internal/server/remote/serve_tunnel_test.go
+++ b/internal/server/remote/serve_tunnel_test.go
@@ -1,0 +1,118 @@
+package remote
+
+import (
+	"bufio"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/tunnel"
+	"github.com/hashicorp/yamux"
+)
+
+// TestServeTunnelDemux is the core fleetd-side test: with FeatureGRPC negotiated,
+// every yamux stream is TAG-prefixed, and serveTunnel must route TagMCP streams to
+// the MCP reverse proxy and TagGRPC streams (bytes intact after the tag) to the
+// gRPC listener — without one stream type disturbing the other, and closing
+// unknown-tag streams without wedging the loop.
+func TestServeTunnelDemux(t *testing.T) {
+	mcp := newFakeMCP()
+	defer mcp.srv.Close()
+
+	fleetdConn, gwConn := tcpPair(t)
+	fleetdSession, err := tunnel.ClientSession(fleetdConn, io.Discard)
+	if err != nil {
+		t.Fatalf("client session: %v", err)
+	}
+	defer fleetdSession.Close()
+	gwSession, err := tunnel.ServerSession(gwConn, io.Discard)
+	if err != nil {
+		t.Fatalf("server session: %v", err)
+	}
+	defer gwSession.Close()
+
+	grpcLis := NewChanListener()
+	defer grpcLis.Close()
+	go func() { _ = serveTunnel(fleetdSession, mcp.port(t), grpcLis) }()
+
+	// --- TagGRPC: the post-tag bytes must arrive intact on grpcLis. ---
+	gstream, err := gwSession.Open()
+	if err != nil {
+		t.Fatalf("open grpc stream: %v", err)
+	}
+	if err := tunnel.WriteTag(gstream, tunnel.TagGRPC); err != nil {
+		t.Fatalf("write grpc tag: %v", err)
+	}
+	if _, err := io.WriteString(gstream, "hello-grpc"); err != nil {
+		t.Fatalf("write grpc bytes: %v", err)
+	}
+	got := make(chan string, 1)
+	go func() {
+		c, err := grpcLis.Accept()
+		if err != nil {
+			got <- "ERR:" + err.Error()
+			return
+		}
+		b := make([]byte, len("hello-grpc"))
+		if _, err := io.ReadFull(c, b); err != nil {
+			got <- "READ:" + err.Error()
+			return
+		}
+		got <- string(b)
+	}()
+	select {
+	case s := <-got:
+		if s != "hello-grpc" {
+			t.Fatalf("grpc stream payload = %q, want hello-grpc", s)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("grpc-tagged stream never reached the gRPC listener")
+	}
+
+	// --- TagMCP: an HTTP request must reach the MCP reverse proxy, auth intact. ---
+	if body := mcpRoundTrip(t, gwSession, "Bearer demux-test"); body != "Bearer demux-test" {
+		t.Fatalf("mcp echo through demux = %q", body)
+	}
+
+	// --- Unknown tag: the stream is closed and the loop survives. ---
+	ustream, err := gwSession.Open()
+	if err != nil {
+		t.Fatalf("open unknown stream: %v", err)
+	}
+	_ = tunnel.WriteTag(ustream, 0x42)
+	_ = ustream.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if _, err := ustream.Read(make([]byte, 1)); err == nil {
+		t.Fatal("unknown-tag stream should be closed by fleetd")
+	}
+
+	// The loop still serves MCP after the bad stream.
+	if body := mcpRoundTrip(t, gwSession, "Bearer after-bad"); body != "Bearer after-bad" {
+		t.Fatalf("mcp after unknown tag = %q", body)
+	}
+}
+
+// mcpRoundTrip opens a TagMCP stream on gw, drives a GET /echo through it, and
+// returns the echoed Authorization header.
+func mcpRoundTrip(t *testing.T, gw *yamux.Session, auth string) string {
+	t.Helper()
+	stream, err := gw.Open()
+	if err != nil {
+		t.Fatalf("open mcp stream: %v", err)
+	}
+	if err := tunnel.WriteTag(stream, tunnel.TagMCP); err != nil {
+		t.Fatalf("write mcp tag: %v", err)
+	}
+	req, _ := http.NewRequest(http.MethodGet, "http://tunnel/echo", nil)
+	req.Header.Set("Authorization", auth)
+	if err := req.Write(stream); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(stream), req)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return string(b)
+}

--- a/internal/server/remote_auth.go
+++ b/internal/server/remote_auth.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"context"
+	"crypto/subtle"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// remote_auth.go gates the TUNNEL-facing gRPC server (the one reachable through
+// the remote gateway) behind the MCP bearer token. Every RPC must carry
+// `authorization: Bearer <token>` metadata. The LOCAL unix-socket gRPC server has
+// NO interceptor — it is same-user and 0600, so it stays auth-less and unchanged.
+//
+// The token is the SAME one MCP uses (~/.fleet/mcp.token): one secret gates remote
+// access on both paths. The gateway never sees the token as a credential it
+// validates — it only routes bytes; the check happens here, at the daemon.
+
+const authMetadataKey = "authorization"
+
+// bearerAuthInterceptors returns unary + stream interceptors that require
+// `authorization: Bearer <token>` metadata, compared in constant time.
+func bearerAuthInterceptors(token string) (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor) {
+	want := []byte("Bearer " + token)
+
+	check := func(ctx context.Context) error {
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return status.Error(codes.Unauthenticated, "missing credentials")
+		}
+		vals := md.Get(authMetadataKey)
+		if len(vals) == 0 {
+			return status.Error(codes.Unauthenticated, "missing authorization")
+		}
+		if subtle.ConstantTimeCompare([]byte(vals[0]), want) != 1 {
+			return status.Error(codes.Unauthenticated, "invalid token")
+		}
+		return nil
+	}
+
+	unary := func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if err := check(ctx); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+	stream := func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := check(ss.Context()); err != nil {
+			return err
+		}
+		return handler(srv, ss)
+	}
+	return unary, stream
+}

--- a/internal/server/remote_auth_test.go
+++ b/internal/server/remote_auth_test.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+func dialBuf(t *testing.T, gs *grpc.Server) fleetgrpc.FleetServiceClient {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	go func() { _ = gs.Serve(lis) }()
+	t.Cleanup(gs.Stop)
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) { return lis.DialContext(ctx) }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return fleetgrpc.NewFleetServiceClient(conn)
+}
+
+// TestTunnelAuthInterceptors verifies the tunnel-facing gRPC server requires the
+// MCP bearer token (unary + stream) and rejects missing/wrong tokens.
+func TestTunnelAuthInterceptors(t *testing.T) {
+	const token = "test-token-123"
+	authUnary, authStream := bearerAuthInterceptors(token)
+	gs := grpc.NewServer(grpc.ChainUnaryInterceptor(authUnary), grpc.ChainStreamInterceptor(authStream))
+	fleetgrpc.RegisterFleetServiceServer(gs, newService())
+	client := dialBuf(t, gs)
+
+	withToken := metadata.AppendToOutgoingContext(context.Background(), "authorization", "Bearer "+token)
+	if _, err := client.Hello(withToken, &fleetgrpc.HelloRequest{}); err != nil {
+		t.Fatalf("Hello WITH token should succeed: %v", err)
+	}
+	if _, err := client.Hello(context.Background(), &fleetgrpc.HelloRequest{}); status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("Hello WITHOUT token: want Unauthenticated, got %v", err)
+	}
+	wrong := metadata.AppendToOutgoingContext(context.Background(), "authorization", "Bearer nope")
+	if _, err := client.Hello(wrong, &fleetgrpc.HelloRequest{}); status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("Hello WRONG token: want Unauthenticated, got %v", err)
+	}
+
+	// Stream RPC is gated too: the interceptor rejects before the handler runs.
+	stream, err := client.Watch(context.Background(), &fleetgrpc.WatchRequest{})
+	if err == nil {
+		_, err = stream.Recv()
+	}
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("Watch WITHOUT token: want Unauthenticated, got %v", err)
+	}
+}
+
+// TestLocalServerStaysAuthLess confirms a server built like the local unix-socket
+// one (no interceptors) still serves without any token — the local path is
+// unchanged.
+func TestLocalServerStaysAuthLess(t *testing.T) {
+	gs := grpc.NewServer()
+	fleetgrpc.RegisterFleetServiceServer(gs, newService())
+	client := dialBuf(t, gs)
+	if _, err := client.Hello(context.Background(), &fleetgrpc.HelloRequest{}); err != nil {
+		t.Fatalf("local Hello without a token must succeed: %v", err)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -123,15 +123,37 @@ func Serve(ctx context.Context) error {
 		}()
 	}
 
+	// Tunnel-facing gRPC server: exposes the SAME FleetService as the local unix
+	// socket, but gated by the MCP bearer token (the local socket stays auth-less).
+	// It is Served over an in-memory listener fed by the tunnel demux, so there is
+	// no extra port/socket; the gateway tunnels gRPC alongside MCP whenever both
+	// ends negotiate FeatureGRPC. Only wired when MCP is up (we have a port +
+	// token); enabling remote MCP in config exposes this too (one toggle).
+	var remoteOpts []remote.Option
+	if mcpPort != 0 {
+		if token, err := loadOrCreateMCPToken(); err == nil {
+			grpcLis := remote.NewChanListener()
+			authUnary, authStream := bearerAuthInterceptors(token)
+			tunnelGRPC := grpc.NewServer(grpc.ChainUnaryInterceptor(authUnary), grpc.ChainStreamInterceptor(authStream))
+			fleetgrpc.RegisterFleetServiceServer(tunnelGRPC, svc)
+			go func() { _ = tunnelGRPC.Serve(grpcLis) }()
+			defer tunnelGRPC.Stop()
+			remoteOpts = append(remoteOpts, remote.WithGRPCListener(grpcLis))
+		} else {
+			flog.Warn("remote grpc: load token", "err", err)
+		}
+	}
+
 	// Remote-MCP gateway tunnel: an outbound, OPT-IN connection that exposes the
-	// loopback MCP server to the internet through a remote fleet gateway. Like MCP
-	// itself it is auxiliary — the supervisor stays idle until the config enables
-	// it, and a connect failure only affects remote access, never the local
-	// daemon. It publishes its status (incl. the gateway-assigned Public MCP URL)
-	// through the hub so the TUI settings page reflects it live.
+	// loopback MCP server (and, when negotiated, the gRPC server above) to the
+	// internet through a remote fleet gateway. Like MCP itself it is auxiliary —
+	// the supervisor stays idle until the config enables it, and a connect failure
+	// only affects remote access, never the local daemon. It publishes its status
+	// (incl. the gateway-assigned Public MCP URL) through the hub so the TUI
+	// settings page reflects it live.
 	svc.remote = remote.NewManager(mcpPort, versionOrDev(), func(st *fleetgrpc.RemoteMcpStatus) {
 		svc.hub.post(func(h *hub) { h.broadcastRemoteMcpStatus(st) })
-	})
+	}, remoteOpts...)
 	go svc.remote.Run(hubCtx)
 	if cfg, err := state.LoadConfig(); err == nil {
 		svc.remote.Reconcile(cfg.RemoteMcpSettings.Enabled, cfg.RemoteMcpSettings.GatewayURL)

--- a/internal/tunnel/tag.go
+++ b/internal/tunnel/tag.go
@@ -1,0 +1,40 @@
+package tunnel
+
+import "io"
+
+// tag.go defines the per-stream type tag used once the FeatureGRPC capability is
+// negotiated. Every yamux stream the gateway opens then begins with a single TAG
+// byte that tells fleetd how to handle the rest of the stream:
+//
+//	TagMCP  → the stream carries an HTTP request for the loopback MCP server.
+//	TagGRPC → the stream carries a raw native-gRPC (HTTP/2) connection that fleetd
+//	          splices to its gRPC server.
+//
+// The gateway writes the tag as the FIRST bytes of the stream, before relaying
+// any client/payload bytes, so fleetd can read it immediately without sniffing
+// or blocking on data that has not arrived yet. The tag is a stream-level prefix,
+// NOT a control frame — it rides inside an established yamux session, after the
+// RegisterRequest/RegisterReply handshake.
+//
+// Because an un-upgraded peer does not know about tags, tags are used ONLY when
+// FeatureGRPC is in the negotiated feature set (see tunnel.go); otherwise the
+// tunnel stays byte-for-byte the legacy MCP-only stream.
+const (
+	TagMCP  byte = 0x00
+	TagGRPC byte = 0x01
+)
+
+// WriteTag writes a single stream-type tag byte.
+func WriteTag(w io.Writer, tag byte) error {
+	_, err := w.Write([]byte{tag})
+	return err
+}
+
+// ReadTag reads a single stream-type tag byte.
+func ReadTag(r io.Reader) (byte, error) {
+	var b [1]byte
+	if _, err := io.ReadFull(r, b[:]); err != nil {
+		return 0, err
+	}
+	return b[0], nil
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -32,6 +32,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"slices"
 
 	"github.com/hashicorp/yamux"
 )
@@ -45,6 +46,11 @@ type RegisterRequest struct {
 	SessionID string `json:"session_id,omitempty"`
 	// ClientVersion is the fleetd version, for the gateway's logs/diagnostics.
 	ClientVersion string `json:"client_version,omitempty"`
+	// Features lists optional tunnel capabilities fleetd supports (e.g.
+	// FeatureGRPC). The gateway echoes back the subset it ALSO supports in
+	// RegisterReply.Features; both sides then only use a feature when it appears
+	// in that negotiated set. Absent (old fleetd) means the base MCP-only tunnel.
+	Features []string `json:"features,omitempty"`
 }
 
 // RegisterReply is the gateway's response. On success Error is empty, SessionID
@@ -54,6 +60,31 @@ type RegisterReply struct {
 	SessionID string `json:"session_id,omitempty"`
 	PublicURL string `json:"public_url,omitempty"`
 	Error     string `json:"error,omitempty"`
+	// Features is the negotiated set: the intersection of what fleetd requested
+	// and what the gateway supports. Absent (old gateway) means MCP-only.
+	Features []string `json:"features,omitempty"`
+}
+
+// FeatureGRPC negotiates tunneling the daemon's gRPC server alongside MCP. When
+// it is in the negotiated set, the gateway tags each opened stream (see tag.go)
+// and serves a /grpc/<id> route, and fleetd demuxes tagged streams.
+const FeatureGRPC = "grpc"
+
+// HasFeature reports whether features contains f.
+func HasFeature(features []string, f string) bool {
+	return slices.Contains(features, f)
+}
+
+// Negotiate returns the features present in BOTH requested and supported (the
+// set the gateway puts in RegisterReply.Features), preserving requested order.
+func Negotiate(requested, supported []string) []string {
+	var out []string
+	for _, r := range requested {
+		if HasFeature(supported, r) {
+			out = append(out, r)
+		}
+	}
+	return out
 }
 
 // MaxFrameSize caps a control frame so a malicious or garbled peer cannot make

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -5,13 +5,14 @@ import (
 	"encoding/binary"
 	"io"
 	"net"
+	"reflect"
 	"strings"
 	"testing"
 )
 
 func TestFrameRoundTrip(t *testing.T) {
 	var buf bytes.Buffer
-	in := RegisterRequest{SessionID: "abc123", ClientVersion: "v1.2.3"}
+	in := RegisterRequest{SessionID: "abc123", ClientVersion: "v1.2.3", Features: []string{FeatureGRPC}}
 	if err := WriteFrame(&buf, in); err != nil {
 		t.Fatalf("WriteFrame: %v", err)
 	}
@@ -19,14 +20,14 @@ func TestFrameRoundTrip(t *testing.T) {
 	if err := ReadFrame(&buf, &out); err != nil {
 		t.Fatalf("ReadFrame: %v", err)
 	}
-	if out != in {
+	if !reflect.DeepEqual(out, in) {
 		t.Fatalf("round-trip mismatch: got %+v want %+v", out, in)
 	}
 }
 
 func TestFrameReplyRoundTrip(t *testing.T) {
 	var buf bytes.Buffer
-	in := RegisterReply{SessionID: "s1", PublicURL: "https://gw/mcp/s1"}
+	in := RegisterReply{SessionID: "s1", PublicURL: "https://gw/mcp/s1", Features: []string{FeatureGRPC}}
 	if err := WriteFrame(&buf, in); err != nil {
 		t.Fatalf("WriteFrame: %v", err)
 	}
@@ -34,9 +35,73 @@ func TestFrameReplyRoundTrip(t *testing.T) {
 	if err := ReadFrame(&buf, &out); err != nil {
 		t.Fatalf("ReadFrame: %v", err)
 	}
-	if out != in {
+	if !reflect.DeepEqual(out, in) {
 		t.Fatalf("round-trip mismatch: got %+v want %+v", out, in)
 	}
+}
+
+func TestTagRoundTrip(t *testing.T) {
+	for _, tag := range []byte{TagMCP, TagGRPC, 0x7f} {
+		var buf bytes.Buffer
+		if err := WriteTag(&buf, tag); err != nil {
+			t.Fatalf("WriteTag(%#x): %v", tag, err)
+		}
+		got, err := ReadTag(&buf)
+		if err != nil {
+			t.Fatalf("ReadTag(%#x): %v", tag, err)
+		}
+		if got != tag {
+			t.Fatalf("tag round-trip: got %#x want %#x", got, tag)
+		}
+	}
+}
+
+func TestReadTagShortRead(t *testing.T) {
+	if _, err := ReadTag(bytes.NewReader(nil)); err == nil {
+		t.Fatal("ReadTag on empty reader should error")
+	}
+}
+
+func TestNegotiate(t *testing.T) {
+	if got := Negotiate([]string{FeatureGRPC, "future"}, []string{FeatureGRPC}); !reflect.DeepEqual(got, []string{FeatureGRPC}) {
+		t.Fatalf("Negotiate intersection = %v, want [grpc]", got)
+	}
+	if got := Negotiate([]string{FeatureGRPC}, nil); len(got) != 0 {
+		t.Fatalf("Negotiate with no support = %v, want empty", got)
+	}
+	if !HasFeature([]string{"a", FeatureGRPC}, FeatureGRPC) || HasFeature([]string{"a"}, FeatureGRPC) {
+		t.Fatal("HasFeature wrong")
+	}
+}
+
+// TestRegisterBackwardCompat confirms an old peer's frame (no "features" key)
+// decodes to an absent feature set — so a version-skewed tunnel stays MCP-only.
+func TestRegisterBackwardCompat(t *testing.T) {
+	var req RegisterRequest
+	if err := ReadFrame(frameOf(t, `{"session_id":"s","client_version":"v1"}`), &req); err != nil {
+		t.Fatalf("decode legacy request: %v", err)
+	}
+	if len(req.Features) != 0 {
+		t.Fatalf("legacy request should have no features, got %v", req.Features)
+	}
+	var reply RegisterReply
+	if err := ReadFrame(frameOf(t, `{"session_id":"s","public_url":"https://gw/mcp/s"}`), &reply); err != nil {
+		t.Fatalf("decode legacy reply: %v", err)
+	}
+	if HasFeature(reply.Features, FeatureGRPC) {
+		t.Fatal("legacy reply must not advertise grpc")
+	}
+}
+
+// frameOf wraps raw JSON in the length-prefixed frame format for ReadFrame.
+func frameOf(t *testing.T, jsonBody string) io.Reader {
+	t.Helper()
+	var buf bytes.Buffer
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(jsonBody)))
+	buf.Write(hdr[:])
+	buf.WriteString(jsonBody)
+	return &buf
 }
 
 // TestReadFrameRejectsOversizeHeader guards the allocation cap: a hostile length


### PR DESCRIPTION
## What

**PR 1 of 3** exposing the daemon's **gRPC server** through the existing fleet gateway, for full remote control (a remote `fleet` CLI/TUI). This is the **fleetd half**; the gateway `/grpc` route and the remote client are the next two PRs.

It is **inert in production until a gateway negotiates the new feature** — a version-skewed rollout keeps the existing MCP tunnel byte-for-byte unchanged.

Designed via a spike (raw-splicing native gRPC), with the owner's decisions: **auth reuses the MCP bearer token**, and gRPC **rides the same tunnel/toggle as MCP**.

## Why raw-splice (the spike's key finding)

The gRPC service has **bidirectional streaming** (`rpc Exec(stream ExecIn) returns (stream ExecOut)`) plus server-streaming (`Watch`, jobs, `Logs`). gRPC-Web and Connect-over-HTTP/1.1 **can't do bidi**, so the only way to carry the full API is to move **native gRPC/HTTP-2 as opaque bytes** end to end. The gateway (next PR) will hijack `/grpc/<id>` and raw-splice; fleetd just needs to recognize gRPC streams and feed them to a gRPC server — which is what this PR adds.

## Changes

- **`internal/tunnel`**: `RegisterRequest`/`RegisterReply` gain `Features []string` + `FeatureGRPC` negotiation (`HasFeature`/`Negotiate`), and a per-stream **tag byte** (`tag.go`: `TagMCP`/`TagGRPC`, `WriteTag`/`ReadTag`). Negotiation is what makes the rollout safe in any order — an un-upgraded peer never advertises/accepts the feature, so no tag is ever written and the tunnel stays the legacy MCP-only path.
- **`internal/server/remote`**: kept `serveProxy` (legacy, MCP-only); added **`serveTunnel`** — an `Accept`+`ReadTag`+dispatch loop that routes `TagMCP` streams to the MCP reverse proxy and `TagGRPC` streams (raw native h2) to a gRPC listener. `ChanListener` is an in-memory `net.Listener` fed by the demux. `Manager` advertises `FeatureGRPC` only when a gRPC listener is wired, and uses `serveTunnel` only when the gateway negotiated it.
- **`internal/server`**: a **second** in-process `grpc.Server` (same `FleetService` impl) gated by the **MCP bearer token** via a metadata interceptor, Served over the demux listener. The **local unix-socket server is unchanged and stays auth-less** (same-user, `0600`).

## Tests (pass under `-race`)

Tag round-trip + register backward-compat + `Negotiate`; **demux routing** (mcp/grpc/unknown tags, payload-after-tag intact, the loop survives a bad stream); **auth** accept/reject for unary *and* stream RPCs + a control proving the local server still serves tokenless; ChanListener behavior. No new dependencies.

## Reviewer notes

- Import boundary preserved (`internal/tunnel` stays a leaf; `remote`/`server` are server-side; depguard passes).
- An adversarial multi-agent review (demux concurrency, auth/server wiring, protocol back/forward-compat) returned **no findings**.

Part of the remote-gRPC follow-on to #97. Next: the gateway `/grpc/<id>` route + raw splice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
