### PR TITLE
feat(tui): show instance tag on its own line when expanded

### DIFF
--- a/integration/tests/320_tui_tag_visible.sh
+++ b/integration/tests/320_tui_tag_visible.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Description: After tagging an instance, the tag is rendered in the instance row and survives a TUI restart.
+# Description: After tagging an instance, the tag renders on its own line under the expanded instance row, stays hidden while collapsed, and survives a TUI restart.
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
@@ -41,12 +41,12 @@ tui_wait_for "Tagged itest-fleet/alpha: release-blocker" 5
 tui_wait_for_absent "Tag instance" 5
 
 # ===========================================
-# 1. The tag must be rendered in the row. page_fleet renders it as
-#    `  # <tag>` appended to the instance line. Capture once and assert
-#    on the literal token — the dim style does not change the substring.
+# 1. While the instance is collapsed (sessions hidden) the tag must NOT
+#    render anywhere — it only shows on its own line under an expanded
+#    instance.
 # ===========================================
-info "asserting tag visible in row"
-tui_assert_contains "# release-blocker" "tag should be rendered in instance row after save"
+info "asserting tag hidden while collapsed"
+tui_assert_not_contains "# release-blocker" "tag must stay hidden while instance is collapsed"
 
 # Persistence in state.json — same contract as test 210, kept here so
 # this test is self-contained.
