### PR TITLE
feat(grpc): gateway /grpc route + remote client + full E2E (#97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,38 @@ to your daemons. A `GET /healthz` on the public listener returns `ok`.
   secret (never placed in the URL), so a URL holder cannot hijack your tunnel.
 - All gateway traffic is TLS; the daemon verifies the gateway's certificate.
 
+### Remote control (gRPC)
+
+The same gateway tunnel can also carry the daemon's **gRPC** API, so a remote
+`fleet` client can drive your daemon directly — list/up/down, watch live status,
+stream logs, change config, and so on. It rides the **same tunnel and the same
+on/off toggle** as remote MCP (no separate setting); the gateway serves it at
+`https://<gateway>/grpc/<id>` (same id as the MCP URL, `/grpc` instead of `/mcp`).
+
+Point a `fleet` client at it with two env vars:
+
+```bash
+export FLEET_GATEWAY="https://gateway.example.com/grpc/<id>"
+export FLEET_TOKEN="<token from ~/.fleet/mcp.token>"   # omit on the same host as the daemon
+fleet ls          # …now talks to the REMOTE daemon
+```
+
+`FLEET_GATEWAY` takes precedence over `FLEET_SERVER` and the local socket; a remote
+endpoint is never auto-spawned, and a daemon/client version mismatch is a hard
+error.
+
+> ⚠️ **Security — this is full remote control.** The bearer token authorizes
+> *every* gRPC call, so the **same `~/.fleet/mcp.token` now grants full control of
+> your daemon over the internet** — not just the read-mostly MCP tools. The gateway
+> terminates TLS, so its operator can see your traffic and token (the same trust
+> model as remote MCP). Only enable this with a gateway you run or trust, and treat
+> the token as a high-value secret.
+
+> **Note:** interactive `fleet exec` (a remote shell) is **not yet supported** over
+> the gateway — it currently runs the command on the *client's* host. Every other
+> RPC works remotely today; remote interactive shell awaits a server-side `Exec`
+> handler.
+
 ## Requirements
 
 - Linux, including Ubuntu on WSL2

--- a/internal/fleetclient/dial.go
+++ b/internal/fleetclient/dial.go
@@ -8,7 +8,6 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
 	"github.com/BenjaminBenetti/fleet-man/internal/version"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 // Conn is a connected fleet client. Service() returns the gRPC client; callers
@@ -30,7 +29,7 @@ func (c *Conn) Close() error { return c.conn.Close() }
 // incompatible remote/newer one). For a remote endpoint it dials only.
 func Dial(ctx context.Context) (*Conn, error) {
 	ep := selectEndpoint()
-	conn, err := grpc.NewClient(ep.Target(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(ep.Target(), ep.DialOptions()...)
 	if err != nil {
 		return nil, fmt.Errorf("create client for %s: %w", ep, err)
 	}

--- a/internal/fleetclient/endpoint.go
+++ b/internal/fleetclient/endpoint.go
@@ -11,8 +11,11 @@ package fleetclient
 
 import (
 	"os"
+	"strings"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetpaths"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // Endpoint abstracts WHERE the server is and HOW we reach it, so commands never
@@ -26,28 +29,60 @@ type Endpoint interface {
 	// whether auto-spawn / version-restart are permitted).
 	IsLocal() bool
 	String() string
+	// DialOptions are the grpc.DialOptions for this endpoint (transport creds, and
+	// for a gateway endpoint the CONNECT dialer + per-RPC token).
+	DialOptions() []grpc.DialOption
+}
+
+// insecureCreds is the transport for unix-socket / plain-TCP endpoints (and the
+// inner h2c of a gateway tunnel, whose outer TLS the dialer establishes).
+func insecureCreds() []grpc.DialOption {
+	return []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 }
 
 // localEndpoint is the per-user unix socket; auto-spawnable.
 type localEndpoint struct{ socket string }
 
-func (e localEndpoint) Target() string { return "unix://" + e.socket }
-func (e localEndpoint) IsLocal() bool  { return true }
-func (e localEndpoint) String() string { return "unix:" + e.socket }
+func (e localEndpoint) Target() string                  { return "unix://" + e.socket }
+func (e localEndpoint) IsLocal() bool                   { return true }
+func (e localEndpoint) String() string                  { return "unix:" + e.socket }
+func (e localEndpoint) DialOptions() []grpc.DialOption  { return insecureCreds() }
 
-// remoteEndpoint is a future TCP target (e.g. a remote TUI). Not auto-spawnable.
+// remoteEndpoint is a plain TCP target (e.g. a remote TUI). Not auto-spawnable.
 type remoteEndpoint struct{ addr string }
 
-func (e remoteEndpoint) Target() string { return "dns:///" + e.addr }
-func (e remoteEndpoint) IsLocal() bool  { return false }
-func (e remoteEndpoint) String() string { return e.addr }
+func (e remoteEndpoint) Target() string                 { return "dns:///" + e.addr }
+func (e remoteEndpoint) IsLocal() bool                  { return false }
+func (e remoteEndpoint) String() string                 { return e.addr }
+func (e remoteEndpoint) DialOptions() []grpc.DialOption { return insecureCreds() }
 
-// selectEndpoint picks the transport. FLEET_SERVER=host:port forces a remote
-// endpoint (no auto-spawn, version mismatch is a hard error); otherwise the
-// local auto-spawned unix socket.
+// selectEndpoint picks the transport, in precedence order:
+//   - FLEET_GATEWAY=https://gw/grpc/<id> → through a fleet gateway (the bearer
+//     token from FLEET_TOKEN, or ~/.fleet/mcp.token for a same-host user).
+//   - FLEET_SERVER=host:port → a plain remote TCP target.
+//   - otherwise → the local auto-spawned unix socket.
+//
+// Remote endpoints (gateway/server) are not auto-spawned and a version mismatch
+// is a hard error.
 func selectEndpoint() Endpoint {
+	if gw := os.Getenv("FLEET_GATEWAY"); gw != "" {
+		return gatewayEndpoint{rawURL: gw, token: gatewayToken()}
+	}
 	if addr := os.Getenv("FLEET_SERVER"); addr != "" {
 		return remoteEndpoint{addr: addr}
 	}
 	return localEndpoint{socket: fleetpaths.SocketPath()}
+}
+
+// gatewayToken resolves the bearer token for a gateway endpoint: FLEET_TOKEN, or
+// the on-disk MCP token (so a user on the same host as their daemon need only
+// supply the URL).
+func gatewayToken() string {
+	if t := os.Getenv("FLEET_TOKEN"); t != "" {
+		return strings.TrimSpace(t)
+	}
+	if data, err := os.ReadFile(fleetpaths.McpTokenPath()); err == nil {
+		return strings.TrimSpace(string(data))
+	}
+	return ""
 }

--- a/internal/fleetclient/grpc_gateway.go
+++ b/internal/fleetclient/grpc_gateway.go
@@ -1,0 +1,132 @@
+package fleetclient
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	"google.golang.org/grpc"
+)
+
+// grpc_gateway.go dials the daemon's gRPC server THROUGH a fleet gateway, so a
+// remote `fleet` client can drive a daemon it cannot reach directly. The gateway
+// exposes a hijack+splice endpoint at https://<gw>/grpc/<id>; the dialer TLS-dials
+// the gateway, performs the CONNECT-style handshake, and hands gRPC the resulting
+// raw conn to run native HTTP/2 over. Every RPC carries the MCP bearer token as
+// metadata, which the daemon validates.
+//
+// This stays inside the fleetclient import boundary (stdlib + grpc only).
+
+// gatewayEndpoint reaches the daemon through a fleet gateway. rawURL is the public
+// gRPC URL the gateway minted (FLEET_GATEWAY); token is the MCP bearer token.
+type gatewayEndpoint struct {
+	rawURL string
+	token  string
+}
+
+// Target is a dummy: the real address lives in the CONNECT dialer, but gRPC
+// requires a non-empty target.
+func (e gatewayEndpoint) Target() string { return "passthrough:///fleet-gateway" }
+
+// IsLocal is false — no auto-spawn / version-restart for a remote daemon.
+func (e gatewayEndpoint) IsLocal() bool { return false }
+
+// String is the gateway URL (which carries no secret).
+func (e gatewayEndpoint) String() string { return e.rawURL }
+
+// DialOptions wires the CONNECT dialer + the per-RPC bearer token. The inner
+// transport is insecure because TLS terminates at the gateway (the dialer
+// established it); the gRPC connection then runs h2c over the tunneled conn.
+func (e gatewayEndpoint) DialOptions() []grpc.DialOption {
+	return append(insecureCreds(),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return dialGatewayConn(ctx, e.rawURL)
+		}),
+		grpc.WithPerRPCCredentials(bearerPerRPC{token: e.token}),
+	)
+}
+
+// dialGatewayConn TLS-dials the gateway and performs the /grpc/<id> handshake: it
+// sends a plain request to the path and expects "200 Connection Established",
+// after which the connection is a transparent byte pipe to the daemon's gRPC
+// server. The returned conn preserves any bytes the handshake reader buffered.
+func dialGatewayConn(ctx context.Context, rawURL string) (net.Conn, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse FLEET_GATEWAY: %w", err)
+	}
+	if u.Scheme != "https" {
+		return nil, fmt.Errorf("FLEET_GATEWAY must be https, got %q", u.Scheme)
+	}
+	host := u.Host
+	if u.Port() == "" {
+		host = net.JoinHostPort(u.Hostname(), "443")
+	}
+	if u.Path == "" || u.Path == "/" {
+		return nil, fmt.Errorf("FLEET_GATEWAY must include the /grpc/<id> path")
+	}
+
+	d := &tls.Dialer{Config: &tls.Config{ServerName: u.Hostname(), MinVersion: tls.VersionTLS12}}
+	conn, err := d.DialContext(ctx, "tcp", host)
+	if err != nil {
+		return nil, fmt.Errorf("dial gateway %s: %w", host, err)
+	}
+	if c, err := gatewayHandshake(conn, host, u.Path); err != nil {
+		_ = conn.Close()
+		return nil, err
+	} else {
+		return c, nil
+	}
+}
+
+// gatewayHandshake sends the tunnel request and reads the 200 response, returning
+// a conn that yields any post-header buffered bytes before the live stream.
+func gatewayHandshake(conn net.Conn, host, path string) (net.Conn, error) {
+	if _, err := fmt.Fprintf(conn, "GET %s HTTP/1.1\r\nHost: %s\r\n\r\n", path, host); err != nil {
+		return nil, fmt.Errorf("gateway handshake write: %w", err)
+	}
+	br := bufio.NewReader(conn)
+	status, err := br.ReadString('\n')
+	if err != nil {
+		return nil, fmt.Errorf("gateway handshake read: %w", err)
+	}
+	if !strings.Contains(status, " 200 ") {
+		return nil, fmt.Errorf("gateway did not establish the tunnel (%s) — is the gateway up to date and the session live?", strings.TrimSpace(status))
+	}
+	for { // consume to the end of the response headers
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return nil, fmt.Errorf("gateway handshake headers: %w", err)
+		}
+		if line == "\r\n" || line == "\n" {
+			break
+		}
+	}
+	// Reads go through br (draining any buffered bytes first); writes go straight
+	// to the conn.
+	return bufConn{Conn: conn, r: br}, nil
+}
+
+// bufConn is a net.Conn whose Read drains a bufio.Reader (so handshake-buffered
+// bytes are not lost) before reading the underlying conn.
+type bufConn struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+func (c bufConn) Read(p []byte) (int, error) { return c.r.Read(p) }
+
+// bearerPerRPC attaches `authorization: Bearer <token>` to every RPC.
+type bearerPerRPC struct{ token string }
+
+func (b bearerPerRPC) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	return map[string]string{"authorization": "Bearer " + b.token}, nil
+}
+
+// RequireTransportSecurity is false: TLS terminates at the gateway, so the inner
+// gRPC transport is "insecure" from gRPC's point of view.
+func (b bearerPerRPC) RequireTransportSecurity() bool { return false }

