### PR TITLE
feat(mcp): async-first lifecycle tools — fleet_up returns a job handle

### DIFF
--- a/internal/admiralskill/SKILL.md
+++ b/internal/admiralskill/SKILL.md
@@ -60,25 +60,43 @@ workspace_dir, created_at, error), optionally filtered to one fleet. `fleet_vers
 the daemon's version and liveness. `fleet_logs` returns an instance's container
 logs (use `tail` to cap to the last N lines).
 
-**Manage instance lifecycle.** These block until the job finishes server-side
-(`fleet_up` provisions a devcontainer — expect minutes, not seconds) and return
-`{success, instance, warnings}`; a failed job surfaces as a tool error.
+**Manage instance lifecycle.** The slow, job-shaped tools — `fleet_up`,
+`fleet_clone`, `fleet_down`, `fleet_destroy_fleet` — are async-first: they
+return within seconds with `{job_id, done: false, instance}` while the job
+keeps running server-side. Kick off as many as you need (e.g. bulk-provision
+several instances), keep working, then poll `fleet_job_status {job_id}` until
+`state` leaves `running` — it reports `succeeded` (with `warnings` and the
+final `result` record) or `failed` (with `error`). The instance's `status` in
+`fleet_list` tells the same story (`creating → running`, or `failed` with
+`error`; teardown shows `deleting` until the record disappears). Pass
+`wait: true` to block until the job finishes instead — `fleet_up` provisions a
+devcontainer (expect minutes, not seconds), so only do that when your
+tool-call timeout allows it. A blocking call returns
+`{job_id, done: true, success, instance, warnings}`, and a failed blocking job
+surfaces as a tool error.
 
-- `fleet_up {fleet, instance, remote?, branch?, backend?}` creates and starts an
-  instance. `remote` (a git URL) is required only when creating the first
-  instance of a new fleet; after that the fleet's recorded remote is used.
+- `fleet_up {fleet, instance, remote?, branch?, backend?, wait?}` creates and
+  starts an instance. `remote` (a git URL) is required only when creating the
+  first instance of a new fleet; after that the fleet's recorded remote is used.
   `backend` selects where it runs: `devcontainer`, `coder`, or `codespaces`.
   Omitted, it falls back to the host's configured default backend
   (`devcontainer` out of the box) — the others need prior configuration, so
   leave it unset or pass `devcontainer` unless the user says otherwise.
 - `fleet_start` / `fleet_stop {fleet, instance}` resume / pause an instance.
-  Stop preserves the workspace; start brings it back.
-- `fleet_down {fleet, instance}` stops and removes a single instance.
-  `fleet_destroy_fleet {fleet}` removes a whole fleet and all its instances.
-  **Both are irreversible** and discard any uncommitted work in those instances.
-- `fleet_clone {fleet, source, destination, ...}` duplicates an instance,
-  keeping its installed state (optional `display_name`, `tag`, `color`,
-  `branch` overrides).
+  Stop preserves the workspace; start brings it back. These always block —
+  they finish in seconds.
+- `fleet_down {fleet, instance, wait?}` stops and removes a single instance.
+  `fleet_destroy_fleet {fleet, wait?}` removes a whole fleet and all its
+  instances. **Both are irreversible** and discard any uncommitted work in
+  those instances.
+- `fleet_clone {fleet, source, destination, ..., wait?}` duplicates an
+  instance, keeping its installed state (optional `display_name`, `tag`,
+  `color`, `branch` overrides).
+- `fleet_job_status {job_id}` reports a lifecycle job:
+  `{state: running|succeeded|failed, error?, warnings?, result?}`. A failed job
+  is data here (`state: "failed"`), not a tool error. An unknown `job_id`
+  (daemon restarted, or the result expired) is a tool error — fall back to the
+  instance's `status`/`error` in `fleet_list`.
 
 **Run a one-off command.** `fleet_exec {fleet, instance, command}` runs a
 command inside an instance and returns `{stdout, stderr, exit_code}`. `command`
@@ -116,10 +134,14 @@ the task as its prompt, then read the session to see what it's doing or asking.
 - Sessions are detached and survive between tool calls; reading one is a
   snapshot of its current screen, not a stream.
 - Errors come back as tool errors with a clear message (instance not found, not
-  running, job failed); the one exception is `fleet_exec`, where a non-zero
-  exit is ordinary result data.
+  running, blocking job failed); the exceptions are `fleet_exec`, where a
+  non-zero exit is ordinary result data, and `fleet_job_status`, where a failed
+  job is ordinary result data (`state: "failed"`).
 - Lifecycle `warnings` are non-fatal issues from an otherwise-successful job —
   surface them, don't treat them as failure.
+- When awaiting an async job, poll `fleet_job_status` every few seconds (a
+  `fleet_up` typically takes 1–3 minutes) rather than spinning; you can do
+  other work between polls.
 - If the `fleet_*` MCP tools are not available, the `fleet` CLI offers the same
   operations from the shell (`fleet --help`). The MCP server is registered in
   Claude Code automatically when the fleet TUI runs; a missing registration
@@ -138,13 +160,14 @@ INSPECT
   fleet_version                                     # daemon version/liveness
   fleet_logs {fleet, instance, tail?}               # container logs
 
-LIFECYCLE  (block until the job completes; up can take minutes)
-  fleet_up {fleet, instance, remote?, branch?, backend?}
-  fleet_start {fleet, instance}                     # resume a stopped instance
-  fleet_stop {fleet, instance}                      # pause, keep workspace
-  fleet_down {fleet, instance}                      # remove one instance      (irreversible)
-  fleet_destroy_fleet {fleet}                       # remove fleet + instances (irreversible)
-  fleet_clone {fleet, source, destination, display_name?, tag?, color?, branch?}
+LIFECYCLE  (async-first: returns {job_id, done:false} in seconds; wait:true blocks)
+  fleet_up {fleet, instance, remote?, branch?, backend?, wait?}
+  fleet_clone {fleet, source, destination, display_name?, tag?, color?, branch?, wait?}
+  fleet_down {fleet, instance, wait?}               # remove one instance      (irreversible)
+  fleet_destroy_fleet {fleet, wait?}                # remove fleet + instances (irreversible)
+  fleet_job_status {job_id}                         # poll: running | succeeded | failed
+  fleet_start {fleet, instance}                     # resume a stopped instance (blocks)
+  fleet_stop {fleet, instance}                      # pause, keep workspace     (blocks)
 
 EXECUTION
   fleet_exec {fleet, instance, command: [argv...]}  # one-shot; exit_code is data

--- a/internal/server/jobs.go
+++ b/internal/server/jobs.go
@@ -151,14 +151,25 @@ var jobDownInstance = func(inst *fleet.Instance) error {
 
 // --- job registry ---
 
+// finishedJobRetention bounds the finished-job registry (FIFO eviction). It
+// only needs to cover a reasonable polling window for async callers; a poller
+// that comes back later falls back to the instance record (fleet_list), which
+// holds the durable status/error.
+const finishedJobRetention = 256
+
 type jobManager struct {
 	seq    int64
 	mu     sync.Mutex
 	active map[string]*job
+	// finished retains terminal jobs (bounded by finishedJobRetention) so an
+	// async caller — e.g. the MCP fleet_job_status tool — can still read a job's
+	// outcome after it completes. finishedIDs is the FIFO eviction order.
+	finished    map[string]*job
+	finishedIDs []string
 }
 
 func newJobManager() *jobManager {
-	return &jobManager{active: make(map[string]*job)}
+	return &jobManager{active: make(map[string]*job), finished: make(map[string]*job)}
 }
 
 type job struct {
@@ -192,10 +203,29 @@ func (m *jobManager) finish(id string) {
 	m.mu.Lock()
 	j := m.active[id]
 	delete(m.active, id)
+	if j != nil {
+		m.finished[id] = j
+		m.finishedIDs = append(m.finishedIDs, id)
+		for len(m.finishedIDs) > finishedJobRetention {
+			delete(m.finished, m.finishedIDs[0])
+			m.finishedIDs = m.finishedIDs[1:]
+		}
+	}
 	m.mu.Unlock()
 	if j != nil {
 		j.closeSubs()
 	}
+}
+
+// get returns a job by id — in-flight or recently finished — or nil if unknown
+// (never started, evicted, or pre-dating a daemon restart).
+func (m *jobManager) get(id string) *job {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if j, ok := m.active[id]; ok {
+		return j
+	}
+	return m.finished[id]
 }
 
 // summaries snapshots the in-flight jobs for GetState/Watch.
@@ -260,6 +290,21 @@ func (j *job) closeSubs() {
 		close(ch)
 		delete(j.subs, ch)
 	}
+}
+
+// outcome returns the job's terminal JobDone, or nil while it is still running.
+func (j *job) outcome() *fleetgrpc.JobDone {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if !j.done {
+		return nil
+	}
+	for i := len(j.history) - 1; i >= 0; i-- {
+		if d := j.history[i].GetDone(); d != nil {
+			return d
+		}
+	}
+	return nil
 }
 
 // runJob is the shared driver: emit JobStarted, run work (which may emit further
@@ -381,13 +426,19 @@ func loadInstanceSnapshot(fleetName, instanceName string) *fleetgrpc.Instance {
 
 // --- RPC handlers ---
 
-// CreateInstance pre-creates the StatusCreating record server-side (this removes
-// the client-side pre-create write that drove issue #63), then runs the
-// provisioning job.
-func (s *service) CreateInstance(req *fleetgrpc.CreateInstanceRequest, stream fleetgrpc.FleetService_CreateInstanceServer) error {
+// Each lifecycle RPC below is split into a start*Job half (validate, pre-write
+// the transitional record, start the server-owned job goroutine) and a thin
+// streaming wrapper that relays the job's events. The split lets the MCP tools
+// start a job and return its handle immediately (async-first, issue #134)
+// while the gRPC path keeps streaming until JobDone.
+
+// startCreateInstanceJob pre-creates the StatusCreating record server-side
+// (this removes the client-side pre-create write that drove issue #63), then
+// starts the provisioning job.
+func (s *service) startCreateInstanceJob(req *fleetgrpc.CreateInstanceRequest) (*job, error) {
 	fleetName, instanceName := req.GetFleet(), req.GetInstance()
 	if fleetName == "" || instanceName == "" {
-		return status.Error(codes.InvalidArgument, "fleet and instance are required")
+		return nil, status.Error(codes.InvalidArgument, "fleet and instance are required")
 	}
 
 	backendType := s.resolveBackend(req.GetBackend())
@@ -422,7 +473,7 @@ func (s *service) CreateInstance(req *fleetgrpc.CreateInstanceRequest, stream fl
 		})
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 	s.pushState()
 
@@ -431,17 +482,26 @@ func (s *service) CreateInstance(req *fleetgrpc.CreateInstanceRequest, stream fl
 		err := jobRunCreate(fleetName, instanceName, remote, req.GetBranch(), req.GetVerbose(), backendType)
 		return loadInstanceSnapshot(fleetName, instanceName), nil, err
 	})
+	return j, nil
+}
+
+// CreateInstance starts the provisioning job and relays its events.
+func (s *service) CreateInstance(req *fleetgrpc.CreateInstanceRequest, stream fleetgrpc.FleetService_CreateInstanceServer) error {
+	j, err := s.startCreateInstanceJob(req)
+	if err != nil {
+		return err
+	}
 	return relay(j, stream)
 }
 
-// CloneInstance pre-creates the StatusCloning destination record (copying the
-// source's Config/Backend/Tag/Color/Branch per the contract), then runs the
-// clone job.
-func (s *service) CloneInstance(req *fleetgrpc.CloneInstanceRequest, stream fleetgrpc.FleetService_CloneInstanceServer) error {
+// startCloneInstanceJob pre-creates the StatusCloning destination record
+// (copying the source's Config/Backend/Tag/Color/Branch per the contract), then
+// starts the clone job.
+func (s *service) startCloneInstanceJob(req *fleetgrpc.CloneInstanceRequest) (*job, error) {
 	fleetName := req.GetFleet()
 	srcName, destName := req.GetSourceInstance(), req.GetNewInstance()
 	if fleetName == "" || srcName == "" || destName == "" {
-		return status.Error(codes.InvalidArgument, "fleet, source_instance and new_instance are required")
+		return nil, status.Error(codes.InvalidArgument, "fleet, source_instance and new_instance are required")
 	}
 
 	wsDir := filepath.Join(state.WorkspacesDir(), fleetName, destName, fleetName)
@@ -485,7 +545,7 @@ func (s *service) CloneInstance(req *fleetgrpc.CloneInstanceRequest, stream flee
 		return f.AddInstance(dest)
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 	s.pushState()
 
@@ -494,43 +554,69 @@ func (s *service) CloneInstance(req *fleetgrpc.CloneInstanceRequest, stream flee
 		err := jobRunClone(fleetName, srcName, destName, false)
 		return loadInstanceSnapshot(fleetName, destName), nil, err
 	})
+	return j, nil
+}
+
+// CloneInstance starts the clone job and relays its events.
+func (s *service) CloneInstance(req *fleetgrpc.CloneInstanceRequest, stream fleetgrpc.FleetService_CloneInstanceServer) error {
+	j, err := s.startCloneInstanceJob(req)
+	if err != nil {
+		return err
+	}
 	return relay(j, stream)
 }
 
-func (s *service) StartInstance(req *fleetgrpc.StartInstanceRequest, stream fleetgrpc.FleetService_StartInstanceServer) error {
+func (s *service) startStartInstanceJob(req *fleetgrpc.StartInstanceRequest) (*job, error) {
 	if req.GetFleet() == "" || req.GetInstance() == "" {
-		return status.Error(codes.InvalidArgument, "fleet and instance are required")
+		return nil, status.Error(codes.InvalidArgument, "fleet and instance are required")
 	}
 	j := s.jobs.start(fleetgrpc.JobKind_JOB_KIND_START_INSTANCE, req.GetFleet(), req.GetInstance(), time.Now())
 	go s.runJob(j, func() (*fleetgrpc.Instance, []string, error) {
 		err := jobRunStart(req.GetFleet(), req.GetInstance())
 		return loadInstanceSnapshot(req.GetFleet(), req.GetInstance()), nil, err
 	})
+	return j, nil
+}
+
+func (s *service) StartInstance(req *fleetgrpc.StartInstanceRequest, stream fleetgrpc.FleetService_StartInstanceServer) error {
+	j, err := s.startStartInstanceJob(req)
+	if err != nil {
+		return err
+	}
 	return relay(j, stream)
 }
 
-func (s *service) StopInstance(req *fleetgrpc.StopInstanceRequest, stream fleetgrpc.FleetService_StopInstanceServer) error {
+func (s *service) startStopInstanceJob(req *fleetgrpc.StopInstanceRequest) (*job, error) {
 	if req.GetFleet() == "" || req.GetInstance() == "" {
-		return status.Error(codes.InvalidArgument, "fleet and instance are required")
+		return nil, status.Error(codes.InvalidArgument, "fleet and instance are required")
 	}
 	j := s.jobs.start(fleetgrpc.JobKind_JOB_KIND_STOP_INSTANCE, req.GetFleet(), req.GetInstance(), time.Now())
 	go s.runJob(j, func() (*fleetgrpc.Instance, []string, error) {
 		err := jobRunStop(req.GetFleet(), req.GetInstance())
 		return loadInstanceSnapshot(req.GetFleet(), req.GetInstance()), nil, err
 	})
+	return j, nil
+}
+
+func (s *service) StopInstance(req *fleetgrpc.StopInstanceRequest, stream fleetgrpc.FleetService_StopInstanceServer) error {
+	j, err := s.startStopInstanceJob(req)
+	if err != nil {
+		return err
+	}
 	return relay(j, stream)
 }
 
-// DestroyInstance tears down one instance, or (destroy_fleet) every instance in
-// the fleet plus the fleet record. Best-effort: container/workspace failures
-// become warnings, and the record is removed regardless.
-func (s *service) DestroyInstance(req *fleetgrpc.DestroyInstanceRequest, stream fleetgrpc.FleetService_DestroyInstanceServer) error {
+// startDestroyInstanceJob validates the target, marks it deleting, and starts
+// the teardown job for one instance or (destroy_fleet) the whole fleet.
+// Best-effort: container/workspace failures become warnings, and the record is
+// removed regardless.
+func (s *service) startDestroyInstanceJob(req *fleetgrpc.DestroyInstanceRequest) (*job, error) {
 	fleetName := req.GetFleet()
 	if fleetName == "" {
-		return status.Error(codes.InvalidArgument, "fleet is required")
+		return nil, status.Error(codes.InvalidArgument, "fleet is required")
 	}
 	if !req.GetDestroyFleet() && req.GetInstance() == "" {
-		return status.Error(codes.InvalidArgument, "instance is required unless destroy_fleet is set")
+		return nil, status.Error(codes.InvalidArgument, "instance is required unless destroy_fleet is set")
 	}
 
 	// Validate the target exists so a typo'd / stale name fails fast (the CLI
@@ -538,20 +624,48 @@ func (s *service) DestroyInstance(req *fleetgrpc.DestroyInstanceRequest, stream 
 	if st, err := state.Load(); err == nil {
 		f, ok := st.Fleets[fleetName]
 		if !ok {
-			return status.Errorf(codes.NotFound, "fleet %q not found", fleetName)
+			return nil, status.Errorf(codes.NotFound, "fleet %q not found", fleetName)
 		}
 		if !req.GetDestroyFleet() {
 			if _, err := f.GetInstance(req.GetInstance()); err != nil {
-				return status.Errorf(codes.NotFound, "instance %q not found in fleet %q", req.GetInstance(), fleetName)
+				return nil, status.Errorf(codes.NotFound, "instance %q not found in fleet %q", req.GetInstance(), fleetName)
 			}
 		}
 	}
 
 	target := req.GetInstance()
+	// Mark the targets StatusDeleting server-side (the teardown sibling of the
+	// StatusCreating pre-write) so pollers — fleet_list, async MCP callers, the
+	// TUI — see the teardown in flight instead of a stale running/stopped
+	// status. Best-effort: the job removes the records regardless, so a failed
+	// mark only costs the transitional status.
+	_ = state.Update(func(st *state.State) error {
+		f, ok := st.Fleets[fleetName]
+		if !ok {
+			return nil
+		}
+		for _, inst := range f.Instances {
+			if req.GetDestroyFleet() || inst.Name == target {
+				inst.Status = fleet.StatusDeleting
+			}
+		}
+		return nil
+	})
+	s.pushState()
+
 	j := s.jobs.start(fleetgrpc.JobKind_JOB_KIND_DESTROY_INSTANCE, fleetName, target, time.Now())
 	go s.runJob(j, func() (*fleetgrpc.Instance, []string, error) {
 		return nil, s.destroy(fleetName, target, req.GetDestroyFleet()), nil
 	})
+	return j, nil
+}
+
+// DestroyInstance starts the teardown job and relays its events.
+func (s *service) DestroyInstance(req *fleetgrpc.DestroyInstanceRequest, stream fleetgrpc.FleetService_DestroyInstanceServer) error {
+	j, err := s.startDestroyInstanceJob(req)
+	if err != nil {
+		return err
+	}
 	return relay(j, stream)
 }
 

--- a/internal/server/jobs_test.go
+++ b/internal/server/jobs_test.go
@@ -217,6 +217,34 @@ func TestDestroyInstanceJobRemovesRecord(t *testing.T) {
 	}
 }
 
+// TestJobManagerFinishedRetention asserts a finished job stays resolvable by id
+// (for async pollers) until FIFO eviction pushes it out.
+func TestJobManagerFinishedRetention(t *testing.T) {
+	m := newJobManager()
+
+	first := m.start(fleetgrpc.JobKind_JOB_KIND_CREATE_INSTANCE, "f", "i0", time.Now())
+	firstID := first.summary.GetJobId()
+	if m.get(firstID) != first {
+		t.Fatalf("active job not resolvable by id")
+	}
+	m.finish(firstID)
+	if m.get(firstID) != first {
+		t.Fatalf("finished job should stay resolvable by id")
+	}
+	if len(m.summaries()) != 0 {
+		t.Fatalf("finished job must not be advertised as active")
+	}
+
+	// Filling the retention window evicts the oldest finished job.
+	for range finishedJobRetention {
+		j := m.start(fleetgrpc.JobKind_JOB_KIND_CREATE_INSTANCE, "f", "i", time.Now())
+		m.finish(j.summary.GetJobId())
+	}
+	if m.get(firstID) != nil {
+		t.Fatalf("oldest finished job should be evicted after %d newer ones", finishedJobRetention)
+	}
+}
+
 func TestActiveJobsSurfacedInGetState(t *testing.T) {
 	isolateFleetDir(t)
 	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -230,10 +230,10 @@ func newMCPServer(svc *service) *mcp.Server {
 
 // streamCollector is an in-process gRPC server stream that captures every Send
 // into a slice instead of writing to a real transport. It lets the MCP tools
-// call the streaming service handlers (CreateInstance, Logs, ...) directly and
-// collect their emitted events synchronously. The embedded grpc.ServerStream is
-// nil — the handlers only ever call Send and Context, so the other
-// ServerStream methods (SetHeader/RecvMsg/...) are never invoked.
+// call the streaming service handlers (Logs, ...) directly and collect their
+// emitted events synchronously. The embedded grpc.ServerStream is nil — the
+// handlers only ever call Send and Context, so the other ServerStream methods
+// (SetHeader/RecvMsg/...) are never invoked.
 type streamCollector[T any] struct {
 	grpc.ServerStream
 	ctx    context.Context
@@ -243,32 +243,46 @@ type streamCollector[T any] struct {
 func (c *streamCollector[T]) Send(ev *T) error         { c.events = append(c.events, ev); return nil }
 func (c *streamCollector[T]) Context() context.Context { return c.ctx }
 
-// runLifecycleJob drives one server-streaming lifecycle RPC (CreateInstance,
-// StartInstance, ...) to completion in-process and returns its single result:
-// the final instance record, any non-fatal warnings, and an error if the job
-// failed or never produced a JobDone.
-//
-// The lifecycle handlers block until the job emits JobDone (relay forwards
-// history+live events until the terminal one), so this call is synchronous with
-// respect to job completion. The job itself runs in a server-owned goroutine and
-// is decoupled from ctx: if ctx is cancelled the handler returns early but the
-// job keeps running server-side (matching the gRPC path).
-func runLifecycleJob(ctx context.Context, open func(grpc.ServerStreamingServer[fleetgrpc.JobEvent]) error) (final *fleetgrpc.Instance, warnings []string, err error) {
-	c := &streamCollector[fleetgrpc.JobEvent]{ctx: ctx}
-	// A non-nil error here is a pre-job gRPC status (InvalidArgument/NotFound/
-	// AlreadyExists) returned before any JobDone was produced.
-	if rpcErr := open(c); rpcErr != nil {
-		return nil, nil, rpcErr
-	}
-	for _, ev := range c.events {
+// awaitJob blocks until j emits its JobDone (or ctx is cancelled) and returns
+// the job's single result: the final instance record, any non-fatal warnings,
+// and an error if the job failed. The job runs in a server-owned goroutine
+// decoupled from ctx — cancellation abandons the WAIT, never the job (matching
+// the gRPC path, where a dropped stream leaves the job running).
+func awaitJob(ctx context.Context, j *job) (final *fleetgrpc.Instance, warnings []string, err error) {
+	hist, ch := j.subscribe()
+	for _, ev := range hist {
 		if d := ev.GetDone(); d != nil {
-			if !d.GetSuccess() {
-				return d.GetInstance(), d.GetWarnings(), errors.New(d.GetError())
-			}
-			return d.GetInstance(), d.GetWarnings(), nil
+			return doneOutcome(d)
 		}
 	}
-	return nil, nil, errors.New("job ended without a result")
+	if ch == nil {
+		// A terminal history without a JobDone violates the jobs.proto contract;
+		// surface it rather than hanging.
+		return nil, nil, errors.New("job ended without a result")
+	}
+	defer j.unsubscribe(ch)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		case ev, ok := <-ch:
+			if !ok {
+				return nil, nil, errors.New("job ended without a result")
+			}
+			if d := ev.GetDone(); d != nil {
+				return doneOutcome(d)
+			}
+		}
+	}
+}
+
+// doneOutcome unpacks a JobDone into awaitJob's result shape: a failed job
+// becomes an error carrying the job's message.
+func doneOutcome(d *fleetgrpc.JobDone) (*fleetgrpc.Instance, []string, error) {
+	if !d.GetSuccess() {
+		return d.GetInstance(), d.GetWarnings(), errors.New(d.GetError())
+	}
+	return d.GetInstance(), d.GetWarnings(), nil
 }
 
 // mergeCtx returns a context cancelled when EITHER input is cancelled, plus a

--- a/internal/server/mcp_jobs_test.go
+++ b/internal/server/mcp_jobs_test.go
@@ -1,0 +1,230 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// mcp_jobs_test.go covers the async-first MCP lifecycle flow (issue #134):
+// fleet_up & co return a {job_id, done:false} handle immediately, completion/
+// failure/warnings are polled via fleet_job_status, and wait:true restores the
+// blocking behavior.
+
+// startHub runs svc's hub loop for the test (jobs post state snapshots to it).
+func startHub(t *testing.T, svc *service) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	go svc.hub.run(ctx)
+	t.Cleanup(cancel)
+}
+
+// pollJobStatus polls fleet_job_status until the job leaves "running" (or the
+// deadline passes), returning the terminal status.
+func pollJobStatus(t *testing.T, cs *mcp.ClientSession, jobID string) FleetJobStatusOutput {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var js FleetJobStatusOutput
+	for {
+		callJSON(t, cs, "fleet_job_status", map[string]any{"job_id": jobID}, &js)
+		if js.State != "running" {
+			return js
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("job %s never left running", jobID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestMCPUpAsyncJobLifecycle drives the full async flow: fleet_up returns a job
+// handle while provisioning is still in flight, fleet_job_status reports it
+// running, and after the job completes it reports succeeded with the final
+// instance record.
+func TestMCPUpAsyncJobLifecycle(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Remote: "git@x:a.git"},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	release := make(chan struct{})
+	orig := jobRunCreate
+	jobRunCreate = func(fleetName, instanceName, remote, branch string, verbose bool, b fleet.BackendType) error {
+		<-release // hold provisioning in flight until the test releases it
+		return state.Update(func(st *state.State) error {
+			inst, _ := st.Fleets[fleetName].GetInstance(instanceName)
+			inst.Status = fleet.StatusRunning
+			inst.ContainerID = "fake-cid"
+			return nil
+		})
+	}
+	defer func() { jobRunCreate = orig }()
+
+	svc := newService()
+	startHub(t, svc)
+	cs := mcpConnect(t, svc)
+
+	// The kickoff returns immediately (the job is parked on `release`).
+	var out FleetJobOutput
+	callJSON(t, cs, "fleet_up", map[string]any{"fleet": "alpha", "instance": "i1"}, &out)
+	if out.Done || out.Success || out.JobID == "" {
+		t.Fatalf("async fleet_up should return done=false with a job_id: %+v", out)
+	}
+	if out.Instance == nil || out.Instance.Status != "creating" {
+		t.Fatalf("async fleet_up should return the transitional creating record: %+v", out.Instance)
+	}
+
+	// In flight: the job polls as running, and fleet_list shows creating.
+	var js FleetJobStatusOutput
+	callJSON(t, cs, "fleet_job_status", map[string]any{"job_id": out.JobID}, &js)
+	if js.State != "running" || js.Kind != "create_instance" || js.Fleet != "alpha" || js.Instance != "i1" {
+		t.Fatalf("in-flight job status mismatch: %+v", js)
+	}
+	var list FleetListOutput
+	callJSON(t, cs, "fleet_list", map[string]any{"fleet": "alpha"}, &list)
+	if len(list.Instances) != 1 || list.Instances[0].Status != "creating" {
+		t.Fatalf("fleet_list should show the creating instance: %+v", list.Instances)
+	}
+
+	close(release)
+	js = pollJobStatus(t, cs, out.JobID)
+	if js.State != "succeeded" || js.Error != "" {
+		t.Fatalf("finished job should be succeeded: %+v", js)
+	}
+	if js.Result == nil || js.Result.Status != "running" || js.Result.ContainerID != "fake-cid" {
+		t.Fatalf("finished job should carry the final instance record: %+v", js.Result)
+	}
+}
+
+// TestMCPUpWaitBlocksUntilDone asserts wait:true retains the old block-until-
+// done semantics: one call, final record in hand.
+func TestMCPUpWaitBlocksUntilDone(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Remote: "git@x:a.git"},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	orig := jobRunCreate
+	jobRunCreate = func(fleetName, instanceName, remote, branch string, verbose bool, b fleet.BackendType) error {
+		return state.Update(func(st *state.State) error {
+			inst, _ := st.Fleets[fleetName].GetInstance(instanceName)
+			inst.Status = fleet.StatusRunning
+			return nil
+		})
+	}
+	defer func() { jobRunCreate = orig }()
+
+	svc := newService()
+	startHub(t, svc)
+	cs := mcpConnect(t, svc)
+
+	var out FleetJobOutput
+	callJSON(t, cs, "fleet_up", map[string]any{"fleet": "alpha", "instance": "i1", "wait": true}, &out)
+	if !out.Done || !out.Success || out.JobID == "" {
+		t.Fatalf("blocking fleet_up should return done=true success=true: %+v", out)
+	}
+	if out.Instance == nil || out.Instance.Status != "running" {
+		t.Fatalf("blocking fleet_up should return the final record: %+v", out.Instance)
+	}
+}
+
+// TestMCPUpAsyncFailureSurfacesViaJobStatus asserts a failed async job is
+// readable over MCP: state=failed with the job's error message (as data, not a
+// tool error — pollers must be able to read it).
+func TestMCPUpAsyncFailureSurfacesViaJobStatus(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Remote: "git@x:a.git"},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	orig := jobRunCreate
+	jobRunCreate = func(fleetName, instanceName, remote, branch string, verbose bool, b fleet.BackendType) error {
+		return context.DeadlineExceeded // any error; the message must surface
+	}
+	defer func() { jobRunCreate = orig }()
+
+	svc := newService()
+	startHub(t, svc)
+	cs := mcpConnect(t, svc)
+
+	var out FleetJobOutput
+	callJSON(t, cs, "fleet_up", map[string]any{"fleet": "alpha", "instance": "i1"}, &out)
+	js := pollJobStatus(t, cs, out.JobID)
+	if js.State != "failed" || !strings.Contains(js.Error, "deadline exceeded") {
+		t.Fatalf("failed job should report state=failed with the error: %+v", js)
+	}
+}
+
+// TestMCPJobStatusUnknownJob asserts an unknown job id is a tool error that
+// points the caller at fleet_list as the fallback.
+func TestMCPJobStatusUnknownJob(t *testing.T) {
+	isolateFleetDir(t)
+	cs := mcpConnect(t, newService())
+
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "fleet_job_status", Arguments: map[string]any{"job_id": "job-0-999"},
+	})
+	if err != nil {
+		t.Fatalf("transport error: %v", err)
+	}
+	if !res.IsError || !strings.Contains(toolText(res), "not found") || !strings.Contains(toolText(res), "fleet_list") {
+		t.Fatalf("want 'not found' tool error pointing at fleet_list, got IsError=%v text=%q", res.IsError, toolText(res))
+	}
+}
+
+// TestMCPDownAsyncMarksDeleting drives an async fleet_down: the kickoff returns
+// the record marked deleting (pollable via fleet_list), and after the job
+// finishes the record is gone and the job reports succeeded.
+func TestMCPDownAsyncMarksDeleting(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Instances: []*fleet.Instance{
+			{Name: "i1", Status: fleet.StatusRunning, ContainerID: "c1"},
+		}},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	release := make(chan struct{})
+	orig := jobDownInstance
+	jobDownInstance = func(inst *fleet.Instance) error {
+		<-release // hold the teardown in flight
+		return nil
+	}
+	defer func() { jobDownInstance = orig }()
+
+	svc := newService()
+	startHub(t, svc)
+	cs := mcpConnect(t, svc)
+
+	var out FleetJobOutput
+	callJSON(t, cs, "fleet_down", map[string]any{"fleet": "alpha", "instance": "i1"}, &out)
+	if out.Done || out.JobID == "" {
+		t.Fatalf("async fleet_down should return done=false with a job_id: %+v", out)
+	}
+	if out.Instance == nil || out.Instance.Status != "deleting" {
+		t.Fatalf("async fleet_down should return the record marked deleting: %+v", out.Instance)
+	}
+
+	close(release)
+	js := pollJobStatus(t, cs, out.JobID)
+	if js.State != "succeeded" {
+		t.Fatalf("teardown job should succeed: %+v", js)
+	}
+	var list FleetListOutput
+	callJSON(t, cs, "fleet_list", map[string]any{"fleet": "alpha"}, &list)
+	if len(list.Instances) != 0 {
+		t.Fatalf("instance record should be removed after fleet_down: %+v", list.Instances)
+	}
+}

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -114,7 +114,7 @@ func TestNewMCPServerRegistersAllTools(t *testing.T) {
 	want := []string{
 		"fleet_list", "fleet_status", "fleet_version", "fleet_logs",
 		"fleet_up", "fleet_start", "fleet_stop", "fleet_down",
-		"fleet_destroy_fleet", "fleet_clone",
+		"fleet_destroy_fleet", "fleet_clone", "fleet_job_status",
 		"fleet_exec", "fleet_session_spawn", "fleet_session_exec", "fleet_session_read",
 		"fleet_session_list",
 	}

--- a/internal/server/mcp_tools.go
+++ b/internal/server/mcp_tools.go
@@ -17,7 +17,6 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/tui"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 )
 
@@ -31,6 +30,14 @@ import (
 // Names are flat and prefixed `fleet_` (the MCP spec restricts tool names to
 // [A-Za-z0-9_.-]). cwd-based fleet/instance inference — a host/client concept —
 // is dropped: tools take explicit fleet and instance arguments.
+//
+// The slow, job-shaped lifecycle tools (fleet_up, fleet_clone, fleet_down,
+// fleet_destroy_fleet) are ASYNC-FIRST (issue #134): they start the server-
+// owned job and return a {job_id, done:false} handle within seconds, instead of
+// blocking past the MCP client's tool-call timeout (provisioning takes
+// minutes). Completion, failure, and warnings are polled via fleet_job_status
+// (or fleet_list's status/error). wait:true opts back into blocking. fleet_start
+// and fleet_stop stay blocking — they finish in seconds.
 
 // registerMCPTools wires every fleet tool onto srv.
 func registerMCPTools(srv *mcp.Server, s *service) {
@@ -55,28 +62,32 @@ func registerMCPTools(srv *mcp.Server, s *service) {
 	// --- lifecycle ---
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "fleet_up",
-		Description: "Create (provision) a new instance in a fleet. Provide remote (git URL) when creating the first instance of a new fleet.",
+		Description: "Create (provision) a new instance in a fleet. Returns immediately with a job_id to poll via fleet_job_status (provisioning takes minutes); pass wait:true to block until done instead. Provide remote (git URL) when creating the first instance of a new fleet.",
 	}, s.mcpUp)
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "fleet_start",
-		Description: "Start a previously stopped instance's container.",
+		Description: "Start a previously stopped instance's container. Blocks until started.",
 	}, s.mcpStart)
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "fleet_stop",
-		Description: "Stop an instance's container, keeping the instance record.",
+		Description: "Stop an instance's container, keeping the instance record. Blocks until stopped.",
 	}, s.mcpStop)
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "fleet_down",
-		Description: "Stop and remove a single instance: tears down its container, removes its workspace, and deletes the record.",
+		Description: "Stop and remove a single instance: tears down its container, removes its workspace, and deletes the record. Returns immediately with a job_id to poll via fleet_job_status; pass wait:true to block until done.",
 	}, s.mcpDown)
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "fleet_destroy_fleet",
-		Description: "Destroy an entire fleet: tears down every instance and removes the fleet record.",
+		Description: "Destroy an entire fleet: tears down every instance and removes the fleet record. Returns immediately with a job_id to poll via fleet_job_status; pass wait:true to block until done.",
 	}, s.mcpDestroyFleet)
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "fleet_clone",
-		Description: "Clone an existing instance into a new one within the same fleet, preserving its container state.",
+		Description: "Clone an existing instance into a new one within the same fleet, preserving its container state. Returns immediately with a job_id to poll via fleet_job_status; pass wait:true to block until done.",
 	}, s.mcpClone)
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "fleet_job_status",
+		Description: "Report the state of a lifecycle job (running, succeeded, or failed) with its error and warnings. Poll this to await a job started by fleet_up, fleet_clone, fleet_down, or fleet_destroy_fleet.",
+	}, s.mcpJobStatus)
 
 	// --- exec & sessions ---
 	mcp.AddTool(srv, &mcp.Tool{
@@ -140,25 +151,44 @@ func toMCPInstance(fleetName string, inst *fleetgrpc.Instance) *mcpInstance {
 	return m
 }
 
-// FleetJobOutput is the result of a lifecycle tool. Warnings are non-fatal
-// issues from an otherwise-successful job (e.g. a best-effort teardown step).
+// FleetJobOutput is the result of a lifecycle tool. An async kickoff (the
+// default for fleet_up/fleet_clone/fleet_down/fleet_destroy_fleet) returns
+// done=false the moment the job starts: job_id is the handle to poll via
+// fleet_job_status, and instance is the transitional record (creating/cloning/
+// deleting; absent for fleet-wide jobs). A blocking call (wait:true, and always
+// fleet_start/fleet_stop) returns done=true with the final record. Warnings are
+// non-fatal issues from an otherwise-successful job (e.g. a best-effort
+// teardown step).
 type FleetJobOutput struct {
-	Success  bool         `json:"success"`
+	JobID    string       `json:"job_id,omitempty"`
+	Done     bool         `json:"done"`
+	Success  bool         `json:"success,omitempty"`
 	Instance *mcpInstance `json:"instance,omitempty"`
 	Warnings []string     `json:"warnings,omitempty"`
 }
 
-// jobResult turns a lifecycle outcome into a tool result: a failed job becomes a
-// tool error (any warnings folded into the message); a successful one returns
-// the final instance + warnings.
-func jobResult(fleetName string, final *fleetgrpc.Instance, warnings []string, err error) (*mcp.CallToolResult, FleetJobOutput, error) {
+// jobResult turns a completed lifecycle outcome into a tool result: a failed
+// job becomes a tool error (any warnings folded into the message); a successful
+// one returns the final instance + warnings.
+func jobResult(fleetName, jobID string, final *fleetgrpc.Instance, warnings []string, err error) (*mcp.CallToolResult, FleetJobOutput, error) {
 	if err != nil {
 		if len(warnings) > 0 {
 			return nil, FleetJobOutput{}, fmt.Errorf("%w (warnings: %s)", mcpErr(err), strings.Join(warnings, "; "))
 		}
 		return nil, FleetJobOutput{}, mcpErr(err)
 	}
-	return nil, FleetJobOutput{Success: true, Instance: toMCPInstance(fleetName, final), Warnings: warnings}, nil
+	return nil, FleetJobOutput{JobID: jobID, Done: true, Success: true, Instance: toMCPInstance(fleetName, final), Warnings: warnings}, nil
+}
+
+// asyncJobResult is the immediate return of an async lifecycle kickoff: the job
+// handle plus the instance's current transitional record (nil for fleet-wide
+// jobs, or if the job already removed the record). The caller discovers
+// completion by polling fleet_job_status {job_id} or fleet_list.
+func asyncJobResult(fleetName string, j *job) (*mcp.CallToolResult, FleetJobOutput, error) {
+	return nil, FleetJobOutput{
+		JobID:    j.summary.GetJobId(),
+		Instance: toMCPInstance(fleetName, loadInstanceSnapshot(fleetName, j.summary.GetInstance())),
+	}, nil
 }
 
 // FleetInstanceInput identifies one instance.
@@ -297,6 +327,7 @@ type FleetUpInput struct {
 	Remote   string `json:"remote,omitempty" jsonschema:"git remote URL; required only when creating the first instance of a new fleet"`
 	Branch   string `json:"branch,omitempty" jsonschema:"git branch to check out; defaults to the repository's default branch"`
 	Backend  string `json:"backend,omitempty" jsonschema:"backend type: devcontainer (default), coder, or codespaces"`
+	Wait     bool   `json:"wait,omitempty" jsonschema:"block until provisioning completes instead of returning a job handle immediately; provisioning takes minutes, so only set this with a generous tool-call timeout"`
 }
 
 func (s *service) mcpUp(ctx context.Context, _ *mcp.CallToolRequest, in FleetUpInput) (*mcp.CallToolResult, FleetJobOutput, error) {
@@ -321,65 +352,91 @@ func (s *service) mcpUp(ctx context.Context, _ *mcp.CallToolRequest, in FleetUpI
 	if in.Branch != "" {
 		req.Branch = &in.Branch
 	}
+	j, err := s.startCreateInstanceJob(req)
+	if err != nil {
+		return nil, FleetJobOutput{}, mcpErr(err)
+	}
+	if !in.Wait {
+		return asyncJobResult(in.Fleet, j)
+	}
 	jctx, cancel := mergeCtx(s.bgCtx, ctx)
 	defer cancel()
-	final, warnings, err := runLifecycleJob(jctx, func(st grpc.ServerStreamingServer[fleetgrpc.JobEvent]) error {
-		return s.CreateInstance(req, st)
-	})
-	return jobResult(in.Fleet, final, warnings, err)
+	final, warnings, err := awaitJob(jctx, j)
+	return jobResult(in.Fleet, j.summary.GetJobId(), final, warnings, err)
 }
 
 func (s *service) mcpStart(ctx context.Context, _ *mcp.CallToolRequest, in FleetInstanceInput) (*mcp.CallToolResult, FleetJobOutput, error) {
 	if in.Fleet == "" || in.Instance == "" {
 		return nil, FleetJobOutput{}, errors.New("fleet and instance are required")
 	}
+	j, err := s.startStartInstanceJob(&fleetgrpc.StartInstanceRequest{Fleet: in.Fleet, Instance: in.Instance})
+	if err != nil {
+		return nil, FleetJobOutput{}, mcpErr(err)
+	}
 	jctx, cancel := mergeCtx(s.bgCtx, ctx)
 	defer cancel()
-	final, warnings, err := runLifecycleJob(jctx, func(st grpc.ServerStreamingServer[fleetgrpc.JobEvent]) error {
-		return s.StartInstance(&fleetgrpc.StartInstanceRequest{Fleet: in.Fleet, Instance: in.Instance}, st)
-	})
-	return jobResult(in.Fleet, final, warnings, err)
+	final, warnings, err := awaitJob(jctx, j)
+	return jobResult(in.Fleet, j.summary.GetJobId(), final, warnings, err)
 }
 
 func (s *service) mcpStop(ctx context.Context, _ *mcp.CallToolRequest, in FleetInstanceInput) (*mcp.CallToolResult, FleetJobOutput, error) {
 	if in.Fleet == "" || in.Instance == "" {
 		return nil, FleetJobOutput{}, errors.New("fleet and instance are required")
 	}
+	j, err := s.startStopInstanceJob(&fleetgrpc.StopInstanceRequest{Fleet: in.Fleet, Instance: in.Instance})
+	if err != nil {
+		return nil, FleetJobOutput{}, mcpErr(err)
+	}
 	jctx, cancel := mergeCtx(s.bgCtx, ctx)
 	defer cancel()
-	final, warnings, err := runLifecycleJob(jctx, func(st grpc.ServerStreamingServer[fleetgrpc.JobEvent]) error {
-		return s.StopInstance(&fleetgrpc.StopInstanceRequest{Fleet: in.Fleet, Instance: in.Instance}, st)
-	})
-	return jobResult(in.Fleet, final, warnings, err)
+	final, warnings, err := awaitJob(jctx, j)
+	return jobResult(in.Fleet, j.summary.GetJobId(), final, warnings, err)
 }
 
-func (s *service) mcpDown(ctx context.Context, _ *mcp.CallToolRequest, in FleetInstanceInput) (*mcp.CallToolResult, FleetJobOutput, error) {
+type FleetDownInput struct {
+	Fleet    string `json:"fleet" jsonschema:"fleet name"`
+	Instance string `json:"instance" jsonschema:"instance name"`
+	Wait     bool   `json:"wait,omitempty" jsonschema:"block until the teardown completes instead of returning a job handle immediately"`
+}
+
+func (s *service) mcpDown(ctx context.Context, _ *mcp.CallToolRequest, in FleetDownInput) (*mcp.CallToolResult, FleetJobOutput, error) {
 	if in.Fleet == "" || in.Instance == "" {
 		return nil, FleetJobOutput{}, errors.New("fleet and instance are required")
 	}
 	instance := in.Instance
-	jctx, cancel := mergeCtx(s.bgCtx, ctx)
-	defer cancel()
-	final, warnings, err := runLifecycleJob(jctx, func(st grpc.ServerStreamingServer[fleetgrpc.JobEvent]) error {
-		return s.DestroyInstance(&fleetgrpc.DestroyInstanceRequest{Fleet: in.Fleet, Instance: &instance}, st)
-	})
-	return jobResult(in.Fleet, final, warnings, err)
-}
-
-type FleetNameInput struct {
-	Fleet string `json:"fleet" jsonschema:"fleet name"`
-}
-
-func (s *service) mcpDestroyFleet(ctx context.Context, _ *mcp.CallToolRequest, in FleetNameInput) (*mcp.CallToolResult, FleetJobOutput, error) {
-	if in.Fleet == "" {
-		return nil, FleetJobOutput{}, errors.New("fleet is required")
+	j, err := s.startDestroyInstanceJob(&fleetgrpc.DestroyInstanceRequest{Fleet: in.Fleet, Instance: &instance})
+	if err != nil {
+		return nil, FleetJobOutput{}, mcpErr(err)
+	}
+	if !in.Wait {
+		return asyncJobResult(in.Fleet, j)
 	}
 	jctx, cancel := mergeCtx(s.bgCtx, ctx)
 	defer cancel()
-	final, warnings, err := runLifecycleJob(jctx, func(st grpc.ServerStreamingServer[fleetgrpc.JobEvent]) error {
-		return s.DestroyInstance(&fleetgrpc.DestroyInstanceRequest{Fleet: in.Fleet, DestroyFleet: true}, st)
-	})
-	return jobResult(in.Fleet, final, warnings, err)
+	final, warnings, err := awaitJob(jctx, j)
+	return jobResult(in.Fleet, j.summary.GetJobId(), final, warnings, err)
+}
+
+type FleetDestroyFleetInput struct {
+	Fleet string `json:"fleet" jsonschema:"fleet name"`
+	Wait  bool   `json:"wait,omitempty" jsonschema:"block until the teardown completes instead of returning a job handle immediately"`
+}
+
+func (s *service) mcpDestroyFleet(ctx context.Context, _ *mcp.CallToolRequest, in FleetDestroyFleetInput) (*mcp.CallToolResult, FleetJobOutput, error) {
+	if in.Fleet == "" {
+		return nil, FleetJobOutput{}, errors.New("fleet is required")
+	}
+	j, err := s.startDestroyInstanceJob(&fleetgrpc.DestroyInstanceRequest{Fleet: in.Fleet, DestroyFleet: true})
+	if err != nil {
+		return nil, FleetJobOutput{}, mcpErr(err)
+	}
+	if !in.Wait {
+		return asyncJobResult(in.Fleet, j)
+	}
+	jctx, cancel := mergeCtx(s.bgCtx, ctx)
+	defer cancel()
+	final, warnings, err := awaitJob(jctx, j)
+	return jobResult(in.Fleet, j.summary.GetJobId(), final, warnings, err)
 }
 
 type FleetCloneInput struct {
@@ -390,6 +447,7 @@ type FleetCloneInput struct {
 	Tag         string `json:"tag,omitempty" jsonschema:"optional tag override for the clone"`
 	Color       string `json:"color,omitempty" jsonschema:"optional color override for the clone"`
 	Branch      string `json:"branch,omitempty" jsonschema:"optional branch override for the clone"`
+	Wait        bool   `json:"wait,omitempty" jsonschema:"block until the clone completes instead of returning a job handle immediately; cloning can take minutes"`
 }
 
 func (s *service) mcpClone(ctx context.Context, _ *mcp.CallToolRequest, in FleetCloneInput) (*mcp.CallToolResult, FleetJobOutput, error) {
@@ -409,12 +467,70 @@ func (s *service) mcpClone(ctx context.Context, _ *mcp.CallToolRequest, in Fleet
 	if in.Branch != "" {
 		req.BranchOverride = &in.Branch
 	}
+	j, err := s.startCloneInstanceJob(req)
+	if err != nil {
+		return nil, FleetJobOutput{}, mcpErr(err)
+	}
+	if !in.Wait {
+		return asyncJobResult(in.Fleet, j)
+	}
 	jctx, cancel := mergeCtx(s.bgCtx, ctx)
 	defer cancel()
-	final, warnings, err := runLifecycleJob(jctx, func(st grpc.ServerStreamingServer[fleetgrpc.JobEvent]) error {
-		return s.CloneInstance(req, st)
-	})
-	return jobResult(in.Fleet, final, warnings, err)
+	final, warnings, err := awaitJob(jctx, j)
+	return jobResult(in.Fleet, j.summary.GetJobId(), final, warnings, err)
+}
+
+type FleetJobStatusInput struct {
+	JobID string `json:"job_id" jsonschema:"job id returned by a lifecycle tool"`
+}
+
+// FleetJobStatusOutput reports one lifecycle job. State is running until the
+// job finishes, then succeeded or failed (with Error). Result is the final
+// instance record from the job, when it produced one. A failed job is DATA
+// here (state:"failed"), not a tool error — polling must be able to read the
+// failure.
+type FleetJobStatusOutput struct {
+	JobID     string       `json:"job_id"`
+	Kind      string       `json:"kind"`
+	Fleet     string       `json:"fleet"`
+	Instance  string       `json:"instance,omitempty"`
+	State     string       `json:"state"`
+	StartedAt string       `json:"started_at,omitempty"`
+	Ms        int64        `json:"ms,omitempty"`
+	Error     string       `json:"error,omitempty"`
+	Warnings  []string     `json:"warnings,omitempty"`
+	Result    *mcpInstance `json:"result,omitempty"`
+}
+
+func (s *service) mcpJobStatus(_ context.Context, _ *mcp.CallToolRequest, in FleetJobStatusInput) (*mcp.CallToolResult, FleetJobStatusOutput, error) {
+	if in.JobID == "" {
+		return nil, FleetJobStatusOutput{}, errors.New("job_id is required")
+	}
+	j := s.jobs.get(in.JobID)
+	if j == nil {
+		return nil, FleetJobStatusOutput{}, fmt.Errorf("job %q not found (it may pre-date a daemon restart, or its result expired); check the instance's status and error via fleet_list instead", in.JobID)
+	}
+	out := FleetJobStatusOutput{
+		JobID:    j.summary.GetJobId(),
+		Kind:     jobKindName(j.summary.GetKind()),
+		Fleet:    j.summary.GetFleet(),
+		Instance: j.summary.GetInstance(),
+		State:    "running",
+	}
+	if ts := j.summary.GetStartedAt(); ts != nil {
+		out.StartedAt = ts.AsTime().UTC().Format(time.RFC3339)
+	}
+	if d := j.outcome(); d != nil {
+		out.State = "succeeded"
+		if !d.GetSuccess() {
+			out.State = "failed"
+			out.Error = d.GetError()
+		}
+		out.Ms = d.GetMs()
+		out.Warnings = d.GetWarnings()
+		out.Result = toMCPInstance(j.summary.GetFleet(), d.GetInstance())
+	}
+	return nil, out, nil
 }
 
 // --- exec & session tools ---


### PR DESCRIPTION
Closes #134.

## Problem

`fleet_up` blocked until the provisioning job finished server-side (~75–135s per devcontainer), which blows past MCP client tool-call timeouts. The call fails with a generic client-side timeout while the job keeps running, the caller can't distinguish "still provisioning" from "failed", and there is no way to await completion over MCP afterwards — bulk provisioning had to fall back to the CLI.

## Change

The job-shaped lifecycle tools — `fleet_up`, `fleet_clone`, `fleet_down`, `fleet_destroy_fleet` — are now **async-first**: they start the server-owned job and return `{job_id, done: false, instance}` within seconds, where `instance` is the transitional record (`creating`/`cloning`/`deleting`). `fleet_start`/`fleet_stop` stay blocking (they finish in seconds).

Completion is discoverable entirely over MCP, two ways:

- **`fleet_job_status {job_id}`** (new tool) reports `{state: running|succeeded|failed, error?, warnings?, result?}`. A failed job is *data* here, not a tool error — pollers must be able to read the failure. An unknown job id (daemon restart, result expired) is a tool error pointing at `fleet_list` as the fallback.
- **`fleet_list`** polling: `creating → running`, or `failed` with `error`; destroy targets are now marked `deleting` server-side while the teardown job runs, until the record disappears.

`wait: true` opts back into the old block-until-done semantics and returns `{job_id, done: true, success, instance, warnings}` (a failed blocking job still surfaces as a tool error).

## Implementation

- **`internal/server/jobs.go`** — each lifecycle RPC is split into a `start*Job` half (validate, pre-write the transitional record, start the job goroutine) and a thin streaming wrapper that relays events; the gRPC surface is byte-for-byte unchanged. The job manager now retains finished jobs (FIFO-bounded at 256) so async callers can poll an outcome after completion. Destroy jobs mark their targets `StatusDeleting` before starting — the teardown sibling of the existing `StatusCreating` pre-write.
- **`internal/server/mcp.go`** — `runLifecycleJob` (drive a streaming handler in-process and collect until JobDone) is replaced by `awaitJob` on the job handle; `streamCollector` remains for `fleet_logs`.
- **`internal/server/mcp_tools.go`** — `wait` input on the four async-first tools, `job_id`/`done` on `FleetJobOutput`, and the new `fleet_job_status` tool.
- **`internal/admiralskill/SKILL.md`** — documents the async flow (kick off several, keep working, poll every few seconds) and the updated tool reference.

## Acceptance criteria

- [x] `fleet_up` (without `wait`) returns within a few seconds with a job/instance handle
- [x] A caller can determine job completion, failure (with error message), and warnings entirely over MCP
- [x] `fleet_up {wait: true}` retains today's block-until-done semantics
- [x] Skill/tool documentation updated to describe the async flow

## Tests

New `mcp_jobs_test.go` covers: the full async flow (kickoff returns while the job is parked on a release channel; status polls `running → succeeded` with the final record; `fleet_list` shows `creating` mid-flight), `wait: true` blocking, failed-job reporting via `fleet_job_status`, unknown job id, and async `fleet_down` (record marked `deleting`, then gone). Plus a job-manager retention/eviction unit test. Whole server package passes under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)