### PR TITLE
feat(launch): traverse parent directories to find the fleet devcontainer.json

### DIFF
--- a/internal/backend/devcontainer/customizations_loader.go
+++ b/internal/backend/devcontainer/customizations_loader.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 // devcontainerConfig is the narrow view of a devcontainer.json that
@@ -40,6 +41,63 @@ func LoadFleetCustomizations(workspaceDir string) (FleetCustomizations, error) {
 		return FleetCustomizations{}, fmt.Errorf("parse devcontainer.json customizations: %w", err)
 	}
 	return cfg.Customizations.Fleet, nil
+}
+
+// devcontainerConfigProbe decodes just enough of a devcontainer.json to
+// tell whether the customizations block CONTAINS a "fleet" namespace:
+// the pointer stays nil when the key is absent (or null), and points at
+// the decoded block when present — even an empty {} one. The plain
+// devcontainerConfig cannot make that distinction because its struct
+// field decodes an absent key and an empty block to the same zero value.
+type devcontainerConfigProbe struct {
+	Customizations struct {
+		Fleet *FleetCustomizations `json:"fleet"`
+	} `json:"customizations"`
+}
+
+// LoadFleetCustomizationsUpward searches startDir and then each of its
+// parents, up to the filesystem root, for a devcontainer.json whose
+// customizations block contains a "fleet" namespace, and returns that
+// block along with the path of the file it came from. It backs `fleet
+// launch` run from anywhere inside a project tree, not just its root.
+//
+// A devcontainer.json WITHOUT a fleet block does not stop the climb:
+// the project the user cares about may be a parent of an unconfigured
+// nested one, and a file with no fleet block has nothing to offer
+// fleet-man anyway. Reaching the root without a hit returns the zero
+// value and an empty path — like LoadFleetCustomizations, absence means
+// "defaults", not an error. A devcontainer.json that fails to parse IS
+// an error (naming the file): silently climbing past a malformed config
+// onto some ancestor's would launch the wrong project's links.
+func LoadFleetCustomizationsUpward(startDir string) (FleetCustomizations, string, error) {
+	// Absolutise so the parent walk terminates: Dir(".") is "." forever,
+	// while Dir of an absolute path converges on the root.
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return FleetCustomizations{}, "", err
+	}
+
+	for {
+		configPath, rawJSON, err := findDevcontainerJSON(dir)
+		switch {
+		case err == nil:
+			var probe devcontainerConfigProbe
+			if err := json.Unmarshal(toStrictJSON(rawJSON), &probe); err != nil {
+				return FleetCustomizations{}, "", fmt.Errorf("parse %s customizations: %w", configPath, err)
+			}
+			if probe.Customizations.Fleet != nil {
+				return *probe.Customizations.Fleet, configPath, nil
+			}
+		case !errors.Is(err, os.ErrNotExist):
+			return FleetCustomizations{}, "", err
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return FleetCustomizations{}, "", nil
+		}
+		dir = parent
+	}
 }
 
 // LoadFleetCustomizationsFromFile reads fleet-man's "customizations.fleet"

