### PR TITLE
feat(gateway): stable session URLs across gateway restarts (signed resume JWT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ fleet gateway \
 | `--public-addr` | `:443` | MCP + `/healthz` listener — HTTP/1.1 (HTTPS when a cert is set, else HTTP) |
 | `--grpc-addr` | `:50051` | Native gRPC listener — HTTP/2 (h2c when cert-less, h2 under TLS). Hosts remote `fleet` control **and** fleetd registration. Empty disables both |
 | `--max-sessions` | `1024` | Cap on concurrent tunnels |
+| `--session-key` | (random per boot) | Secret key signing the session-resume tokens daemons present on reconnect. Set it (or `FLEET_GATEWAY_SESSION_KEY`) so daemons keep the **same session URL across gateway restarts**; left unset, a restart hands every daemon a fresh URL |
 
 Two ports must be reachable: expose `--public-addr` to MCP agents and `--grpc-addr`
 to remote `fleet` clients **and your daemons** (they register over it). A
@@ -307,6 +308,11 @@ then serves plain HTTP.
   **the token is the secret** — share both only with agents you trust.
 - The id in the URL is *not* the reconnect credential: the daemon holds a separate
   secret (never placed in the URL), so a URL holder cannot hijack your tunnel.
+- **Session-resume tokens are bearer reclaim capabilities.** Each registration
+  returns a JWT signed with `--session-key`; the daemon stores it (mode `0600`,
+  next to the secret) and presents it on reconnect, which is what keeps the URL
+  stable across gateway restarts. Anyone holding the token can claim that session,
+  so guard the signing key like any other server secret.
 - The public connection is TLS when the gateway holds a cert (the daemon verifies
   it against the system roots), or when a reverse proxy terminates TLS in front of
   it. Running the gateway itself on plain HTTP is only safe behind such a proxy (or

--- a/doc/gateway.md
+++ b/doc/gateway.md
@@ -78,10 +78,12 @@ machinery runs over it as would over a TCP conn — there is no separate control
       │  (TLS for https / h2c for http)                  │   wrap stream as net.Conn
       │                                                  │
       │  RegisterRequest frame ───────────────────────────▶  claim a session
-      │   { session_id?, client_version, features:[grpc] }   • mint secret + publicID
+      │   { session_id?, session_token?,                 │   • mint secret + publicID
+      │     client_version, features:[grpc] }            │     (or resurrect from token)
       │                                                  │   • negotiate features
       │  ◀───────────────────────────────────────  RegisterReply frame
-      │     { session_id, public_url, features:[grpc] }  │
+      │     { session_id, session_token,                 │
+      │       public_url, features:[grpc] }              │
       │                                                  │
       │  ===== both wrap the SAME stream in yamux ====    │
       │   fleetd = yamux CLIENT      gateway = yamux SERVER
@@ -105,6 +107,15 @@ Key points:
   The secret is **never** placed in the URL, so a holder of the URL cannot hijack
   the tunnel. A disconnected session is held for a grace TTL (~10 min) before the
   reaper frees its URL.
+
+- **Stable URLs across gateway restarts.** The reply also carries a
+  **session‑resume token**: a JWT over the session's two ids, HMAC‑signed with the
+  gateway's `--session-key` (`token.go`). The daemon persists it next to the
+  secret and presents it on reconnect; a **restarted** gateway — whose in‑memory
+  registry is empty — verifies the signature and *resurrects* the session under
+  its original ids, so the public URL survives the restart. Without
+  `--session-key` the signing key is random per boot and a restart hands out
+  fresh URLs (the pre‑token behavior).
 
 - **Feature negotiation.** `fleetd` advertises the capabilities it supports
   (`features: ["grpc"]`); the gateway replies with the **intersection** of what
@@ -263,6 +274,11 @@ Security properties:
   streams, but **every request without a valid token is rejected** by `fleetd`.
 - **No hijack.** The reconnect *secret* is distinct from the public id and never
   appears in the URL, so a URL holder cannot re‑register the session.
+- **The session‑resume token is a bearer reclaim capability.** It is returned
+  only on the register stream and stored by the daemon at `0600`; whoever holds
+  it (or the `--session-key` that signs it) can claim that session's URL. The
+  verifier pins the algorithm (HS256, constant‑time compare) and requires the
+  claim ids to be exactly 256‑bit hex before they touch the registry or a URL.
 - **The local unix socket stays auth‑less** (same‑user, `0600`) — only the
   *tunnel‑facing* servers require the token.
 - **Public traffic is TLS — terminated either by the gateway or by a proxy in
@@ -313,7 +329,9 @@ OS system roots) **or** `http://` (plaintext h2c), defaulting the port to 443/80
 ## 8. Lifecycle & resilience
 
 - **Reconnect.** If the tunnel drops, `remote.Manager` reconnects with jittered
-  exponential backoff, resending its secret so the gateway re‑binds the same URL.
+  exponential backoff, resending its secret (and the signed session‑resume token)
+  so the gateway re‑binds the same URL — even when the drop was the gateway
+  itself restarting, provided it runs with a stable `--session-key`.
 - **Reaping.** The gateway holds a disconnected session (URL reserved) for a grace
   TTL, then a reaper frees it — so a `kill -9`'d daemon's URL is released, but a
   brief network blip keeps the URL stable.

--- a/internal/cli/gateway.go
+++ b/internal/cli/gateway.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"os"
+
 	"github.com/BenjaminBenetti/fleet-man/internal/gateway"
 	"github.com/spf13/cobra"
 )
@@ -28,9 +30,15 @@ func newGatewayCmd() *cobra.Command {
 			"the gateway (use a publicly-trusted cert, e.g. from Let's Encrypt, so fleet\n" +
 			"daemons can verify it). Omit both to serve plain HTTP — intended for running\n" +
 			"behind a TLS-terminating reverse proxy (e.g. Kubernetes/Traefik), which then\n" +
-			"presents the public cert. Set --public-url's scheme to match (https vs http).",
+			"presents the public cert. Set --public-url's scheme to match (https vs http).\n\n" +
+			"Set --session-key (or FLEET_GATEWAY_SESSION_KEY) to a stable secret so fleet\n" +
+			"daemons keep their session URL across gateway restarts; without it each boot\n" +
+			"uses a random key and a restart hands every daemon a fresh URL.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if cfg.SessionKey == "" {
+				cfg.SessionKey = os.Getenv("FLEET_GATEWAY_SESSION_KEY")
+			}
 			return gateway.Serve(cmd.Context(), cfg)
 		},
 	}
