### PR TITLE
fix: unify tmux session naming between CLI and TUI

### DIFF
--- a/internal/admiralskill/SKILL.md
+++ b/internal/admiralskill/SKILL.md
@@ -88,6 +88,10 @@ fleet exec-in-session <instance> <session> "<command>"   # type a command + Ente
 fleet read-session <instance> <session> [--scrollback N] # capture the session's screen
 ```
 
+Session names are canonicalized to `<instance>~<name>` internally so the
+session appears as a regular session group in the fleet TUI — keep using the
+short name with these commands; they all resolve it the same way.
+
 `exec-in-session` sends keystrokes (it does not wait for completion), so to
 follow progress you read the session back. `read-session --scrollback N` returns
 the last N lines (`0` = just the visible screen, `-1` = full history). To put an

--- a/internal/cli/exec_in_session.go
+++ b/internal/cli/exec_in_session.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/BenjaminBenetti/fleet-man/internal/dotfiles"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +31,9 @@ Examples:
 				return err
 			}
 
-			sessionName := args[1]
+			// Same canonicalization as spawn-session, so the short name an
+			// agent created with still targets the right session.
+			sessionName := tui.ResolveSessionName(target.Instance, args[1])
 			command := strings.Join(args[2:], " ")
 
 			if instance.Status != fleet.StatusRunning {

--- a/internal/cli/read_session.go
+++ b/internal/cli/read_session.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/BenjaminBenetti/fleet-man/internal/dotfiles"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +35,9 @@ Examples:
 				return err
 			}
 
-			sessionName := args[1]
+			// Same canonicalization as spawn-session, so the short name an
+			// agent created with still targets the right session.
+			sessionName := tui.ResolveSessionName(target.Instance, args[1])
 
 			if instance.Status != fleet.StatusRunning {
 				return fmt.Errorf("instance %s is not running (status: %s)", args[0], instance.Status)

--- a/internal/cli/session_commands_test.go
+++ b/internal/cli/session_commands_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
+	"github.com/BenjaminBenetti/fleet-man/internal/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -413,4 +414,58 @@ func countLines(s, prefix string) int {
 		}
 	}
 	return n
+}
+
+// TestSpawnSession_TUISplitDoesNotDuplicateSession is the regression test
+// for the session-duplication bug: spawn-session used to create a
+// bare-named session ("main") that the TUI surfaced as a pseudo-group
+// whose ID is the session name. Pressing the split key then ran
+// `fleet shell <inst> --group main`, which minted "agent-1~main~<hex>" —
+// a *real* group named "main", duplicating the spawned session in the UI.
+//
+// fleet shell itself needs an interactive TTY plus a server to resolve
+// the exec argv, so this test replays its --group branch (the session
+// name mint, via the same tui helper shell.go calls) against the same
+// tmux server spawn-session wrote to, then asserts everything landed in
+// one group.
+func TestSpawnSession_TUISplitDoesNotDuplicateSession(t *testing.T) {
+	target := seedState(t, fleet.StatusRunning)
+	tmuxDir := useHostTmux(t)
+
+	// 1. An agent creates a session via the CLI.
+	if err := run(t, newSpawnSessionCmd(), target, "main"); err != nil {
+		t.Fatalf("spawn-session: %v", err)
+	}
+
+	// 2. The user attaches in the TUI and presses the split key: the
+	// rebound key runs `fleet shell agent-1 --group main`, which creates
+	// a new pane session named by NewGroupPaneSessionName.
+	sanitized := tui.SanitizeSessionName("agent-1")
+	paneSession := tui.NewGroupPaneSessionName(sanitized, "main")
+	if out, err := hostTmux(t, tmuxDir, "new-session", "-d", "-s", paneSession); err != nil {
+		t.Fatalf("create pane session: %v\n%s", err, out)
+	}
+
+	// 3. Both sessions must belong to the single group "main" of this
+	// instance. Pre-fix, the bare "main" session fails the prefix check
+	// and showed up as a second, duplicate group.
+	out, err := hostTmux(t, tmuxDir, "ls", "-F", "#{session_name}")
+	if err != nil {
+		t.Fatalf("tmux ls failed: %v\n%s", err, out)
+	}
+	var names []string
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		if line != "" {
+			names = append(names, line)
+		}
+	}
+	if len(names) != 2 {
+		t.Fatalf("expected exactly 2 sessions (group root + split pane), got %d:\n%s", len(names), out)
+	}
+	groupRoot := "agent-1~main"
+	for _, name := range names {
+		if !strings.HasPrefix(name, groupRoot) {
+			t.Fatalf("session %q does not belong to group %q — duplicate group regression:\n%s", name, groupRoot, out)
+		}
+	}
 }

--- a/internal/cli/session_commands_test.go
+++ b/internal/cli/session_commands_test.go
@@ -193,8 +193,29 @@ func TestSpawnSession_CreatesSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tmux ls failed: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "demo:") {
-		t.Fatalf("tmux ls did not list 'demo' session:\n%s", out)
+	// spawn-session canonicalizes names to the TUI group convention
+	// (<instance>~<name>) so the session shows up as a regular group.
+	if !strings.Contains(out, "agent-1~demo:") {
+		t.Fatalf("tmux ls did not list 'agent-1~demo' session:\n%s", out)
+	}
+}
+
+func TestSpawnSession_AcceptsCanonicalName(t *testing.T) {
+	target := seedState(t, fleet.StatusRunning)
+	tmuxDir := useHostTmux(t)
+
+	// A name that already follows the <instance>~<group> convention must
+	// pass through unchanged, not get double-prefixed.
+	if err := run(t, newSpawnSessionCmd(), target, "agent-1~demo"); err != nil {
+		t.Fatalf("spawn-session returned error: %v", err)
+	}
+
+	out, err := hostTmux(t, tmuxDir, "ls")
+	if err != nil {
+		t.Fatalf("tmux ls failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "agent-1~demo:") || strings.Contains(out, "agent-1~agent-1~") {
+		t.Fatalf("expected exactly 'agent-1~demo', got:\n%s", out)
 	}
 }
 

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"os/exec"
@@ -41,18 +39,16 @@ existing group, or --session to reconnect to a specific named session.`,
 			var sessionName string
 			switch {
 			case sessionFlag != "":
-				// Reconnect to a specific existing session.
-				sessionName = sessionFlag
+				// Reconnect to a specific existing session. Short names are
+				// canonicalized so `--session foo` reaches the same session
+				// `spawn-session <inst> foo` created.
+				sessionName = tui.ResolveSessionName(target.Instance, sessionFlag)
 			case groupFlag != "":
 				// Add a new pane to an existing group.
-				var suffix [2]byte
-				_, _ = rand.Read(suffix[:])
-				sessionName = sanitized + "~" + groupFlag + "~" + hex.EncodeToString(suffix[:])
+				sessionName = tui.NewGroupPaneSessionName(sanitized, groupFlag)
 			default:
 				// Create a new group (root session).
-				var suffix [3]byte
-				_, _ = rand.Read(suffix[:])
-				sessionName = sanitized + "~" + hex.EncodeToString(suffix[:])
+				sessionName = tui.NewGroupRootSessionName(sanitized)
 			}
 
 			// Tag the outer tmux pane with the session name so the TUI can read