--- a/internal/fleetclient/grpc_gateway_test.go
+++ b/internal/fleetclient/grpc_gateway_test.go
@@ -1,0 +1,122 @@
+package fleetclient
+
+import (
+	"context"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubGateway accepts one connection, consumes the HTTP request headers, replies
+// with statusLine + CRLFCRLF, then (if echo) echoes subsequent bytes.
+func stubGateway(t *testing.T, statusLine string, echo bool) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		buf := make([]byte, 1024)
+		// Read until end of headers.
+		got := ""
+		for !strings.Contains(got, "\r\n\r\n") {
+			n, err := c.Read(buf)
+			if err != nil {
+				return
+			}
+			got += string(buf[:n])
+		}
+		_, _ = io.WriteString(c, statusLine+"\r\n\r\n")
+		if echo {
+			_, _ = io.Copy(c, c)
+		}
+	}()
+	t.Cleanup(func() { _ = ln.Close() })
+	return ln
+}
+
+func TestGatewayHandshakeRoundTrip(t *testing.T) {
+	ln := stubGateway(t, "HTTP/1.1 200 Connection Established", true)
+	raw, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer raw.Close()
+
+	conn, err := gatewayHandshake(raw, "gw", "/grpc/abc")
+	if err != nil {
+		t.Fatalf("handshake: %v", err)
+	}
+	if _, err := io.WriteString(conn, "hello-tunnel"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make([]byte, len("hello-tunnel"))
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	if string(got) != "hello-tunnel" {
+		t.Fatalf("echo = %q, want hello-tunnel", got)
+	}
+}
+
+func TestGatewayHandshakeNon200(t *testing.T) {
+	ln := stubGateway(t, "HTTP/1.1 404 Not Found", false)
+	raw, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer raw.Close()
+	if _, err := gatewayHandshake(raw, "gw", "/grpc/abc"); err == nil {
+		t.Fatal("non-200 handshake should error")
+	}
+}
+
+func TestDialGatewayConnBadURL(t *testing.T) {
+	ctx := context.Background()
+	for _, u := range []string{
+		"http://gw/grpc/x", // must be https
+		"https://gw",       // missing /grpc/<id> path
+		"https://gw/",      // empty path
+		"://nope",          // unparseable
+	} {
+		if _, err := dialGatewayConn(ctx, u); err == nil {
+			t.Fatalf("dialGatewayConn(%q) should error", u)
+		}
+	}
+}
+
+func TestSelectEndpointGatewayPrecedence(t *testing.T) {
+	t.Setenv("FLEET_GATEWAY", "https://gw.example.com/grpc/abc123")
+	t.Setenv("FLEET_SERVER", "1.2.3.4:9000") // gateway must win
+	t.Setenv("FLEET_TOKEN", "tok")
+
+	ep := selectEndpoint()
+	ge, ok := ep.(gatewayEndpoint)
+	if !ok {
+		t.Fatalf("FLEET_GATEWAY should select a gatewayEndpoint, got %T", ep)
+	}
+	if ep.IsLocal() {
+		t.Fatal("gateway endpoint must not be local (no auto-spawn)")
+	}
+	if ge.token != "tok" {
+		t.Fatalf("token = %q, want tok", ge.token)
+	}
+	if !strings.Contains(ep.String(), "gw.example.com") || strings.Contains(ep.String(), "tok") {
+		t.Fatalf("String() should show the URL without the token: %q", ep.String())
+	}
+}
+
+func TestGatewayTokenFromEnv(t *testing.T) {
+	t.Setenv("FLEET_TOKEN", "  env-token  ")
+	if got := gatewayToken(); got != "env-token" {
+		t.Fatalf("gatewayToken() = %q, want trimmed env-token", got)
+	}
+}

--- a/internal/fleetclient/spawn.go
+++ b/internal/fleetclient/spawn.go
@@ -13,7 +13,6 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetpaths"
 	"github.com/BenjaminBenetti/fleet-man/internal/version"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 // ensureServerLocal makes sure a local fleet server is reachable, spawning one
@@ -91,7 +90,7 @@ func waitReady(ctx context.Context, ep Endpoint, within time.Duration) error {
 func pingOK(ep Endpoint) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	conn, err := grpc.NewClient(ep.Target(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(ep.Target(), ep.DialOptions()...)
 	if err != nil {
 		return false
 	}

--- a/internal/gateway/control.go
+++ b/internal/gateway/control.go
@@ -39,6 +39,11 @@ func (s *Server) serveControl(ctx context.Context, ln net.Listener, sem chan str
 	}
 }
 
+// gatewayFeatures lists the optional tunnel features this gateway supports and
+// offers in the register handshake. fleetd advertises what IT supports; the
+// negotiated set is the intersection.
+var gatewayFeatures = []string{tunnel.FeatureGRPC}
+
 // handleControl performs the register handshake on conn, attaches the resulting
 // yamux session to the registry, and keeps the connection alive until the tunnel
 // closes (fleetd gone) or the gateway shuts down.
@@ -62,6 +67,13 @@ func (s *Server) handleControl(ctx context.Context, conn net.Conn) {
 		_ = conn.Close()
 		return
 	}
+
+	// Negotiate optional tunnel features (gRPC). Only features BOTH ends support
+	// become active; an old fleetd (no Features) negotiates none — the tunnel stays
+	// MCP-only and untagged, preserving the existing wire.
+	reply.Features = tunnel.Negotiate(req.Features, gatewayFeatures)
+	sess.grpc.Store(tunnel.HasFeature(reply.Features, tunnel.FeatureGRPC))
+
 	// On any failure before bind, free a freshly-reserved slot so it doesn't count
 	// against the cap (a no-op for a reclaimed, already-bound session).
 	if err := tunnel.WriteFrame(conn, reply); err != nil {

--- a/internal/gateway/grpc_route_test.go
+++ b/internal/gateway/grpc_route_test.go
@@ -1,0 +1,208 @@
+package gateway
+
+import (
+	"bufio"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/tunnel"
+)
+
+// testChanListener is a tiny in-memory net.Listener used by the simulated fleetd
+// to feed demuxed MCP streams to an http.Server.
+type testChanListener struct {
+	conns chan net.Conn
+	done  chan struct{}
+	once  sync.Once
+}
+
+func newTestChanListener() *testChanListener {
+	return &testChanListener{conns: make(chan net.Conn), done: make(chan struct{})}
+}
+func (l *testChanListener) push(c net.Conn) {
+	select {
+	case l.conns <- c:
+	case <-l.done:
+		_ = c.Close()
+	}
+}
+func (l *testChanListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.conns:
+		return c, nil
+	case <-l.done:
+		return nil, net.ErrClosed
+	}
+}
+func (l *testChanListener) Close() error   { l.once.Do(func() { close(l.done) }); return nil }
+func (l *testChanListener) Addr() net.Addr { return testAddr{} }
+
+type testAddr struct{}
+
+func (testAddr) Network() string { return "test" }
+func (testAddr) String() string  { return "test" }
+
+// dialFleetdGRPC simulates a fleet daemon that NEGOTIATES gRPC and demuxes tagged
+// streams: TagMCP streams are served by an HTTP echo handler, TagGRPC streams are
+// raw byte-echoed (standing in for the native gRPC server). Returns the reply.
+func dialFleetdGRPC(t *testing.T, controlAddr string, pool *x509.CertPool) tunnel.RegisterReply {
+	t.Helper()
+	conn, err := tls.Dial("tcp", controlAddr, &tls.Config{RootCAs: pool, ServerName: "127.0.0.1"})
+	if err != nil {
+		t.Fatalf("dial control: %v", err)
+	}
+	if err := tunnel.WriteFrame(conn, tunnel.RegisterRequest{Features: []string{tunnel.FeatureGRPC}}); err != nil {
+		t.Fatalf("write register: %v", err)
+	}
+	var reply tunnel.RegisterReply
+	if err := tunnel.ReadFrame(conn, &reply); err != nil {
+		t.Fatalf("read reply: %v", err)
+	}
+	if reply.Error != "" {
+		t.Fatalf("gateway refused: %s", reply.Error)
+	}
+	sess, err := tunnel.ClientSession(conn, io.Discard)
+	if err != nil {
+		t.Fatalf("client session: %v", err)
+	}
+
+	mcpLis := newTestChanListener()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/echo", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, r.Header.Get("Authorization"))
+	})
+	mcpSrv := &http.Server{Handler: mux}
+	go func() { _ = mcpSrv.Serve(mcpLis) }()
+
+	go func() {
+		for {
+			stream, err := sess.Accept()
+			if err != nil {
+				return
+			}
+			go func(stream net.Conn) {
+				tag, err := tunnel.ReadTag(stream)
+				if err != nil {
+					_ = stream.Close()
+					return
+				}
+				switch tag {
+				case tunnel.TagMCP:
+					mcpLis.push(stream)
+				case tunnel.TagGRPC:
+					_, _ = io.Copy(stream, stream) // raw echo (stand-in for gRPC)
+				default:
+					_ = stream.Close()
+				}
+			}(stream)
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = mcpSrv.Close()
+		_ = mcpLis.Close()
+		_ = sess.Close()
+		_ = conn.Close()
+	})
+	return reply
+}
+
+// TestGatewayGRPCRoute drives the new /grpc route end to end (on the gateway
+// side): negotiation, the hijack+200 handshake, a raw round-trip through the
+// splice, AND that MCP still works on the same negotiated (tagged) session.
+func TestGatewayGRPCRoute(t *testing.T) {
+	cert, pool := genTestTLS(t)
+	s, controlAddr, publicAddr := startTestGateway(t, cert, "https://gw.example.com")
+
+	reply := dialFleetdGRPC(t, controlAddr, pool)
+	if !tunnel.HasFeature(reply.Features, tunnel.FeatureGRPC) {
+		t.Fatalf("gateway did not negotiate grpc: features=%v", reply.Features)
+	}
+	id := publicIDOf(t, reply.PublicURL)
+	waitRegistered(t, s, id)
+
+	// gRPC route: hijack handshake, then a raw byte round-trip through the splice.
+	raw, err := tls.Dial("tcp", publicAddr, &tls.Config{RootCAs: pool, ServerName: "127.0.0.1"})
+	if err != nil {
+		t.Fatalf("dial public: %v", err)
+	}
+	defer raw.Close()
+	if _, err := fmt.Fprintf(raw, "GET /grpc/%s HTTP/1.1\r\nHost: gw\r\n\r\n", id); err != nil {
+		t.Fatalf("write grpc handshake: %v", err)
+	}
+	br := bufio.NewReader(raw)
+	status, err := br.ReadString('\n')
+	if err != nil || !strings.Contains(status, "200") {
+		t.Fatalf("grpc handshake status = %q err=%v, want 200", status, err)
+	}
+	for { // consume to end of headers (the blank line)
+		line, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read headers: %v", err)
+		}
+		if line == "\r\n" || line == "\n" {
+			break
+		}
+	}
+	if _, err := io.WriteString(raw, "ping-grpc"); err != nil {
+		t.Fatalf("write through splice: %v", err)
+	}
+	got := make([]byte, len("ping-grpc"))
+	if _, err := io.ReadFull(br, got); err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	if string(got) != "ping-grpc" {
+		t.Fatalf("grpc splice echo = %q, want ping-grpc", got)
+	}
+
+	// MCP still works on the SAME negotiated session (gateway writes TagMCP).
+	client := httpsClient(pool)
+	if body := getBody(t, client, "https://"+publicAddr+"/mcp/"+id+"/echo", "Bearer mcp-on-grpc"); body != "Bearer mcp-on-grpc" {
+		t.Fatalf("mcp on negotiated session = %q", body)
+	}
+}
+
+// TestGatewayGRPCNotNegotiated confirms /grpc 404s when the session is a legacy
+// (MCP-only) fleetd that did not negotiate the feature.
+func TestGatewayGRPCNotNegotiated(t *testing.T) {
+	cert, pool := genTestTLS(t)
+	s, controlAddr, publicAddr := startTestGateway(t, cert, "https://gw.example.com")
+
+	reply := dialFleetd(t, controlAddr, pool, "") // sends no Features
+	if len(reply.Features) != 0 {
+		t.Fatalf("legacy fleetd should negotiate no features, got %v", reply.Features)
+	}
+	id := publicIDOf(t, reply.PublicURL)
+	waitRegistered(t, s, id)
+
+	client := httpsClient(pool)
+	resp, err := client.Get("https://" + publicAddr + "/grpc/" + id)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("/grpc on a non-negotiated session -> %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestGatewayGRPCUnknownSession404(t *testing.T) {
+	cert, pool := genTestTLS(t)
+	_, _, publicAddr := startTestGateway(t, cert, "https://gw.example.com")
+	client := httpsClient(pool)
+	resp, err := client.Get("https://" + publicAddr + "/grpc/" + strings.Repeat("b", 64))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("/grpc unknown -> %d, want 404", resp.StatusCode)
+	}
+}

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -6,13 +6,17 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/tunnel"
 )
 
 // proxy.go serves the public HTTPS endpoint. Agents connect to
 // https://<host>/mcp/<publicID>[/...]; each request is reverse-proxied down the