--- a/internal/backend/devcontainer/customizations_loader_test.go
+++ b/internal/backend/devcontainer/customizations_loader_test.go
@@ -3,6 +3,7 @@ package devcontainer
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -239,6 +240,161 @@ func TestLoadFleetCustomizationsMalformedErrors(t *testing.T) {
 
 	if _, err := LoadFleetCustomizations(dir); err == nil {
 		t.Fatal("LoadFleetCustomizations on malformed JSON = nil, want error")
+	}
+}
+
+// TestLoadFleetCustomizationsUpwardInStartDir verifies the upward search
+// finds a config in the start directory itself, without climbing.
+func TestLoadFleetCustomizationsUpwardInStartDir(t *testing.T) {
+	dir := t.TempDir()
+	writeDevcontainer(t, dir, `{
+		"customizations": {
+			"fleet": { "browser": { "initialUrl": "http://localhost:3000" } }
+		}
+	}`)
+
+	fc, path, err := LoadFleetCustomizationsUpward(dir)
+	if err != nil {
+		t.Fatalf("LoadFleetCustomizationsUpward = %v, want nil", err)
+	}
+	if want := filepath.Join(dir, ".devcontainer", "devcontainer.json"); path != want {
+		t.Errorf("path = %q, want %q", path, want)
+	}
+	if got, want := fc.Browser.InitialURL, "http://localhost:3000"; got != want {
+		t.Errorf("InitialURL = %q, want %q", got, want)
+	}
+}
+
+// TestLoadFleetCustomizationsUpwardClimbs verifies the search walks up
+// through intermediate directories (with no devcontainer.json of their
+// own) to the project root's config — the `fleet launch`-from-a-subdir
+// case the function exists for.
+func TestLoadFleetCustomizationsUpwardClimbs(t *testing.T) {
+	root := t.TempDir()
+	writeDevcontainer(t, root, `{
+		"customizations": {
+			"fleet": {
+				"fleetLaunch": { "sites": [ { "title": "API", "url": "http://localhost:3000" } ] }
+			}
+		}
+	}`)
+
+	deep := filepath.Join(root, "src", "internal", "deep")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatalf("mkdir deep tree: %v", err)
+	}
+
+	fc, path, err := LoadFleetCustomizationsUpward(deep)
+	if err != nil {
+		t.Fatalf("LoadFleetCustomizationsUpward = %v, want nil", err)
+	}
+	if want := filepath.Join(root, ".devcontainer", "devcontainer.json"); path != want {
+		t.Errorf("path = %q, want %q", path, want)
+	}
+	if got := len(fc.FleetLaunch.Sites); got != 1 {
+		t.Fatalf("len(Sites) = %d, want 1", got)
+	}
+}
+
+// TestLoadFleetCustomizationsUpwardSkipsFleetlessConfig verifies that a
+// devcontainer.json WITHOUT a customizations.fleet block does not stop
+// the climb: the search continues to an ancestor that has one.
+func TestLoadFleetCustomizationsUpwardSkipsFleetlessConfig(t *testing.T) {
+	root := t.TempDir()
+	writeDevcontainer(t, root, `{
+		"customizations": {
+			"fleet": { "browser": { "initialUrl": "http://localhost:9999" } }
+		}
+	}`)
+
+	nested := filepath.Join(root, "nested-project")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	writeDevcontainer(t, nested, `{
+		"customizations": { "vscode": { "extensions": ["golang.go"] } }
+	}`)
+
+	fc, path, err := LoadFleetCustomizationsUpward(nested)
+	if err != nil {
+		t.Fatalf("LoadFleetCustomizationsUpward = %v, want nil", err)
+	}
+	if want := filepath.Join(root, ".devcontainer", "devcontainer.json"); path != want {
+		t.Errorf("path = %q, want %q", path, want)
+	}
+	if got, want := fc.Browser.InitialURL, "http://localhost:9999"; got != want {
+		t.Errorf("InitialURL = %q, want %q", got, want)
+	}
+}
+
+// TestLoadFleetCustomizationsUpwardEmptyFleetBlockStops verifies that an
+// explicitly present (but empty) fleet block stops the climb: presence
+// of the namespace, not configured content, is the stopping condition.
+func TestLoadFleetCustomizationsUpwardEmptyFleetBlockStops(t *testing.T) {
+	root := t.TempDir()
+	writeDevcontainer(t, root, `{
+		"customizations": {
+			"fleet": { "browser": { "initialUrl": "http://localhost:9999" } }
+		}
+	}`)
+
+	nested := filepath.Join(root, "nested-project")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	writeDevcontainer(t, nested, `{
+		"customizations": { "fleet": {} }
+	}`)
+
+	fc, path, err := LoadFleetCustomizationsUpward(nested)
+	if err != nil {
+		t.Fatalf("LoadFleetCustomizationsUpward = %v, want nil", err)
+	}
+	if want := filepath.Join(nested, ".devcontainer", "devcontainer.json"); path != want {
+		t.Errorf("path = %q, want %q", path, want)
+	}
+	if fc.Browser.InitialURL != "" {
+		t.Errorf("InitialURL = %q, want empty (nested empty fleet block wins)", fc.Browser.InitialURL)
+	}
+}
+
+// TestLoadFleetCustomizationsUpwardNotFound verifies that reaching the
+// filesystem root without finding a fleet-configured devcontainer.json
+// yields the zero value, an empty path, and no error.
+func TestLoadFleetCustomizationsUpwardNotFound(t *testing.T) {
+	fc, path, err := LoadFleetCustomizationsUpward(t.TempDir())
+	if err != nil {
+		t.Fatalf("LoadFleetCustomizationsUpward = %v, want nil", err)
+	}
+	if path != "" {
+		t.Errorf("path = %q, want empty", path)
+	}
+	if fc.Browser.InitialURL != "" || fc.FleetLaunch.Configured() {
+		t.Errorf("customizations = %+v, want zero value", fc)
+	}
+}
+
+// TestLoadFleetCustomizationsUpwardMalformedErrors verifies that a
+// malformed devcontainer.json on the way up is an error naming the file,
+// rather than being silently skipped in favour of an ancestor's config.
+func TestLoadFleetCustomizationsUpwardMalformedErrors(t *testing.T) {
+	root := t.TempDir()
+	writeDevcontainer(t, root, `{
+		"customizations": { "fleet": {} }
+	}`)
+
+	nested := filepath.Join(root, "nested-project")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	writeDevcontainer(t, nested, `{ "customizations": { "fleet": { `)
+
+	_, _, err := LoadFleetCustomizationsUpward(nested)
+	if err == nil {
+		t.Fatal("LoadFleetCustomizationsUpward over malformed JSON = nil, want error")
+	}
+	if want := filepath.Join(nested, ".devcontainer", "devcontainer.json"); !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q does not name the malformed file %q", err, want)
 	}
 }
 

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -44,7 +44,7 @@ func newLaunchCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&configPath, "config", "", "devcontainer.json to read (default: auto-detect in the current directory)")
+	cmd.Flags().StringVar(&configPath, "config", "", "devcontainer.json to read (default: auto-detect by searching the current directory, then each parent, for one with a customizations.fleet block)")
 
 	return cmd
 }