--- a/internal/cli/spawn_session.go
+++ b/internal/cli/spawn_session.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/BenjaminBenetti/fleet-man/internal/dotfiles"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -27,7 +28,12 @@ Examples:
 				return err
 			}
 
-			sessionName := args[1]
+			// Canonicalize to the TUI's group naming convention
+			// (<instance>~<name>) so the session shows up as a regular
+			// session group — a bare-named session would surface as a
+			// pseudo-group and splitting it from the TUI would mint a
+			// duplicate real group with the same name.
+			sessionName := tui.ResolveSessionName(target.Instance, args[1])
 
 			if instance.Status != fleet.StatusRunning {
 				return fmt.Errorf("instance %s is not running (status: %s)", args[0], instance.Status)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -821,18 +821,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			fleetPage.splitSession = msg.session
 			fleetPage.activeGroup = ActiveGroup{Ref: msg.ref, GroupID: msg.groupID}
 			m.sessionStore.SetLastActive(msg.ref, lastSession{sessionName: msg.session, groupID: msg.groupID})
-			// Mirror the isGroupedSession guard the attach path uses
-			// (page_fleet.go handleEnter): for a bare-named session the
-			// groupID is a pseudo-group ID (the session name itself), and
-			// passing it to `fleet shell --group` would mint a new
-			// <instance>~<name>~<hex> session — a duplicate real group
-			// named after the bare session. Bind without a group instead
-			// so a split starts a fresh group.
-			splitGroupID := msg.groupID
-			if !isGroupedSession(SanitizeSessionName(msg.ref.Instance), msg.session) {
-				splitGroupID = ""
-			}
-			bindHostSplitKeys(msg.ref.Key(), splitGroupID)
+			bindHostSplitKeys(msg.ref.Key(), splitBindGroupID(msg.ref.Instance, msg.session, msg.groupID))
 			extraCmds = append(extraCmds, m.refreshInstanceSessions(msg.ref))
 		}
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -821,7 +821,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			fleetPage.splitSession = msg.session
 			fleetPage.activeGroup = ActiveGroup{Ref: msg.ref, GroupID: msg.groupID}
 			m.sessionStore.SetLastActive(msg.ref, lastSession{sessionName: msg.session, groupID: msg.groupID})