-// matching tunnel to fleetd's loopback MCP server. The gateway is a transparent
-// pipe — it forwards the Authorization header (the MCP bearer token) untouched,
-// so the loopback server's auth stays the real boundary.
+// matching tunnel to fleetd's loopback MCP server. When the session negotiated
+// FeatureGRPC, /grpc/<publicID> is also served: that one HIJACKS the connection
+// and raw-splices native gRPC down the tunnel. The gateway is a transparent pipe
+// — it forwards the Authorization header (the bearer token) untouched, so the
+// daemon's auth stays the real boundary.
 
 // publicHandler builds the router for the public listener.
 func (s *Server) publicHandler() http.Handler {
@@ -22,6 +26,9 @@ func (s *Server) publicHandler() http.Handler {
 	// so the exact form is the common case; the subpath form is for completeness.
 	mux.HandleFunc("/mcp/{id}", s.handleMCP)
 	mux.HandleFunc("/mcp/{id}/{rest...}", s.handleMCP)
+	// gRPC tunnel: a hijack+splice endpoint (only live when the session negotiated
+	// FeatureGRPC). The remote client opens it once and runs native gRPC over it.
+	mux.HandleFunc("/grpc/{id}", s.handleGRPC)
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, "ok\n")
@@ -55,7 +62,7 @@ func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
 			// One fresh yamux stream per request; no pooling of tunnel streams.
 			DisableKeepAlives: true,
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return sess.open()
+				return sess.open(tunnel.TagMCP)
 			},
 		},
 		// Flush each write immediately so SSE (text/event-stream) responses stream