--- a/internal/launchtui/headless.go
+++ b/internal/launchtui/headless.go
@@ -25,7 +25,7 @@ import (
 // section and an "Apps" section, each entry showing the title used to launch it
 // and its target. It needs no host connection. Backs `fleet launch list`.
 func List(cfg Config, w io.Writer) error {
-	fl, err := loadCustomizations(cfg.ConfigPath)
+	fl, _, err := loadCustomizations(cfg.ConfigPath)
 	if err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func LaunchByName(cfg Config, name string, out io.Writer) error {
 		out = io.Discard
 	}
 
-	fl, err := loadCustomizations(cfg.ConfigPath)
+	fl, _, err := loadCustomizations(cfg.ConfigPath)
 	if err != nil {
 		return err
 	}

--- a/internal/launchtui/launchtui.go
+++ b/internal/launchtui/launchtui.go
@@ -38,10 +38,12 @@ import (
 // socket.
 type Config struct {
 	// ConfigPath is the devcontainer.json to read. Empty means auto-detect by
-	// searching the current directory for .devcontainer/devcontainer.json or
-	// ./devcontainer.json (LoadFleetCustomizations(".")). A non-empty path is
-	// read directly (LoadFleetCustomizationsFromFile) and a missing file is an
-	// error.
+	// searching the current directory and then each parent directory for a
+	// .devcontainer/devcontainer.json or .devcontainer.json containing a
+	// customizations.fleet block (LoadFleetCustomizationsUpward(".")), so
+	// `fleet launch` works from anywhere inside the project tree. A non-empty
+	// path is read directly (LoadFleetCustomizationsFromFile) and a missing
+	// file is an error.
 	ConfigPath string
 	// SocketPath overrides the control socket the client dials. Empty means the
 	// standard container-side path (control.ContainerSocketPath). Tests set
@@ -68,12 +70,16 @@ func (c Config) socketPath() string {
 // the grid but reporting that opens won't work) so the user can still see what
 // is configured.
 func Run(cfg Config) error {
-	fl, err := loadCustomizations(cfg.ConfigPath)
+	fl, configPath, err := loadCustomizations(cfg.ConfigPath)
 	if err != nil {
 		return err
 	}
 	if !fl.FleetLaunch.Configured() {
-		fmt.Println("Fleet Launch has nothing to show: no links (fleetLaunch.sites) or apps (fleetLaunch.apps) are configured in this devcontainer.json.")
+		if configPath == "" {
+			fmt.Println("Fleet Launch has nothing to show: no devcontainer.json with a customizations.fleet block was found in the current directory or any parent.")
+		} else {
+			fmt.Printf("Fleet Launch has nothing to show: no links (fleetLaunch.sites) or apps (fleetLaunch.apps) are configured in %s.\n", configPath)
+		}
 		return nil
 	}
 
@@ -91,10 +97,15 @@ func Run(cfg Config) error {
 }
 
 // loadCustomizations reads the fleetLaunch configuration from an explicit path
-// when one is given, otherwise auto-detects it from the current directory.
-func loadCustomizations(configPath string) (devcontainer.FleetCustomizations, error) {
+// when one is given, otherwise auto-detects it by searching the current
+// directory and then each parent for a devcontainer.json containing a
+// customizations.fleet block — so `fleet launch` works from any subdirectory
+// of the project, not just its root. The returned path names the file the
+// configuration came from; it is empty when auto-detection found nothing.
+func loadCustomizations(configPath string) (devcontainer.FleetCustomizations, string, error) {
 	if configPath != "" {
-		return devcontainer.LoadFleetCustomizationsFromFile(configPath)
+		fl, err := devcontainer.LoadFleetCustomizationsFromFile(configPath)
+		return fl, configPath, err
 	}
-	return devcontainer.LoadFleetCustomizations(".")
+	return devcontainer.LoadFleetCustomizationsUpward(".")
 }


### PR DESCRIPTION
Closes #122

## What

`fleet launch` (`fl`) auto-detection no longer requires being run from the project root. When no `--config` is given, it now climbs from the current directory toward the filesystem root and uses the first `devcontainer.json` (`.devcontainer/devcontainer.json` or `.devcontainer.json`, same order as the devcontainer CLI) whose `customizations` block contains a `"fleet"` namespace. All three forms benefit (`fleet launch`, `fleet launch list`, `fleet launch <name>`).

## Behavior details

- A `devcontainer.json` **without** a fleet block does not stop the climb (per the issue: traverse until a file *containing the fleet customization block* is found) — e.g. a nested project configured only for VS Code is skipped in favor of the fleet-configured ancestor.
- An explicitly present-but-empty `"fleet": {}` block **does** stop the climb: presence of the namespace, not configured content, is the stopping condition.
- A malformed `devcontainer.json` on the way up is a hard error naming the file, rather than silently climbing past it onto some ancestor's config (which would launch the wrong project's links).
- Reaching the root with no hit keeps today's graceful behavior (zero-value defaults), and the TUI message now distinguishes "no fleet devcontainer.json found in the current directory or any parent" from "found one, but fleetLaunch isn't configured in <path>".
- Host-side callers (`internal/server/browser.go`, `internal/landingpage`) that pass explicit instance workspace dirs intentionally keep the non-traversing `LoadFleetCustomizations` — climbing out of an instance workspace would be wrong there.

## Implementation

- New `LoadFleetCustomizationsUpward(startDir)` in `internal/backend/devcontainer` returning the customizations plus the path they came from; key presence is probed with a `*FleetCustomizations` pointer field since the existing struct can't distinguish an absent fleet key from an empty block.
- `launchtui.loadCustomizations` now returns the resolved path too; `--config` help text updated.

## Testing

- 6 new unit tests: found in start dir, climbs through intermediate dirs, skips a fleet-less config, empty fleet block stops the climb, not-found returns zero value/no error, malformed file errors naming the path.
- `go vet ./...` and full `go test ./...` pass.
- Manually verified: `fleet launch list` from a deep subdirectory finds the project root's config (including JSONC comments/trailing commas), and from outside any project it degrades gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)