### PR TITLE
feat: inject FLEET_INSTANCE_NAME env var via fleet.rc

### DIFF
--- a/internal/create/clone.go
+++ b/internal/create/clone.go
@@ -133,11 +133,13 @@ func RunClone(fleetName, srcInstance, destInstance string, verbose bool) (err er
 	// inherits whatever the source had — which may be stale if the host
 	// has been updated since the source was staged. EnsureFresh skips
 	// when the binary already matches; EnsureFleetRC always rewrites,
-	// which is cheap (small file, one exec). Non-fatal like in Run.
+	// which is cheap (small file, one exec) and also re-stamps
+	// FLEET_INSTANCE_NAME with the clone's own name rather than the
+	// source's. Non-fatal like in Run.
 	if _, err := fleetlaunch.EnsureFresh(instanceBackend, destWorkspaceDir, nil); err != nil {
 		state.WriteWarn(fleetName, destInstance, fmt.Sprintf("stage fleet-launch: %v", err))
 	}
-	if err := fleetlaunch.EnsureFleetRC(instanceBackend, destWorkspaceDir, homeDirForFleet(fleetName)); err != nil {
+	if err := fleetlaunch.EnsureFleetRC(instanceBackend, destWorkspaceDir, homeDirForFleet(fleetName), destInstance); err != nil {
 		state.WriteWarn(fleetName, destInstance, fmt.Sprintf("stage fleet.rc: %v", err))
 	}
 

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -135,7 +135,7 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backen
 	// shells can source fleet-aware aliases. Respects the fleet's
 	// HomeDir setting; empty falls back to fleetlaunch.DefaultHomeDir.
 	// Non-fatal for the same reason as the binary stage.
-	if err := fleetlaunch.EnsureFleetRC(instanceBackend, wsDir, homeDirForFleet(fleetName)); err != nil {
+	if err := fleetlaunch.EnsureFleetRC(instanceBackend, wsDir, homeDirForFleet(fleetName), instanceName); err != nil {
 		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("stage fleet.rc: %v", err))
 	}
 

--- a/internal/fleetlaunch/fleetrc.go
+++ b/internal/fleetlaunch/fleetrc.go
@@ -32,7 +32,26 @@ const bashrcMarker = ".fleet/fleet.rc"
 //go:embed fleet.rc
 var fleetRCContent string
 
-// EnsureFleetRC writes the embedded fleet.rc into the container at
+// renderFleetRC returns the fleet.rc content to stage into a container:
+// the embedded base rc plus a per-instance block exporting
+// FLEET_INSTANCE_NAME, so in-container tools can tell which instance
+// they are running in. The name is single-quoted with embedded quotes
+// escaped, so any name is safe to source. An empty name skips the
+// block, leaving the rc identical to the embedded base.
+func renderFleetRC(instanceName string) string {
+	if instanceName == "" {
+		return fleetRCContent
+	}
+	quoted := "'" + strings.ReplaceAll(instanceName, "'", `'\''`) + "'"
+	return fleetRCContent + fmt.Sprintf(`
+# FLEET_INSTANCE_NAME — the name of this fleet instance, so in-container
+# tools can tell which instance they're running in.
+export FLEET_INSTANCE_NAME=%s
+`, quoted)
+}
+
+// EnsureFleetRC writes the rendered fleet.rc (embedded base plus the
+// FLEET_INSTANCE_NAME export for instanceName) into the container at
 // <homeDir>/.fleet/fleet.rc and ensures the user's ~/.bashrc sources
 // it on shell startup. homeDir is the absolute path of the in-container
 // home (from FleetSettings.HomeDir); an empty string falls back to
@@ -47,7 +66,7 @@ var fleetRCContent string
 //     already present, so re-stages don't accumulate duplicates.
 //
 // All paths live in the user's home, so no sudo is needed.
-func EnsureFleetRC(instanceBackend backend.Backend, workspaceDir, homeDir string) error {
+func EnsureFleetRC(instanceBackend backend.Backend, workspaceDir, homeDir, instanceName string) error {
 	if homeDir == "" {
 		homeDir = DefaultHomeDir
 	}
@@ -60,7 +79,7 @@ func EnsureFleetRC(instanceBackend backend.Backend, workspaceDir, homeDir string
 	// the script literal.
 	write := fmt.Sprintf(`mkdir -p %s && cat > %s`, rcDir, target)
 	cmd := instanceBackend.ExecCommand(workspaceDir, []string{"sh", "-c", write})
-	cmd.Stdin = strings.NewReader(fleetRCContent)
+	cmd.Stdin = strings.NewReader(renderFleetRC(instanceName))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("write fleet.rc: %w (%s)", err, strings.TrimSpace(string(out)))
 	}

--- a/internal/fleetlaunch/fleetrc_test.go
+++ b/internal/fleetlaunch/fleetrc_test.go
@@ -1,0 +1,30 @@
+package fleetlaunch
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderFleetRCExportsInstanceName(t *testing.T) {
+	got := renderFleetRC("builder-1")
+	if !strings.HasPrefix(got, fleetRCContent) {
+		t.Fatalf("rendered rc does not start with the embedded base rc")
+	}
+	if !strings.Contains(got, "export FLEET_INSTANCE_NAME='builder-1'\n") {
+		t.Fatalf("rendered rc missing instance name export, got:\n%s", got)
+	}
+}
+
+func TestRenderFleetRCQuotesSingleQuotesInName(t *testing.T) {
+	got := renderFleetRC("o'brien")
+	want := `export FLEET_INSTANCE_NAME='o'\''brien'`
+	if !strings.Contains(got, want) {
+		t.Fatalf("rendered rc missing escaped export %q, got:\n%s", want, got)
+	}
+}
+
+func TestRenderFleetRCEmptyNameLeavesBaseUnchanged(t *testing.T) {
+	if got := renderFleetRC(""); got != fleetRCContent {
+		t.Fatalf("empty instance name should return the embedded rc unchanged, got:\n%s", got)
+	}
+}

--- a/internal/instanceops/post_start_hook.go
+++ b/internal/instanceops/post_start_hook.go
@@ -25,7 +25,7 @@ var postStartHook = func(fleetName string, instance *fleet.Instance, homeDir str
 	if _, err := fleetlaunch.EnsureFresh(instanceBackend, instance.WorkspaceDir, nil); err != nil {
 		state.WriteWarn(fleetName, instance.Name, fmt.Sprintf("stage fleet-launch: %v", err))
 	}
-	if err := fleetlaunch.EnsureFleetRC(instanceBackend, instance.WorkspaceDir, homeDir); err != nil {
+	if err := fleetlaunch.EnsureFleetRC(instanceBackend, instance.WorkspaceDir, homeDir, instance.Name); err != nil {
 		state.WriteWarn(fleetName, instance.Name, fmt.Sprintf("stage fleet.rc: %v", err))
 	}
 }


### PR DESCRIPTION
Closes #126

## What

Every fleet-managed instance now gets `FLEET_INSTANCE_NAME` exported in its shell environment, set to the instance's name, so in-container tools can tell which instance they're running in.

## How

The existing `fleet.rc` staging path does the work: `renderFleetRC` returns the embedded base rc plus a per-instance block exporting `FLEET_INSTANCE_NAME`, and `EnsureFleetRC` streams that rendered content instead of the raw embed. The name is single-quoted with embedded quotes escaped, so any instance name sources safely; an empty name leaves the rc byte-identical to the base.

`EnsureFleetRC` gains an `instanceName` parameter, threaded through all three stage paths:

- **create** — new instances get their name on first stage
- **clone** — the always-rewrite now also re-stamps the var with the clone's own name (the committed image carries the *source* instance's rc, so without this the clone would report the wrong name)
- **post-start hook** — restarted instances stay current

## Testing

- Unit tests for `renderFleetRC`: export present, single-quote escaping, empty-name passthrough
- `go build ./...`, `go vet ./...`, full `go test ./...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)