### PR TITLE
feat(flog): record gateway tunnel ops + lifecycle jobs in fleet.log

### DIFF
--- a/internal/flog/flog.go
+++ b/internal/flog/flog.go
@@ -1,10 +1,11 @@
 // Package flog is fleet-man's application-wide event log.
 //
 // Major lifecycle actions across the codebase — fleet and instance
-// create/destroy, instance start/stop/clone, session create/kill/rename,
-// port-forwards, browser opens, TUI start/stop — and every command run
-// against a container write structured records here so the whole system's
-// behavior can be traced from one place: ~/.fleet/fleet.log.
+// create/destroy, instance start/stop/clone, server-side jobs, session
+// create/kill/rename, port-forwards, browser opens, TUI start/stop, the
+// remote-gateway tunnel's connects/drops — and every command run against a
+// container write structured records here so the whole system's behavior can
+// be traced from one place: ~/.fleet/fleet.log.
 //
 // This is deliberately distinct from the per-instance creation logs under
 // ~/.fleet/logs/<fleet>-<instance>.log, which capture a single instance's
@@ -96,7 +97,8 @@ func initLogger() {
 //
 // Keep keys consistent across call sites so the log stays greppable. The
 // conventional keys are: fleet, instance, session, backend, container,
-// branch, remote, from, to, port, ms, and err.
+// branch, remote, from, to, port, ms, err, job, kind, warn, gateway, and
+// publicURL.
 func Info(msg string, args ...any)  { L().Info(msg, args...) }
 func Warn(msg string, args ...any)  { L().Warn(msg, args...) }
 func Error(msg string, args ...any) { L().Error(msg, args...) }

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -49,6 +50,11 @@ func (s *service) SetConfig(_ context.Context, req *fleetgrpc.SetConfigRequest) 
 	if s.remote != nil {
 		s.remote.Reconcile(saved.RemoteMcpSettings.Enabled, saved.RemoteMcpSettings.GatewayURL)
 	}
+
+	// The remote-gateway fields are the ones whose effects outlive this RPC (the
+	// tunnel supervisor reacts to them), so call them out; the manager logs the
+	// resulting connection transitions itself.
+	flog.Info("config updated", "remoteMcp", saved.RemoteMcpSettings.Enabled, "gateway", saved.RemoteMcpSettings.GatewayURL)
 
 	return &fleetgrpc.SetConfigReply{Config: configToProto(saved)}, nil
 }

--- a/internal/server/jobs.go
+++ b/internal/server/jobs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/debcache"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetnet"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/imagecache"
 	"github.com/BenjaminBenetti/fleet-man/internal/instanceops"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