@@ -42,6 +50,7 @@ func newGatewayCmd() *cobra.Command {
 	f.StringVar(&cfg.TLSCert, "tls-cert", "", "path to the TLS certificate, PEM (optional; set with --tls-key to enable TLS)")
 	f.StringVar(&cfg.TLSKey, "tls-key", "", "path to the TLS private key, PEM (optional; set with --tls-cert to enable TLS)")
 	f.IntVar(&cfg.MaxSessions, "max-sessions", 0, "max concurrent tunnels (0 = default 1024)")
+	f.StringVar(&cfg.SessionKey, "session-key", "", "secret key signing session-resume tokens, so daemons keep their session URL across gateway restarts (empty = random per boot; FLEET_GATEWAY_SESSION_KEY is also read)")
 
 	return cmd
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -31,7 +31,11 @@
 // comes from the unguessable 256-bit public id in the URL, and the real access
 // boundary remains the MCP bearer token, which the gateway forwards untouched to
 // fleetd's loopback MCP server. The reclaim credential (the tunnel "secret") is
-// kept out of the public URL so URL holders cannot hijack a tunnel.
+// kept out of the public URL so URL holders cannot hijack a tunnel. Every
+// registration also returns a session-resume token — a JWT over the session's
+// ids signed with the gateway's session key (--session-key) — which fleetd
+// presents on reconnect so its session URL stays stable even across gateway
+// restarts (see token.go).
 package gateway
 
 import (
@@ -92,6 +96,7 @@ type Config struct {
 	TLSCert     string // path to the TLS certificate (PEM). Optional; both TLSCert and TLSKey together enable TLS.
 	TLSKey      string // path to the TLS private key (PEM). Optional; both TLSCert and TLSKey together enable TLS.
 	MaxSessions int    // cap on concurrent tunnels. Default 1024.
+	SessionKey  string // secret key signing session-resume tokens (token.go). Empty = a random per-boot key, so session URLs do not survive a gateway restart.
 }
 
 // Server is a configured gateway. Build with New, then Run. tlsConfig is nil when
@@ -134,9 +139,14 @@ func New(cfg Config) (*Server, error) {
 	}
 	cfg.PublicURL = strings.TrimRight(cfg.PublicURL, "/")
 
+	signer, err := newTokenSigner(cfg.SessionKey)
+	if err != nil {
+		return nil, fmt.Errorf("gateway: session token key: %w", err)
+	}
+
 	return &Server{
 		cfg:        cfg,
-		reg:        newRegistry(cfg.PublicURL, cfg.MaxSessions),
+		reg:        newRegistry(cfg.PublicURL, cfg.MaxSessions, signer),
 		tlsConfig:  tlsConfig,
 		log:        slog.Default(),
 		pendingSem: make(chan struct{}, cfg.MaxSessions+maxPendingHandshakes),
@@ -212,6 +222,9 @@ func (s *Server) ServeListeners(ctx context.Context, publicLn, grpcLn net.Listen
 
 	s.log.Info("fleet gateway started",
 		"public", s.cfg.PublicAddr, "grpc", s.cfg.GRPCAddr, "public_url", s.cfg.PublicURL)
+	if s.cfg.SessionKey == "" {
+		s.log.Warn("gateway: no --session-key set; session URLs will not survive a gateway restart")
+	}
 
 	select {
 	case <-ctx.Done():

--- a/internal/gateway/gateway_e2e_test.go
+++ b/internal/gateway/gateway_e2e_test.go
@@ -70,11 +70,17 @@ func genTestTLS(t *testing.T) (tls.Certificate, *x509.CertPool) {
 // public (TLS) + gRPC (plain — grpc.Creds adds TLS) listeners, returning their
 // addresses (public, grpc). fleetd registers over the gRPC listener.
 func startTestGateway(t *testing.T, cert tls.Certificate, publicBase string) (*Server, string, string) {
+	return startTestGatewayKeyed(t, cert, publicBase, "")
+}
+
+// startTestGatewayKeyed is startTestGateway with an explicit session key, for
+// restart tests that need two gateway instances sharing a token-signing key.
+func startTestGatewayKeyed(t *testing.T, cert tls.Certificate, publicBase, sessionKey string) (*Server, string, string) {
 	t.Helper()
 	tlsCfg := &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}
 	s := &Server{
-		cfg:       Config{PublicURL: publicBase, MaxSessions: 64},
-		reg:       newRegistry(publicBase, 64),
+		cfg:       Config{PublicURL: publicBase, MaxSessions: 64, SessionKey: sessionKey},
+		reg:       newRegistry(publicBase, 64, testSigner(t, sessionKey)),
 		tlsConfig: tlsCfg,
 		log:       slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
@@ -98,7 +104,7 @@ func startTestGatewayPlain(t *testing.T, publicBase string) (*Server, string, st
 	t.Helper()
 	s := &Server{
 		cfg:       Config{PublicURL: publicBase, MaxSessions: 64},
-		reg:       newRegistry(publicBase, 64),
+		reg:       newRegistry(publicBase, 64, testSigner(t, "")),
 		tlsConfig: nil,
 		log:       slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}

--- a/internal/gateway/register_test.go
+++ b/internal/gateway/register_test.go
@@ -22,7 +22,7 @@ import (
 func TestGatewayRegisterFloodShed(t *testing.T) {
 	s := &Server{
 		cfg:        Config{PublicURL: "http://gw.example.com", MaxSessions: 64},
-		reg:        newRegistry("http://gw.example.com", 64),
+		reg:        newRegistry("http://gw.example.com", 64, testSigner(t, "")),
 		log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
 		pendingSem: make(chan struct{}, 2), // tiny cap for the test
 	}
@@ -105,5 +105,57 @@ func TestGatewayReconnectAfterDrop(t *testing.T) {
 	}
 	if r2.SessionID != r1.SessionID {
 		t.Fatalf("reconnect secret changed %q -> %q", r1.SessionID, r2.SessionID)
+	}
+}
+
+// TestGatewayRestartStableURL exercises issue #120 over the real Register
+// transport: a daemon that registered against one gateway reconnects to a
+// RESTARTED gateway (a fresh instance sharing the --session-key) presenting the
+// session token from its first reply, and recovers the SAME public URL. A
+// restarted gateway with a DIFFERENT key hands out a fresh URL instead.
+func TestGatewayRestartStableURL(t *testing.T) {
+	cert, pool := genTestTLS(t)
+	const key = "stable-session-key"
+
+	// First boot: register fresh.
+	_, _, grpcAddr1 := startTestGatewayKeyed(t, cert, "https://gw.example.com", key)
+	conn1 := openRegisterStream(t, grpcAddr1, tlsCreds(pool))
+	r1, err := tunnel.Handshake(conn1, tunnel.RegisterRequest{ClientVersion: "v"}, 5*time.Second)
+	if err != nil || r1.Error != "" {
+		t.Fatalf("handshake 1: err=%v reply.Error=%q", err, r1.Error)
+	}
+	if r1.SessionToken == "" {
+		t.Fatal("registration must return a session token")
+	}
+	_ = conn1.Close()
+
+	// "Restart": an entirely new gateway instance (empty registry), same key.
+	_, _, grpcAddr2 := startTestGatewayKeyed(t, cert, "https://gw.example.com", key)
+	conn2 := openRegisterStream(t, grpcAddr2, tlsCreds(pool))
+	r2, err := tunnel.Handshake(conn2, tunnel.RegisterRequest{
+		SessionID:     r1.SessionID,
+		SessionToken:  r1.SessionToken,
+		ClientVersion: "v",
+	}, 5*time.Second)
+	if err != nil || r2.Error != "" {
+		t.Fatalf("handshake 2: err=%v reply.Error=%q", err, r2.Error)
+	}
+	if r2.PublicURL != r1.PublicURL || r2.SessionID != r1.SessionID {
+		t.Fatalf("session must survive the restart: url %q -> %q", r1.PublicURL, r2.PublicURL)
+	}
+
+	// A restart with a DIFFERENT key cannot verify the token: fresh URL.
+	_, _, grpcAddr3 := startTestGatewayKeyed(t, cert, "https://gw.example.com", "rotated-key")
+	conn3 := openRegisterStream(t, grpcAddr3, tlsCreds(pool))
+	r3, err := tunnel.Handshake(conn3, tunnel.RegisterRequest{
+		SessionID:     r1.SessionID,
+		SessionToken:  r1.SessionToken,
+		ClientVersion: "v",
+	}, 5*time.Second)
+	if err != nil || r3.Error != "" {
+		t.Fatalf("handshake 3: err=%v reply.Error=%q", err, r3.Error)
+	}
+	if r3.PublicURL == r1.PublicURL {
+		t.Fatal("a gateway with a different key must NOT honor the token")
 	}
 }

--- a/internal/gateway/registry.go
+++ b/internal/gateway/registry.go
@@ -25,6 +25,7 @@ type registry struct {
 	byPublic   map[string]*session
 	publicBase string // e.g. "https://gw.example.com" or "http://gw.example.com" (no trailing slash)
 	max        int
+	signer     *tokenSigner // signs the session-resume token in every reply (see token.go)
 }
 
 // errAtCapacity is returned by claim when the session cap is reached. Since the
@@ -32,12 +33,13 @@ type registry struct {
 // guard against unbounded session creation.
 var errAtCapacity = errors.New("gateway at capacity")
 
-func newRegistry(publicBase string, max int) *registry {
+func newRegistry(publicBase string, max int, signer *tokenSigner) *registry {
 	return &registry{
 		bySecret:   make(map[string]*session),
 		byPublic:   make(map[string]*session),
 		publicBase: publicBase,
 		max:        max,
+		signer:     signer,
 	}
 }
 
@@ -53,23 +55,51 @@ func newID() (string, error) {
 }
 
 // claim resolves a registration to a session and the reply to send back. On a
-// reclaim (req.SessionID is a known secret) it returns the existing session
-// (isNew=false) and its original public URL. Otherwise it RESERVES a fresh slot:
-// it checks the cap and inserts the new session into bySecret atomically (under
-// the registry lock), so the MaxSessions cap is a HARD limit even under a burst
-// of concurrent first-time registrations. The reserved session is not yet
-// routable (byPublic is populated at bind); the caller must bind() on a
-// successful handshake or release() the reservation on failure.
+// reclaim (req.SessionID is a known secret, or req.SessionToken is a session
+// token this gateway's key signed) it returns the session — live, or
+// resurrected under its original ids — and its original public URL. Otherwise
+// it RESERVES a fresh slot: it checks the cap and inserts the new session into
+// bySecret atomically (under the registry lock), so the MaxSessions cap is a
+// HARD limit even under a burst of concurrent first-time registrations. A
+// reserved-or-resurrected session is not yet routable (byPublic is populated at
+// bind); the caller must bind() on a successful handshake or release() the
+// reservation on failure (isNew marks those).
 func (r *registry) claim(req tunnel.RegisterRequest) (s *session, reply tunnel.RegisterReply, isNew bool, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if req.SessionID != "" {
 		if existing, ok := r.bySecret[req.SessionID]; ok {
-			return existing, tunnel.RegisterReply{SessionID: existing.secret, PublicURL: existing.publicURL}, false, nil
+			return existing, r.reply(existing), false, nil
 		}
-		// Unknown secret (e.g. the gateway restarted, or a stale file): fall
-		// through and mint a fresh session rather than failing.
+		// Unknown secret (e.g. the gateway restarted, or a stale file): try the
+		// signed session token below before minting a fresh session.
+	}
+
+	// Stable-URL path (issue #120): the secret is not in memory — typically
+	// because the gateway restarted and lost its registry — but the request
+	// carries a session token signed with this gateway's session key. The
+	// signature proves a gateway holding the key minted these ids, so resurrect
+	// the session under them and the daemon keeps its public URL.
+	if claims, ok := r.signer.verify(req.SessionToken); ok {
+		if existing, ok := r.bySecret[claims.Secret]; ok {
+			return existing, r.reply(existing), false, nil
+		}
+		if len(r.bySecret) >= r.max {
+			return nil, tunnel.RegisterReply{}, false, errAtCapacity
+		}
+		if _, taken := r.byPublic[claims.PublicID]; !taken {
+			s = &session{
+				secret:    claims.Secret,
+				publicID:  claims.PublicID,
+				publicURL: r.publicBase + "/mcp/" + claims.PublicID,
+				createdAt: time.Now(),
+			}
+			r.bySecret[claims.Secret] = s // reserve the slot, as for a fresh mint
+			return s, r.reply(s), true, nil
+		}
+		// The public id is already routed by a DIFFERENT session (impossible for
+		// honestly-minted ids; defensive): fall through to a fresh mint.
 	}
 
 	if len(r.bySecret) >= r.max {
@@ -91,7 +121,19 @@ func (r *registry) claim(req tunnel.RegisterRequest) (s *session, reply tunnel.R
 		createdAt: time.Now(),
 	}
 	r.bySecret[secret] = s // reserve the slot now -> cap is a hard limit
-	return s, tunnel.RegisterReply{SessionID: secret, PublicURL: s.publicURL}, true, nil
+	return s, r.reply(s), true, nil
+}
+
+// reply builds the success RegisterReply for s. It mints a FRESH session token
+// every time (claims and reclaims alike), so the daemon always ends up holding
+// a token signed with the gateway's current key — a rotated key self-heals on
+// the first successful reconnect.
+func (r *registry) reply(s *session) tunnel.RegisterReply {
+	return tunnel.RegisterReply{
+		SessionID:    s.secret,
+		PublicURL:    s.publicURL,
+		SessionToken: r.signer.mint(s.secret, s.publicID),
+	}
 }
 
 // bind installs the live tunnel on a claimed session and makes it routable. It

--- a/internal/gateway/registry_test.go
+++ b/internal/gateway/registry_test.go
@@ -11,6 +11,17 @@ import (
 	"github.com/hashicorp/yamux"
 )
 
+// testSigner returns a tokenSigner on key (a random per-boot key when empty),
+// failing the test instead of returning an error.
+func testSigner(t *testing.T, key string) *tokenSigner {
+	t.Helper()
+	s, err := newTokenSigner(key)
+	if err != nil {
+		t.Fatalf("new token signer: %v", err)
+	}
+	return s
+}
+
 // fakeTunnel returns a live yamux session (the gateway/server end) backed by an
 // in-memory pipe, so registry tests can bind real sessions without a network.
 func fakeTunnel(t *testing.T) *yamux.Session {
@@ -34,7 +45,7 @@ func fakeTunnel(t *testing.T) *yamux.Session {
 }
 
 func TestRegistryClaimMintsDistinctUnguessableIDs(t *testing.T) {
-	r := newRegistry("https://gw.example.com", 16)
+	r := newRegistry("https://gw.example.com", 16, testSigner(t, ""))
 
 	s1, reply1, _, err := r.claim(tunnel.RegisterRequest{})
 	if err != nil {
@@ -66,7 +77,7 @@ func TestRegistryClaimMintsDistinctUnguessableIDs(t *testing.T) {
 }
 
 func TestRegistryReclaimReturnsSameURL(t *testing.T) {
-	r := newRegistry("https://gw", 16)
+	r := newRegistry("https://gw", 16, testSigner(t, ""))
 
 	s, reply, isNew, err := r.claim(tunnel.RegisterRequest{})
 	if err != nil {
@@ -105,8 +116,123 @@ func TestRegistryReclaimReturnsSameURL(t *testing.T) {
 	}
 }
 
+// TestRegistryRepliesCarrySessionToken verifies every successful claim — fresh
+// and reclaim alike — returns a session token the registry's own signer minted
+// for that session's ids.
+func TestRegistryRepliesCarrySessionToken(t *testing.T) {
+	r := newRegistry("https://gw", 16, testSigner(t, "k"))
+
+	s, reply, _, err := r.claim(tunnel.RegisterRequest{})
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	claims, ok := r.signer.verify(reply.SessionToken)
+	if !ok {
+		t.Fatal("fresh claim must return a verifiable session token")
+	}
+	if claims.Secret != s.secret || claims.PublicID != s.publicID {
+		t.Fatal("token claims must carry the session's ids")
+	}
+
+	// An in-memory reclaim returns a (fresh) token too.
+	_, reply2, _, err := r.claim(tunnel.RegisterRequest{SessionID: reply.SessionID})
+	if err != nil {
+		t.Fatalf("reclaim: %v", err)
+	}
+	if c2, ok := r.signer.verify(reply2.SessionToken); !ok || c2.Secret != s.secret {
+		t.Fatal("reclaim must return a verifiable token for the same session")
+	}
+}
+
+// TestRegistryTokenResurrectsSessionAcrossRestart is the stable-URL property of
+// issue #120: a fresh registry (a restarted gateway) holding the SAME signing
+// key resurrects a session — same secret, same public URL — from the session
+// token alone.
+func TestRegistryTokenResurrectsSessionAcrossRestart(t *testing.T) {
+	const key = "stable-signing-key"
+	r1 := newRegistry("https://gw", 16, testSigner(t, key))
+	_, reply1, _, err := r1.claim(tunnel.RegisterRequest{})
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	// "Restart": a brand-new registry that knows nothing, with the same key.
+	r2 := newRegistry("https://gw", 16, testSigner(t, key))
+	s2, reply2, isNew, err := r2.claim(tunnel.RegisterRequest{
+		SessionID:    reply1.SessionID,
+		SessionToken: reply1.SessionToken,
+	})
+	if err != nil {
+		t.Fatalf("resurrect claim: %v", err)
+	}
+	if reply2.PublicURL != reply1.PublicURL || reply2.SessionID != reply1.SessionID {
+		t.Fatalf("resurrected session changed: url %q -> %q, id changed=%v",
+			reply1.PublicURL, reply2.PublicURL, reply2.SessionID != reply1.SessionID)
+	}
+	if !isNew {
+		t.Fatal("a resurrected session is a new reservation (must be releasable on a failed handshake)")
+	}
+
+	// A second registration with the same token (e.g. a duplicate dial) reclaims
+	// the now-live entry rather than minting another.
+	s3, reply3, isNew3, err := r2.claim(tunnel.RegisterRequest{SessionToken: reply1.SessionToken})
+	if err != nil {
+		t.Fatalf("duplicate resurrect: %v", err)
+	}
+	if isNew3 || s3 != s2 || reply3.PublicURL != reply1.PublicURL {
+		t.Fatal("a second token claim must reclaim the resurrected session in memory")
+	}
+}
+
+// TestRegistryTokenFromDifferentKeyMintsFresh: a token signed under another key
+// (rotated key, or the random per-boot default) is ignored — the daemon just
+// gets a fresh session, never an error.
+func TestRegistryTokenFromDifferentKeyMintsFresh(t *testing.T) {
+	r1 := newRegistry("https://gw", 16, testSigner(t, "key-a"))
+	_, reply1, _, err := r1.claim(tunnel.RegisterRequest{})
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	r2 := newRegistry("https://gw", 16, testSigner(t, "key-b"))
+	_, reply2, isNew, err := r2.claim(tunnel.RegisterRequest{
+		SessionID:    reply1.SessionID,
+		SessionToken: reply1.SessionToken,
+	})
+	if err != nil {
+		t.Fatalf("claim with foreign token: %v", err)
+	}
+	if !isNew || reply2.PublicURL == reply1.PublicURL {
+		t.Fatal("a token under a different key must mint a FRESH session")
+	}
+	// And the fresh reply's token is signed with the new key (self-healing).
+	if _, ok := r2.signer.verify(reply2.SessionToken); !ok {
+		t.Fatal("fresh reply must carry a token under the current key")
+	}
+}
+
+// TestRegistryTokenResurrectionRespectsCapacity: a resurrected session occupies
+// a slot like any other, so the MaxSessions cap still holds.
+func TestRegistryTokenResurrectionRespectsCapacity(t *testing.T) {
+	const key = "cap-key"
+	r1 := newRegistry("https://gw", 1, testSigner(t, key))
+	_, reply1, _, err := r1.claim(tunnel.RegisterRequest{})
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	// The "restarted" gateway is already full.
+	r2 := newRegistry("https://gw", 1, testSigner(t, key))
+	if _, _, _, err := r2.claim(tunnel.RegisterRequest{}); err != nil {
+		t.Fatalf("fill: %v", err)
+	}
+	if _, _, _, err := r2.claim(tunnel.RegisterRequest{SessionToken: reply1.SessionToken}); err != errAtCapacity {
+		t.Fatalf("resurrection past the cap: want errAtCapacity, got %v", err)
+	}
+}
+
 func TestRegistryReclaimReplacesAndClosesOldTunnel(t *testing.T) {
-	r := newRegistry("https://gw", 16)
+	r := newRegistry("https://gw", 16, testSigner(t, ""))
 	s, reply, _, _ := r.claim(tunnel.RegisterRequest{})
 	old := fakeTunnel(t)
 	r.bind(s, old)
@@ -124,7 +250,7 @@ func TestRegistryReclaimReplacesAndClosesOldTunnel(t *testing.T) {
 }
 
 func TestRegistryCapacity(t *testing.T) {
-	r := newRegistry("https://gw", 1)
+	r := newRegistry("https://gw", 1, testSigner(t, ""))
 	s, _, _, err := r.claim(tunnel.RegisterRequest{})
 	if err != nil {
 		t.Fatalf("claim 1: %v", err)
@@ -140,7 +266,7 @@ func TestRegistryCapacity(t *testing.T) {
 // must hold even for concurrent FIRST-TIME claims that haven't bound yet, because
 // the slot is reserved (in bySecret) at claim, not at bind.
 func TestRegistryCapacityIsHardAtClaim(t *testing.T) {
-	r := newRegistry("https://gw", 1)
+	r := newRegistry("https://gw", 1, testSigner(t, ""))
 	if _, _, _, err := r.claim(tunnel.RegisterRequest{}); err != nil {
 		t.Fatalf("claim 1: %v", err)
 	}
@@ -153,7 +279,7 @@ func TestRegistryCapacityIsHardAtClaim(t *testing.T) {
 // TestRegistryReleaseFreesReservation verifies a failed-handshake reservation is
 // freed (and frees the cap slot), while release is a no-op for a bound session.
 func TestRegistryReleaseFreesReservation(t *testing.T) {
-	r := newRegistry("https://gw", 1)
+	r := newRegistry("https://gw", 1, testSigner(t, ""))
 	s, _, isNew, _ := r.claim(tunnel.RegisterRequest{})
 	if !isNew {
 		t.Fatal("want new")
@@ -165,7 +291,7 @@ func TestRegistryReleaseFreesReservation(t *testing.T) {
 	}
 
 	// release is a no-op once bound.
-	r2 := newRegistry("https://gw", 16)
+	r2 := newRegistry("https://gw", 16, testSigner(t, ""))
 	bs, _, _, _ := r2.claim(tunnel.RegisterRequest{})
 	r2.bind(bs, fakeTunnel(t))
 	r2.release(bs)
@@ -177,7 +303,7 @@ func TestRegistryReleaseFreesReservation(t *testing.T) {
 // TestRegistryReapsAbandonedReservation verifies the reaper backstop frees a
 // reservation whose handshake never completed.
 func TestRegistryReapsAbandonedReservation(t *testing.T) {
-	r := newRegistry("https://gw", 16)
+	r := newRegistry("https://gw", 16, testSigner(t, ""))
 	s, _, _, _ := r.claim(tunnel.RegisterRequest{}) // never bound, never released
 	// Within the reservation grace: kept.
 	r.reap(s.createdAt.Add(reservationGrace/2), sessionTTL)
@@ -192,7 +318,7 @@ func TestRegistryReapsAbandonedReservation(t *testing.T) {
 }
 
 func TestRegistryReapHonorsGraceTTL(t *testing.T) {
-	r := newRegistry("https://gw", 16)
+	r := newRegistry("https://gw", 16, testSigner(t, ""))
 	const ttl = 5 * time.Minute
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 

--- a/internal/gateway/token.go
+++ b/internal/gateway/token.go
@@ -66,10 +66,15 @@ func newTokenSigner(key string) (*tokenSigner, error) {
 	return &tokenSigner{key: b}, nil
 }
 
-// mint signs a session-resume token for a session's ids.
+// mint signs a session-resume token for a session's ids. It returns "" if the
+// claims fail to marshal — impossible for today's strings + int64, but should a
+// future field make it possible, registration must degrade to "no token" (the
+// session URL just won't survive a restart) rather than sign garbage.
 func (t *tokenSigner) mint(secret, publicID string) string {
-	// Marshaling a struct of strings + int64 cannot fail.
-	claims, _ := json.Marshal(sessionClaims{Secret: secret, PublicID: publicID, IssuedAt: time.Now().Unix()})
+	claims, err := json.Marshal(sessionClaims{Secret: secret, PublicID: publicID, IssuedAt: time.Now().Unix()})
+	if err != nil {
+		return ""
+	}
 	signingInput := sessionTokenHeader + "." + base64.RawURLEncoding.EncodeToString(claims)
 	return signingInput + "." + t.sign(signingInput)
 }

--- a/internal/gateway/token.go
+++ b/internal/gateway/token.go
@@ -1,0 +1,119 @@
+package gateway
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// token.go mints and verifies the session-resume token: a JWT, returned in
+// every RegisterReply, that encodes the session's two ids and is signed
+// (HMAC-SHA256) with the gateway's session key. fleetd stores it alongside the
+// session secret and presents it on reconnect; because the SIGNATURE proves the
+// ids were minted by a gateway holding the key, a restarted gateway — whose
+// in-memory registry is empty — can resurrect the session under its original
+// public URL instead of minting a fresh one (issue #120).
+//
+// The JWT is implemented directly on the stdlib (the gateway deliberately
+// depends only on grpc + internal/tunnel): base64url(header) "."
+// base64url(claims) "." base64url(HMAC(key, header "." claims)). Only the
+// gateway ever signs or verifies these tokens — fleetd treats them as opaque —
+// which keeps the implementation surface to one fixed algorithm.
+
+// sessionTokenHeader is the encoded JOSE header of every session token. The
+// algorithm is pinned: verify requires the header segment to match this string
+// byte-for-byte, so algorithm-confusion forgeries (alg=none and friends) are
+// rejected before any crypto runs.
+var sessionTokenHeader = base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+
+// sessionClaims is the JWT payload: the ids that define a session. A token is
+// a bearer reclaim capability — whoever holds it can claim the session's
+// public URL — so it is returned only on the register stream to the fleetd
+// that owns the session (which persists it 0600, like the secret).
+type sessionClaims struct {
+	// Secret is the session's reclaim credential (the registry.bySecret key).
+	Secret string `json:"sec"`
+	// PublicID is the id in the session's public URL.
+	PublicID string `json:"pub"`
+	// IssuedAt is the standard iat claim (seconds since epoch). Informational
+	// only: tokens do not expire — they are exactly as long-lived as the
+	// session secret they carry.
+	IssuedAt int64 `json:"iat"`
+}
+
+// tokenSigner signs and verifies session-resume tokens with an HMAC-SHA256 key.
+type tokenSigner struct {
+	key []byte
+}
+
+// newTokenSigner returns a signer for key. An empty key gets a random per-boot
+// key: tokens still verify for the life of the process, but a restarted
+// gateway cannot verify them, so session URLs do not survive the restart
+// (the documented behavior when --session-key is not set).
+func newTokenSigner(key string) (*tokenSigner, error) {
+	if key != "" {
+		return &tokenSigner{key: []byte(key)}, nil
+	}
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return nil, err
+	}
+	return &tokenSigner{key: b}, nil
+}
+
+// mint signs a session-resume token for a session's ids.
+func (t *tokenSigner) mint(secret, publicID string) string {
+	// Marshaling a struct of strings + int64 cannot fail.
+	claims, _ := json.Marshal(sessionClaims{Secret: secret, PublicID: publicID, IssuedAt: time.Now().Unix()})
+	signingInput := sessionTokenHeader + "." + base64.RawURLEncoding.EncodeToString(claims)
+	return signingInput + "." + t.sign(signingInput)
+}
+
+// sign returns the encoded HMAC-SHA256 signature of signingInput.
+func (t *tokenSigner) sign(signingInput string) string {
+	mac := hmac.New(sha256.New, t.key)
+	mac.Write([]byte(signingInput))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// verify checks token's shape and signature and returns its claims. ok is
+// false for anything this signer's key did not mint: a missing/malformed
+// token, a header other than the pinned HS256 one, a bad signature, or claim
+// ids that are not 256-bit hex (belt-and-braces — the claims feed registry map
+// keys and the public URL path, so they must be exactly id-shaped).
+func (t *tokenSigner) verify(token string) (sessionClaims, bool) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 || parts[0] != sessionTokenHeader {
+		return sessionClaims{}, false
+	}
+	if !hmac.Equal([]byte(t.sign(parts[0]+"."+parts[1])), []byte(parts[2])) {
+		return sessionClaims{}, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return sessionClaims{}, false
+	}
+	var c sessionClaims
+	if err := json.Unmarshal(payload, &c); err != nil {
+		return sessionClaims{}, false
+	}
+	if !isHexID(c.Secret) || !isHexID(c.PublicID) {
+		return sessionClaims{}, false
+	}
+	return c, true
+}
+
+// isHexID reports whether s is shaped like an id newID mints: 64 hex chars
+// (256 bits).
+func isHexID(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(s)
+	return err == nil
+}

--- a/internal/gateway/token_test.go
+++ b/internal/gateway/token_test.go
@@ -1,0 +1,102 @@
+package gateway
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+// hexID returns a valid 64-char hex id built from a short label, for tests.
+func hexID(label byte) string {
+	return strings.Repeat(string("0123456789abcdef"[label%16]), 64)
+}
+
+func TestTokenMintVerifyRoundTrip(t *testing.T) {
+	s := testSigner(t, "round-trip-key")
+	sec, pub := hexID(1), hexID(2)
+
+	tok := s.mint(sec, pub)
+	if tok == "" {
+		t.Fatal("mint returned an empty token")
+	}
+	claims, ok := s.verify(tok)
+	if !ok {
+		t.Fatal("freshly-minted token must verify")
+	}
+	if claims.Secret != sec || claims.PublicID != pub {
+		t.Fatalf("claims round trip: got (%q,%q), want (%q,%q)", claims.Secret, claims.PublicID, sec, pub)
+	}
+	if claims.IssuedAt == 0 {
+		t.Fatal("iat claim should be stamped")
+	}
+}
+
+// TestTokenSameKeyAcrossSigners is the restart property: a signer built later
+// with the SAME key (a new gateway process) verifies tokens an earlier one
+// minted.
+func TestTokenSameKeyAcrossSigners(t *testing.T) {
+	tok := testSigner(t, "shared-key").mint(hexID(1), hexID(2))
+	if _, ok := testSigner(t, "shared-key").verify(tok); !ok {
+		t.Fatal("a token must verify across signer instances sharing the key")
+	}
+	if _, ok := testSigner(t, "different-key").verify(tok); ok {
+		t.Fatal("a token must NOT verify under a different key")
+	}
+}
+
+// TestTokenRandomKeyPerBoot: two signers with no configured key (the default)
+// must not trust each other's tokens — that is exactly the documented
+// no---session-key restart behavior.
+func TestTokenRandomKeyPerBoot(t *testing.T) {
+	a, b := testSigner(t, ""), testSigner(t, "")
+	tok := a.mint(hexID(1), hexID(2))
+	if _, ok := a.verify(tok); !ok {
+		t.Fatal("a random-key signer must verify its own tokens")
+	}
+	if _, ok := b.verify(tok); ok {
+		t.Fatal("two random-key signers must not share trust")
+	}
+}
+
+func TestTokenVerifyRejectsForgeries(t *testing.T) {
+	s := testSigner(t, "forgery-key")
+	valid := s.mint(hexID(1), hexID(2))
+	parts := strings.Split(valid, ".")
+
+	b64 := func(raw string) string { return base64.RawURLEncoding.EncodeToString([]byte(raw)) }
+	otherClaims := b64(`{"sec":"` + hexID(3) + `","pub":"` + hexID(4) + `","iat":1}`)
+
+	cases := map[string]string{
+		"empty":               "",
+		"garbage":             "not-a-token",
+		"two segments":        parts[0] + "." + parts[1],
+		"four segments":       valid + ".extra",
+		"swapped claims":      parts[0] + "." + otherClaims + "." + parts[2],
+		"truncated signature": parts[0] + "." + parts[1] + "." + parts[2][:len(parts[2])-2],
+		"alg none":            b64(`{"alg":"none","typ":"JWT"}`) + "." + parts[1] + ".",
+		"alg RS256":           b64(`{"alg":"RS256","typ":"JWT"}`) + "." + parts[1] + "." + parts[2],
+		"claims not base64":   parts[0] + ".!!!." + parts[2],
+	}
+	for name, tok := range cases {
+		if _, ok := s.verify(tok); ok {
+			t.Errorf("%s: forged token must not verify", name)
+		}
+	}
+}
+
+// TestTokenVerifyRejectsNonIDClaims: even a correctly-signed token is rejected
+// when its ids are not 256-bit hex — the claims feed registry map keys and the
+// public URL path, so they must be exactly id-shaped.
+func TestTokenVerifyRejectsNonIDClaims(t *testing.T) {
+	s := testSigner(t, "shape-key")
+	for name, tok := range map[string]string{
+		"path traversal public id": s.mint(hexID(1), "../../evil"),
+		"short secret":             s.mint("abc123", hexID(2)),
+		"empty ids":                s.mint("", ""),
+		"non-hex chars":            s.mint(hexID(1), strings.Repeat("z", 64)),
+	} {
+		if _, ok := s.verify(tok); ok {
+			t.Errorf("%s: token with non-id claims must not verify", name)
+		}
+	}
+}

--- a/internal/server/remote/manager.go
+++ b/internal/server/remote/manager.go
@@ -226,7 +226,12 @@ func (m *Manager) connectAndServe(ctx context.Context, gatewayURL string) (regis
 	// Register handshake over the stream (before yamux), bounded by its own timeout
 	// (the StreamConn has no deadlines) so a silent gateway can't hang the attempt.
 	prev := loadSession(gatewayURL)
-	req := tunnel.RegisterRequest{SessionID: prev.SessionID, ClientVersion: m.clientVersion, Features: m.features()}
+	req := tunnel.RegisterRequest{
+		SessionID:     prev.SessionID,
+		SessionToken:  prev.SessionToken,
+		ClientVersion: m.clientVersion,
+		Features:      m.features(),
+	}
 	reply, err := tunnel.Handshake(conn, req, handshakeTimeout)
 	if err != nil {
 		return false, fmt.Errorf("register handshake: %w", err)
@@ -235,9 +240,15 @@ func (m *Manager) connectAndServe(ctx context.Context, gatewayURL string) (regis
 		return false, fmt.Errorf("gateway refused registration: %s", reply.Error)
 	}
 
-	// Registered. Persist the sticky session and report the public URL.
+	// Registered. Persist the sticky session (id + resume token) and report the
+	// public URL.
 	registered = true
-	_ = saveSession(sessionFile{SessionID: reply.SessionID, PublicURL: reply.PublicURL, GatewayURL: gatewayURL})
+	_ = saveSession(sessionFile{
+		SessionID:    reply.SessionID,
+		SessionToken: reply.SessionToken,
+		PublicURL:    reply.PublicURL,
+		GatewayURL:   gatewayURL,
+	})
 	m.publish(statusConnected(reply.PublicURL))
 
 	session, err := tunnel.ClientSession(conn, m.logOut)

--- a/internal/server/remote/manager_test.go
+++ b/internal/server/remote/manager_test.go
@@ -88,7 +88,7 @@ func TestSessionFileRoundTripAndStale(t *testing.T) {
 		t.Fatalf("ensure dir: %v", err)
 	}
 
-	in := sessionFile{SessionID: "sid1", PublicURL: "https://gw/mcp/sid1", GatewayURL: "https://gw"}
+	in := sessionFile{SessionID: "sid1", SessionToken: "jwt1", PublicURL: "https://gw/mcp/sid1", GatewayURL: "https://gw"}
 	if err := saveSession(in); err != nil {
 		t.Fatalf("saveSession: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestManagerConnectsServesAndDisables(t *testing.T) {
 		if err := tunnel.ReadFrame(conn, &req); err != nil {
 			return
 		}
-		_ = tunnel.WriteFrame(conn, tunnel.RegisterReply{SessionID: "sess-A", PublicURL: "https://gw/mcp/sess-A"})
+		_ = tunnel.WriteFrame(conn, tunnel.RegisterReply{SessionID: "sess-A", SessionToken: "tok-A", PublicURL: "https://gw/mcp/sess-A"})
 		sess, err := tunnel.ServerSession(conn, io.Discard)
 		if err != nil {
 			return
@@ -249,8 +249,8 @@ func TestManagerConnectsServesAndDisables(t *testing.T) {
 		t.Fatal("gateway never served a request over the tunnel")
 	}
 
-	// Sticky session persisted for reconnect.
-	if s := loadSession("https://gw.example.com"); s.SessionID != "sess-A" || s.PublicURL != "https://gw/mcp/sess-A" {
+	// Sticky session (id + resume token) persisted for reconnect.
+	if s := loadSession("https://gw.example.com"); s.SessionID != "sess-A" || s.SessionToken != "tok-A" || s.PublicURL != "https://gw/mcp/sess-A" {
 		t.Fatalf("session not persisted: %+v", s)
 	}
 
@@ -274,7 +274,7 @@ func TestManagerStickyReconnect(t *testing.T) {
 	}
 	defer ln.Close()
 
-	regIDs := make(chan string, 8)
+	regs := make(chan tunnel.RegisterRequest, 8)
 	var conns atomic.Int32
 	gwDone := make(chan struct{})
 	defer close(gwDone)
@@ -291,12 +291,12 @@ func TestManagerStickyReconnect(t *testing.T) {
 					return
 				}
 				n := conns.Add(1)
-				regIDs <- req.SessionID
+				regs <- req
 				sid := req.SessionID
 				if sid == "" {
 					sid = "sticky-1"
 				}
-				if err := tunnel.WriteFrame(conn, tunnel.RegisterReply{SessionID: sid, PublicURL: "https://gw/mcp/" + sid}); err != nil {
+				if err := tunnel.WriteFrame(conn, tunnel.RegisterReply{SessionID: sid, SessionToken: "tok-sticky", PublicURL: "https://gw/mcp/" + sid}); err != nil {
 					return
 				}
 				if n == 1 {
@@ -318,26 +318,27 @@ func TestManagerStickyReconnect(t *testing.T) {
 	go m.Run(ctx)
 	m.Reconcile(true, "https://gw.example.com")
 
-	// First registration: no prior session id.
-	if got := waitForReg(t, regIDs, 5*time.Second); got != "" {
-		t.Fatalf("first registration session id = %q, want empty", got)
+	// First registration: no prior session id or resume token.
+	if got := waitForReg(t, regs, 5*time.Second); got.SessionID != "" || got.SessionToken != "" {
+		t.Fatalf("first registration carried id=%q token=%q, want both empty", got.SessionID, got.SessionToken)
 	}
-	// Second registration (after the forced drop): the sticky id.
-	if got := waitForReg(t, regIDs, 5*time.Second); got != "sticky-1" {
-		t.Fatalf("reconnect registration session id = %q, want sticky-1", got)
+	// Second registration (after the forced drop): the sticky id AND the cached
+	// session token from the first reply.
+	if got := waitForReg(t, regs, 5*time.Second); got.SessionID != "sticky-1" || got.SessionToken != "tok-sticky" {
+		t.Fatalf("reconnect registration carried id=%q token=%q, want sticky-1/tok-sticky", got.SessionID, got.SessionToken)
 	}
 	// And it lands CONNECTED on the kept connection.
 	waitForState(t, statusCh, fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED, 5*time.Second)
 }
 
-func waitForReg(t *testing.T, ch <-chan string, timeout time.Duration) string {
+func waitForReg(t *testing.T, ch <-chan tunnel.RegisterRequest, timeout time.Duration) tunnel.RegisterRequest {
 	t.Helper()
 	select {
-	case id := <-ch:
-		return id
+	case req := <-ch:
+		return req
 	case <-time.After(timeout):
 		t.Fatal("timed out waiting for a registration")
-		return ""
+		return tunnel.RegisterRequest{}
 	}
 }
 

--- a/internal/server/remote/session.go
+++ b/internal/server/remote/session.go
@@ -10,12 +10,18 @@ import (
 // session.go persists the sticky gateway session so that, across reconnects and
 // daemon restarts, fleetd asks the gateway for the SAME public URL. The file
 // (~/.fleet/gateway_session.json, 0600) records the assigned session id, the
-// public URL, and the gateway URL it was issued for.
+// gateway-signed session token, the public URL, and the gateway URL it was
+// issued for.
 
 type sessionFile struct {
-	SessionID  string `json:"session_id"`
-	PublicURL  string `json:"public_url"`
-	GatewayURL string `json:"gateway_url"`
+	SessionID string `json:"session_id"`
+	// SessionToken is the gateway-signed session-resume JWT from the last
+	// successful registration (opaque to fleetd). Presented on reconnect so a
+	// RESTARTED gateway — which no longer knows SessionID — can verify the
+	// token against its signing key and hand back the same public URL.
+	SessionToken string `json:"session_token,omitempty"`
+	PublicURL    string `json:"public_url"`
+	GatewayURL   string `json:"gateway_url"`
 }
 
 // loadSession returns the persisted session IF it was issued for gatewayURL. A

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -46,6 +46,12 @@ type RegisterRequest struct {
 	// SessionID, when non-empty, asks the gateway to re-use a prior session's
 	// public URL (sticky reconnect). Empty requests a fresh one.
 	SessionID string `json:"session_id,omitempty"`
+	// SessionToken, when non-empty, is the gateway-signed session token from a
+	// previous RegisterReply. A gateway that does not recognize SessionID
+	// (typically because it restarted and lost its in-memory registry) verifies
+	// the token's signature against its session key and, on success, resurrects
+	// the session under its ORIGINAL public URL instead of minting a fresh one.
+	SessionToken string `json:"session_token,omitempty"`
 	// ClientVersion is the fleetd version, for the gateway's logs/diagnostics.
 	ClientVersion string `json:"client_version,omitempty"`
 	// Features lists optional tunnel capabilities fleetd supports (e.g.
@@ -61,7 +67,13 @@ type RegisterRequest struct {
 type RegisterReply struct {
 	SessionID string `json:"session_id,omitempty"`
 	PublicURL string `json:"public_url,omitempty"`
-	Error     string `json:"error,omitempty"`
+	// SessionToken is a JWT, signed with the gateway's session key, encoding
+	// this session's ids. fleetd persists it with the session id and presents
+	// both on reconnect, so the session (and its public URL) survives a gateway
+	// restart when the gateway runs with a stable --session-key. Empty from an
+	// old gateway.
+	SessionToken string `json:"session_token,omitempty"`
+	Error        string `json:"error,omitempty"`
 	// Features is the negotiated set: the intersection of what fleetd requested
 	// and what the gateway supports. Absent (old gateway) means MCP-only.
 	Features []string `json:"features,omitempty"`


### PR DESCRIPTION
Closes #120

## Problem

A fleetd's session URL was only stable for as long as **the gateway** stayed up: the reclaim secret lived solely in the gateway's in-memory registry, so a gateway restart forced every daemon onto a fresh URL.

## Approach

After registration the gateway now also returns a **session-resume token**: a JWT over the session's two ids (`sec` = reclaim secret, `pub` = public id), HMAC-SHA256-signed with a secret key given to `fleet gateway` on boot (`--session-key`, or `FLEET_GATEWAY_SESSION_KEY`; random per boot when unset — the pre-existing restart behavior, with a startup warning). fleetd caches the token in `~/.fleet/gateway_session.json` (0600, next to the secret) and presents it on reconnect.

On a reconnect whose secret is unknown (the gateway restarted and lost its registry), the gateway verifies the token's signature and **resurrects the session under its original ids** — same public URL — instead of minting a fresh session.

## Details

- **`internal/gateway/token.go`** — stdlib-only HS256 JWT mint/verify, keeping the gateway's documented "tunnel + stdlib + grpc only" import discipline. The verifier pins the JOSE header byte-for-byte (no alg confusion), compares signatures in constant time, and requires both claim ids to be exactly 256-bit hex before they touch registry maps or the URL path.
- **`registry.claim`** — token resurrection sits between the in-memory reclaim and the fresh mint. A resurrected session occupies a normal slot (the `MaxSessions` cap stays a hard limit) and is `isNew`, so a failed handshake still releases it. Every successful reply mints a *fresh* token, so a rotated `--session-key` self-heals on the first reconnect.
- **`internal/tunnel`** — `SessionToken` added to `RegisterRequest`/`RegisterReply`. Old⇄new peers stay compatible in both directions (unknown JSON fields are ignored; an empty token changes nothing).
- **fleetd (`internal/server/remote`)** — caches `reply.SessionToken` with the session id and resends both on reconnect; the token is opaque to fleetd.
- **Docs** — README gateway flag table + security model, `doc/gateway.md` handshake/sticky-session/security/lifecycle sections.

## Security notes

- Registration remains unauthenticated by design; the token only changes *reclaim*, not access. The MCP bearer token stays the real boundary.
- The resume token is a bearer reclaim capability equivalent in power to the existing secret; it never appears in the public URL and is only sent down the register stream.

## Testing

- `token_test.go`: round trip, cross-instance same-key verification, wrong-key/random-key rejection, forgery cases (alg none/RS256, tampered claims, truncated sig), and rejection of signed-but-non-id claims (e.g. path-traversal public id).
- `registry_test.go`: resurrection across a simulated restart (same key), fresh mint under a different key, capacity enforcement on resurrection, token presence on reclaims.
- `register_test.go`: `TestGatewayRestartStableURL` — full Register-stream handshake against two separate gateway instances sharing a key (same URL back), plus a rotated-key instance (fresh URL).
- `manager_test.go`: session file round-trips the token; the manager persists it and resends it on sticky reconnect.

`go test ./...` and `golangci-lint run` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)