@@ -67,4 +74,47 @@ func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 	rp.ServeHTTP(w, r)
+}
+
+// handleGRPC tunnels a native gRPC connection to fleetd. The remote fleet client
+// sends a plain request to /grpc/<id>; the gateway HIJACKS the connection, opens a
+// fresh (TagGRPC) yamux stream, replies "200 Connection Established", and then
+// just splices raw bytes both ways. Because it never parses the payload, native
+// HTTP/2 — multiple RPCs, server-streaming, and bidi — all ride transparently;
+// the bearer token is checked by fleetd's gRPC interceptor (in-band metadata),
+// not here.
+func (s *Server) handleGRPC(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	sess := s.reg.lookup(id)
+	if sess == nil || !sess.grpc.Load() {
+		http.Error(w, "unknown session or gRPC not available", http.StatusNotFound)
+		return
+	}
+
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "gRPC tunnel unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	// Open the tunnel stream BEFORE hijacking, so a tunnel failure can still be
+	// reported as a normal HTTP error.
+	stream, err := sess.open(tunnel.TagGRPC)
+	if err != nil {
+		http.Error(w, "tunnel unavailable", http.StatusBadGateway)
+		return
+	}
+
+	clientConn, _, err := hj.Hijack()
+	if err != nil {
+		_ = stream.Close()
+		return
+	}
+	// From here we own clientConn; no more http.ResponseWriter use.
+	if _, err := io.WriteString(clientConn, "HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
+		_ = clientConn.Close()
+		_ = stream.Close()
+		return
+	}
+	splice(clientConn, stream)
 }