-			bindHostSplitKeys(msg.ref.Key(), msg.groupID)
+			// Mirror the isGroupedSession guard the attach path uses
+			// (page_fleet.go handleEnter): for a bare-named session the
+			// groupID is a pseudo-group ID (the session name itself), and
+			// passing it to `fleet shell --group` would mint a new
+			// <instance>~<name>~<hex> session — a duplicate real group
+			// named after the bare session. Bind without a group instead
+			// so a split starts a fresh group.
+			splitGroupID := msg.groupID
+			if !isGroupedSession(SanitizeSessionName(msg.ref.Instance), msg.session) {
+				splitGroupID = ""
+			}
+			bindHostSplitKeys(msg.ref.Key(), splitGroupID)
 			extraCmds = append(extraCmds, m.refreshInstanceSessions(msg.ref))
 		}
 

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -2083,7 +2083,7 @@ func (fleetPage *fleetPage) saveCreateSession(m *model) tea.Cmd {
 	}
 
 	sanitized := SanitizeSessionName(instance.Name)
-	fullName := groupSessionName(sanitized, name)
+	fullName := GroupSessionName(sanitized, name)
 
 	fleetPage.mode = viewNormal
 	fleetPage.blurDialogFields()

--- a/internal/tui/groups.go
+++ b/internal/tui/groups.go
@@ -204,6 +204,21 @@ func isGroupedSession(sanitizedInstance, sessionName string) bool {
 	return ok
 }
 
+// splitBindGroupID returns the group ID that is safe to pass to
+// `fleet shell --group` when rebinding the outer tmux split keys after
+// attaching to sessionName. It mirrors the isGroupedSession guard the
+// attach path uses (page_fleet.go handleEnter): for a bare-named session
+// the groupID is a pseudo-group ID (the session name itself), and
+// passing it to --group would mint a <instance>~<name>~<hex> session — a
+// duplicate real group named after the bare session. Returning "" makes
+// a split start a fresh group instead.
+func splitBindGroupID(instanceName, sessionName, groupID string) string {
+	if !isGroupedSession(SanitizeSessionName(instanceName), sessionName) {
+		return ""
+	}
+	return groupID
+}
+
 // groupCycleMsg is sent after the debounce timer expires to confirm
 // a session group switch.
 type groupCycleMsg struct {

--- a/internal/tui/groups.go
+++ b/internal/tui/groups.go
@@ -97,14 +97,44 @@ func savedGroupSessionNames(sg savedGroup, sanitizedInstance string) []string {
 		seen[name] = true
 	}
 	if len(sessions) == 0 {
-		sessions = append(sessions, groupSessionName(sanitizedInstance, sg.GroupID))
+		sessions = append(sessions, GroupSessionName(sanitizedInstance, sg.GroupID))
 	}
 	return sessions
 }
 
