### PR TITLE
feat(gateway): configure all flags via FLEET_GATEWAY_* env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,12 @@ fleet gateway \
 | `--max-sessions` | `1024` | Cap on concurrent tunnels |
 | `--session-key` | (random per boot) | Secret key signing the session-resume tokens daemons present on reconnect. Set it (or `FLEET_GATEWAY_SESSION_KEY`) so daemons keep the **same session URL across gateway restarts**; left unset, a restart hands every daemon a fresh URL |
 
+Every flag is also settable via environment variable — `FLEET_GATEWAY_<FLAG>` with
+dashes as underscores (e.g. `FLEET_GATEWAY_PUBLIC_URL`,
+`FLEET_GATEWAY_MAX_SESSIONS`) — which is handy for configuring the
+[Docker image](#run-it-with-docker) in Kubernetes. A flag given on the command
+line wins over its environment variable.
+
 Two ports must be reachable: expose `--public-addr` to MCP agents and `--grpc-addr`
 to remote `fleet` clients **and your daemons** (they register over it). A
 `GET /healthz` on the public listener returns `ok`.
@@ -280,7 +286,8 @@ bind unprivileged ports and needs no cert.
 
 Every tagged release also publishes a gateway image to the GitHub Container
 Registry, so you don't have to build the binary yourself. It's the same
-`fleet gateway`, with the flags passed as `docker run` arguments:
+`fleet gateway`, with the flags passed as `docker run` arguments (or as
+`FLEET_GATEWAY_*` environment variables — see the table above):
 
 ```bash
 docker run -d --name fleet-gateway \

--- a/deploy/gateway/Dockerfile
+++ b/deploy/gateway/Dockerfile
@@ -52,4 +52,8 @@ COPY --from=build /out/fleet /usr/local/bin/fleet
 # separate TCP control port. A GET /healthz on the public listener returns "ok".
 EXPOSE 443 50051
 
+# Configure via args to `docker run` (appended to the entrypoint) or via
+# FLEET_GATEWAY_<FLAG> environment variables (dashes as underscores, e.g.
+# FLEET_GATEWAY_PUBLIC_URL) — the latter suits Kubernetes manifests. Flags given
+# on the command line win over their environment variables.
 ENTRYPOINT ["/usr/local/bin/fleet", "gateway"]

--- a/internal/cli/gateway.go
+++ b/internal/cli/gateway.go
@@ -1,10 +1,13 @@
 package cli
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/gateway"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // newGatewayCmd runs the fleet gateway: the remote, operator-hosted relay that
@@ -33,12 +36,16 @@ func newGatewayCmd() *cobra.Command {
 			"presents the public cert. Set --public-url's scheme to match (https vs http).\n\n" +
 			"Set --session-key (or FLEET_GATEWAY_SESSION_KEY) to a stable secret so fleet\n" +
 			"daemons keep their session URL across gateway restarts; without it each boot\n" +
-			"uses a random key and a restart hands every daemon a fresh URL.",
+			"uses a random key and a restart hands every daemon a fresh URL.\n\n" +
+			"Every flag can also be set via environment variable — FLEET_GATEWAY_<FLAG>\n" +
+			"with dashes as underscores (e.g. FLEET_GATEWAY_PUBLIC_URL,\n" +
+			"FLEET_GATEWAY_MAX_SESSIONS) — handy for the Docker image and Kubernetes.\n" +
+			"A flag given on the command line wins over its environment variable.",
 		Args: cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			return applyGatewayEnv(cmd.Flags())
+		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if cfg.SessionKey == "" {
-				cfg.SessionKey = os.Getenv("FLEET_GATEWAY_SESSION_KEY")
-			}
 			return gateway.Serve(cmd.Context(), cfg)
 		},
 	}
@@ -53,4 +60,28 @@ func newGatewayCmd() *cobra.Command {
 	f.StringVar(&cfg.SessionKey, "session-key", "", "secret key signing session-resume tokens, so daemons keep their session URL across gateway restarts (empty = random per boot; FLEET_GATEWAY_SESSION_KEY is also read)")
 
 	return cmd
+}
+
+// applyGatewayEnv fills in any gateway flag not given on the command line from
+// its FLEET_GATEWAY_<FLAG> environment variable (dashes become underscores, e.g.
+// --public-url ← FLEET_GATEWAY_PUBLIC_URL), so the Docker image is configurable
+// in Kubernetes without rebuilding the args list (issue #135). Explicit flags
+// win; an env value that fails the flag's parser (e.g. a non-numeric
+// FLEET_GATEWAY_MAX_SESSIONS) is an error naming the variable.
+func applyGatewayEnv(fs *pflag.FlagSet) error {
+	var err error
+	fs.VisitAll(func(f *pflag.Flag) {
+		if err != nil || f.Changed || f.Name == "help" {
+			return
+		}
+		env := "FLEET_GATEWAY_" + strings.ReplaceAll(strings.ToUpper(f.Name), "-", "_")
+		val, ok := os.LookupEnv(env)
+		if !ok {
+			return
+		}
+		if setErr := fs.Set(f.Name, val); setErr != nil {
+			err = fmt.Errorf("invalid %s: %w", env, setErr)
+		}
+	})
+	return err
 }

--- a/internal/cli/gateway_test.go
+++ b/internal/cli/gateway_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// flagValue parses args against a fresh gateway command, applies the
+// FLEET_GATEWAY_* environment, and returns the named flag's final value.
+func gatewayFlagAfterEnv(t *testing.T, args []string, name string) string {
+	t.Helper()
+	cmd := newGatewayCmd()
+	if err := cmd.ParseFlags(args); err != nil {
+		t.Fatalf("ParseFlags(%v): %v", args, err)
+	}
+	if err := applyGatewayEnv(cmd.Flags()); err != nil {
+		t.Fatalf("applyGatewayEnv: %v", err)
+	}
+	return cmd.Flags().Lookup(name).Value.String()
+}
+
+func TestGatewayEnvFillsUnsetFlags(t *testing.T) {
+	t.Setenv("FLEET_GATEWAY_PUBLIC_URL", "https://gw.example.com")
+	t.Setenv("FLEET_GATEWAY_MAX_SESSIONS", "42")
+	t.Setenv("FLEET_GATEWAY_SESSION_KEY", "s3cret")
+
+	if got := gatewayFlagAfterEnv(t, nil, "public-url"); got != "https://gw.example.com" {
+		t.Errorf("public-url = %q, want env value", got)
+	}
+	if got := gatewayFlagAfterEnv(t, nil, "max-sessions"); got != "42" {
+		t.Errorf("max-sessions = %q, want 42", got)
+	}
+	if got := gatewayFlagAfterEnv(t, nil, "session-key"); got != "s3cret" {
+		t.Errorf("session-key = %q, want env value", got)
+	}
+}
+
+func TestGatewayFlagWinsOverEnv(t *testing.T) {
+	t.Setenv("FLEET_GATEWAY_PUBLIC_URL", "https://from-env.example.com")
+
+	got := gatewayFlagAfterEnv(t, []string{"--public-url", "https://from-flag.example.com"}, "public-url")
+	if got != "https://from-flag.example.com" {
+		t.Errorf("public-url = %q, want flag value to win over env", got)
+	}
+}
+
+func TestGatewayEnvEmptyValueApplies(t *testing.T) {
+	// An empty env value is still "set" — it must be able to clear a defaulted
+	// flag (an empty --grpc-addr disables the gRPC listener).
+	t.Setenv("FLEET_GATEWAY_GRPC_ADDR", "")
+
+	if got := gatewayFlagAfterEnv(t, nil, "grpc-addr"); got != "" {
+		t.Errorf("grpc-addr = %q, want empty from env", got)
+	}
+}
+
+func TestGatewayEnvBadValueNamesVariable(t *testing.T) {
+	t.Setenv("FLEET_GATEWAY_MAX_SESSIONS", "not-a-number")
+
+	cmd := newGatewayCmd()
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	err := applyGatewayEnv(cmd.Flags())
+	if err == nil {
+		t.Fatal("applyGatewayEnv: want error for non-numeric FLEET_GATEWAY_MAX_SESSIONS")
+	}
+	if !strings.Contains(err.Error(), "FLEET_GATEWAY_MAX_SESSIONS") {
+		t.Errorf("error %q does not name the offending variable", err)
+	}
+}


### PR DESCRIPTION
Closes #135

## What

Every `fleet gateway` flag is now also settable via environment variable — `FLEET_GATEWAY_<FLAG>` with dashes as underscores:

| Flag | Env var |
|------|---------|
| `--public-url` | `FLEET_GATEWAY_PUBLIC_URL` |
| `--public-addr` | `FLEET_GATEWAY_PUBLIC_ADDR` |
| `--grpc-addr` | `FLEET_GATEWAY_GRPC_ADDR` |
| `--tls-cert` | `FLEET_GATEWAY_TLS_CERT` |
| `--tls-key` | `FLEET_GATEWAY_TLS_KEY` |
| `--max-sessions` | `FLEET_GATEWAY_MAX_SESSIONS` |
| `--session-key` | `FLEET_GATEWAY_SESSION_KEY` (unchanged) |

This makes the gateway Docker image configurable from Kubernetes manifests via `env:` instead of rebuilding the container args list.

## How

A `PreRunE` on the gateway command walks the flag set and fills any flag not given on the command line from its `FLEET_GATEWAY_*` variable via `pflag.Set`, so each flag's own parser/validation applies. This generalizes (and replaces) the previous `FLEET_GATEWAY_SESSION_KEY` special case — that variable keeps its exact name and semantics.

Naming follows the existing `FLEET_GATEWAY_SESSION_KEY` precedent (`FLEET_GATEWAY_` rather than bare `FLEET_`), which keeps these distinct from any future daemon-side `FLEET_*` vars.

Semantics:
- A flag given on the command line **wins** over its environment variable.
- An **empty** env value counts as set (e.g. `FLEET_GATEWAY_GRPC_ADDR=""` disables the gRPC listener, same as `--grpc-addr ""`).
- A value that fails the flag's parser errors out naming the variable: `invalid FLEET_GATEWAY_MAX_SESSIONS: ...`.

## Testing

- New unit tests cover: env fills unset flags (string + int), flag-beats-env precedence, empty env value applies, and the bad-value error names the variable.
- Smoke-tested the built binary: no env still errors `--public-url is required`; with `FLEET_GATEWAY_PUBLIC_URL`/`FLEET_GATEWAY_PUBLIC_ADDR`/`FLEET_GATEWAY_GRPC_ADDR` set the gateway boots and serves; `FLEET_GATEWAY_MAX_SESSIONS=abc` fails with a clear message.
- `make lint` clean, `go test ./internal/cli/...` green.

Docs updated: `fleet gateway --help` long text, the README flag table + Docker section, and the gateway Dockerfile comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)