### PR TITLE
fix(devcontainer): isolate CLI tmp dir to stop concurrent-up race

### DIFF
--- a/integration/tests/600_concurrent_up_distinct.sh
+++ b/integration/tests/600_concurrent_up_distinct.sh
@@ -70,6 +70,11 @@ if [ -n "${failed_names}" ]; then
   info "retrying failed invocations sequentially"
   rc=0
   for n in ${failed_names}; do
+    # A failed concurrent attempt already pre-created the instance record
+    # server-side (StatusCreating, written before the devcontainer job runs),
+    # so a bare re-`up` is rejected with AlreadyExists and can never recover.
+    # Clear the partial record first so the sequential retry provisions clean.
+    "${FLEET_BIN}" destroy "${FIXTURE_REPO_NAME}/${n}" >/dev/null 2>&1 || true
     if ! fleet_up "${n}" >"${tmpdir}/retry_${n}.log" 2>&1; then
       rc=1
     fi

--- a/internal/backend/devcontainer/devcontainer_backend.go
+++ b/internal/backend/devcontainer/devcontainer_backend.go
@@ -98,6 +98,21 @@ func (devcontainerBackend *DevcontainerBackend) Up(workspaceDir string, mounts [
 	}
 	defer restore()
 
+	// Isolate the devcontainer CLI's scratch directory for this invocation.
+	// The CLI materialises its generated `updateUID.Dockerfile-<ver>` under a
+	// FIXED name in `$TMPDIR/devcontainercli-runner/`, writing a temp sibling
+	// and renaming it onto that path. Two concurrent `devcontainer up`
+	// processes that share one TMPDIR therefore collide on the rename and one
+	// dies with `ENOENT ... rename .../updateUID.Dockerfile-<ver>`. A
+	// per-invocation TMPDIR gives each process its own runner dir, so
+	// concurrent ups never race (guarded by integration test
+	// 600_concurrent_up_distinct, the #63 regression).
+	runnerTmp, err := os.MkdirTemp("", "fleet-devcontainer-")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(runnerTmp)
+
 	args := []string{"up", "--workspace-folder", workspaceDir}
 	args, err = devcontainerUpArgs(args)
 	if err != nil {
@@ -110,7 +125,7 @@ func (devcontainerBackend *DevcontainerBackend) Up(workspaceDir string, mounts [
 	if err != nil {
 		return nil, err
 	}
-	cmd.Env = env
+	cmd.Env = withIsolatedTmp(env, runnerTmp)
 
 	// Capture stdout for JSON parsing, tee to os.Stdout so it appears
 	// in log files when run from the TUI background process.
@@ -154,6 +169,21 @@ func devcontainerUpArgs(base []string) ([]string, error) {
 	default:
 		return nil, fmt.Errorf("invalid FLEET_DEVCONTAINER_UPDATE_REMOTE_USER_UID value %q (valid: default, never, on, off)", mode)
 	}
+}
+
+// withIsolatedTmp returns env with TMPDIR pointed at dir, replacing any
+// inherited TMPDIR. The devcontainer CLI (Node's os.tmpdir()) reads TMPDIR
+// first on Unix, so this redirects its `devcontainercli-runner` scratch into a
+// per-invocation directory — see Up for why that race-proofing matters.
+func withIsolatedTmp(env []string, dir string) []string {
+	out := make([]string, 0, len(env)+1)
+	for _, e := range env {
+		if strings.HasPrefix(e, "TMPDIR=") {
+			continue
+		}
+		out = append(out, e)
+	}
+	return append(out, "TMPDIR="+dir)
 }
 
 // devcontainerEnv applies BuildKit-related env tweaks based on the

--- a/internal/backend/devcontainer/devcontainer_test.go
+++ b/internal/backend/devcontainer/devcontainer_test.go
@@ -2,10 +2,36 @@ package devcontainer
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 )
+
+func TestWithIsolatedTmp(t *testing.T) {
+	got := withIsolatedTmp([]string{"PATH=/bin", "TMPDIR=/tmp", "HOME=/root"}, "/scratch/x")
+
+	if slices.Contains(got, "TMPDIR=/tmp") {
+		t.Fatalf("withIsolatedTmp kept inherited TMPDIR: %#v", got)
+	}
+	if !slices.Contains(got, "TMPDIR=/scratch/x") {
+		t.Fatalf("withIsolatedTmp missing override TMPDIR: %#v", got)
+	}
+	if !slices.Contains(got, "PATH=/bin") || !slices.Contains(got, "HOME=/root") {
+		t.Fatalf("withIsolatedTmp dropped unrelated env: %#v", got)
+	}
+
+	// Exactly one TMPDIR survives so the override is unambiguous.
+	n := 0
+	for _, e := range got {
+		if strings.HasPrefix(e, "TMPDIR=") {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("withIsolatedTmp produced %d TMPDIR entries, want 1: %#v", n, got)
+	}
+}
 
 func TestScreenCaptureZeroValue(t *testing.T) {
 	// A zero-value ScreenCapture should indicate failure (OK=false).

--- a/internal/backend/devcontainer/devcontainer_test.go
+++ b/internal/backend/devcontainer/devcontainer_test.go
@@ -9,27 +9,39 @@ import (
 )
 
 func TestWithIsolatedTmp(t *testing.T) {
-	got := withIsolatedTmp([]string{"PATH=/bin", "TMPDIR=/tmp", "HOME=/root"}, "/scratch/x")
-
-	if slices.Contains(got, "TMPDIR=/tmp") {
-		t.Fatalf("withIsolatedTmp kept inherited TMPDIR: %#v", got)
-	}
-	if !slices.Contains(got, "TMPDIR=/scratch/x") {
-		t.Fatalf("withIsolatedTmp missing override TMPDIR: %#v", got)
-	}
-	if !slices.Contains(got, "PATH=/bin") || !slices.Contains(got, "HOME=/root") {
-		t.Fatalf("withIsolatedTmp dropped unrelated env: %#v", got)
+	tests := []struct {
+		name string
+		env  []string
+	}{
+		{name: "replaces inherited TMPDIR", env: []string{"PATH=/bin", "TMPDIR=/tmp", "HOME=/root"}},
+		{name: "appends when none inherited", env: []string{"PATH=/bin", "HOME=/root"}},
 	}
 
-	// Exactly one TMPDIR survives so the override is unambiguous.
-	n := 0
-	for _, e := range got {
-		if strings.HasPrefix(e, "TMPDIR=") {
-			n++
-		}
-	}
-	if n != 1 {
-		t.Fatalf("withIsolatedTmp produced %d TMPDIR entries, want 1: %#v", n, got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := withIsolatedTmp(tt.env, "/scratch/x")
+
+			if slices.Contains(got, "TMPDIR=/tmp") {
+				t.Fatalf("withIsolatedTmp kept inherited TMPDIR: %#v", got)
+			}
+			if !slices.Contains(got, "TMPDIR=/scratch/x") {
+				t.Fatalf("withIsolatedTmp missing override TMPDIR: %#v", got)
+			}
+			if !slices.Contains(got, "PATH=/bin") || !slices.Contains(got, "HOME=/root") {
+				t.Fatalf("withIsolatedTmp dropped unrelated env: %#v", got)
+			}
+
+			// Exactly one TMPDIR survives so the override is unambiguous.
+			n := 0
+			for _, e := range got {
+				if strings.HasPrefix(e, "TMPDIR=") {
+					n++
+				}
+			}
+			if n != 1 {
+				t.Fatalf("withIsolatedTmp produced %d TMPDIR entries, want 1: %#v", n, got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

`600_concurrent_up_distinct` failed (run 185, both attempts) with:

```
ENOENT: no such file or directory, rename
  '/tmp/devcontainercli-runner/updateUID.Dockerfile-0.87.0-...'
  -> '/tmp/devcontainercli-runner/updateUID.Dockerfile-0.87.0'
... AlreadyExists for itest-fleet/charlie
```

Two compounding bugs:

1. **The race (ENOENT).** The devcontainer CLI writes its generated `updateUID.Dockerfile-<ver>` under a **fixed** name in `$TMPDIR/devcontainercli-runner/`, materialising a temp sibling then renaming it onto that path. Three concurrent `devcontainer up` processes share one `/tmp`, so they collide on the rename and one dies with `ENOENT`.

2. **Why the retry can't recover (AlreadyExists).** A failed concurrent `up` has *already* written the instance's `StatusCreating` record server-side (`CreateInstance` does `state.Update → AddInstance` **before** running the devcontainer job). The test's sequential retry then re-`up`s the same name → `codes.AlreadyExists`. The retry was structurally incapable of recovering — which is why attempt 2 reproduced identically.

## Fix

- **Root cause:** give each `Up()` invocation its own `TMPDIR` (Node's `os.tmpdir()` reads `TMPDIR` first on Unix), so the CLI's `devcontainercli-runner` scratch dir is per-process and concurrent ups never race. Dir is created with `os.MkdirTemp` and removed on return.
- **Defense in depth:** the test's sequential retry now `destroy`s the partial record before re-`up`ping, so any transient first-attempt failure can actually recover.

## Testing

- New unit test `TestWithIsolatedTmp` covering the env override.
- `go build ./...`, `go vet`, and the devcontainer backend unit tests pass.
- Integration test `600_concurrent_up_distinct` shell syntax validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)