--- a/internal/gateway/session.go
+++ b/internal/gateway/session.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/BenjaminBenetti/fleet-man/internal/tunnel"
 	"github.com/hashicorp/yamux"
 )
 
@@ -30,6 +32,13 @@ type session struct {
 	// createdAt is when the session slot was reserved (at claim). Used by the
 	// reaper to evict a reservation whose handshake never completed (never bound).
 	createdAt time.Time
+
+	// grpc reports whether THIS connection negotiated FeatureGRPC. When set, the
+	// gateway tags every stream it opens (TagMCP / TagGRPC) and serves the
+	// /grpc/<id> route; when clear (legacy fleetd), streams are untagged and only
+	// MCP is served. Atomic because it is set on the control goroutine and read on
+	// public-request goroutines, and re-set on reconnect.
+	grpc atomic.Bool
 
 	mu sync.Mutex
 	ym *yamux.Session // current live tunnel; nil until bind; replaced on reconnect
@@ -83,12 +92,25 @@ func (s *session) reapable(now time.Time, ttl time.Duration) bool {
 // open dials a fresh multiplexed stream to fleetd over the live tunnel. Each
 // inbound public request gets its own stream, so SSE and concurrent requests
 // never interleave.
-func (s *session) open() (net.Conn, error) {
+func (s *session) open(tag byte) (net.Conn, error) {
 	s.mu.Lock()
 	ym := s.ym
 	s.mu.Unlock()
 	if ym == nil {
 		return nil, errNoTunnel
 	}
-	return ym.Open()
+	conn, err := ym.Open()
+	if err != nil {
+		return nil, err
+	}
+	// When this connection negotiated gRPC, fleetd demuxes streams by a leading
+	// tag byte, so the gateway must write it as the first bytes of every stream.
+	// Legacy (un-negotiated) sessions get untagged streams (the old MCP wire).
+	if s.grpc.Load() {
+		if err := tunnel.WriteTag(conn, tag); err != nil {
+			_ = conn.Close()
+			return nil, err
+		}
+	}
+	return conn, nil
 }

--- a/internal/gateway/splice.go
+++ b/internal/gateway/splice.go
@@ -1,0 +1,37 @@
+package gateway
+
+import (
+	"io"
+	"net"
+	"sync"
+)
+
+// splice connects two conns, copying bytes in both directions until either side
+// ends, then closing both. It is byte-transparent: it never parses the payload,
+// which is exactly why it can carry native HTTP/2 (gRPC) — including bidi and
+// server-streaming — unmodified. gRPC half-close, flow control, and trailers are
+// in-band h2 frames the splice forwards verbatim; teardown happens only when one
+// io.Copy returns, i.e. the whole connection closed (GOAWAY / peer done), never
+// per-RPC.
+func splice(a, b net.Conn) {
+	var once sync.Once
+	closeBoth := func() {
+		once.Do(func() {
+			_ = a.Close()
+			_ = b.Close()
+		})
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(a, b)
+		closeBoth()
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(b, a)
+		closeBoth()
+	}()
+	wg.Wait()
+}

--- a/internal/server/grpc_remote_e2e_test.go
+++ b/internal/server/grpc_remote_e2e_test.go
@@ -1,0 +1,287 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetpaths"
+	"github.com/BenjaminBenetti/fleet-man/internal/gateway"
+	"github.com/BenjaminBenetti/fleet-man/internal/server/remote"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+// grpc_remote_e2e_test.go is the full-stack validation for tunneling gRPC through
+// the gateway: a REAL fleetd gRPC server (token-gated) is exposed through a REAL
+// gateway by a REAL remote.Manager tunnel, and driven by a REAL gRPC client that
+// connects via the gateway's /grpc/<id> hijack endpoint. It exercises unary,
+// server-streaming, and a BIDI round-trip — the last proves native HTTP/2 (incl.
+// interleaved send/recv) survives the raw splice, the key transport guarantee.
+
+// --- a bidi echo service (uses real proto messages, so the default codec works) ---
+
+const echoMethod = "/fleet.test.Echo/Bidi"
+
+var echoDesc = grpc.ServiceDesc{
+	ServiceName: "fleet.test.Echo",
+	HandlerType: (*any)(nil),
+	Streams: []grpc.StreamDesc{{
+		StreamName:    "Bidi",
+		ServerStreams: true,
+		ClientStreams: true,
+		Handler: func(_ any, stream grpc.ServerStream) error {
+			for {
+				var in fleetgrpc.HelloRequest
+				if err := stream.RecvMsg(&in); err != nil {
+					if err == io.EOF {
+						return nil
+					}
+					return err
+				}
+				if err := stream.SendMsg(&fleetgrpc.HelloReply{ServerVersion: in.GetClientVersion()}); err != nil {
+					return err
+				}
+			}
+		},
+	}},
+}
+
+// readerConn reads through a bufio.Reader (so handshake-buffered bytes aren't
+// lost) but writes straight to the conn.
+type readerConn struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+func (c readerConn) Read(p []byte) (int, error) { return c.r.Read(p) }
+
+// testBearer attaches the token like the production gateway dialer's creds.
+type testBearer struct{ token string }
+
+func (b testBearer) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	return map[string]string{"authorization": "Bearer " + b.token}, nil
+}
+func (b testBearer) RequireTransportSecurity() bool { return false }
+
+// grpcStack stands up the full real stack and returns a function that dials a
+// fresh gRPC ClientConn through the gateway (optionally with the token), plus the
+// token.
+func grpcStack(t *testing.T) (dial func(withToken bool) *grpc.ClientConn, token string) {
+	t.Helper()
+	isolateFleetDir(t)
+	if err := mkFleetDir(); err != nil {
+		t.Fatalf("mkdir fleet dir: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	svc := newService()
+	go svc.hub.run(ctx)
+
+	mcpHTTP, mcpPort := startMCPServer(svc)
+	if mcpHTTP == nil {
+		t.Fatal("MCP server failed to start")
+	}
+	t.Cleanup(func() { _ = mcpHTTP.Close() })
+	var err error
+	token, err = loadOrCreateMCPToken()
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+
+	// Tunnel-facing gRPC server (FleetService + echo), token-gated, fed by the demux.
+	grpcLis := remote.NewChanListener()
+	authUnary, authStream := bearerAuthInterceptors(token)
+	tunnelGRPC := grpc.NewServer(grpc.ChainUnaryInterceptor(authUnary), grpc.ChainStreamInterceptor(authStream))
+	fleetgrpc.RegisterFleetServiceServer(tunnelGRPC, svc)
+	tunnelGRPC.RegisterService(&echoDesc, nil)
+	go func() { _ = tunnelGRPC.Serve(grpcLis) }()
+	t.Cleanup(tunnelGRPC.Stop)
+
+	// Real gateway on ephemeral TLS listeners.
+	pool, certPath, keyPath := genTestTLSFiles(t)
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		t.Fatalf("load keypair: %v", err)
+	}
+	serverTLS := &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}
+	controlLn, err := tls.Listen("tcp", "127.0.0.1:0", serverTLS)
+	if err != nil {
+		t.Fatalf("control listen: %v", err)
+	}
+	t.Cleanup(func() { _ = controlLn.Close() })
+	publicLn, err := tls.Listen("tcp", "127.0.0.1:0", serverTLS)
+	if err != nil {
+		t.Fatalf("public listen: %v", err)
+	}
+	t.Cleanup(func() { _ = publicLn.Close() })
+	publicBase := "https://" + publicLn.Addr().String()
+
+	gw, err := gateway.New(gateway.Config{PublicURL: publicBase, TLSCert: certPath, TLSKey: keyPath})
+	if err != nil {
+		t.Fatalf("gateway.New: %v", err)
+	}
+	go func() { _ = gw.ServeListeners(ctx, controlLn, publicLn) }()
+
+	// Real manager with the gRPC listener wired.
+	statusCh := make(chan *fleetgrpc.RemoteMcpStatus, 64)
+	controlAddr := controlLn.Addr().String()
+	mgr := remote.NewManager(mcpPort, "e2e",
+		func(st *fleetgrpc.RemoteMcpStatus) { statusCh <- st },
+		remote.WithDialFunc(func(dctx context.Context, _ string) (net.Conn, error) {
+			return (&tls.Dialer{Config: &tls.Config{RootCAs: pool, ServerName: "127.0.0.1"}}).DialContext(dctx, "tcp", controlAddr)
+		}),
+		remote.WithGRPCListener(grpcLis),
+	)
+	go mgr.Run(ctx)
+	mgr.Reconcile(true, "https://gw.example.com")
+
+	// Wait for CONNECTED and derive the gRPC tunnel path from the MCP public URL.
+	var publicURL string
+	deadline := time.After(10 * time.Second)
+	for publicURL == "" {
+		select {
+		case st := <-statusCh:
+			if st.GetState() == fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED {
+				publicURL = st.GetPublicUrl()
+			}
+		case <-deadline:
+			t.Fatal("tunnel never connected")
+		}
+	}
+	u, _ := url.Parse(publicURL)
+	id := strings.TrimPrefix(u.Path, "/mcp/")
+	grpcPath := "/grpc/" + id
+	publicAddr := publicLn.Addr().String()
+
+	dial = func(withToken bool) *grpc.ClientConn {
+		opts := []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithContextDialer(func(dctx context.Context, _ string) (net.Conn, error) {
+				c, err := (&tls.Dialer{Config: &tls.Config{RootCAs: pool, ServerName: "127.0.0.1"}}).DialContext(dctx, "tcp", publicAddr)
+				if err != nil {
+					return nil, err
+				}
+				if _, err := fmt.Fprintf(c, "GET %s HTTP/1.1\r\nHost: gw\r\n\r\n", grpcPath); err != nil {
+					_ = c.Close()
+					return nil, err
+				}
+				br := bufio.NewReader(c)
+				st, err := br.ReadString('\n')
+				if err != nil || !strings.Contains(st, " 200 ") {
+					_ = c.Close()
+					return nil, fmt.Errorf("gateway handshake: %q err=%v", st, err)
+				}
+				for {
+					line, err := br.ReadString('\n')
+					if err != nil {
+						_ = c.Close()
+						return nil, err
+					}
+					if line == "\r\n" || line == "\n" {
+						break
+					}
+				}
+				return readerConn{Conn: c, r: br}, nil
+			}),
+		}
+		if withToken {
+			opts = append(opts, grpc.WithPerRPCCredentials(testBearer{token: token}))
+		}
+		conn, err := grpc.NewClient("passthrough:///fleet-gateway", opts...)
+		if err != nil {
+			t.Fatalf("grpc client: %v", err)
+		}
+		t.Cleanup(func() { _ = conn.Close() })
+		return conn
+	}
+	return dial, token
+}
+
+func TestRemoteGRPCEndToEnd(t *testing.T) {
+	dial, _ := grpcStack(t)
+	conn := dial(true)
+	client := fleetgrpc.NewFleetServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// --- Unary through the tunnel ---
+	hello, err := client.Hello(ctx, &fleetgrpc.HelloRequest{ClientVersion: "e2e"})
+	if err != nil {
+		t.Fatalf("Hello through gateway gRPC: %v", err)
+	}
+	if hello.GetPid() == 0 {
+		t.Fatal("Hello returned an empty reply")
+	}
+
+	// --- Server-streaming through the tunnel (Watch initial snapshot) ---
+	ws, err := client.Watch(ctx, &fleetgrpc.WatchRequest{IncludeInitialState: true})
+	if err != nil {
+		t.Fatalf("Watch open: %v", err)
+	}
+	ev, err := ws.Recv()
+	if err != nil {
+		t.Fatalf("Watch recv: %v", err)
+	}
+	if ev.GetStateChanged() == nil {
+		t.Fatalf("first Watch event is not StateChanged: %T", ev.GetKind())
+	}
+
+	// --- Bidi round-trip through the tunnel (interleaved send/recv) ---
+	stream, err := conn.NewStream(ctx, &grpc.StreamDesc{StreamName: "Bidi", ServerStreams: true, ClientStreams: true}, echoMethod)
+	if err != nil {
+		t.Fatalf("open bidi: %v", err)
+	}
+	for i := 0; i < 4; i++ {
+		msg := fmt.Sprintf("ping-%d", i)
+		if err := stream.SendMsg(&fleetgrpc.HelloRequest{ClientVersion: msg}); err != nil {
+			t.Fatalf("bidi send %d: %v", i, err)
+		}
+		// Read the echo BEFORE sending the next — the interleaving pattern that
+		// would deadlock a blocking splice.
+		var got fleetgrpc.HelloReply
+		if err := stream.RecvMsg(&got); err != nil {
+			t.Fatalf("bidi recv %d: %v", i, err)
+		}
+		if got.GetServerVersion() != msg {
+			t.Fatalf("bidi echo %d = %q, want %q", i, got.GetServerVersion(), msg)
+		}
+	}
+	if err := stream.CloseSend(); err != nil {
+		t.Fatalf("close send: %v", err)
+	}
+	var trailing fleetgrpc.HelloReply
+	if err := stream.RecvMsg(&trailing); err != io.EOF {
+		t.Fatalf("after CloseSend want io.EOF, got %v", err)
+	}
+}
+
+// TestRemoteGRPCRejectsNoToken confirms the daemon's interceptor rejects an
+// unauthenticated RPC even though it reached fleetd through the tunnel.
+func TestRemoteGRPCRejectsNoToken(t *testing.T) {
+	dial, _ := grpcStack(t)
+	client := fleetgrpc.NewFleetServiceClient(dial(false)) // no token creds
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := client.Hello(ctx, &fleetgrpc.HelloRequest{ClientVersion: "e2e"})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("Hello without token through the tunnel: want Unauthenticated, got %v", err)
+	}
+}
+
+// mkFleetDir ensures ~/.fleet exists (startMCPServer writes the token there).
+func mkFleetDir() error { _, err := fleetpaths.EnsureDir(); return err }


