### PR TITLE
ci(gateway): build & publish fleet-gateway image on release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Trim the build context for the gateway image (deploy/gateway/Dockerfile, built
+# from the repo root). Only cmd/ + internal/ + go.{mod,sum} are needed to build
+# the binary; everything below is dead weight or shouldn't enter the image build.
+.git
+dist
+_site
+web
+qa
+doc
+readme-image.png
+*.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ permissions:
   contents: write
   pages: write
   id-token: write
+  # Push the fleet-gateway image to the GitHub Container Registry.
+  packages: write
 
 concurrency:
   group: pages
@@ -140,3 +142,69 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  # Build and publish the fleet-gateway image to ghcr alongside the release, so
+  # tagging a new version also ships a matching gateway image. The gateway is the
+  # same `fleet` binary run as `fleet gateway` (see deploy/gateway/Dockerfile).
+  # Independent of the `release` job — it has no `needs`, so a slow/failed binary
+  # release doesn't block the image and vice-versa.
+  gateway-image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      # Keep the image's Go in lockstep with the repo, exactly as qa-image.yml does.
+      - name: Resolve Go version from go.mod
+        id: go
+        run: echo "version=$(awk '/^go /{print $2; exit}' go.mod)" >> "$GITHUB_OUTPUT"
+
+      # ghcr image names must be lowercase; the owner (BenjaminBenetti) is not.
+      - name: Compute image name
+        id: img
+        run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}/gateway" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.img.outputs.name }}
+          # SemVer tags strip the leading "v". A pre-release (-beta) gets only the
+          # full version tag — metadata-action skips {{major}}.{{minor}} and the
+          # moving "latest" tag for pre-releases (latest=auto), so betas never
+          # become the default `:latest` pull, mirroring the release job.
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=short
+          flavor: |
+            latest=auto
+
+      - name: Build and push (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./deploy/gateway/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GO_VERSION=${{ steps.go.outputs.version }}
+            VERSION=${{ github.ref_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,13 @@ jobs:
   gateway-image:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # The workflow-level concurrency group is "pages" and conceptually about the
+    # Pages deploy; give the image publish its own per-ref group so it's never
+    # cancelled mid-push (a cancel between build and push leaves ghcr with an
+    # incomplete image). Same reasoning as qa-image.yml.
+    concurrency:
+      group: gateway-image-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,25 @@ fleet gateway \
 Both ports must be reachable; expose `--public-addr` to agents and `--control-addr`
 to your daemons. A `GET /healthz` on the public listener returns `ok`.
 
-<<<<<<< Updated upstream
+#### Run it with Docker
+
+Every tagged release also publishes a gateway image to the GitHub Container
+Registry, so you don't have to build the binary yourself. It's the same
+`fleet gateway`, with the flags passed as `docker run` arguments:
+
+```bash
+docker run -d --name fleet-gateway \
+  -p 443:443 -p 8443:8443 \
+  -v /etc/fleet/tls:/tls:ro \
+  ghcr.io/benjaminbenetti/fleet-man/gateway:latest \
+  --public-url https://gateway.example.com \
+  --tls-cert /tls/fullchain.pem \
+  --tls-key  /tls/privkey.pem
+```
+
+Image tags track releases: `:latest` (newest stable), `:X.Y.Z`, and `:X.Y`.
+Images are multi-arch (`linux/amd64` + `linux/arm64`).
+
 ### Security model
 
 - **No gateway authentication.** Anyone can open a tunnel; the gateway just routes
@@ -226,58 +244,6 @@ to your daemons. A `GET /healthz` on the public listener returns `ok`.
 - The id in the URL is *not* the reconnect credential: the daemon holds a separate
   secret (never placed in the URL), so a URL holder cannot hijack your tunnel.
 - All gateway traffic is TLS; the daemon verifies the gateway's certificate.
-=======
-### Remote control (gRPC)
-
-The same gateway tunnel can also carry the daemon's **gRPC** API, so a remote
-`fleet` client can drive your daemon directly — list/up/down, watch live status,
-stream logs, change config, and so on. It rides the **same tunnel and the same
-on/off toggle** as remote MCP (no separate setting); the gateway serves it at
-`https://<gateway>/grpc/<id>` (same id as the MCP URL, `/grpc` instead of `/mcp`).
-
-Point a `fleet` client at it with two env vars:
-
-```bash
-export FLEET_GATEWAY="https://gateway.example.com/grpc/<id>"
-export FLEET_TOKEN="<token from ~/.fleet/mcp.token>"   # omit on the same host as the daemon
-fleet ls          # …now talks to the REMOTE daemon
-```
-
-`FLEET_GATEWAY` takes precedence over `FLEET_SERVER` and the local socket; a remote
-endpoint is never auto-spawned.
-
-> **Note:** every gRPC call works remotely *except* interactive `fleet exec` (a
-> remote shell), which currently runs on the client's host — that awaits a
-> server-side handler.
-
-## Environment Variables
-
-Variables fleet **reads** (set them to configure behavior):
-
-| Variable | Values / format | What it does |
-|----------|-----------------|--------------|
-| `FLEET_GATEWAY` | `https://gw/grpc/<id>` | Drive a *remote* daemon through a fleet gateway (full gRPC control). Takes precedence over `FLEET_SERVER` and the local socket. See [Remote MCP](#remote-mcp). |
-| `FLEET_TOKEN` | bearer token | Token for `FLEET_GATEWAY`. Defaults to `~/.fleet/mcp.token` on the daemon's own host. |
-| `FLEET_SERVER` | `host:port` | Drive a remote daemon over plain TCP (no gateway). |
-| `FLEET_DEVCONTAINER_BUILDKIT` | `auto` (default), `never` | BuildKit mode for Fleet-managed devcontainers. See [Devcontainer BuildKit](#devcontainer-buildkit). |
-| `FLEET_DEVCONTAINER_UPDATE_REMOTE_USER_UID` | `default`, `never`, `on`, `off` | Remote-user UID/GID rewrite mode. See [Devcontainer UID Rewrite](#devcontainer-uid-rewrite). |
-| `CODER_URL` | URL | Coder deployment URL (Coder backend). |
-| `CODER_SESSION_TOKEN` | token | Coder API token (Coder backend). |
-| `CODER_CONFIG_DIR` | path | Override the Coder CLI config dir. |
-
-Variables fleet **exports** for MCP clients (written to `~/.fleet/mcp.env`, sourced from `~/.bashrc`):
-
-| Variable | What it does |
-|----------|--------------|
-| `FLEET_MCP_URL` | The loopback MCP endpoint, `http://127.0.0.1:<port>`. |
-| `FLEET_MCP_TOKEN` | The MCP bearer token. |
-| `FLEET_MCP_PORT` | The MCP server's port. |
-
-Fleet also **respects** standard environment when present: `HOME` (the `~/.fleet`
-location), `TMUX` (enables split-pane mode when run inside tmux), `SSH_AUTH_SOCK`
-(forwarded into instances for SSH/git), and `WSL_DISTRO_NAME` / `WSL_INTEROP` /
-`WAYLAND_DISPLAY` (platform detection for clipboard and browser integration).
->>>>>>> Stashed changes
 
 ### Remote control (gRPC)
 
@@ -310,6 +276,34 @@ error.
 > the gateway — it currently runs the command on the *client's* host. Every other
 > RPC works remotely today; remote interactive shell awaits a server-side `Exec`
 > handler.
+
+## Environment Variables
+
+Variables fleet **reads** (set them to configure behavior):
+
+| Variable | Values / format | What it does |
+|----------|-----------------|--------------|
+| `FLEET_GATEWAY` | `https://gw/grpc/<id>` | Drive a *remote* daemon through a fleet gateway (full gRPC control). Takes precedence over `FLEET_SERVER` and the local socket. See [Remote MCP](#remote-mcp). |
+| `FLEET_TOKEN` | bearer token | Token for `FLEET_GATEWAY`. Defaults to `~/.fleet/mcp.token` on the daemon's own host. |
+| `FLEET_SERVER` | `host:port` | Drive a remote daemon over plain TCP (no gateway). |
+| `FLEET_DEVCONTAINER_BUILDKIT` | `auto` (default), `never` | BuildKit mode for Fleet-managed devcontainers. See [Devcontainer BuildKit](#devcontainer-buildkit). |
+| `FLEET_DEVCONTAINER_UPDATE_REMOTE_USER_UID` | `default`, `never`, `on`, `off` | Remote-user UID/GID rewrite mode. See [Devcontainer UID Rewrite](#devcontainer-uid-rewrite). |
+| `CODER_URL` | URL | Coder deployment URL (Coder backend). |
+| `CODER_SESSION_TOKEN` | token | Coder API token (Coder backend). |
+| `CODER_CONFIG_DIR` | path | Override the Coder CLI config dir. |
+
+Variables fleet **exports** for MCP clients (written to `~/.fleet/mcp.env`, sourced from `~/.bashrc`):
+
+| Variable | What it does |
+|----------|--------------|
+| `FLEET_MCP_URL` | The loopback MCP endpoint, `http://127.0.0.1:<port>`. |
+| `FLEET_MCP_TOKEN` | The MCP bearer token. |
+| `FLEET_MCP_PORT` | The MCP server's port. |
+
+Fleet also **respects** standard environment when present: `HOME` (the `~/.fleet`
+location), `TMUX` (enables split-pane mode when run inside tmux), `SSH_AUTH_SOCK`
+(forwarded into instances for SSH/git), and `WSL_DISTRO_NAME` / `WSL_INTEROP`
+/ `WAYLAND_DISPLAY` (platform detection for clipboard and browser integration).
 
 ## Requirements
 

--- a/deploy/gateway/Dockerfile
+++ b/deploy/gateway/Dockerfile
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1
+
+# The fleet gateway image. The gateway is not a separate binary — it is the same
+# `fleet` binary run as `fleet gateway` (see internal/cli/gateway.go and
+# doc/gateway.md). This Dockerfile builds that binary and ships it in a minimal
+# distroless image whose entrypoint is the gateway, so operators can run a public
+# relay with a single `docker run`.
+#
+# Build context is the repository root (the build needs cmd/ + internal/ + go.mod).
+
+# Kept in lockstep with go.mod by the release workflow, which reads the version
+# from go.mod and passes it as a build-arg.
+ARG GO_VERSION=1.25.8
+
+# Build on the native BUILDPLATFORM and cross-compile to TARGETOS/TARGETARCH
+# (provided by buildx). A pure-Go static binary cross-compiles cleanly, so this
+# avoids slow QEMU emulation for the multi-arch build.
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS build
+WORKDIR /src
+
+# Resolve modules first so the dependency layer caches independently of source.
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+COPY . .
+
+# VERSION is the release tag, stamped into internal/version.Version exactly as the
+# release binaries are (see .github/workflows/release.yml).
+ARG VERSION=dev
+ARG TARGETOS
+ARG TARGETARCH
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build \
+      -ldflags "-s -w -X github.com/BenjaminBenetti/fleet-man/internal/version.Version=${VERSION}" \
+      -o /out/fleet ./cmd/fleet
+
+# distroless/static: just a static binary + CA roots (the daemon-facing TLS dial
+# and any outbound HTTPS need the system roots). The root (uid 0) variant is used
+# deliberately so the documented default ports — :443 (public) and :8443
+# (control) — bind out of the box; operators who don't need privileged ports can
+# pass --public-addr/--control-addr and drop the capability.
+FROM gcr.io/distroless/static-debian12:latest
+COPY --from=build /out/fleet /usr/local/bin/fleet
+
+# :443 public listener (HTTPS, MCP agents + remote `fleet`); :8443 control
+# listener (TLS, fleet daemons dial in). A GET /healthz on the public listener
+# returns "ok".
+EXPOSE 443 8443
+
+ENTRYPOINT ["/usr/local/bin/fleet", "gateway"]


### PR DESCRIPTION
## What

Tagging a release now also builds and publishes a **fleet-gateway** Docker image to the GitHub Container Registry, alongside the existing binary release.

The gateway isn't a separate binary — it's the same `fleet` binary run as `fleet gateway` (`internal/cli/gateway.go`, listening on `:443` public / `:8443` control, no `~/.fleet` state). So the image just ships that binary with `fleet gateway` as its entrypoint.

## Changes

- **`deploy/gateway/Dockerfile`** — multi-stage build: cross-compiles a static binary (`CGO_ENABLED=0`, `GOOS/GOARCH` from buildx, built on native `BUILDPLATFORM` to skip QEMU), stamps `internal/version.Version` from the tag exactly like the release binaries, ships on `distroless/static` (root variant so default ports `:443`/`:8443` bind out of the box), `EXPOSE 443 8443`, entrypoint `fleet gateway`.
- **`.dockerignore`** — trims the repo-root build context to what the binary build needs.
- **`.github/workflows/release.yml`** — adds `packages: write` and a `gateway-image` job (no `needs`, runs parallel to the binary release/pages jobs) that pushes multi-arch (`amd64`+`arm64`) to `ghcr.io/<repo>/gateway`. Tags via `docker/metadata-action` (`latest=auto`): stable → `X.Y.Z` / `X.Y` / `latest`; `-beta` → full version only (no `latest`), mirroring the binary release's beta handling. Go version read from `go.mod` like `qa-image.yml`.
- **`README.md`** — documents the published image under *Running a gateway*, and **resolves a stale committed git merge conflict** (the `<<<<<<< Updated upstream` / `Stashed changes` markers straddling the *Security model* / *Remote control (gRPC)* / *Environment Variables* sections). All info retained; the duplicate gRPC subsection was dropped in favor of the complete one, and *Environment Variables* moved to its proper top-level slot.

## Verification

- `CGO_ENABLED=0 go build ./cmd/fleet` succeeds and `fleet gateway --help` shows the expected flags.
- `release.yml` parses cleanly: jobs `[release, pages, gateway-image]`, `packages: write` present.
- No conflict markers remain in `README.md`; heading order is sane.

The multi-arch image build itself runs on the next tag (no push creds locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)