@@ -263,8 +265,14 @@ func (j *job) closeSubs() {
 // runJob is the shared driver: emit JobStarted, run work (which may emit further
 // events via emit), emit JobDone, then unregister + close subscribers. It runs
 // in its own goroutine so it is not tied to the calling RPC's lifetime.
+//
+// Every job is also recorded in the event log (started, each warning, then
+// finished/failed) so fleet.log carries an operation-level trail for ALL
+// lifecycle jobs — including those whose work has no logging of its own.
 func (s *service) runJob(j *job, work func() (finalInstance *fleetgrpc.Instance, warnings []string, err error)) {
 	start := time.Now()
+	kind := jobKindName(j.summary.Kind)
+	flog.Info("job started", "job", j.summary.JobId, "kind", kind, "fleet", j.summary.Fleet, "instance", j.summary.Instance)
 	j.emit(&fleetgrpc.JobEvent{JobId: j.summary.JobId, Event: &fleetgrpc.JobEvent_Started{Started: &fleetgrpc.JobStarted{
 		JobId:     j.summary.JobId,
 		Kind:      j.summary.Kind,
@@ -274,6 +282,15 @@ func (s *service) runJob(j *job, work func() (finalInstance *fleetgrpc.Instance,
 	}}})
 
 	finalInstance, warnings, err := work()
+
+	for _, w := range warnings {
+		flog.Warn("job warning", "job", j.summary.JobId, "kind", kind, "fleet", j.summary.Fleet, "instance", j.summary.Instance, "warn", w)
+	}
+	if err != nil {
+		flog.Error("job failed", "job", j.summary.JobId, "kind", kind, "fleet", j.summary.Fleet, "instance", j.summary.Instance, "ms", flog.MillisSince(start), "err", err)
+	} else {
+		flog.Info("job finished", "job", j.summary.JobId, "kind", kind, "fleet", j.summary.Fleet, "instance", j.summary.Instance, "ms", flog.MillisSince(start))
+	}
 
 	done := &fleetgrpc.JobDone{
 		Success:  err == nil,
@@ -290,6 +307,12 @@ func (s *service) runJob(j *job, work func() (finalInstance *fleetgrpc.Instance,
 	// Nudge a fresh snapshot to Watch subscribers (the work already persisted via
 	// state.Update; this just avoids waiting for the next poller tick).
 	s.pushState()
+}
+
+// jobKindName renders a JobKind as a compact event-log value: "create_instance"
+// rather than the proto's "JOB_KIND_CREATE_INSTANCE".
+func jobKindName(k fleetgrpc.JobKind) string {
+	return strings.ToLower(strings.TrimPrefix(k.String(), "JOB_KIND_"))
 }
 
 // relay streams a job's events (history then live) to a gRPC server stream until

--- a/internal/server/mutations.go
+++ b/internal/server/mutations.go
@@ -75,8 +75,10 @@ func (s *service) DestroyFleet(_ context.Context, req *fleetgrpc.DestroyFleetReq
 	// The deb/image cache + network teardown below is unconditional (idempotent),
 	// so a cache toggled off before destroy can't orphan its container/network.
 	buildkitEnabled := false
+	existed := false
 	if st, err := state.Load(); err == nil {
 		if f, ok := st.Fleets[req.GetName()]; ok {
+			existed = true
 			buildkitEnabled = f.Settings.BuildkitServer
 		}
 	}
@@ -108,6 +110,9 @@ func (s *service) DestroyFleet(_ context.Context, req *fleetgrpc.DestroyFleetReq
 	for _, w := range teardownWarnings {
 		flog.Warn("destroy fleet cache teardown", "fleet", req.GetName(), "warn", w)
 	}
+	if existed {
+		flog.Info("fleet destroyed", "fleet", req.GetName())
+	}
 	return &fleetgrpc.MutationReply{State: snapshot}, nil
 }
 
@@ -137,6 +142,7 @@ func (s *service) SetFleetSettings(_ context.Context, req *fleetgrpc.SetFleetSet
 	if err != nil {
 		return nil, err
 	}
+	flog.Info("fleet settings updated", "fleet", req.GetFleet())
 	return &fleetgrpc.MutationReply{State: snapshot}, nil
 }
 
@@ -168,6 +174,7 @@ func (s *service) SetInstanceMetadata(_ context.Context, req *fleetgrpc.SetInsta
 	if err != nil {
 		return nil, err
 	}
+	flog.Info("instance metadata updated", "fleet", req.GetFleet(), "instance", req.GetInstance())
 	return &fleetgrpc.MutationReply{State: snapshot}, nil
 }
 

--- a/internal/server/remote/manager.go
+++ b/internal/server/remote/manager.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/tunnel"
 )
 
@@ -138,6 +139,10 @@ func (m *Manager) Reconcile(enabled bool, gatewayURL string) {
 // flight, so there is no reconnection storm.
 func (m *Manager) Run(ctx context.Context) {
 	backoff := initialBackoff
+	// prev is the last desired config recorded in the event log, so config
+	// transitions (enable/disable/URL change) log once — not per attempt of the
+	// steady-state reconnect loop.
+	var prev desiredState
 	for {
 		if ctx.Err() != nil {
 			return
@@ -155,6 +160,11 @@ func (m *Manager) Run(ctx context.Context) {
 		d := m.desired
 		m.attemptCancel = cancel
 		m.mu.Unlock()
+
+		if d != prev {
+			logDesiredChange(prev, d)
+			prev = d
+		}
 
 		if !d.enabled || d.gatewayURL == "" {
 			cancel()
@@ -190,9 +200,11 @@ func (m *Manager) Run(ctx context.Context) {
 		if registered {
 			// An established tunnel dropped (gateway restart / network). Reconnect
 			// promptly; the next iteration republishes CONNECTING.
+			flog.Warn("remote gateway tunnel dropped; reconnecting", "gateway", d.gatewayURL, "err", err)
 			backoff = initialBackoff
 		} else {
 			// Never connected this attempt — surface the failure while we back off.
+			flog.Warn("remote gateway connect failed", "gateway", d.gatewayURL, "err", err)
 			m.publish(statusError(err))
 		}
 		if !m.sleep(ctx, jitter(backoff)) {
@@ -238,6 +250,7 @@ func (m *Manager) connectAndServe(ctx context.Context, gatewayURL string) (regis
 	// Registered. Persist the sticky session and report the public URL.
 	registered = true
 	_ = saveSession(sessionFile{SessionID: reply.SessionID, PublicURL: reply.PublicURL, GatewayURL: gatewayURL})
+	flog.Info("remote gateway connected", "gateway", gatewayURL, "publicURL", reply.PublicURL)
 	m.publish(statusConnected(reply.PublicURL))
 
 	session, err := tunnel.ClientSession(conn, m.logOut)
@@ -253,6 +266,22 @@ func (m *Manager) connectAndServe(ctx context.Context, gatewayURL string) (regis
 		return registered, serveTunnel(session, m.mcpPort, m.grpcLis)
 	}
 	return registered, serveProxy(session, m.mcpPort)
+}
+
+// logDesiredChange records a remote-gateway config transition in the event log:
+// enabled, reconfigured (URL change while enabled), or disabled. A change that
+// never turns the tunnel on (e.g. enabled with an empty URL) logs nothing.
+func logDesiredChange(prev, d desiredState) {
+	prevOn := prev.enabled && prev.gatewayURL != ""
+	on := d.enabled && d.gatewayURL != ""
+	switch {
+	case on && !prevOn:
+		flog.Info("remote gateway enabled", "gateway", d.gatewayURL)
+	case on && prevOn:
+		flog.Info("remote gateway reconfigured", "gateway", d.gatewayURL)
+	case prevOn:
+		flog.Info("remote gateway disabled")
+	}
 }
 
 // wait blocks until a Reconcile nudge arrives or ctx is cancelled. It returns


### PR DESCRIPTION
Closes #119

## Problem

fleet.log recorded nothing about the `fleet gateway` connection: the remote tunnel supervisor (`remote.Manager`) published status changes to the TUI but never wrote the event log, so connection state and errors were invisible after the fact. Several other operations (start/stop/destroy/down jobs, config changes) also logged nothing.

## Changes

**Gateway tunnel lifecycle (`internal/server/remote/manager.go`)** — the fleetd side of the tunnel now logs:
- `remote gateway enabled` / `reconfigured` / `disabled` — once per config transition (deduped against the reconnect loop, so steady-state retries don't re-log config)
- `remote gateway connected` — with the gateway URL and assigned public URL
- `remote gateway tunnel dropped; reconnecting` — when an established tunnel drops
- `remote gateway connect failed` — each failed attempt with its error (bounded by the existing 60s-max backoff)

**Lifecycle jobs (`internal/server/jobs.go`)** — `runJob` now records every server-side job uniformly: `job started`, each `job warning`, then `job finished`/`job failed` with duration. This covers start/stop/destroy/`fleet down` (which previously logged nothing) and gives every operation a consistent 2–3 message trail.

**Synchronous mutations** — `config updated` (calling out the remote-gateway fields), `fleet destroyed`, `fleet settings updated`, `instance metadata updated`.

**Docs** — flog package doc updated with the new conventional keys (`job`, `kind`, `warn`, `gateway`, `publicURL`).

## Notes

The gateway *server* (`fleet gateway`) keeps logging to stderr/journald: it is operator-run, deliberately isolated from `~/.fleet`, and depguard enforces that boundary. The fleet.log gap was on the fleetd side, which this fixes.

## Testing

- `make test` (depguard lint + full unit suite) passes.
- The remote manager tests exercise the connect/drop/reconnect paths the new logging sits on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)