### PR DESCRIPTION
## What

The **second and final PR** of exposing the daemon's **gRPC server through the fleet gateway** for remote control. Builds on the merged fleetd half (#112). With this, a remote `fleet` client can drive a daemon it can't reach directly — and the full path is proven end to end.

`fleet client ──HTTPS+CONNECT──▶ gateway /grpc/<id> ──raw splice──▶ yamux tunnel ──▶ fleetd gRPC server`

## How it works

- **Gateway `/grpc/<id>`** (`proxy.go`, `splice.go`): HIJACKs the public HTTPS connection, opens a fresh `TagGRPC` yamux stream, replies `200 Connection Established`, then **raw-splices** bytes (two `io.Copy` goroutines, close-once). Because the splice never parses the payload, **native HTTP/2 — multiple RPCs, server-streaming, and bidi — ride transparently**.
- **Negotiation** (`control.go`, `session.go`): the gateway offers `FeatureGRPC`; `reply.Features` is the intersection with what fleetd advertised. Only a negotiated session gets tagged streams + a live `/grpc` route — a legacy MCP-only fleetd stays byte-identical and `/grpc` 404s for it.
- **Remote client** (`internal/fleetclient`): a `gatewayEndpoint` selected by `FLEET_GATEWAY`, with a `grpc.WithContextDialer` that TLS-dials the gateway, does the `/grpc/<id>` CONNECT handshake, and hands gRPC the raw conn for native h2c. The **MCP bearer token** (`FLEET_TOKEN`, or `~/.fleet/mcp.token` on the same host) is attached via per-RPC credentials. Precedence `FLEET_GATEWAY > FLEET_SERVER > local`; not auto-spawned. Stays within the strict `fleetclient` import boundary (stdlib + grpc only).

