### PR TITLE
feat(admiral): switch skill to MCP tools + auto-register MCP server in Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ programmatically. It starts automatically with the daemon — no extra command.
   matching the daemon's unix socket. The token is generated once and reused
   across restarts.
 
+**Claude Code needs no setup:** launching the fleet TUI registers the server in
+`~/.claude.json` as the user-scope `fleet` entry (URL and token included) and
+re-syncs it on every launch, so a daemon restart that lands on a new port heals
+itself. It also installs the **Fleet Admiral** skill (`~/.claude/skills/fleet-admiral`),
+which teaches the agent how to drive these tools. (Local daemons only: when
+`FLEET_GATEWAY`/`FLEET_SERVER` point the TUI at a remote daemon, registration
+is skipped — point Claude Code at the Public MCP URL from the settings page
+instead, see [Remote MCP](#remote-mcp). Registration is best-effort and never
+blocks startup.) The snippet below is for other MCP clients or manual setups.
+
 For convenience the server also writes `~/.fleet/mcp.env` (mode `0600`) with the
 endpoint as shell exports, and wires `~/.bashrc` to source it, so new shells get:
 

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -71,7 +71,26 @@ fi
 # run.sh does NOT judge results; it only aggregates this file at the end.
 FLEET_ITEST_RESULTS="$(mktemp)"
 export FLEET_ITEST_RESULTS
-trap 'rm -f "${FLEET_ITEST_RESULTS}"' EXIT
+
+# The TUI auto-registers the fleet MCP server in ~/.claude.json, so EVERY test
+# that spawns the TUI mutates the runner's real config (381 is just the one
+# that asserts on it). Snapshot it once and restore on suite exit, so a dev
+# running the suite locally gets their config back exactly as it was.
+CLAUDE_JSON="${HOME}/.claude.json"
+CLAUDE_JSON_SUITE_BAK=""
+if [ -f "${CLAUDE_JSON}" ]; then
+  CLAUDE_JSON_SUITE_BAK="$(mktemp)"
+  cp "${CLAUDE_JSON}" "${CLAUDE_JSON_SUITE_BAK}"
+fi
+_restore_claude_json() {
+  if [ -n "${CLAUDE_JSON_SUITE_BAK}" ] && [ -f "${CLAUDE_JSON_SUITE_BAK}" ]; then
+    mv "${CLAUDE_JSON_SUITE_BAK}" "${CLAUDE_JSON}"
+  else
+    rm -f "${CLAUDE_JSON}"
+  fi
+}
+
+trap 'rm -f "${FLEET_ITEST_RESULTS}"; _restore_claude_json' EXIT
 
 # Sourced common.sh in tests provides teardown_test — we need it here too.
 # shellcheck disable=SC1091

--- a/integration/tests/381_tui_admiral_mcp_install.sh
+++ b/integration/tests/381_tui_admiral_mcp_install.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Description: Launching the TUI registers the fleet MCP server in ~/.claude.json.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+
+CLAUDE_JSON="${HOME}/.claude.json"
+CLAUDE_JSON_BAK="${CLAUDE_JSON}.itest-bak"
+
+# BACKUP_DONE guards the cleanup: only remove the config we observed being
+# created if this run actually got as far as making the backup decision.
+BACKUP_DONE=""
+
+itest_cleanup() {
+  tui_kill
+  # Put the user's real config back exactly as we found it.
+  if [ -f "${CLAUDE_JSON_BAK}" ]; then
+    mv "${CLAUDE_JSON_BAK}" "${CLAUDE_JSON}"
+  elif [ -n "${BACKUP_DONE}" ]; then
+    rm -f "${CLAUDE_JSON}"
+  fi
+}
+itest_begin
+
+# A leftover .itest-bak from a hard-killed previous run holds the user's REAL
+# config — restore it first, never delete it. Then preserve any current config
+# and start without one, so we observe the install create it from scratch.
+if [ -f "${CLAUDE_JSON_BAK}" ]; then
+  mv "${CLAUDE_JSON_BAK}" "${CLAUDE_JSON}"
+fi
+if [ -f "${CLAUDE_JSON}" ]; then
+  mv "${CLAUDE_JSON}" "${CLAUDE_JSON_BAK}"
+fi
+BACKUP_DONE=1
+
+setup_test
+
+# The install is explicitly skipped when the client points at a remote daemon
+# (admiralmcp.EnsureInstalledEventually); neutralize any ambient remote config
+# so the spawned TUI exercises the local path.
+unset FLEET_GATEWAY FLEET_SERVER
+
+# No fleet_up needed: the install fires from tui.Run(), but unlike the skill
+# install it is asynchronous — it waits for the auto-spawned daemon to publish
+# ~/.fleet/mcp.port + mcp.token, then merges the entry. The binary's own
+# deadline is a fixed 30s (internal/tui/app.go), so the poll budget matches it
+# plus headroom rather than scaling with FLEET_TUI_WAIT_SCALE.
+info "Spawning TUI"
+tui_spawn
+
+info "Waiting for fleet MCP server to be registered in ~/.claude.json"
+deadline=$(( $(date +%s) + $(_scale_timeout 35) ))
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  grep -q '"fleet"' "${CLAUDE_JSON}" 2>/dev/null && break
+  sleep 0.25
+done
+
+if ! grep -q '"fleet"' "${CLAUDE_JSON}" 2>/dev/null; then
+  {
+    echo '--- poll timed out; ~/.fleet ---'
+    ls -la "${HOME}/.fleet" 2>/dev/null || true
+  } >&2
+fi
+
+# Distinguish "daemon never published its endpoint" from "installer never
+# wrote the config" before asserting on the config itself.
+assert_file_exists "${HOME}/.fleet/mcp.port"
+assert_file_exists "${HOME}/.fleet/mcp.token"
+assert_file_exists "${CLAUDE_JSON}"
+
+# Assert via exit-code-only greps: the config embeds the live bearer token,
+# which must never be echoed into test logs on failure.
+grep -qF '"mcpServers"' "${CLAUDE_JSON}"   || fail "config missing mcpServers"
+grep -qF '"fleet"' "${CLAUDE_JSON}"        || fail "config missing fleet server entry"
+grep -qF '"type": "http"' "${CLAUDE_JSON}" || fail "fleet entry is not an http server"
+
+# The registered endpoint must match the daemon's live discovery files: the
+# loopback URL on the bound port, and the persistent bearer token.
+port="$(cat "${HOME}/.fleet/mcp.port")"
+token="$(cat "${HOME}/.fleet/mcp.token")"
+grep -qF "\"url\": \"http://127.0.0.1:${port}\"" "${CLAUDE_JSON}" \
+  || fail "registered URL does not match mcp.port (port=${port})"
+grep -qF "Bearer ${token}" "${CLAUDE_JSON}" \
+  || fail "registered Authorization header does not match mcp.token"
+
+pass "TUI startup registers the fleet MCP server in ~/.claude.json"

--- a/internal/admiralmcp/mcp.go
+++ b/internal/admiralmcp/mcp.go
@@ -165,8 +165,13 @@ func EnsureInstalledEventually(wait time.Duration) error {
 // real error.
 func localMCPEndpoint() (url, token string, err error) {
 	portRaw, err := os.ReadFile(fleetpaths.McpPortPath())
-	if err != nil {
+	if errors.Is(err, os.ErrNotExist) {
 		return "", "", fmt.Errorf("%w (%s)", ErrNotReady, fleetpaths.McpPortPath())
+	}
+	if err != nil {
+		// Anything but absence (permission denied, I/O error) is not "the
+		// daemon isn't up yet" — fail fast instead of retrying it away.
+		return "", "", err
 	}
 	portStr := strings.TrimSpace(string(portRaw))
 	if portStr == "" {
@@ -180,8 +185,11 @@ func localMCPEndpoint() (url, token string, err error) {
 	}
 
 	tokenRaw, err := os.ReadFile(fleetpaths.McpTokenPath())
-	if err != nil {
+	if errors.Is(err, os.ErrNotExist) {
 		return "", "", fmt.Errorf("%w (%s)", ErrNotReady, fleetpaths.McpTokenPath())
+	}
+	if err != nil {
+		return "", "", err
 	}
 	token = strings.TrimSpace(string(tokenRaw))
 	if token == "" {

--- a/internal/admiralmcp/mcp.go
+++ b/internal/admiralmcp/mcp.go
@@ -1,0 +1,344 @@
+// Package admiralmcp registers the local fleet MCP server in the user's
+// Claude Code configuration (~/.claude.json) on client startup. It is the
+// companion to internal/admiralskill: the skill teaches an agent HOW to drive
+// fleet's MCP tools, this package makes those tools reachable by installing
+// the user-scope server entry Claude Code reads at session start.
+//
+// The entry is merged, never overwritten wholesale: ~/.claude.json is Claude
+// Code's primary state file, so the whole document is decoded, only
+// mcpServers.fleet is replaced, and the rest is re-encoded untouched (numbers
+// kept verbatim via json.Number so a float64 round-trip can't corrupt large
+// integers). A file that fails to parse is left alone — never write over a
+// config we couldn't read. Writes are atomic (temp file + rename next to the
+// symlink-resolved target) so a crash can't leave a truncated config behind,
+// and the rename is guarded by an optimistic recheck: if another writer (a
+// live Claude Code session, `claude mcp add`) changed the file since it was
+// read, the merge is redone from the fresh content instead of clobbering it.
+// Claude Code honors no locking protocol, so the residual read-to-rename race
+// cannot be closed entirely — but a lost update self-heals on the next
+// startup re-sync.
+//
+// Like the skill install this is idempotent and cheap: when the existing
+// entry already matches the live endpoint nothing is written. The endpoint
+// (loopback URL + bearer token) comes from the ~/.fleet/mcp.port and
+// mcp.token discovery files the daemon publishes when its MCP listener binds;
+// until the daemon is up those don't exist, reported as ErrNotReady so a
+// caller can retry instead of failing.
+package admiralmcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetpaths"
+)
+
+// ===========================================
+// Constants
+// ===========================================
+
+// serverKey is the name the fleet MCP server is registered under in
+// mcpServers. It is also the tool-name prefix Claude Code derives
+// (mcp__fleet__fleet_list, ...), and must stay in sync with the server names
+// used in the SKILL.md and the settings-page snippets.
+const serverKey = "fleet"
+
+// configFile is Claude Code's user-scope state file (in the user's home
+// directory) — the documented location for user-scope (all-projects) MCP
+// servers, under its top-level "mcpServers" key.
+const configFile = ".claude.json"
+
+// mcpServersKey is the top-level ~/.claude.json key holding user-scope MCP
+// servers.
+const mcpServersKey = "mcpServers"
+
+// retryInterval paces EnsureInstalledEventually's polling for the daemon's
+// endpoint files. The cold-start gap is daemon spawn + MCP bind — usually
+// well under a second — so a sub-second cadence resolves the common case on
+// the first or second probe without busy-spinning the slow ones.
+const retryInterval = 500 * time.Millisecond
+
+// mergeAttempts bounds the redo loop when the optimistic recheck detects a
+// concurrent ~/.claude.json writer. More than one collision in a row is
+// already vanishingly rare; on exhaustion the install is abandoned for this
+// startup (it self-heals on the next one).
+const mergeAttempts = 3
+
+// mergeRetryDelay spaces the redo attempts so a burst of writes from a live
+// Claude Code session can settle.
+const mergeRetryDelay = 50 * time.Millisecond
+
+// ===========================================
+// Errors
+// ===========================================
+
+// ErrNotReady reports that the daemon's MCP endpoint discovery files
+// (~/.fleet/mcp.port, mcp.token) are not readable yet — normally just "the
+// daemon hasn't bound its MCP listener yet" during a cold start. Retryable,
+// unlike every other error this package returns.
+var ErrNotReady = errors.New("fleet MCP endpoint not published yet")
+
+// errConcurrentChange reports that ~/.claude.json changed between read and
+// rename; the merge must be redone from the fresh content.
+var errConcurrentChange = errors.New("claude config changed during merge")
+
+// ===========================================
+// Public API
+// ===========================================
+
+// EnsureInstalled merges the live local MCP endpoint into ~/.claude.json as
+// the user-scope server "fleet", and is a no-op when the entry is already
+// current. It returns ErrNotReady while the daemon hasn't published its
+// endpoint files.
+func EnsureInstalled() error {
+	url, token, err := localMCPEndpoint()
+	if err != nil {
+		return err
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(home, configFile)
+
+	// ~/.claude.json may be a symlink (fleet's own Claude-config mount in
+	// instances, dotfile managers). Operate on the real target so the
+	// temp+rename write replaces the file behind the link instead of severing
+	// the link — and so the temp file lands on the target's filesystem,
+	// keeping the rename atomic.
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	for attempt := 1; ; attempt++ {
+		err := mergeEntry(path, url, token)
+		if !errors.Is(err, errConcurrentChange) || attempt == mergeAttempts {
+			return err
+		}
+		time.Sleep(mergeRetryDelay)
+	}
+}
+
+// EnsureInstalledEventually retries EnsureInstalled until it succeeds, hits a
+// non-retryable error, or wait elapses, returning the last result (callers
+// that just want best-effort — the TUI — ignore it). It exists for the TUI's
+// cold-start race: launching the TUI auto-spawns the daemon, and the endpoint
+// files only appear once the daemon's MCP listener binds.
+//
+// When the client is pointed at a remote daemon (FLEET_GATEWAY/FLEET_SERVER)
+// it does nothing: the local discovery files — if they exist at all —
+// describe a daemon the user isn't talking to. The remote MCP URL is surfaced
+// on the TUI settings page for manual configuration instead.
+func EnsureInstalledEventually(wait time.Duration) error {
+	if os.Getenv("FLEET_GATEWAY") != "" || os.Getenv("FLEET_SERVER") != "" {
+		return nil
+	}
+	deadline := time.Now().Add(wait)
+	for {
+		err := EnsureInstalled()
+		if err == nil || !errors.Is(err, ErrNotReady) || !time.Now().Before(deadline) {
+			return err
+		}
+		time.Sleep(retryInterval)
+	}
+}
+
+// ===========================================
+// Endpoint discovery
+// ===========================================
+
+// localMCPEndpoint reads the loopback MCP URL and bearer token from the
+// daemon's discovery files. Missing (or still-empty) files mean the daemon's
+// MCP listener isn't up yet → ErrNotReady; present-but-garbled content is a
+// real error.
+func localMCPEndpoint() (url, token string, err error) {
+	portRaw, err := os.ReadFile(fleetpaths.McpPortPath())
+	if err != nil {
+		return "", "", fmt.Errorf("%w (%s)", ErrNotReady, fleetpaths.McpPortPath())
+	}
+	portStr := strings.TrimSpace(string(portRaw))
+	if portStr == "" {
+		// The daemon's plain WriteFile truncates before it writes, so a reader
+		// can catch the file empty mid-write; that's "not yet", not garbage.
+		return "", "", fmt.Errorf("%w (empty %s)", ErrNotReady, fleetpaths.McpPortPath())
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil || port < 1 || port > 65535 {
+		return "", "", fmt.Errorf("invalid MCP port in %s: %q", fleetpaths.McpPortPath(), portStr)
+	}
+
+	tokenRaw, err := os.ReadFile(fleetpaths.McpTokenPath())
+	if err != nil {
+		return "", "", fmt.Errorf("%w (%s)", ErrNotReady, fleetpaths.McpTokenPath())
+	}
+	token = strings.TrimSpace(string(tokenRaw))
+	if token == "" {
+		return "", "", fmt.Errorf("%w (empty %s)", ErrNotReady, fleetpaths.McpTokenPath())
+	}
+
+	return fmt.Sprintf("http://127.0.0.1:%d", port), token, nil
+}
+
+// serverEntry is the mcpServers value for the fleet server: a Streamable HTTP
+// endpoint plus the bearer token the daemon requires. Literal values (not
+// ${FLEET_MCP_URL} references) on purpose: env expansion only helps when the
+// shell that launched Claude Code sourced ~/.fleet/mcp.env, which bash gets
+// via the .bashrc wire-in but zsh/fish/GUI launches do not. Literals work
+// everywhere, and staleness is a non-issue because every TUI startup re-syncs
+// this entry against the live discovery files.
+func serverEntry(url, token string) map[string]any {
+	return map[string]any{
+		"type": "http",
+		"url":  url,
+		"headers": map[string]any{
+			"Authorization": "Bearer " + token,
+		},
+	}
+}
+
+// ===========================================
+// Config merge
+// ===========================================
+
+// mergeEntry performs one read-merge-write cycle against the (symlink
+// resolved) config path. It returns errConcurrentChange when the file changed
+// underneath the merge, and nil without writing when the entry is already
+// current.
+func mergeEntry(path, url, token string) error {
+	root, snapshot, mode, err := readClaudeConfig(path)
+	if err != nil {
+		return err
+	}
+
+	servers, ok := root[mcpServersKey].(map[string]any)
+	if !ok {
+		if existing, present := root[mcpServersKey]; present && existing != nil {
+			// A non-object mcpServers means the file is malformed; leave it
+			// for the user rather than guess at a repair.
+			return fmt.Errorf("%s: %q is not an object", path, mcpServersKey)
+		}
+		servers = map[string]any{}
+	}
+
+	want := serverEntry(url, token)
+	if reflect.DeepEqual(servers[serverKey], want) {
+		return nil
+	}
+	servers[serverKey] = want
+	root[mcpServersKey] = servers
+
+	return writeClaudeConfig(path, root, mode, snapshot)
+}
+
+// ===========================================
+// Config file I/O
+// ===========================================
+
+// readClaudeConfig decodes the config into a generic tree, also returning the
+// raw bytes it parsed (nil when the file doesn't exist — the snapshot for the
+// pre-rename concurrency check) and the file mode to use on rewrite. The mode
+// preserves the existing file's owner bits but always strips group/other: the
+// rewritten document embeds the MCP bearer token, and that token — not the
+// loopback port — is the MCP access boundary, so it must never be readable by
+// other users (0600 for a fresh file, matching the daemon's token files).
+// Numbers decode as json.Number so re-encoding reproduces them exactly
+// (Claude Code stores large integer timestamps a float64 round-trip would
+// mangle). A file that exists but doesn't parse as a single JSON document is
+// an error: the caller must not write over a config we couldn't read.
+func readClaudeConfig(path string) (root map[string]any, snapshot []byte, mode os.FileMode, err error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return map[string]any{}, nil, 0o600, nil
+	}
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	mode = 0o600
+	if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode().Perm() &^ 0o077
+	}
+
+	if len(bytes.TrimSpace(data)) == 0 {
+		return map[string]any{}, data, mode, nil
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	root = map[string]any{}
+	if err := dec.Decode(&root); err != nil {
+		return nil, nil, 0, fmt.Errorf("parse %s: %w", path, err)
+	}
+	// A JSON `null` document decodes into a nil map WITHOUT an error; treat
+	// it like a blank file so the merge can't panic assigning into nil.
+	if root == nil {
+		root = map[string]any{}
+	}
+	// Anything after the first document (a second object, stray text) means
+	// this is not the single-JSON-object file we know how to merge into.
+	if _, err := dec.Token(); !errors.Is(err, io.EOF) {
+		return nil, nil, 0, fmt.Errorf("parse %s: trailing data after JSON document", path)
+	}
+	return root, data, mode, nil
+}
+
+// writeClaudeConfig atomically replaces path with the re-encoded tree: encode
+// to a buffer, write a temp file in the same directory, then rename over the
+// original. Claude Code re-reads this file at session start; the rename
+// guarantees it can never observe a half-written document. Immediately before
+// the rename the current content is compared against the snapshot the merge
+// was computed from — a mismatch means another writer got in, and renaming
+// would silently revert their change, so errConcurrentChange asks the caller
+// to redo the merge on the fresh content instead.
+func writeClaudeConfig(path string, root map[string]any, mode os.FileMode, snapshot []byte) error {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(root); err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), configFile+".fleet-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	// Best-effort cleanup on any failure below; a no-op after the rename.
+	defer os.Remove(tmpPath)
+
+	if err := tmp.Chmod(mode); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(buf.Bytes()); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	cur, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		cur = nil
+	} else if err != nil {
+		return err
+	}
+	if !bytes.Equal(cur, snapshot) {
+		return errConcurrentChange
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/admiralmcp/mcp_test.go
+++ b/internal/admiralmcp/mcp_test.go
@@ -1,0 +1,402 @@
+package admiralmcp
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withHome points HOME (and USERPROFILE on Windows) at a temp dir so
+// EnsureInstalled reads an isolated ~/.fleet and writes an isolated
+// ~/.claude.json, never touching the real user home.
+func withHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	// Endpoint selection must look local regardless of the developer's shell.
+	t.Setenv("FLEET_GATEWAY", "")
+	t.Setenv("FLEET_SERVER", "")
+	return home
+}
+
+// publishEndpoint writes the daemon's MCP discovery files (~/.fleet/mcp.port,
+// mcp.token) the way the server does on startup.
+func publishEndpoint(t *testing.T, home, port, token string) {
+	t.Helper()
+	dir := filepath.Join(home, ".fleet")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir ~/.fleet: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "mcp.port"), []byte(port), 0o600); err != nil {
+		t.Fatalf("write mcp.port: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "mcp.token"), []byte(token), 0o600); err != nil {
+		t.Fatalf("write mcp.token: %v", err)
+	}
+}
+
+// readConfigTree parses the installed ~/.claude.json for assertions.
+func readConfigTree(t *testing.T, home string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(home, configFile))
+	if err != nil {
+		t.Fatalf("read %s: %v", configFile, err)
+	}
+	root := map[string]any{}
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatalf("parse %s: %v", configFile, err)
+	}
+	return root
+}
+
+// fleetEntry digs mcpServers.fleet out of the parsed config.
+func fleetEntry(t *testing.T, root map[string]any) map[string]any {
+	t.Helper()
+	servers, ok := root[mcpServersKey].(map[string]any)
+	if !ok {
+		t.Fatalf("config has no %q object: %v", mcpServersKey, root)
+	}
+	entry, ok := servers[serverKey].(map[string]any)
+	if !ok {
+		t.Fatalf("config has no %q server entry: %v", serverKey, servers)
+	}
+	return entry
+}
+
+// TestEnsureInstalledNotReadyWithoutEndpoint verifies the retryable ErrNotReady
+// path while the daemon hasn't published its discovery files, and that no
+// config file is created in that state.
+func TestEnsureInstalledNotReadyWithoutEndpoint(t *testing.T) {
+	home := withHome(t)
+
+	if err := EnsureInstalled(); !errors.Is(err, ErrNotReady) {
+		t.Fatalf("EnsureInstalled() with no ~/.fleet = %v, want ErrNotReady", err)
+	}
+
+	// Port alone is not enough: the token gates access.
+	publishEndpoint(t, home, "6012", "tok")
+	if err := os.Remove(filepath.Join(home, ".fleet", "mcp.token")); err != nil {
+		t.Fatalf("remove token: %v", err)
+	}
+	if err := EnsureInstalled(); !errors.Is(err, ErrNotReady) {
+		t.Fatalf("EnsureInstalled() without token = %v, want ErrNotReady", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(home, configFile)); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("%s was created on the not-ready path", configFile)
+	}
+}
+
+// TestEnsureInstalledRejectsGarbledPort verifies a present-but-invalid port
+// file is a real (non-retryable) error, while an EMPTY port file — a reader
+// catching the daemon's truncate-then-write mid-flight — stays retryable.
+func TestEnsureInstalledRejectsGarbledPort(t *testing.T) {
+	home := withHome(t)
+	publishEndpoint(t, home, "not-a-port", "tok")
+
+	err := EnsureInstalled()
+	if err == nil || errors.Is(err, ErrNotReady) {
+		t.Fatalf("EnsureInstalled() with garbled port = %v, want non-retryable error", err)
+	}
+
+	publishEndpoint(t, home, "", "tok")
+	if err := EnsureInstalled(); !errors.Is(err, ErrNotReady) {
+		t.Fatalf("EnsureInstalled() with empty port file = %v, want ErrNotReady", err)
+	}
+}
+
+// TestEnsureInstalledCreatesConfig verifies a fresh install creates
+// ~/.claude.json (0600 — it embeds the bearer token) with the fleet server
+// entry pointing at the published endpoint.
+func TestEnsureInstalledCreatesConfig(t *testing.T) {
+	home := withHome(t)
+	publishEndpoint(t, home, "6017\n", "secret-token\n")
+
+	if err := EnsureInstalled(); err != nil {
+		t.Fatalf("EnsureInstalled() = %v, want nil", err)
+	}
+
+	entry := fleetEntry(t, readConfigTree(t, home))
+	if entry["type"] != "http" {
+		t.Errorf("type = %v, want http", entry["type"])
+	}
+	if entry["url"] != "http://127.0.0.1:6017" {
+		t.Errorf("url = %v, want http://127.0.0.1:6017", entry["url"])
+	}
+	headers, _ := entry["headers"].(map[string]any)
+	if headers["Authorization"] != "Bearer secret-token" {
+		t.Errorf("Authorization = %v, want Bearer secret-token", headers["Authorization"])
+	}
+
+	info, err := os.Stat(filepath.Join(home, configFile))
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("new config mode = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+// TestEnsureInstalledPreservesExistingConfig verifies the merge keeps every
+// unrelated key — including other MCP servers and integers too large for a
+// float64 round-trip — and the existing file mode.
+func TestEnsureInstalledPreservesExistingConfig(t *testing.T) {
+	home := withHome(t)
+	publishEndpoint(t, home, "6012", "tok")
+
+	// 9007199254740993 = 2^53 + 1: corrupted if decoded into a float64.
+	existing := `{
+  "numStartups": 9007199254740993,
+  "projects": {"/workspaces/app": {"allowedTools": []}},
+  "mcpServers": {"other": {"type": "stdio", "command": "other-server"}}
+}`
+	path := filepath.Join(home, configFile)
+	if err := os.WriteFile(path, []byte(existing), 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	if err := EnsureInstalled(); err != nil {
+		t.Fatalf("EnsureInstalled() = %v, want nil", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(data), "9007199254740993") {
+		t.Errorf("large integer was corrupted on rewrite:\n%s", data)
+	}
+
+	root := readConfigTree(t, home)
+	if _, ok := root["projects"].(map[string]any); !ok {
+		t.Errorf("projects key lost on rewrite: %v", root)
+	}
+	servers := root[mcpServersKey].(map[string]any)
+	if _, ok := servers["other"].(map[string]any); !ok {
+		t.Errorf("unrelated MCP server lost on rewrite: %v", servers)
+	}
+	fleetEntry(t, root) // fleet entry added alongside
+
+	// A permissive pre-existing mode is deliberately clamped to owner-only:
+	// the rewrite embeds the MCP bearer token, which is the MCP access
+	// boundary and must never be group/world-readable.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("rewrite mode = %v, want 0600 (clamped from 0644)", info.Mode().Perm())
+	}
+}
+
+// TestEnsureInstalledTreatsNullConfigAsEmpty verifies a ~/.claude.json
+// containing the JSON literal `null` (which decodes into a nil map without an
+// error) installs cleanly instead of panicking on assignment into a nil map —
+// the install runs in a TUI goroutine, so a panic here would kill the TUI.
+func TestEnsureInstalledTreatsNullConfigAsEmpty(t *testing.T) {
+	home := withHome(t)
+	publishEndpoint(t, home, "6012", "tok")
+
+	path := filepath.Join(home, configFile)
+	if err := os.WriteFile(path, []byte("null\n"), 0o600); err != nil {
+		t.Fatalf("seed null config: %v", err)
+	}
+
+	if err := EnsureInstalled(); err != nil {
+		t.Fatalf("EnsureInstalled() on null config = %v, want nil", err)
+	}
+	fleetEntry(t, readConfigTree(t, home))
+}
+
+// TestEnsureInstalledRefusesTrailingGarbage verifies a file whose first JSON
+// document parses but is followed by junk is rejected and left untouched —
+// it is not the single-document file we know how to merge into.
+func TestEnsureInstalledRefusesTrailingGarbage(t *testing.T) {
+	home := withHome(t)
+	publishEndpoint(t, home, "6012", "tok")
+
+	path := filepath.Join(home, configFile)
+	corrupt := []byte("{\"keep\": true}\ngarbage")
+	if err := os.WriteFile(path, corrupt, 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	if err := EnsureInstalled(); err == nil {
+		t.Fatalf("EnsureInstalled() with trailing garbage = nil, want error")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(got) != string(corrupt) {
+		t.Errorf("config with trailing garbage was modified: %q", got)
+	}
+}
+
+// TestEnsureInstalledFollowsSymlinkedConfig verifies a symlinked
+// ~/.claude.json (fleet's own Claude-config mount in instances, dotfile
+// managers) keeps the link intact and updates the file behind it.
+func TestEnsureInstalledFollowsSymlinkedConfig(t *testing.T) {
+	home := withHome(t)
+	publishEndpoint(t, home, "6012", "tok")
+
+	target := filepath.Join(home, "real-claude.json")
+	if err := os.WriteFile(target, []byte(`{"projects": {}}`), 0o600); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	link := filepath.Join(home, configFile)
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := EnsureInstalled(); err != nil {
+		t.Fatalf("EnsureInstalled() through symlink = %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("~/%s is no longer a symlink — the link was severed", configFile)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if !strings.Contains(string(data), `"fleet"`) {
+		t.Errorf("symlink target was not updated:\n%s", data)
+	}
+}
+
+// TestEnsureInstalledIsIdempotent verifies the no-op path: when the installed
+// entry already matches the live endpoint, the config is not rewritten.
+func TestEnsureInstalledIsIdempotent(t *testing.T) {
+	home := withHome(t)
+	publishEndpoint(t, home, "6012", "tok")
+
+	if err := EnsureInstalled(); err != nil {
+		t.Fatalf("first EnsureInstalled() = %v", err)
+	}
+	path := filepath.Join(home, configFile)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+
+	if err := EnsureInstalled(); err != nil {
+		t.Fatalf("second EnsureInstalled() = %v", err)
+	}
+	info2, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat config after second run: %v", err)
+	}
+	if !info2.ModTime().Equal(info.ModTime()) {
+		t.Errorf("config was rewritten on the no-op path (mtime changed)")
+	}
+}
+
+// TestEnsureInstalledRefreshesStaleEntry verifies a daemon restart that lands
+// on a different port updates the registered URL.
+func TestEnsureInstalledRefreshesStaleEntry(t *testing.T) {
+	home := withHome(t)
+	publishEndpoint(t, home, "6012", "tok")
+
+	if err := EnsureInstalled(); err != nil {
+		t.Fatalf("EnsureInstalled() = %v", err)
+	}
+
+	publishEndpoint(t, home, "6013", "tok")
+	if err := EnsureInstalled(); err != nil {
+		t.Fatalf("EnsureInstalled() after port change = %v", err)
+	}
+
+	entry := fleetEntry(t, readConfigTree(t, home))
+	if entry["url"] != "http://127.0.0.1:6013" {
+		t.Errorf("url = %v, want refreshed http://127.0.0.1:6013", entry["url"])
+	}
+}
+
+// TestEnsureInstalledRefusesUnparseableConfig verifies a corrupt
+// ~/.claude.json is reported and left byte-for-byte untouched — never
+// clobbered.
+func TestEnsureInstalledRefusesUnparseableConfig(t *testing.T) {
+	home := withHome(t)
+	publishEndpoint(t, home, "6012", "tok")
+
+	path := filepath.Join(home, configFile)
+	corrupt := []byte(`{"mcpServers": {`)
+	if err := os.WriteFile(path, corrupt, 0o600); err != nil {
+		t.Fatalf("seed corrupt config: %v", err)
+	}
+
+	if err := EnsureInstalled(); err == nil {
+		t.Fatalf("EnsureInstalled() on corrupt config = nil, want error")
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(got) != string(corrupt) {
+		t.Errorf("corrupt config was modified: %q", got)
+	}
+}
+
+// TestEnsureInstalledRefusesNonObjectMcpServers verifies a malformed (but
+// parseable) mcpServers value is an error, not silently replaced.
+func TestEnsureInstalledRefusesNonObjectMcpServers(t *testing.T) {
+	home := withHome(t)
+	publishEndpoint(t, home, "6012", "tok")
+
+	path := filepath.Join(home, configFile)
+	if err := os.WriteFile(path, []byte(`{"mcpServers": []}`), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	if err := EnsureInstalled(); err == nil {
+		t.Fatalf("EnsureInstalled() with non-object mcpServers = nil, want error")
+	}
+}
+
+// TestEnsureInstalledEventuallySkipsRemote verifies the remote-daemon guard:
+// with FLEET_GATEWAY set, nothing is installed even though local discovery
+// files exist (they describe a daemon the user isn't talking to).
+func TestEnsureInstalledEventuallySkipsRemote(t *testing.T) {
+	home := withHome(t)
+	publishEndpoint(t, home, "6012", "tok")
+	t.Setenv("FLEET_GATEWAY", "https://gw.example:50051/abc")
+
+	if err := EnsureInstalledEventually(time.Second); err != nil {
+		t.Fatalf("EnsureInstalledEventually() remote = %v, want nil", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, configFile)); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("%s was created for a remote daemon", configFile)
+	}
+}
+
+// TestEnsureInstalledEventuallyWaitsForEndpoint verifies the cold-start path:
+// the endpoint files appearing mid-wait still get installed.
+func TestEnsureInstalledEventuallyWaitsForEndpoint(t *testing.T) {
+	home := withHome(t)
+
+	// Publish the endpoint files mid-wait, without t.Fatalf (which must not be
+	// called from a non-test goroutine); a failed write just times the test out.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		dir := filepath.Join(home, ".fleet")
+		_ = os.MkdirAll(dir, 0o700)
+		_ = os.WriteFile(filepath.Join(dir, "mcp.port"), []byte("6012"), 0o600)
+		_ = os.WriteFile(filepath.Join(dir, "mcp.token"), []byte("tok"), 0o600)
+	}()
+
+	if err := EnsureInstalledEventually(10 * time.Second); err != nil {
+		t.Fatalf("EnsureInstalledEventually() = %v, want nil", err)
+	}
+	fleetEntry(t, readConfigTree(t, home))
+}

--- a/internal/admiralmcp/mcp_test.go
+++ b/internal/admiralmcp/mcp_test.go
@@ -110,6 +110,27 @@ func TestEnsureInstalledRejectsGarbledPort(t *testing.T) {
 	}
 }
 
+// TestEnsureInstalledFailsFastOnUnreadablePort verifies a read failure that
+// is NOT absence (here: the port path is a directory) is a non-retryable
+// error — only "file doesn't exist yet" means the daemon isn't up.
+func TestEnsureInstalledFailsFastOnUnreadablePort(t *testing.T) {
+	home := withHome(t)
+	publishEndpoint(t, home, "6012", "tok")
+
+	portPath := filepath.Join(home, ".fleet", "mcp.port")
+	if err := os.Remove(portPath); err != nil {
+		t.Fatalf("remove port file: %v", err)
+	}
+	if err := os.Mkdir(portPath, 0o700); err != nil {
+		t.Fatalf("mkdir in place of port file: %v", err)
+	}
+
+	err := EnsureInstalled()
+	if err == nil || errors.Is(err, ErrNotReady) {
+		t.Fatalf("EnsureInstalled() with unreadable port = %v, want non-retryable error", err)
+	}
+}
+
 // TestEnsureInstalledCreatesConfig verifies a fresh install creates
 // ~/.claude.json (0600 — it embeds the bearer token) with the fleet server
 // entry pointing at the published endpoint.

--- a/internal/admiralskill/SKILL.md
+++ b/internal/admiralskill/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: fleet-admiral
-description: Gives you instructions on how to use the fleet tool. Use this when you need to know how to use fleet
-or the user is asking you to interact with fleet in some way, especially in the case of kicking of multiple agents 
-in fleet instances.
+description: >-
+  Teaches you what fleet is and how to drive its MCP tools (fleet_list,
+  fleet_up, fleet_exec, fleet_session_spawn, ...). Use this when you need to
+  interact with fleet in any way, especially when kicking off coding agents
+  in fleet instances.
 ---
 
 # Fleet Admiral
 
 `fleet` manages a fleet of isolated dev instances — each a devcontainer with its
 own checkout of a repository — and can run a coding agent inside any of them.
-This skill gives you an understanding of what fleet is and how to drive its CLI,
-so you can put it to use however a task calls for. It does not prescribe a
-workflow: you decide how to apply these capabilities to what the user asks.
+fleet exposes its capabilities as MCP tools (the `fleet_*` tools from the
+`fleet` MCP server). This skill gives you an understanding of what fleet is and
+how to drive those tools, so you can put them to use however a task calls for.
+It does not prescribe a workflow: you decide how to apply these capabilities to
+what the user asks.
 
 ## Concepts
 
@@ -23,118 +27,131 @@ workflow: you decide how to apply these capabilities to what the user asks.
      └── instance C
 ```
 
-- **Fleet** — a group of instances tied to one repository. Derived from the repo
-  (its name comes from the repo URL basename).
+- **Fleet** — a group of instances tied to one repository. You name it when
+  you create its first instance (conventionally the repo basename, but any
+  name works); use `fleet_list`/`fleet_status` to find existing names rather
+  than deriving them from URLs.
 - **Instance** — one devcontainer: an isolated workspace you can run
   commands in, open in an editor, or run an agent inside. It has a lifecycle
-  (`creating → running ⇄ stopped → deleting`, plus `failed`).
+  (`creating → running ⇄ stopped → deleting`, plus `failed`; transitional
+  `cloning`, `starting`, and `stopping` can also appear in `fleet_list`).
 - **Session** — a named, *detached* tmux session inside an instance. Sessions are
   how you interact non-interactively with something long-lived in an instance
   (most importantly, a coding agent): you create the session, send keystrokes to
-  it, and read back its current screen. It persists across separate CLI calls
+  it, and read back its current screen. It persists across separate tool calls
   until you stop the instance or kill it.
 
 ## Addressing instances
 
-Most commands take an instance reference: `<fleet>/<instance>` 
+Tools that target an instance take explicit `fleet` and `instance` string
+parameters — there is no working-directory inference and no combined
+`fleet/instance` form. (Fleet-level tools take just `fleet`; `fleet_clone`
+names its instances `source` and `destination`.) Use `fleet_list` or
+`fleet_status` to discover the names when you don't know them.
 
-## What the CLI can do
+## What the tools can do
 
-**Inspect state.** `fleet status` prints fleet-wide summary counts;
-`fleet list [fleet]` prints a per-instance table (name, status, branch,
-container, created). Output is human-readable text, not JSON — parse the columns
-if you need to act on it programmatically.
+All tools return structured JSON — no text output to parse.
 
-**Manage instance lifecycle.**
+**Inspect state.** `fleet_status` summarizes every fleet (instance counts by
+running/stopped/other, plus the repo remote). `fleet_list` returns per-instance
+records (fleet, instance, status, branch, tag, backend, container_id,
+workspace_dir, created_at, error), optionally filtered to one fleet. `fleet_version` reports
+the daemon's version and liveness. `fleet_logs` returns an instance's container
+logs (use `tail` to cap to the last N lines).
 
-- `fleet up <name> [--repo URL] [--branch BRANCH] [--backend devcontainer|coder|codespaces]`
-  creates and starts an instance. The repo is resolved from `--repo`, the
-  fleet's recorded remote, or the current directory's git remote. `--backend`
-  selects where it runs (Docker devcontainer by default; also Coder or GitHub
-  Codespaces). Backends need to be configured, so unless specified by user, prefer devcontainer backend
-- `fleet start <name>` / `fleet stop <name>` resume / pause an instance. Stop
-  preserves the workspace; start brings it back.
-- `fleet down <name>` stops and removes a single instance. `fleet destroy <fleet>`
-  removes a whole fleet and all its instances. **Both are irreversible** and
-  discard any uncommitted work in those instances.
+**Manage instance lifecycle.** These block until the job finishes server-side
+(`fleet_up` provisions a devcontainer — expect minutes, not seconds) and return
+`{success, instance, warnings}`; a failed job surfaces as a tool error.
 
-**Run a one-off command.** `fleet exec <name> <command...>` runs a command inside
-an instance and inherits your terminal (e.g. `fleet exec api go test ./...`). Use
-this when you don't need anything persistent.
+- `fleet_up {fleet, instance, remote?, branch?, backend?}` creates and starts an
+  instance. `remote` (a git URL) is required only when creating the first
+  instance of a new fleet; after that the fleet's recorded remote is used.
+  `backend` selects where it runs: `devcontainer`, `coder`, or `codespaces`.
+  Omitted, it falls back to the host's configured default backend
+  (`devcontainer` out of the box) — the others need prior configuration, so
+  leave it unset or pass `devcontainer` unless the user says otherwise.
+- `fleet_start` / `fleet_stop {fleet, instance}` resume / pause an instance.
+  Stop preserves the workspace; start brings it back.
+- `fleet_down {fleet, instance}` stops and removes a single instance.
+  `fleet_destroy_fleet {fleet}` removes a whole fleet and all its instances.
+  **Both are irreversible** and discard any uncommitted work in those instances.
+- `fleet_clone {fleet, source, destination, ...}` duplicates an instance,
+  keeping its installed state (optional `display_name`, `tag`, `color`,
+  `branch` overrides).
 
-> **Passing flags to your command — use `--`.** `fleet` parses flags *before* the
-> command you want to run, so any `-x` / `--flag` belonging to that command is
-> otherwise swallowed by fleet itself and you get `Error: unknown flag: --foo`.
-> Put a `--` after the instance (and session) arguments; everything after it is
-> passed through verbatim:
->
-> ```bash
-> fleet exec <instance> -- git log --oneline          # NOT: fleet exec <instance> git log --oneline
-> fleet exec-in-session <instance> <session> -- npm test --watch
-> ```
->
-> This bites the common cases — `-la`, `--oneline`, `-f`, `-n 5`. For
-> `exec-in-session` you can equivalently quote the whole command as a single
-> argument (`... <session> "npm test --watch"`), since it joins the remaining
-> args into one string before sending them; for `fleet exec`, prefer `--` so the
-> command's arguments stay as separate argv elements.
+**Run a one-off command.** `fleet_exec {fleet, instance, command}` runs a
+command inside an instance and returns `{stdout, stderr, exit_code}`. `command`
+is an argv **array**, not a shell string — `["git", "log", "--oneline"]` — so
+there is no quoting or flag-parsing to worry about. A non-zero exit comes back
+as data, not a tool error: check `exit_code`. Not for long-running or
+interactive commands — use a session for those.
 
 **Drive an agent (or any long-lived process) via sessions.** This is the
 non-interactive loop for working with a coding agent inside an instance:
 
-```bash
-fleet spawn-session <instance> <session>                 # create a detached tmux session
-fleet exec-in-session <instance> <session> "<command>"   # type a command + Enter into it
-fleet read-session <instance> <session> [--scrollback N] # capture the session's screen
-```
+- `fleet_session_spawn {fleet, instance, session}` — create a detached tmux
+  session.
+- `fleet_session_exec {fleet, instance, session, command}` — type a command
+  (one shell string) into the session + Enter. Fire-and-forget: it sends
+  keystrokes and returns immediately, without waiting for the command.
+- `fleet_session_read {fleet, instance, session, scrollback?}` — capture the
+  session's screen. `scrollback`: `0` (default) = just the visible screen,
+  positive N = the last N history lines, negative = full history.
+- `fleet_session_list {fleet, instance}` — the instance's tmux sessions
+  (session, windows, created_at, attached).
 
 Session names are canonicalized to `<instance>~<name>` internally so the
 session appears as a regular session group in the fleet TUI — keep using the
-short name with these commands; they all resolve it the same way.
+short name with these tools (they all resolve it the same way);
+`fleet_session_list` reports the canonical names.
 
-`exec-in-session` sends keystrokes (it does not wait for completion), so to
-follow progress you read the session back. `read-session --scrollback N` returns
-the last N lines (`0` = just the visible screen, `-1` = full history). To put an
-agent to work, launch the agent in the session with the task as its prompt, then
-read the session to see what it's doing or asking.
+To put an agent to work, spawn a session, exec the agent's launch command with
+the task as its prompt, then read the session to see what it's doing or asking.
 
 ## Behaviors worth knowing
 
-- Commands return exit code `0` on success, non-zero on failure, and print
-  errors to stderr.
-- `exec`, `shell`, and the `*-session` commands attach to your TTY / send raw
-  keystrokes — they assume an interactive terminal model.
-- Sessions are detached and survive between CLI invocations; reading one is a
+- An instance must be `running` to exec into it or use its sessions;
+  `fleet_start` a `stopped` one first.
+- Sessions are detached and survive between tool calls; reading one is a
   snapshot of its current screen, not a stream.
-- An instance must be `running` to exec into it or use its sessions; `start` a
-  `stopped` one first.
-- `fleet` parses its own flags first: separate the command you want to run with
-  `--` (see "Passing flags to your command") or its flags will be intercepted.
+- Errors come back as tool errors with a clear message (instance not found, not
+  running, job failed); the one exception is `fleet_exec`, where a non-zero
+  exit is ordinary result data.
+- Lifecycle `warnings` are non-fatal issues from an otherwise-successful job —
+  surface them, don't treat them as failure.
+- If the `fleet_*` MCP tools are not available, the `fleet` CLI offers the same
+  operations from the shell (`fleet --help`). The MCP server is registered in
+  Claude Code automatically when the fleet TUI runs; a missing registration
+  usually means fleet hasn't been started yet, the current Claude Code session
+  predates the registration (the config is read at session start — a new
+  session picks it up), or fleet points at a remote daemon via
+  `FLEET_GATEWAY`/`FLEET_SERVER`, where registration is intentionally skipped
+  and the MCP config must be copied from the TUI settings page.
 
-## Command reference
+## Tool reference
 
 ```
-LIFECYCLE
-  fleet up <name> [--repo URL] [--branch BRANCH] [--backend devcontainer|coder|codespaces]
-  fleet start <name>            # resume a stopped instance
-  fleet stop <name>             # pause, keep workspace
-  fleet down <name>             # stop + remove one instance        (irreversible)
-  fleet destroy <fleet>         # remove a fleet and all instances  (irreversible)
-  fleet clone <src> <dst>       # duplicate an instance (keeps installed state)
+INSPECT
+  fleet_status                                      # per-fleet + total counts
+  fleet_list {fleet?}                               # instance records
+  fleet_version                                     # daemon version/liveness
+  fleet_logs {fleet, instance, tail?}               # container logs
 
-INTROSPECTION
-  fleet status                  # fleet-wide summary counts
-  fleet list [fleet]            # per-instance table (name, status, branch, ...)
+LIFECYCLE  (block until the job completes; up can take minutes)
+  fleet_up {fleet, instance, remote?, branch?, backend?}
+  fleet_start {fleet, instance}                     # resume a stopped instance
+  fleet_stop {fleet, instance}                      # pause, keep workspace
+  fleet_down {fleet, instance}                      # remove one instance      (irreversible)
+  fleet_destroy_fleet {fleet}                       # remove fleet + instances (irreversible)
+  fleet_clone {fleet, source, destination, display_name?, tag?, color?, branch?}
 
-EXECUTION  (use `--` before a command that has its own flags)
-  fleet exec <name> -- <cmd...>           # e.g. fleet exec api -- git log --oneline
+EXECUTION
+  fleet_exec {fleet, instance, command: [argv...]}  # one-shot; exit_code is data
 
-SESSIONS (interact with an agent / long-lived process in an instance)
-  fleet spawn-session <instance> <session>
-  fleet exec-in-session <instance> <session> -- <cmd...>   # or quote: "<cmd>"
-  fleet read-session <instance> <session> [--scrollback N]   # 0 = screen, N = last N, -1 = all
-
-ADDRESSING
-  <instance>           # when run inside the repo's directory (fleet inferred)
-  <fleet>/<instance>   # from anywhere
+SESSIONS  (interact with an agent / long-lived process in an instance)
+  fleet_session_spawn {fleet, instance, session}
+  fleet_session_exec {fleet, instance, session, command: "shell string"}
+  fleet_session_read {fleet, instance, session, scrollback?}   # 0 screen, N last N, <0 all
+  fleet_session_list {fleet, instance}
 ```

--- a/internal/admiralskill/skill.go
+++ b/internal/admiralskill/skill.go
@@ -4,9 +4,10 @@
 //
 // The skill is a single SKILL.md that teaches a coding agent to act as an
 // orchestrator: spinning up fleet instances and delegating work to the agents
-// inside them via the `fleet` CLI. It is embedded into the fleet binary at build
-// time (//go:embed) so deployment is just the binary — there is no separate
-// asset to ship.
+// inside them via fleet's MCP tools (registered in Claude Code by the
+// companion package internal/admiralmcp). It is embedded into the fleet binary
+// at build time (//go:embed) so deployment is just the binary — there is no
+// separate asset to ship.
 //
 // Installation is hash-gated to keep startup cheap: a .hash file alongside the
 // installed SKILL.md records the sha256 of the content that was written. On each

--- a/internal/server/mcp_tools.go
+++ b/internal/server/mcp_tools.go
@@ -15,6 +15,7 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/dotfiles"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/tui"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
@@ -479,13 +480,18 @@ func (s *service) mcpSessionSpawn(ctx context.Context, _ *mcp.CallToolRequest, i
 	if err != nil {
 		return nil, FleetSessionMessageOutput{}, err
 	}
+	// Canonicalize to the TUI's group naming convention (<instance>~<name>),
+	// exactly like the CLI session commands — a bare-named session would
+	// surface as a pseudo-group in the TUI and splitting it would mint a
+	// duplicate real group with the same name.
+	sessionName := tui.ResolveSessionName(in.Instance, in.Session)
 	cctx, cancel := mergeCtx(s.bgCtx, ctx)
 	defer cancel()
-	snippet := dotfiles.TmuxEnsureInstalled + fmt.Sprintf(`tmux new-session -d -s %s`, dotfiles.ShQuote(in.Session))
+	snippet := dotfiles.TmuxEnsureInstalled + fmt.Sprintf(`tmux new-session -d -s %s`, dotfiles.ShQuote(sessionName))
 	if out, err := runContainerShell(cctx, inst, snippet); err != nil {
 		return nil, FleetSessionMessageOutput{}, fmt.Errorf("spawn session %q: %w: %s", in.Session, err, strings.TrimSpace(out))
 	}
-	return nil, FleetSessionMessageOutput{Message: fmt.Sprintf("created tmux session %q in %s/%s", in.Session, in.Fleet, in.Instance)}, nil
+	return nil, FleetSessionMessageOutput{Message: fmt.Sprintf("created tmux session %q in %s/%s", sessionName, in.Fleet, in.Instance)}, nil
 }
 
 type FleetSessionExecInput struct {
@@ -503,13 +509,16 @@ func (s *service) mcpSessionExec(ctx context.Context, _ *mcp.CallToolRequest, in
 	if err != nil {
 		return nil, FleetSessionMessageOutput{}, err
 	}
+	// Resolve the short name the agent uses to the same canonical session
+	// fleet_session_spawn created (no-op for already-canonical names).
+	sessionName := tui.ResolveSessionName(in.Instance, in.Session)
 	cctx, cancel := mergeCtx(s.bgCtx, ctx)
 	defer cancel()
-	snippet := fmt.Sprintf(`tmux send-keys -t %s %s Enter`, dotfiles.ShQuote(in.Session), dotfiles.ShQuote(in.Command))
+	snippet := fmt.Sprintf(`tmux send-keys -t %s %s Enter`, dotfiles.ShQuote(sessionName), dotfiles.ShQuote(in.Command))
 	if out, err := runContainerShell(cctx, inst, snippet); err != nil {
 		return nil, FleetSessionMessageOutput{}, fmt.Errorf("exec in session %q: %w: %s", in.Session, err, strings.TrimSpace(out))
 	}
-	return nil, FleetSessionMessageOutput{Message: fmt.Sprintf("sent command to session %q; read the session to see output", in.Session)}, nil
+	return nil, FleetSessionMessageOutput{Message: fmt.Sprintf("sent command to session %q; read the session to see output", sessionName)}, nil
 }
 
 type FleetSessionReadInput struct {
@@ -531,6 +540,8 @@ func (s *service) mcpSessionRead(ctx context.Context, _ *mcp.CallToolRequest, in
 	if err != nil {
 		return nil, FleetSessionReadOutput{}, err
 	}
+	// Same short-name resolution as fleet_session_spawn/exec.
+	sessionName := tui.ResolveSessionName(in.Instance, in.Session)
 	cctx, cancel := mergeCtx(s.bgCtx, ctx)
 	defer cancel()
 	// Translate scrollback into tmux's -S start-line: negative => full history
@@ -542,7 +553,7 @@ func (s *service) mcpSessionRead(ctx context.Context, _ *mcp.CallToolRequest, in
 	case in.Scrollback > 0:
 		startFlag = fmt.Sprintf("-S -%d ", in.Scrollback)
 	}
-	snippet := fmt.Sprintf(`tmux capture-pane -p %s-t %s`, startFlag, dotfiles.ShQuote(in.Session))
+	snippet := fmt.Sprintf(`tmux capture-pane -p %s-t %s`, startFlag, dotfiles.ShQuote(sessionName))
 	out, err := runContainerShell(cctx, inst, snippet)
 	if err != nil {
 		return nil, FleetSessionReadOutput{}, fmt.Errorf("read session %q: %w: %s", in.Session, err, strings.TrimSpace(out))

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/admiralmcp"
 	"github.com/BenjaminBenetti/fleet-man/internal/admiralskill"
 	"github.com/BenjaminBenetti/fleet-man/internal/codespaceerr"
 	"github.com/BenjaminBenetti/fleet-man/internal/configutil"
@@ -1037,6 +1038,14 @@ func Run() error {
 	// skill-install hiccup must never block startup, and client code does not
 	// write the server-owned event log.
 	_ = admiralskill.EnsureInstalled()
+
+	// Register the fleet MCP server in the user's Claude Code config
+	// (~/.claude.json) so an agent can actually CALL the tools that skill
+	// teaches. Backgrounded because on a cold start the endpoint files only
+	// appear once the auto-spawned daemon binds its MCP listener; the helper
+	// polls for them and gives up silently — same best-effort contract as the
+	// skill install, an MCP-install hiccup must never block (or slow) startup.
+	go admiralmcp.EnsureInstalledEventually(30 * time.Second)
 
 	m := newModel()
 


### PR DESCRIPTION
## What

Two halves of the same feature:

1. **Skill rewrite** — `internal/admiralskill/SKILL.md` now teaches fleet's MCP tools (`fleet_list`, `fleet_up`, `fleet_exec`, `fleet_session_*`, ...) instead of the CLI. Every claim is cross-checked against the actual tool schemas in `internal/server/mcp_tools.go`: explicit `fleet`/`instance` params, argv-array `fleet_exec` with `exit_code`-as-data, session scrollback semantics, lifecycle blocking + `{success, instance, warnings}`, irreversibility warnings. CLI-era content (the `--` flag-parsing trap, column parsing) is gone. Frontmatter is now a valid YAML folded scalar (the old multi-line plain scalar was malformed).

2. **MCP auto-install** — new `internal/admiralmcp` package, called from `tui.Run()` right beside the existing skill install. It merges a user-scope `fleet` server entry (Streamable HTTP URL + bearer token from `~/.fleet/mcp.port` / `mcp.token`) into `~/.claude.json`, so Claude Code can drive fleet with zero manual setup.

## Install semantics

- **Merge, never overwrite**: full-document decode with `json.Number` (large integers survive re-encoding), only `mcpServers.fleet` is touched; an unparseable config (corrupt JSON, trailing garbage, non-object `mcpServers`) is left byte-for-byte alone.
- **Atomic + symlink-aware**: temp file + rename next to the symlink-resolved target (fleet's own Claude-config instance mount is a symlink; dotfile managers too).
- **Concurrent-writer safe-ish**: optimistic pre-rename recheck — if `~/.claude.json` changed since the read (live Claude Code session, `claude mcp add`), the merge is redone from fresh content instead of clobbering; bounded retries, residual race self-heals on next startup.
- **Token-safe**: file mode clamped to owner-only — the entry embeds the MCP bearer token, which is the access boundary for the loopback port.
- **Best-effort**: backgrounded goroutine, polls for the daemon's endpoint files (cold start auto-spawn race), gives up silently after 30s, never blocks startup. Panic-proofed against `null`/blank/garbled configs. Skipped for remote daemons (`FLEET_GATEWAY`/`FLEET_SERVER`) — the settings page snippet covers that case.
- **Self-healing**: literal URL/token (not `${FLEET_MCP_*}` — env expansion only works for bash launches that sourced `mcp.env`), re-synced on every TUI start, so a daemon restart that lands on a new port heals on next launch.

## Tests

- 13 unit tests: fresh install, idempotent no-op (mtime), stale-port refresh, preserve-unrelated-keys (incl. a 2^53+1 integer), corrupt/trailing-garbage/non-object refusal, `null`-config no-panic, symlink preservation, empty-port retryability, remote skip, cold-start wait.
- Integration test `381` mirrors `380`: spawns the TUI, waits for the async install, asserts the registered URL/token match the daemon's live discovery files. Backs up and restores the runner's real `~/.claude.json` (stale-backup recovery included); the token is never echoed into test logs. `run.sh` additionally snapshots `~/.claude.json` suite-wide since every TUI-spawning test now mutates it.
- Verified end-to-end against a live daemon: registered entry written 0600, and the exact URL+token from the config completed an MCP `initialize` handshake (401 without it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Rebase note

Rebased onto #124 (tmux session-naming unification). That PR canonicalized the CLI session commands but not the MCP session tools — which this PR now points agents at — so a follow-up commit extends the same `tui.ResolveSessionName` canonicalization to `fleet_session_spawn`/`exec`/`read`. Agent-created sessions surface as regular session groups in the TUI instead of pseudo-groups; the skill documents the `<instance>~<name>` convention.