-// groupSessionName builds a session name for the root session of a new group.
-func groupSessionName(sanitizedInstance, groupID string) string {
+// GroupSessionName builds the root session name for a group:
+// <instance>~<groupID>. Exported because the CLI (fleet shell,
+// spawn-session, …) must mint names with the exact same convention the
+// TUI parses — a session created outside it surfaces as a pseudo-group
+// and splits then duplicate it (see ResolveSessionName).
+func GroupSessionName(sanitizedInstance, groupID string) string {
 	return sanitizedInstance + groupSep + groupID
+}
+
+// NewGroupRootSessionName mints the root session name for a brand-new
+// group with a random group ID.
+func NewGroupRootSessionName(sanitizedInstance string) string {
+	return GroupSessionName(sanitizedInstance, randomHex(3))
+}
+
+// NewGroupPaneSessionName mints a session name for an additional pane in
+// an existing group: <instance>~<groupID>~<hex>.
+func NewGroupPaneSessionName(sanitizedInstance, groupID string) string {
+	return GroupSessionName(sanitizedInstance, groupID) + groupSep + randomHex(2)
+}
+
+// ResolveSessionName maps a user-supplied session name to its canonical
+// grouped form for the given instance. Names that already follow the
+// convention pass through unchanged; anything else becomes the root
+// session of a group named after it: <instance>~<name>. This keeps the
+// short names agents use with spawn-session/exec-in-session/read-session
+// pointing at the same session the TUI manages.
+func ResolveSessionName(instanceName, name string) string {
+	sanitized := SanitizeSessionName(instanceName)
+	if isGroupedSession(sanitized, name) {
+		return name
+	}
+	return GroupSessionName(sanitized, SanitizeSessionName(name))
 }
 
 // parseGroupID extracts the group ID from a session name, if it follows

--- a/internal/tui/groups_test.go
+++ b/internal/tui/groups_test.go
@@ -360,3 +360,35 @@ func TestRestoreSessionNamesUsesSavedLayoutOverLiveDiscovery(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveSessionNameCanonicalizesBareNames(t *testing.T) {
+	// A short, user/agent-supplied name becomes the root session of a
+	// group named after it — the same name the TUI's create-session
+	// dialog would mint.
+	if got := ResolveSessionName("agent-1", "main"); got != "agent-1~main" {
+		t.Fatalf("ResolveSessionName bare = %q, want %q", got, "agent-1~main")
+	}
+	// Instance names are sanitized the same way the TUI sanitizes them.
+	if got := ResolveSessionName("my.fleet/agent", "main"); got != "my-fleet-agent~main" {
+		t.Fatalf("ResolveSessionName sanitized instance = %q, want %q", got, "my-fleet-agent~main")
+	}
+	// The session name itself is sanitized too.
+	if got := ResolveSessionName("agent-1", "my.task"); got != "agent-1~my-task" {
+		t.Fatalf("ResolveSessionName sanitized name = %q, want %q", got, "agent-1~my-task")
+	}
+}
+
+func TestResolveSessionNamePassesThroughConformingNames(t *testing.T) {
+	// Root and pane names that already follow the convention for this
+	// instance must not be double-prefixed.
+	for _, name := range []string{"agent-1~a1b2c3", "agent-1~a1b2c3~ff", "agent-1~main"} {
+		if got := ResolveSessionName("agent-1", name); got != name {
+			t.Fatalf("ResolveSessionName(%q) = %q, want unchanged", name, got)
+		}
+	}
+	// A name conforming to a *different* instance's convention is not a
+	// group of this instance — it gets canonicalized under this instance.
+	if got := ResolveSessionName("agent-1", "other~main"); got != "agent-1~other~main" {
+		t.Fatalf("ResolveSessionName foreign = %q, want %q", got, "agent-1~other~main")
+	}
+}

--- a/internal/tui/groups_test.go
+++ b/internal/tui/groups_test.go
@@ -392,3 +392,44 @@ func TestResolveSessionNamePassesThroughConformingNames(t *testing.T) {
 		t.Fatalf("ResolveSessionName foreign = %q, want %q", got, "agent-1~other~main")
 	}
 }
+
+// TestCliSpawnedSessionFormsRealGroup pins the CLI↔TUI naming contract
+// behind the session-duplication bug: a session created via
+// `fleet spawn-session <inst> main` must parse as a *real* group named
+// "main" (not a pseudo-group), and the pane session a split mints for
+// that group must land in the same group.
+func TestCliSpawnedSessionFormsRealGroup(t *testing.T) {
+	root := ResolveSessionName("agent-1", "main") // what spawn-session creates
+
+	groups := groupSessions("agent-1", []tmuxSession{{Name: root}})
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d: %#v", len(groups), groups)
+	}
+	if groups[0].GroupID != "main" {
+		t.Fatalf("GroupID = %q, want %q (pseudo-group would carry the full session name)", groups[0].GroupID, "main")
+	}
+
+	pane := NewGroupPaneSessionName("agent-1", groups[0].GroupID)
+	groups = groupSessions("agent-1", []tmuxSession{{Name: root}, {Name: pane}})
+	if len(groups) != 1 {
+		t.Fatalf("split duplicated the group: %#v", groups)
+	}
+	if len(groups[0].Sessions) != 2 {
+		t.Fatalf("group has %d sessions, want 2: %#v", len(groups[0].Sessions), groups[0])
+	}
+}
+
+// TestSplitBindGroupID covers the guard on the split-key rebinding: a
+// bare-named session's pseudo-group ID must never reach
+// `fleet shell --group`, while a real group's ID passes through.
+func TestSplitBindGroupID(t *testing.T) {
+	if got := splitBindGroupID("agent-1", "agent-1~abc123", "abc123"); got != "abc123" {
+		t.Fatalf("grouped session: got %q, want %q", got, "abc123")
+	}
+	if got := splitBindGroupID("agent-1", "agent-1~abc123~ff", "abc123"); got != "abc123" {
+		t.Fatalf("grouped pane session: got %q, want %q", got, "abc123")
+	}
+	if got := splitBindGroupID("agent-1", "main", "main"); got != "" {
+		t.Fatalf("bare session: got %q, want empty (pseudo-group ID must be stripped)", got)
+	}
+}

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -1963,7 +1963,7 @@ func (fleetPage *fleetPage) openInstanceSession(m *model, fleetName string, inst
 	}
 
 	newGroupID := randomHex(3)