```bash
export FLEET_GATEWAY="https://gateway.example.com/grpc/<id>"
export FLEET_TOKEN="<token from ~/.fleet/mcp.token>"
fleet ls   # drives the REMOTE daemon
```

## Tests (pass under `-race`)

- **Gateway `/grpc` route:** hijack+splice round-trip, feature negotiation, and 404 when not negotiated / unknown id.
- **Client dialer:** the CONNECT handshake, non-200 handling, URL validation, and `FLEET_GATEWAY` precedence/token resolution.
- **Full real-stack E2E** (the headline): real gateway + real tunnel + real token-gated gRPC server + a **real gRPC client through the gateway dialer** — exercising **unary** (`Hello`), **server-streaming** (`Watch`), a **bidi interleaved round-trip** (proving the raw splice carries native h2 without deadlock), and **no-token → `Unauthenticated`**.

## Security & honest caveats (in the README)

- ⚠️ The bearer token now grants **full daemon control over the internet** — not just the read-mostly MCP tools. The gateway terminates TLS, so its operator sees the traffic (same trust model as remote MCP). Documented prominently.
- Like `/mcp`, `/grpc` splices before fleetd authenticates; the token check is fleetd's gRPC interceptor (the gateway holds no token). DoS is bounded by `MaxSessions` + `ReadHeaderTimeout`.
- **Remote interactive `exec` is not yet supported** — it currently runs the command on the *client's* host; remote shell awaits a server-side `Exec` handler. Every other RPC works remotely today.

## Reviewer notes

- The gateway stays an **isolated module** (imports only `internal/tunnel` + stdlib + yamux). The `fleetclient` import boundary is preserved (depguard passes). No new dependencies.
- An adversarial multi-agent review (splice/hijack lifecycle, the CONNECT dialer, negotiation/isolation/security) returned **no confirmed findings**.

Completes the remote-gRPC follow-on to #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