@@ -54,7 +54,20 @@ tag_value=$(grep -oE '"tag"[[:space:]]*:[[:space:]]*"[^"]*"' "${HOME}/.fleet/sta
 assert_contains "${tag_value}" "release-blocker" "tag missing from state.json after save"
 
 # ===========================================
-# 2. Quit + relaunch the TUI; the tag must still render.
+# 2. Expand the instance; the tag renders as a dim `# <tag>` line
+#    directly under the instance row. Capture once and assert on the
+#    literal token — the dim style does not change the substring.
+# ===========================================
+info "expanding alpha"
+tui_send Space
+tui_wait_for "+ new session" 15
+
+info "asserting tag visible while expanded"
+tui_assert_contains "# release-blocker" "tag should render under the expanded instance row"
+
+# ===========================================
+# 3. Quit + relaunch the TUI; expansion resets, so the tag is hidden
+#    again until the instance is re-expanded.
 # ===========================================
 info "quitting TUI"
 tui_send q
@@ -74,7 +87,16 @@ tui_spawn
 tui_wait_for "alpha" 15
 tui_wait_for "○ idle" 60
 
-info "asserting tag visible after relaunch"
-tui_assert_contains "# release-blocker" "tag should still render after TUI relaunch"
+info "asserting tag hidden after relaunch (instance starts collapsed)"
+tui_assert_not_contains "# release-blocker" "tag must stay hidden after relaunch while collapsed"
 
-pass "TUI tag is rendered in the row and persists across restart"
+info "expanding alpha after relaunch"
+tui_send j
+sleep 0.3
+tui_send Space
+tui_wait_for "+ new session" 15
+
+info "asserting tag visible after relaunch + expand"
+tui_assert_contains "# release-blocker" "tag should still render after TUI relaunch once expanded"
+
+pass "TUI tag renders under the expanded row, hides when collapsed, and persists across restart"

--- a/integration/tests/350_tui_tag_clear.sh
+++ b/integration/tests/350_tui_tag_clear.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Description: Re-opening the tag dialog with empty input clears the tag from the row and state.json.
+# Description: Re-opening the tag dialog with empty input clears the tag line from the expanded instance and from state.json.
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
@@ -14,8 +14,9 @@ tui_wait_for "alpha"  15
 tui_wait_for "○ idle" 60
 
 # ===========================================
-# Step 1 — set a tag the test will later clear. The row must visibly
-# show "# wip" once saved.
+# Step 1 — set a tag the test will later clear. The tag renders on its
+# own line under the instance row, but only while the instance is
+# expanded, so expand alpha before asserting "# wip" is visible.
 # ===========================================
 TAG="wip"
 info "moving cursor to alpha"
@@ -30,7 +31,11 @@ sleep 0.3
 tui_send Enter
 tui_wait_for "Tagged itest-fleet/alpha: ${TAG}" 5
 tui_wait_for_absent "Tag instance" 5
-tui_assert_contains "# ${TAG}" "tag must render in row after save"
+
+info "expanding alpha"
+tui_send Space
+tui_wait_for "+ new session" 15
+tui_assert_contains "# ${TAG}" "tag must render under the expanded instance row after save"
 
 # state.json sanity — the tag field is "wip".
 tag_value=$(grep -oE '"tag"[[:space:]]*:[[:space:]]*"[^"]*"' "${HOME}/.fleet/state.json" | head -1 || true)
@@ -38,11 +43,12 @@ assert_contains "${tag_value}" "${TAG}" "tag should be in state.json after save"
 
 # ===========================================
 # Step 2 — re-open the dialog. The text input is prefilled with the
-# current tag (page_fleet.go:599 SetValue(inst.Tag)), so we backspace
+# current tag (SetValue(inst.Tag) in the 't' handler), so we backspace
 # every character to leave it empty, then submit.
 # ===========================================
-# Defensive cursor re-seat — after dialog close, cursor stays on alpha,
-# but small wiggle protects against any buildRows reorder edge cases.
+# Defensive cursor re-seat — after dialog close, cursor stays on alpha.
+# The j/k wiggle also exercises the cursor skipping the (non-selectable)
+# tag line that now sits directly under alpha.
 tui_send j
 sleep 0.2
 tui_send k
@@ -65,12 +71,13 @@ tui_wait_for "Cleared tag for itest-fleet/alpha" 5
 tui_wait_for_absent "Tag instance" 5
 
 # ===========================================
-# Step 3 — the row must no longer carry the "# wip" suffix. The status
-# message itself contains "wip" only via "Cleared tag for itest-fleet/
-# alpha" — which does NOT include the tag — so plain absence is safe.
+# Step 3 — the tag line must be gone even though the instance is still
+# expanded. The status message itself contains "wip" only via "Cleared
+# tag for itest-fleet/alpha" — which does NOT include the tag — so plain
+# absence is safe.
 # ===========================================
-info "verifying tag no longer rendered in row"
-tui_assert_not_contains "# ${TAG}" "tag suffix must be gone from row after clear"
+info "verifying tag line no longer rendered"
+tui_assert_not_contains "# ${TAG}" "tag line must be gone after clear"
 
 # state.json: tag field is the empty string.
 tag_value=$(grep -oE '"tag"[[:space:]]*:[[:space:]]*"[^"]*"' "${HOME}/.fleet/state.json" | head -1 || true)
@@ -79,7 +86,8 @@ if [ -n "${tag_value}" ]; then
   assert_contains "${tag_value}" '""' "tag should be empty in state.json after clear"
 fi
 
-# Persistence check — relaunch the TUI and verify the row stays clean.
+# Persistence check — relaunch the TUI, re-expand, and verify the tag
+# line stays gone.
 info "quitting TUI"
 tui_send q
 deadline=$(( $(date +%s) + 10 ))
@@ -93,6 +101,10 @@ info "respawning TUI"
 tui_spawn
 tui_wait_for "alpha"  15
 tui_wait_for "○ idle" 60
+tui_send j
+sleep 0.3
+tui_send Space
+tui_wait_for "+ new session" 15
 tui_assert_not_contains "# ${TAG}" "cleared tag must stay cleared after restart"
 
-pass "TUI tag-clear round-trip removes tag from row + state and persists"
+pass "TUI tag-clear round-trip removes the tag line + state and persists"

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -516,7 +516,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch page := m.currentPage.(type) {
 			case *fleetPage:
 				if page.mode == viewNormal && page.listRowY >= 0 {
-					if idx := mouseMsg.Y - page.listRowY; idx >= 0 && idx < len(page.rows) {
+					if idx := mouseMsg.Y - page.listRowY; idx >= 0 && idx < len(page.rows) && page.rows[idx].selectable() {
 						page.cursor = idx
 						hit = true
 						if page.rows[idx].kind == rowInstance {

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -795,6 +795,9 @@ func (fleetPage *fleetPage) saveTagInstance(m *model) tea.Cmd {
 
 	fleetPage.mode = viewNormal
 	fleetPage.blurDialogFields()
+	// The tag renders as its own row under an expanded instance, so the
+	// row list must be rebuilt for the change to show immediately.
+	fleetPage.buildRows(m)
 	if tag == "" {
 		m.message = fmt.Sprintf("Cleared tag for %s/%s", fleetPage.dialogFleet, fleetPage.dialogInst)
 	} else {

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -310,6 +310,9 @@ func (fleetPage *fleetPage) buildRows(m *model) {
 				fleetPage.rows = append(fleetPage.rows, row{kind: rowInstance, fleetName: name, instance: instance})
 				ref := InstanceRef{Fleet: name, Instance: instance.Name}
 				if m.sessionStore.IsExpanded(ref) {
+					if instance.Tag != "" {
+						fleetPage.rows = append(fleetPage.rows, row{kind: rowInstanceTag, fleetName: name, instance: instance})
+					}
 					liveGroups := make(map[string]bool)
 					for _, g := range m.sessionStore.Groups(ref) {
 						liveGroups[g.GroupID] = true
@@ -339,6 +342,11 @@ func (fleetPage *fleetPage) buildRows(m *model) {
 	}
 	if fleetPage.cursor >= len(fleetPage.rows) {
 		fleetPage.cursor = max(0, len(fleetPage.rows)-1)
+	}
+	// A rebuild can shift rows so the cursor lands on a display-only row
+	// (e.g. a tag line inserted above a session row); nudge it forward.
+	if r := fleetPage.currentRow(); r != nil && !r.selectable() {
+		fleetPage.moveCursor(1)
 	}
 }
 
@@ -381,12 +389,26 @@ func (fleetPage *fleetPage) currentRow() *row {
 	return &fleetPage.rows[fleetPage.cursor]
 }
 
-// moveCursor moves the cursor by delta, wrapping around.
+// moveCursor moves the cursor by delta rows, wrapping around and
+// skipping rows the cursor may not rest on (e.g. instance tag lines).
 func (fleetPage *fleetPage) moveCursor(delta int) {
-	if len(fleetPage.rows) == 0 || delta == 0 {
+	n := len(fleetPage.rows)
+	if n == 0 || delta == 0 {
 		return
 	}
-	fleetPage.cursor = (fleetPage.cursor + delta + len(fleetPage.rows)) % len(fleetPage.rows)
+	step := 1
+	if delta < 0 {
+		step = -1
+		delta = -delta
+	}
+	for ; delta > 0; delta-- {
+		for range n {
+			fleetPage.cursor = (fleetPage.cursor + step + n) % n
+			if fleetPage.rows[fleetPage.cursor].selectable() {
+				break
+			}
+		}
+	}
 }
 
 // moveCursorToInstance moves the cursor to the next (delta > 0) or previous
@@ -1230,16 +1252,19 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 				if pfLabel := m.portForwards.FormatLabels(pfKey); pfLabel != "" {
 					line += portForwardStyle.Render("  ⇄ " + pfLabel)
 				}
-
-				if instance.Tag != "" {
-					line += dimStyle.Render("  # " + instance.Tag)
-				}
 			}
 
 			if maxW := m.width - 4; maxW > 0 && lipgloss.Width(line) > maxW {
 				line = ansi.Truncate(line, maxW-1, "…")
 			}
 
+			listContent.WriteString(line)
+			listContent.WriteString("\n")
+		} else if r.kind == rowInstanceTag {
+			line := fmt.Sprintf("%s        %s", cursor, dimStyle.Render("# "+r.instance.Tag))
+			if maxW := m.width - 4; maxW > 0 && lipgloss.Width(line) > maxW {
+				line = ansi.Truncate(line, maxW-1, "…")
+			}
 			listContent.WriteString(line)
 			listContent.WriteString("\n")
 		} else {

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -205,6 +205,136 @@ func TestBuildRowsShowsSavedGroupWithoutLiveSessions(t *testing.T) {
 	}
 }
 
+func tagTestModel(fp *fleetPage, inst *fleet.Instance, expanded bool) *model {
+	store := NewSessionStore()
+	if expanded {
+		store.SetExpanded(InstanceRef{Fleet: "alpha", Instance: inst.Name}, true)
+	}
+	return &model{
+		st: &state.State{
+			Fleets: map[string]*fleet.Fleet{
+				"alpha": {Name: "alpha", Instances: []*fleet.Instance{inst}},
+			},
+		},
+		sessionStore: store,
+		fleetPage:    fp,
+	}
+}
+
+func TestBuildRowsInsertsTagRowUnderExpandedInstance(t *testing.T) {
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning, Tag: "refactor auth"}
+	fp := newFleetPage()
+	m := tagTestModel(fp, inst, true)
+
+	fp.buildRows(m)
+
+	kinds := make([]rowKind, len(fp.rows))
+	for i, r := range fp.rows {
+		kinds[i] = r.kind
+	}
+	want := []rowKind{rowFleetHeader, rowInstance, rowInstanceTag, rowNewSession, rowSettings}
+	if !slices.Equal(kinds, want) {
+		t.Fatalf("row kinds = %v, want %v", kinds, want)
+	}
+}
+
+func TestBuildRowsOmitsTagRowWhenNotExpanded(t *testing.T) {
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning, Tag: "refactor auth"}
+	fp := newFleetPage()
+	m := tagTestModel(fp, inst, false)
+
+	fp.buildRows(m)
+
+	for _, r := range fp.rows {
+		if r.kind == rowInstanceTag {
+			t.Fatalf("tag row present for collapsed instance: %#v", fp.rows)
+		}
+	}
+}
+
+func TestBuildRowsOmitsTagRowWhenTagEmpty(t *testing.T) {
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning}
+	fp := newFleetPage()
+	m := tagTestModel(fp, inst, true)
+
+	fp.buildRows(m)
+
+	for _, r := range fp.rows {
+		if r.kind == rowInstanceTag {
+			t.Fatalf("tag row present for untagged instance: %#v", fp.rows)
+		}
+	}
+}
+
+func TestMoveCursorSkipsTagRow(t *testing.T) {
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning, Tag: "refactor auth"}
+	fp := newFleetPage()
+	fp.rows = []row{
+		{kind: rowFleetHeader, fleetName: "alpha"},
+		{kind: rowInstance, fleetName: "alpha", instance: inst},
+		{kind: rowInstanceTag, fleetName: "alpha", instance: inst},
+		{kind: rowNewSession, fleetName: "alpha", instance: inst},
+		{kind: rowSettings},
+	}
+
+	fp.cursor = 1
+	fp.moveCursor(1)
+	if fp.cursor != 3 {
+		t.Fatalf("cursor = %d after moving down, want 3 (tag row skipped)", fp.cursor)
+	}
+
+	fp.moveCursor(-1)
+	if fp.cursor != 1 {
+		t.Fatalf("cursor = %d after moving up, want 1 (tag row skipped)", fp.cursor)
+	}
+}
+
+func TestBuildRowsNudgesCursorOffTagRow(t *testing.T) {
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning, Tag: "refactor auth"}
+	fp := newFleetPage()
+	m := tagTestModel(fp, inst, true)
+
+	// Index 2 becomes the tag row once buildRows inserts it.
+	fp.cursor = 2
+	fp.buildRows(m)
+
+	if fp.rows[fp.cursor].kind == rowInstanceTag {
+		t.Fatalf("cursor resting on tag row at index %d", fp.cursor)
+	}
+	if fp.cursor != 3 {
+		t.Fatalf("cursor = %d, want 3 (nudged to next selectable row)", fp.cursor)
+	}
+}
+
+func TestViewFleetListRendersTagOnOwnLine(t *testing.T) {
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning, Tag: "refactor auth"}
+	fp := newFleetPage()
+	m := tagTestModel(fp, inst, true)
+	fp.buildRows(m)
+
+	view := fp.viewFleetList(m)
+	if !strings.Contains(view, "# refactor auth") {
+		t.Fatalf("view missing tag line:\n%s", view)
+	}
+	for line := range strings.SplitSeq(view, "\n") {
+		if strings.Contains(line, "agent-1") && strings.Contains(line, "refactor auth") {
+			t.Fatalf("tag rendered on the instance line: %q", line)
+		}
+	}
+}
+
+func TestViewFleetListHidesTagWhenNotExpanded(t *testing.T) {
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning, Tag: "refactor auth"}
+	fp := newFleetPage()
+	m := tagTestModel(fp, inst, false)
+	fp.buildRows(m)
+
+	view := fp.viewFleetList(m)
+	if strings.Contains(view, "refactor auth") {
+		t.Fatalf("tag visible for collapsed instance:\n%s", view)
+	}
+}
+
 func TestPruneSavedGroupsKeepsSavedGroupWhenDiscoveryIsEmpty(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/tui/rows.go
+++ b/internal/tui/rows.go
@@ -14,6 +14,7 @@ type rowKind int
 const (
 	rowFleetHeader rowKind = iota
 	rowInstance
+	rowInstanceTag
 	rowSession
 	rowNewSession
 	rowSettings
@@ -27,6 +28,12 @@ type row struct {
 	sessionName string // set when kind == rowSession or rowNewSession
 	groupID     string // set for grouped session rows
 	groupSize   int    // number of sessions in the group (for display)
+}
+
+// selectable reports whether the cursor may rest on this row. Instance
+// tag rows are display-only; navigation and mouse clicks skip them.
+func (r row) selectable() bool {
+	return r.kind != rowInstanceTag
 }
 
 // lastSession tracks the most recently used session for an instance,


### PR DESCRIPTION
Closes #121

The user-configurable instance tag used to render at the end of the instance status line, where it is usually truncated away whenever a split pane is open. It now renders as a dim `# tag` line directly under the instance line, and only while the instance is expanded (i.e. when sessions are showing), so it stays visible alongside a split pane.

## Changes

- New `rowInstanceTag` row kind, inserted by `buildRows` right after an expanded instance's row when the instance has a tag. Collapsed instances (or empty tags) get no tag row.
- Removed the inline `  # tag` suffix from the instance status line.
- The tag row is not selectable:
  - `moveCursor` (j/k, arrows) skips over it in both directions, wrapping included.
  - Mouse clicks on the tag line are ignored.
  - `buildRows` nudges the cursor off the tag row when a rebuild shifts rows underneath it (e.g. tagging an instance while the cursor sits on its first session row).
  - `shift+j/k` instance jumping already only stops on instance rows.
- `saveTagInstance` now rebuilds rows so setting/clearing a tag shows up immediately while expanded.

## AC

- [x] Tag appears on a new line under the instance line
- [x] Only visible when the instance is expanded
- [x] Cursor jumps over the line; it is not selectable

## Testing

- Unit tests for row building (tag row placement, collapsed/empty-tag omission), cursor skipping in both directions, cursor normalization after rebuild, and view rendering (tag on its own line when expanded, hidden when collapsed).
- `go build ./...`, `go vet`, and full `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)