-	sessName := groupSessionName(sanitized, newGroupID)
+	sessName := GroupSessionName(sanitized, newGroupID)
 	return splitSessionCmd(sessName, newGroupID)
 }
 


### PR DESCRIPTION
## Problem

`fleet spawn-session <instance> main` creates a bare-named tmux session that doesn't follow the TUI's `<instance>~<group>` naming convention. The chain that turns this into duplicated sessions:

1. `groupSessions` (internal/tui/groups.go) wraps the non-conforming session into a pseudo-group whose ID is the session name itself (`main`).
2. On attach, the split-key binding passes that pseudo-group ID to `bindHostSplitKeys` — the attach path right above guards with `isGroupedSession`, but the bind never did.
3. Pressing the split key runs `fleet shell <instance> --group main`, which mints a brand-new session `<instance>~main~<hex>` — a *real* group named `main`, duplicating the bare session in the UI.

Root cause: the session-name construction logic was duplicated between the CLI and the TUI, and the copies disagreed.

## Fix

Make the TUI's naming convention the single source of truth (`internal/tui/groups.go`):

- Export `GroupSessionName`, and add `NewGroupRootSessionName`, `NewGroupPaneSessionName`, and `ResolveSessionName`.
- `spawn-session`, `exec-in-session`, `read-session`, and `fleet shell --session` canonicalize user-supplied names via `ResolveSessionName` (`main` → `<instance>~main`; already-conforming names pass through). The short name an agent spawns with keeps working across all the `*-session` commands.
- `fleet shell` drops its hand-rolled copy of the `~`-joined name construction in favor of the shared helpers.
- Defense in depth for pre-existing bare sessions: the split-key bind in `app.go` now mirrors the `isGroupedSession` guard the attach path already had, so a pseudo-group ID can no longer reach `fleet shell --group`.

## Testing

- New unit tests for `ResolveSessionName` (canonicalization, sanitization, pass-through, foreign-prefix handling).
- New integration test: `spawn-session` with an already-canonical name doesn't double-prefix.
- Updated `TestSpawnSession_CreatesSession` to expect the canonical name; the existing spawn → exec → read round-trip tests pass unchanged through the new resolution.
- `go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)