### PR TITLE
feat: Enable Remote Fleet setting gating the gateway gRPC endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,11 +178,20 @@ In **Settings → Fleet Remote (MCP)**:
    dials out — the gateway's `--grpc-addr`, default port `50051`; behind a proxy
    it's whatever host:port routes to that listener). It is *not* the public address
    agents use.
-2. Flip **Enabled** on.
+2. Flip **Enable Remote MCP** on.
 
 Once connected, the read-only **Public MCP URL** appears (e.g.
 `https://gateway.example.com/mcp/<id>`) — that is the address external tools use.
 The line shows the live connection state (connecting / connected / error).
+
+A second, independent toggle — **Enable Remote Fleet** — exposes the daemon's
+**gRPC control surface** through the same gateway, so a remote `fleet` binary can
+drive this instance (see [Remote control](#remote-control-grpc)). With it off,
+fleetd never negotiates the gRPC tunnel feature, so the gateway rejects any
+incoming gRPC commands aimed at the daemon. With it on, a read-only **Public GRPC
+URL** appears under the Public MCP URL (computed by the gateway from its
+`--public-grpc-url` flag) — that value is what you feed another `fleet` as
+`FLEET_GATEWAY`. The toggles are independent: expose MCP, remote control, or both.
 
 ### Use it from a remote agent
 
@@ -218,6 +227,7 @@ fleet gateway \
 | Flag | Default | Purpose |
 |------|---------|---------|
 | `--public-url` | (required) | External base URL agents use; session URLs are `<public-url>/mcp/<id>`. Scheme (`https`/`http`) must match how the public endpoint is actually served |
+| `--public-grpc-url` | (optional) | External base URL of the gRPC endpoint remote `fleet` clients dial, e.g. `https://gateway.example.com:50051`. Daemons that enable **Remote Fleet** are handed `<public-grpc-url>/grpc/<id>` as their **Public GRPC URL** (shown in the TUI, used as `FLEET_GATEWAY`). Unset = no URL is computed |
 | `--tls-cert` / `--tls-key` | (optional) | TLS certificate + key (PEM). Provide **both** to serve HTTPS, or **neither** for plain HTTP behind a proxy. A lone cert or key is an error |
 | `--public-addr` | `:443` | MCP + `/healthz` listener — HTTP/1.1 (HTTPS when a cert is set, else HTTP) |
 | `--grpc-addr` | `:50051` | Native gRPC listener — HTTP/2 (h2c when cert-less, h2 under TLS). Hosts remote `fleet` control **and** fleetd registration. Empty disables both |
@@ -322,15 +332,20 @@ then serves plain HTTP.
 
 The same gateway tunnel can also carry the daemon's **gRPC** API, so a remote
 `fleet` client can drive your daemon directly — list/up/down, watch live status,
-stream logs, change config, and so on. It rides the **same tunnel and the same
-on/off toggle** as remote MCP (no separate setting). The gateway serves native
-gRPC on its dedicated `--grpc-addr` listener (default `:50051`); the client dials
-it as an ordinary gRPC endpoint and sends the daemon's session id (the same id as
-in the MCP URL) as the `fleet-session` metadata header, so the gateway can route.
+stream logs, change config, and so on. It rides the **same tunnel** as remote MCP
+but has its **own toggle**: flip **Enable Remote Fleet** in Settings → Fleet MCP
+(independent of Enable Remote MCP, so you can expose MCP, remote control, or
+both). The gateway serves native gRPC on its dedicated `--grpc-addr` listener
+(default `:50051`); the client dials it as an ordinary gRPC endpoint and sends the
+daemon's session id (the same id as in the MCP URL) as the `fleet-session`
+metadata header, so the gateway can route.
 
 Point a `fleet` client at it with two env vars — the URL is the gRPC endpoint plus
-the session id (the gateway's `--grpc-addr`, or whatever host:port your reverse
-proxy exposes for gRPC):
+the session id. When the gateway runs with `--public-grpc-url`, the settings page
+shows this exact value as the **Public GRPC URL** (e.g.
+`https://gateway.example.com:50051/grpc/<id>`); otherwise compose it from the
+gateway's `--grpc-addr` (or whatever host:port your reverse proxy exposes for
+gRPC) plus the session id:
 
 ```bash
 export FLEET_GATEWAY="https://gateway.example.com:50051/<id>"

--- a/doc/gateway.md
+++ b/doc/gateway.md
@@ -65,7 +65,8 @@ the whole gateway.
 
 ## 3. Registration (over the gRPC tunnel stream)
 
-When the user enables remote MCP, `fleetd`'s `remote.Manager` opens a long‑lived
+When the user enables remote MCP (or remote fleet — either toggle brings the
+tunnel up), `fleetd`'s `remote.Manager` opens a long‑lived
 gRPC **bidi** stream — the `Register` method (`tunnel.RegisterMethod`) on the
 gateway's gRPC endpoint. Both ends wrap that stream as a `net.Conn`
 (`tunnel.StreamConn`, a raw‑codec adapter), so the *exact same* handshake + yamux
@@ -250,8 +251,15 @@ All of gRPC works through the reverse proxy — unary, server‑streaming (`Watc
 (`FlushInterval: -1`) so streaming isn't buffered, and forwards HTTP/2 trailers
 (`grpc-status`) so per‑RPC status propagates.
 
-> **Note:** the gRPC API rides the *same* tunnel and the *same* on/off toggle as
-> MCP, and reuses the *same* bearer token. Enabling remote MCP exposes both.
+> **Note:** the gRPC API rides the *same* tunnel as MCP and reuses the *same*
+> bearer token, but has its **own toggle** — **Enable Remote Fleet**. fleetd only
+> advertises the `grpc` tunnel feature when that setting is on; without the
+> negotiated feature the gateway answers every `fleet-session` RPC for the session
+> with `NotFound`, and fleetd closes any `TagGRPC` stream regardless. The two
+> toggles are independent: a user can expose MCP, remote control, or both.
+> When the gateway runs with `--public-grpc-url`, a grpc‑negotiating daemon is
+> also handed its **Public GRPC URL** (`<public-grpc-url>/grpc/<publicID>`) in the
+> register reply — the exact `FLEET_GATEWAY` value, surfaced read‑only in the TUI.
 
 ---
 
@@ -336,8 +344,9 @@ OS system roots) **or** `http://` (plaintext h2c), defaulting the port to 443/80
   TTL, then a reaper frees it — so a `kill -9`'d daemon's URL is released, but a
   brief network blip keeps the URL stable.
 - **Status.** `fleetd` publishes the live connection state and the assigned public
-  URL over its Watch stream, so the TUI's settings page shows it in real time. The
-  computed Public MCP URL is *never* stored in config — only pushed over Watch.
+  URLs (MCP, and gRPC when negotiated) over its Watch stream, so the TUI's settings
+  page shows them in real time. The computed Public MCP URL / Public GRPC URL are
+  *never* stored in config — only pushed over Watch.
 
 ---
 

--- a/fleetgrpc/config.pb.go
+++ b/fleetgrpc/config.pb.go
@@ -448,17 +448,24 @@ func (x *BrowserSettings) GetAutoSwitch() bool {
 }
 
 // RemoteMcpSettings mirrors internal/state.RemoteMcpSettings — the user's intent
-// to expose this daemon's local MCP server to the internet through a remote fleet
-// gateway. These are the ONLY two persisted fields: enabled and gateway_url.
+// to expose this daemon's local MCP server (enabled) and/or its gRPC control
+// surface (fleet_enabled) to the internet through a remote fleet gateway. Both
+// ride the SAME tunnel to the same gateway_url; the two toggles are independent,
+// so a user can expose MCP, remote control, or both.
 //
-// The COMPUTED "Public MCP URL" the gateway assigns on connect is deliberately
-// NOT in Config — it is runtime state owned by the server and pushed to the TUI
-// via the Watch RemoteMcpStatus event (watch.proto). Keeping it out of Config is
-// what prevents the SetConfig-replaces-everything contract from clobbering it.
+// The COMPUTED "Public MCP URL" / "Public GRPC URL" the gateway assigns on
+// connect are deliberately NOT in Config — they are runtime state owned by the
+// server and pushed to the TUI via the Watch RemoteMcpStatus event (watch.proto).
+// Keeping them out of Config is what prevents the SetConfig-replaces-everything
+// contract from clobbering them.
 type RemoteMcpSettings struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Enabled       bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
-	GatewayUrl    string                 `protobuf:"bytes,2,opt,name=gateway_url,json=gatewayUrl,proto3" json:"gateway_url,omitempty"`
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	Enabled    bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	GatewayUrl string                 `protobuf:"bytes,2,opt,name=gateway_url,json=gatewayUrl,proto3" json:"gateway_url,omitempty"`
+	// fleet_enabled gates the gateway gRPC endpoint ("Enable Remote Fleet"): when
+	// false fleetd does not negotiate the grpc tunnel feature, so the gateway
+	// rejects any remote `fleet` control RPCs aimed at this daemon.
+	FleetEnabled  bool `protobuf:"varint,3,opt,name=fleet_enabled,json=fleetEnabled,proto3" json:"fleet_enabled,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -505,6 +512,13 @@ func (x *RemoteMcpSettings) GetGatewayUrl() string {
 		return x.GatewayUrl
 	}
 	return ""
+}
+
+func (x *RemoteMcpSettings) GetFleetEnabled() bool {
+	if x != nil {
+		return x.FleetEnabled
+	}
+	return false
 }
 
 type Config struct {
@@ -829,11 +843,12 @@ const file_config_proto_rawDesc = "" +
 	"\vauto_switch\x18\x02 \x01(\bH\x01R\n" +
 	"autoSwitch\x88\x01\x01B\x1e\n" +
 	"\x1c_multiple_browsers_per_fleetB\x0e\n" +
-	"\f_auto_switch\"N\n" +
+	"\f_auto_switch\"s\n" +
 	"\x11RemoteMcpSettings\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x1f\n" +
 	"\vgateway_url\x18\x02 \x01(\tR\n" +
-	"gatewayUrl\"\xd0\x03\n" +
+	"gatewayUrl\x12#\n" +
+	"\rfleet_enabled\x18\x03 \x01(\bR\ffleetEnabled\"\xd0\x03\n" +
 	"\x06Config\x124\n" +
 	"\ageneral\x18\x01 \x01(\v2\x1a.fleetgrpc.GeneralSettingsR\ageneral\x12.\n" +
 	"\x05agent\x18\x02 \x01(\v2\x18.fleetgrpc.AgentSettingsR\x05agent\x127\n" +

--- a/fleetgrpc/config.proto
+++ b/fleetgrpc/config.proto
@@ -75,16 +75,23 @@ message BrowserSettings {
 }
 
 // RemoteMcpSettings mirrors internal/state.RemoteMcpSettings — the user's intent
-// to expose this daemon's local MCP server to the internet through a remote fleet
-// gateway. These are the ONLY two persisted fields: enabled and gateway_url.
+// to expose this daemon's local MCP server (enabled) and/or its gRPC control
+// surface (fleet_enabled) to the internet through a remote fleet gateway. Both
+// ride the SAME tunnel to the same gateway_url; the two toggles are independent,
+// so a user can expose MCP, remote control, or both.
 //
-// The COMPUTED "Public MCP URL" the gateway assigns on connect is deliberately
-// NOT in Config — it is runtime state owned by the server and pushed to the TUI
-// via the Watch RemoteMcpStatus event (watch.proto). Keeping it out of Config is
-// what prevents the SetConfig-replaces-everything contract from clobbering it.
+// The COMPUTED "Public MCP URL" / "Public GRPC URL" the gateway assigns on
+// connect are deliberately NOT in Config — they are runtime state owned by the
+// server and pushed to the TUI via the Watch RemoteMcpStatus event (watch.proto).
+// Keeping them out of Config is what prevents the SetConfig-replaces-everything
+// contract from clobbering them.
 message RemoteMcpSettings {
   bool enabled = 1;
   string gateway_url = 2;
+  // fleet_enabled gates the gateway gRPC endpoint ("Enable Remote Fleet"): when
+  // false fleetd does not negotiate the grpc tunnel feature, so the gateway
+  // rejects any remote `fleet` control RPCs aimed at this daemon.
+  bool fleet_enabled = 3;
 }
 
 message Config {

--- a/fleetgrpc/watch.pb.go
+++ b/fleetgrpc/watch.pb.go
@@ -371,15 +371,18 @@ func (*Event_RemoteMcpStatus) isEvent_Kind() {}
 func (*Event_FileCopy) isEvent_Kind() {}
 
 // RemoteMcpStatus is the computed status the settings page shows after the user
-// enables remote MCP. public_url is the gateway-assigned Public MCP URL (only
-// meaningful when state is CONNECTED); error carries the last failure (when
-// state is ERROR). The tunnel itself lands in a later PR — for now this only
-// ever reports DISABLED, but the full push path is wired end to end.
+// enables remote MCP and/or remote fleet (both share the one gateway tunnel, so
+// one status describes them). public_url is the gateway-assigned Public MCP URL
+// and public_grpc_url the Public GRPC URL a remote `fleet` dials (each only
+// meaningful when state is CONNECTED; public_grpc_url is empty unless the grpc
+// feature was negotiated and the gateway runs with --public-grpc-url); error
+// carries the last failure (when state is ERROR).
 type RemoteMcpStatus struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	State         RemoteMcpConn          `protobuf:"varint,1,opt,name=state,proto3,enum=fleetgrpc.RemoteMcpConn" json:"state,omitempty"`
 	PublicUrl     string                 `protobuf:"bytes,2,opt,name=public_url,json=publicUrl,proto3" json:"public_url,omitempty"`
 	Error         string                 `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`
+	PublicGrpcUrl string                 `protobuf:"bytes,4,opt,name=public_grpc_url,json=publicGrpcUrl,proto3" json:"public_grpc_url,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -431,6 +434,13 @@ func (x *RemoteMcpStatus) GetPublicUrl() string {
 func (x *RemoteMcpStatus) GetError() string {
 	if x != nil {
 		return x.Error
+	}
+	return ""
+}
+
+func (x *RemoteMcpStatus) GetPublicGrpcUrl() string {
+	if x != nil {
+		return x.PublicGrpcUrl
 	}
 	return ""
 }
@@ -704,12 +714,13 @@ const file_watch_proto_rawDesc = "" +
 	"\x0fruntime_changed\x18\a \x01(\v2\x19.fleetgrpc.RuntimeChangedH\x00R\x0eruntimeChanged\x12H\n" +
 	"\x11remote_mcp_status\x18\b \x01(\v2\x1a.fleetgrpc.RemoteMcpStatusH\x00R\x0fremoteMcpStatus\x122\n" +
 	"\tfile_copy\x18\t \x01(\v2\x13.fleetgrpc.FileCopyH\x00R\bfileCopyB\x06\n" +
-	"\x04kind\"v\n" +
+	"\x04kind\"\x9e\x01\n" +
 	"\x0fRemoteMcpStatus\x12.\n" +
 	"\x05state\x18\x01 \x01(\x0e2\x18.fleetgrpc.RemoteMcpConnR\x05state\x12\x1d\n" +
 	"\n" +
 	"public_url\x18\x02 \x01(\tR\tpublicUrl\x12\x14\n" +
-	"\x05error\x18\x03 \x01(\tR\x05error\"6\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\x12&\n" +
+	"\x0fpublic_grpc_url\x18\x04 \x01(\tR\rpublicGrpcUrl\"6\n" +
 	"\fStateChanged\x12&\n" +
 	"\x05state\x18\x01 \x01(\v2\x10.fleetgrpc.StateR\x05state\"F\n" +
 	"\x0eRuntimeChanged\x124\n" +

--- a/fleetgrpc/watch.proto
+++ b/fleetgrpc/watch.proto
@@ -85,14 +85,17 @@ enum RemoteMcpConn {
 }
 
 // RemoteMcpStatus is the computed status the settings page shows after the user
-// enables remote MCP. public_url is the gateway-assigned Public MCP URL (only
-// meaningful when state is CONNECTED); error carries the last failure (when
-// state is ERROR). The tunnel itself lands in a later PR — for now this only
-// ever reports DISABLED, but the full push path is wired end to end.
+// enables remote MCP and/or remote fleet (both share the one gateway tunnel, so
+// one status describes them). public_url is the gateway-assigned Public MCP URL
+// and public_grpc_url the Public GRPC URL a remote `fleet` dials (each only
+// meaningful when state is CONNECTED; public_grpc_url is empty unless the grpc
+// feature was negotiated and the gateway runs with --public-grpc-url); error
+// carries the last failure (when state is ERROR).
 message RemoteMcpStatus {
   RemoteMcpConn state = 1;
   string public_url = 2;
   string error = 3;
+  string public_grpc_url = 4;
 }
 
 // StateChanged is pushed whenever the authoritative PERSISTED model mutates. It

--- a/integration/tests/300_gateway_remote_grpc.sh
+++ b/integration/tests/300_gateway_remote_grpc.sh
@@ -39,21 +39,27 @@ while [ "${GRPC_PORT}" = "${PUBLIC_PORT}" ]; do GRPC_PORT="$(free_port)"; done
 GATEWAY_URL="http://127.0.0.1:${GRPC_PORT}"
 info "gateway public=127.0.0.1:${PUBLIC_PORT} grpc=127.0.0.1:${GRPC_PORT}"
 
-# 1. Enable remote MCP in config, pointing fleetd at the gateway's gRPC endpoint.
-#    fleetd reconciles this at startup and registers over the gRPC Register stream.
+# 1. Enable remote MCP AND remote fleet in config, pointing fleetd at the
+#    gateway's gRPC endpoint. fleetd reconciles this at startup and registers
+#    over the gRPC Register stream; without fleet_enabled it would not negotiate
+#    the grpc tunnel feature and the gateway would refuse remote control RPCs.
 cat > "${HOME}/.fleet/config.json" <<EOF
 {
   "remote_mcp_settings": {
     "enabled": true,
+    "fleet_enabled": true,
     "gateway_url": "${GATEWAY_URL}"
   }
 }
 EOF
 
 # 2. Start the gateway in the background, cert-less (plain HTTP public + h2c gRPC).
+#    --public-grpc-url makes the gateway hand grpc-negotiating daemons their
+#    Public GRPC URL — the exact FLEET_GATEWAY value used below.
 gw_log="${TEST_SCRATCH_DIR}/gateway.log"
 "${FLEET_BIN}" gateway \
   --public-url "http://127.0.0.1:${PUBLIC_PORT}" \
+  --public-grpc-url "${GATEWAY_URL}" \
   --public-addr "127.0.0.1:${PUBLIC_PORT}" \
   --grpc-addr "127.0.0.1:${GRPC_PORT}" \
   >"${gw_log}" 2>&1 &
@@ -87,12 +93,12 @@ done
 assert_file_exists "${session_file}"
 info "registered: $(cat "${session_file}")"
 
-# 5. Build FLEET_GATEWAY from the assigned session id (the segment after /mcp/).
-public_mcp_url=$(grep -oE '"public_url"[[:space:]]*:[[:space:]]*"[^"]+"' "${session_file}" | sed -E 's/.*"([^"]+)"$/\1/')
-[ -n "${public_mcp_url}" ] || fail "no public_url in session file"
-session_id="${public_mcp_url##*/mcp/}"
-{ [ -n "${session_id}" ] && [ "${session_id}" != "${public_mcp_url}" ]; } || fail "could not extract session id from ${public_mcp_url}"
-export FLEET_GATEWAY="${GATEWAY_URL}/${session_id}"
+# 5. FLEET_GATEWAY is the gateway-computed Public GRPC URL
+#    (<public-grpc-url>/grpc/<id>), persisted in the session file — exactly what
+#    the TUI shows the user to feed a remote fleet.
+public_grpc_url=$(grep -oE '"public_grpc_url"[[:space:]]*:[[:space:]]*"[^"]+"' "${session_file}" | sed -E 's/.*"([^"]+)"$/\1/')
+[ -n "${public_grpc_url}" ] || fail "no public_grpc_url in session file — gateway did not hand one out"
+export FLEET_GATEWAY="${public_grpc_url}"
 export FLEET_TOKEN="$(cat "${HOME}/.fleet/mcp.token")"
 info "FLEET_GATEWAY=${FLEET_GATEWAY}"
 

--- a/internal/cli/gateway.go
+++ b/internal/cli/gateway.go
@@ -47,6 +47,7 @@ func newGatewayCmd() *cobra.Command {
 	f.StringVar(&cfg.PublicAddr, "public-addr", ":443", "address MCP agents connect to (HTTPS when a cert is set, else HTTP)")
 	f.StringVar(&cfg.GRPCAddr, "grpc-addr", ":50051", "address for native gRPC + fleetd registration (h2c when cert-less, h2 under TLS); empty disables both")
 	f.StringVar(&cfg.PublicURL, "public-url", "", "external base URL agents use, e.g. https://gw.example.com or http://gw.example.com (required)")
+	f.StringVar(&cfg.PublicGRPCURL, "public-grpc-url", "", "external base URL of the gRPC endpoint that remote `fleet` clients dial, e.g. https://gw.example.com:50051; daemons that enable remote fleet are handed <public-grpc-url>/grpc/<id> as their Public GRPC URL (empty = none)")
 	f.StringVar(&cfg.TLSCert, "tls-cert", "", "path to the TLS certificate, PEM (optional; set with --tls-key to enable TLS)")
 	f.StringVar(&cfg.TLSKey, "tls-key", "", "path to the TLS private key, PEM (optional; set with --tls-cert to enable TLS)")
 	f.IntVar(&cfg.MaxSessions, "max-sessions", 0, "max concurrent tunnels (0 = default 1024)")

--- a/internal/cli/gateway_test.go
+++ b/internal/cli/gateway_test.go
@@ -35,6 +35,14 @@ func TestGatewayEnvFillsUnsetFlags(t *testing.T) {
 	}
 }
 
+func TestGatewayEnvFillsPublicGRPCURL(t *testing.T) {
+	t.Setenv("FLEET_GATEWAY_PUBLIC_GRPC_URL", "https://gw.example.com:50051")
+
+	if got := gatewayFlagAfterEnv(t, nil, "public-grpc-url"); got != "https://gw.example.com:50051" {
+		t.Errorf("public-grpc-url = %q, want env value", got)
+	}
+}
+
 func TestGatewayFlagWinsOverEnv(t *testing.T) {
 	t.Setenv("FLEET_GATEWAY_PUBLIC_URL", "https://from-env.example.com")
 

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -90,13 +90,14 @@ const (
 // optional: provide BOTH to serve HTTPS/TLS on the listeners, or NEITHER to
 // serve plain HTTP (e.g. behind a TLS-terminating reverse proxy like Traefik).
 type Config struct {
-	PublicAddr  string // address MCP agents hit (HTTPS or HTTP). Default ":443".
-	GRPCAddr    string // address the native-gRPC (h2c/h2) listener binds; also where fleetd registers. Empty disables remote gRPC + registration. CLI default ":50051".
-	PublicURL   string // external base URL agents use, e.g. "https://gw.example.com" or "http://gw.example.com". Required.
-	TLSCert     string // path to the TLS certificate (PEM). Optional; both TLSCert and TLSKey together enable TLS.
-	TLSKey      string // path to the TLS private key (PEM). Optional; both TLSCert and TLSKey together enable TLS.
-	MaxSessions int    // cap on concurrent tunnels. Default 1024.
-	SessionKey  string // secret key signing session-resume tokens (token.go). Empty = a random per-boot key, so session URLs do not survive a gateway restart.
+	PublicAddr    string // address MCP agents hit (HTTPS or HTTP). Default ":443".
+	GRPCAddr      string // address the native-gRPC (h2c/h2) listener binds; also where fleetd registers. Empty disables remote gRPC + registration. CLI default ":50051".
+	PublicURL     string // external base URL agents use, e.g. "https://gw.example.com" or "http://gw.example.com". Required.
+	PublicGRPCURL string // external base URL remote `fleet` clients dial for the gRPC endpoint, e.g. "https://gw.example.com:50051". Empty = no Public GRPC URL is handed to daemons.
+	TLSCert       string // path to the TLS certificate (PEM). Optional; both TLSCert and TLSKey together enable TLS.
+	TLSKey        string // path to the TLS private key (PEM). Optional; both TLSCert and TLSKey together enable TLS.
+	MaxSessions   int    // cap on concurrent tunnels. Default 1024.
+	SessionKey    string // secret key signing session-resume tokens (token.go). Empty = a random per-boot key, so session URLs do not survive a gateway restart.
 }
 
 // Server is a configured gateway. Build with New, then Run. tlsConfig is nil when
@@ -138,6 +139,7 @@ func New(cfg Config) (*Server, error) {
 		cfg.MaxSessions = defaultMaxSessions
 	}
 	cfg.PublicURL = strings.TrimRight(cfg.PublicURL, "/")
+	cfg.PublicGRPCURL = strings.TrimRight(strings.TrimSpace(cfg.PublicGRPCURL), "/")
 
 	signer, err := newTokenSigner(cfg.SessionKey)
 	if err != nil {
@@ -146,7 +148,7 @@ func New(cfg Config) (*Server, error) {
 
 	return &Server{
 		cfg:        cfg,
-		reg:        newRegistry(cfg.PublicURL, cfg.MaxSessions, signer),
+		reg:        newRegistry(cfg.PublicURL, cfg.PublicGRPCURL, cfg.MaxSessions, signer),
 		tlsConfig:  tlsConfig,
 		log:        slog.Default(),
 		pendingSem: make(chan struct{}, cfg.MaxSessions+maxPendingHandshakes),

--- a/internal/gateway/gateway_e2e_test.go
+++ b/internal/gateway/gateway_e2e_test.go
@@ -80,7 +80,7 @@ func startTestGatewayKeyed(t *testing.T, cert tls.Certificate, publicBase, sessi
 	tlsCfg := &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}
 	s := &Server{
 		cfg:       Config{PublicURL: publicBase, MaxSessions: 64, SessionKey: sessionKey},
-		reg:       newRegistry(publicBase, 64, testSigner(t, sessionKey)),
+		reg:       newRegistry(publicBase, "", 64, testSigner(t, sessionKey)),
 		tlsConfig: tlsCfg,
 		log:       slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
@@ -104,7 +104,7 @@ func startTestGatewayPlain(t *testing.T, publicBase string) (*Server, string, st
 	t.Helper()
 	s := &Server{
 		cfg:       Config{PublicURL: publicBase, MaxSessions: 64},
-		reg:       newRegistry(publicBase, 64, testSigner(t, "")),
+		reg:       newRegistry(publicBase, "", 64, testSigner(t, "")),
 		tlsConfig: nil,
 		log:       slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}

--- a/internal/gateway/grpc_route_test.go
+++ b/internal/gateway/grpc_route_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io"
+	"log/slog"
 	"net"
 	"strings"
 	"sync"
@@ -231,6 +232,70 @@ func TestGatewayGRPCUnknownSession(t *testing.T) {
 	_, err := grpcEcho(t, insecure.NewCredentials(), grpcAddr, strings.Repeat("b", 64), "x")
 	if status.Code(err) != codes.NotFound {
 		t.Fatalf("unknown session -> %v, want NotFound", err)
+	}
+}
+
+// startTestGatewayPlainGRPCBase is startTestGatewayPlain with a public gRPC base
+// configured (--public-grpc-url), for Public GRPC URL tests.
+func startTestGatewayPlainGRPCBase(t *testing.T, publicBase, grpcBase string) (*Server, string, string) {
+	t.Helper()
+	s := &Server{
+		cfg:       Config{PublicURL: publicBase, PublicGRPCURL: grpcBase, MaxSessions: 64},
+		reg:       newRegistry(publicBase, grpcBase, 64, testSigner(t, "")),
+		tlsConfig: nil,
+		log:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	publicLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("public listen: %v", err)
+	}
+	grpcLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("grpc listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = s.ServeListeners(ctx, publicLn, grpcLn) }()
+	return s, publicLn.Addr().String(), grpcLn.Addr().String()
+}
+
+// TestGatewayPublicGRPCURL verifies the Public GRPC URL contract: a gateway run
+// with --public-grpc-url hands <base>/grpc/<publicID> to a daemon that
+// negotiates the grpc feature, and withholds it from one that does not (remote
+// fleet disabled / legacy fleetd) — so a daemon is never shown a gRPC URL the
+// gateway would refuse to route for it.
+func TestGatewayPublicGRPCURL(t *testing.T) {
+	const grpcBase = "http://gw.example.com:50051"
+	_, _, grpcAddr := startTestGatewayPlainGRPCBase(t, "http://gw.example.com", grpcBase)
+
+	// grpc negotiated -> the reply carries the session's gRPC URL.
+	reply := dialFleetdGRPCPlain(t, grpcAddr)
+	if !tunnel.HasFeature(reply.Features, tunnel.FeatureGRPC) {
+		t.Fatalf("gateway did not negotiate grpc: features=%v", reply.Features)
+	}
+	want := grpcBase + "/grpc/" + publicIDOf(t, reply.PublicURL)
+	if reply.PublicGRPCURL != want {
+		t.Fatalf("public grpc url = %q, want %q", reply.PublicGRPCURL, want)
+	}
+
+	// No grpc feature requested -> the gRPC URL is withheld.
+	legacy := dialFleetdPlain(t, grpcAddr, "")
+	if legacy.PublicGRPCURL != "" {
+		t.Fatalf("non-negotiated session got a public grpc url: %q", legacy.PublicGRPCURL)
+	}
+}
+
+// TestGatewayNoPublicGRPCURLWithoutBase confirms a gateway run WITHOUT
+// --public-grpc-url never mints a gRPC URL, even for a grpc-negotiating daemon.
+func TestGatewayNoPublicGRPCURLWithoutBase(t *testing.T) {
+	_, _, grpcAddr := startTestGatewayPlain(t, "http://gw.example.com")
+
+	reply := dialFleetdGRPCPlain(t, grpcAddr)
+	if !tunnel.HasFeature(reply.Features, tunnel.FeatureGRPC) {
+		t.Fatalf("gateway did not negotiate grpc: features=%v", reply.Features)
+	}
+	if reply.PublicGRPCURL != "" {
+		t.Fatalf("gateway without a grpc base minted a public grpc url: %q", reply.PublicGRPCURL)
 	}
 }
 

--- a/internal/gateway/register.go
+++ b/internal/gateway/register.go
@@ -90,9 +90,16 @@ func (s *Server) bindTunnel(ctx context.Context, conn net.Conn, remote string) e
 	}
 
 	// Negotiate optional tunnel features (gRPC). Only features BOTH ends support
-	// become active; an old fleetd (no Features) negotiates none.
+	// become active; an old fleetd (no Features) negotiates none. A daemon with
+	// remote fleet disabled does not request grpc, so none is negotiated and the
+	// gateway's gRPC route stays dead for this session — its Public GRPC URL is
+	// withheld accordingly.
 	reply.Features = tunnel.Negotiate(req.Features, gatewayFeatures)
-	sess.grpc.Store(tunnel.HasFeature(reply.Features, tunnel.FeatureGRPC))
+	grpcOn := tunnel.HasFeature(reply.Features, tunnel.FeatureGRPC)
+	sess.grpc.Store(grpcOn)
+	if !grpcOn {
+		reply.PublicGRPCURL = ""
+	}
 
 	if err := tunnel.WriteFrame(conn, reply); err != nil {
 		if isNew {

--- a/internal/gateway/register_test.go
+++ b/internal/gateway/register_test.go
@@ -22,7 +22,7 @@ import (
 func TestGatewayRegisterFloodShed(t *testing.T) {
 	s := &Server{
 		cfg:        Config{PublicURL: "http://gw.example.com", MaxSessions: 64},
-		reg:        newRegistry("http://gw.example.com", 64, testSigner(t, "")),
+		reg:        newRegistry("http://gw.example.com", "", 64, testSigner(t, "")),
 		log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
 		pendingSem: make(chan struct{}, 2), // tiny cap for the test
 	}

--- a/internal/gateway/registry.go
+++ b/internal/gateway/registry.go
@@ -24,8 +24,14 @@ type registry struct {
 	bySecret   map[string]*session
 	byPublic   map[string]*session
 	publicBase string // e.g. "https://gw.example.com" or "http://gw.example.com" (no trailing slash)
-	max        int
-	signer     *tokenSigner // signs the session-resume token in every reply (see token.go)
+	// grpcBase is the external base URL of the gateway's gRPC endpoint
+	// (--public-grpc-url, no trailing slash). When set, every reply also carries
+	// the session's Public GRPC URL (<grpcBase>/grpc/<publicID>) — the address a
+	// remote `fleet` dials; fleetclient parses the trailing id back out as the
+	// fleet-session routing key. Empty = no gRPC URL is minted.
+	grpcBase string
+	max      int
+	signer   *tokenSigner // signs the session-resume token in every reply (see token.go)
 }
 
 // errAtCapacity is returned by claim when the session cap is reached. Since the
@@ -33,11 +39,12 @@ type registry struct {
 // guard against unbounded session creation.
 var errAtCapacity = errors.New("gateway at capacity")
 
-func newRegistry(publicBase string, max int, signer *tokenSigner) *registry {
+func newRegistry(publicBase, grpcBase string, max int, signer *tokenSigner) *registry {
 	return &registry{
 		bySecret:   make(map[string]*session),
 		byPublic:   make(map[string]*session),
 		publicBase: publicBase,
+		grpcBase:   grpcBase,
 		max:        max,
 		signer:     signer,
 	}
@@ -128,12 +135,20 @@ func (r *registry) claim(req tunnel.RegisterRequest) (s *session, reply tunnel.R
 // every time (claims and reclaims alike), so the daemon always ends up holding
 // a token signed with the gateway's current key — a rotated key self-heals on
 // the first successful reconnect.
+//
+// PublicGRPCURL is included whenever the gateway has a public gRPC base; the
+// register handler clears it again when the connection does not negotiate the
+// grpc feature, so an MCP-only daemon never sees a gRPC URL it can't serve.
 func (r *registry) reply(s *session) tunnel.RegisterReply {
-	return tunnel.RegisterReply{
+	reply := tunnel.RegisterReply{
 		SessionID:    s.secret,
 		PublicURL:    s.publicURL,
 		SessionToken: r.signer.mint(s.secret, s.publicID),
 	}
+	if r.grpcBase != "" {
+		reply.PublicGRPCURL = r.grpcBase + "/grpc/" + s.publicID
+	}
+	return reply
 }
 
 // bind installs the live tunnel on a claimed session and makes it routable. It

--- a/internal/gateway/registry_test.go
+++ b/internal/gateway/registry_test.go
@@ -45,7 +45,7 @@ func fakeTunnel(t *testing.T) *yamux.Session {
 }
 
 func TestRegistryClaimMintsDistinctUnguessableIDs(t *testing.T) {
-	r := newRegistry("https://gw.example.com", 16, testSigner(t, ""))
+	r := newRegistry("https://gw.example.com", "", 16, testSigner(t, ""))
 
 	s1, reply1, _, err := r.claim(tunnel.RegisterRequest{})
 	if err != nil {
@@ -77,7 +77,7 @@ func TestRegistryClaimMintsDistinctUnguessableIDs(t *testing.T) {
 }
 
 func TestRegistryReclaimReturnsSameURL(t *testing.T) {
-	r := newRegistry("https://gw", 16, testSigner(t, ""))
+	r := newRegistry("https://gw", "", 16, testSigner(t, ""))
 
 	s, reply, isNew, err := r.claim(tunnel.RegisterRequest{})
 	if err != nil {
@@ -120,7 +120,7 @@ func TestRegistryReclaimReturnsSameURL(t *testing.T) {
 // and reclaim alike — returns a session token the registry's own signer minted
 // for that session's ids.
 func TestRegistryRepliesCarrySessionToken(t *testing.T) {
-	r := newRegistry("https://gw", 16, testSigner(t, "k"))
+	r := newRegistry("https://gw", "", 16, testSigner(t, "k"))
 
 	s, reply, _, err := r.claim(tunnel.RegisterRequest{})
 	if err != nil {
@@ -150,14 +150,14 @@ func TestRegistryRepliesCarrySessionToken(t *testing.T) {
 // token alone.
 func TestRegistryTokenResurrectsSessionAcrossRestart(t *testing.T) {
 	const key = "stable-signing-key"
-	r1 := newRegistry("https://gw", 16, testSigner(t, key))
+	r1 := newRegistry("https://gw", "", 16, testSigner(t, key))
 	_, reply1, _, err := r1.claim(tunnel.RegisterRequest{})
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}
 
 	// "Restart": a brand-new registry that knows nothing, with the same key.
-	r2 := newRegistry("https://gw", 16, testSigner(t, key))
+	r2 := newRegistry("https://gw", "", 16, testSigner(t, key))
 	s2, reply2, isNew, err := r2.claim(tunnel.RegisterRequest{
 		SessionID:    reply1.SessionID,
 		SessionToken: reply1.SessionToken,
@@ -188,13 +188,13 @@ func TestRegistryTokenResurrectsSessionAcrossRestart(t *testing.T) {
 // (rotated key, or the random per-boot default) is ignored — the daemon just
 // gets a fresh session, never an error.
 func TestRegistryTokenFromDifferentKeyMintsFresh(t *testing.T) {
-	r1 := newRegistry("https://gw", 16, testSigner(t, "key-a"))
+	r1 := newRegistry("https://gw", "", 16, testSigner(t, "key-a"))
 	_, reply1, _, err := r1.claim(tunnel.RegisterRequest{})
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}
 
-	r2 := newRegistry("https://gw", 16, testSigner(t, "key-b"))
+	r2 := newRegistry("https://gw", "", 16, testSigner(t, "key-b"))
 	_, reply2, isNew, err := r2.claim(tunnel.RegisterRequest{
 		SessionID:    reply1.SessionID,
 		SessionToken: reply1.SessionToken,
@@ -215,14 +215,14 @@ func TestRegistryTokenFromDifferentKeyMintsFresh(t *testing.T) {
 // a slot like any other, so the MaxSessions cap still holds.
 func TestRegistryTokenResurrectionRespectsCapacity(t *testing.T) {
 	const key = "cap-key"
-	r1 := newRegistry("https://gw", 1, testSigner(t, key))
+	r1 := newRegistry("https://gw", "", 1, testSigner(t, key))
 	_, reply1, _, err := r1.claim(tunnel.RegisterRequest{})
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}
 
 	// The "restarted" gateway is already full.
-	r2 := newRegistry("https://gw", 1, testSigner(t, key))
+	r2 := newRegistry("https://gw", "", 1, testSigner(t, key))
 	if _, _, _, err := r2.claim(tunnel.RegisterRequest{}); err != nil {
 		t.Fatalf("fill: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestRegistryTokenResurrectionRespectsCapacity(t *testing.T) {
 }
 
 func TestRegistryReclaimReplacesAndClosesOldTunnel(t *testing.T) {
-	r := newRegistry("https://gw", 16, testSigner(t, ""))
+	r := newRegistry("https://gw", "", 16, testSigner(t, ""))
 	s, reply, _, _ := r.claim(tunnel.RegisterRequest{})
 	old := fakeTunnel(t)
 	r.bind(s, old)
@@ -250,7 +250,7 @@ func TestRegistryReclaimReplacesAndClosesOldTunnel(t *testing.T) {
 }
 
 func TestRegistryCapacity(t *testing.T) {
-	r := newRegistry("https://gw", 1, testSigner(t, ""))
+	r := newRegistry("https://gw", "", 1, testSigner(t, ""))
 	s, _, _, err := r.claim(tunnel.RegisterRequest{})
 	if err != nil {
 		t.Fatalf("claim 1: %v", err)
@@ -266,7 +266,7 @@ func TestRegistryCapacity(t *testing.T) {
 // must hold even for concurrent FIRST-TIME claims that haven't bound yet, because
 // the slot is reserved (in bySecret) at claim, not at bind.
 func TestRegistryCapacityIsHardAtClaim(t *testing.T) {
-	r := newRegistry("https://gw", 1, testSigner(t, ""))
+	r := newRegistry("https://gw", "", 1, testSigner(t, ""))
 	if _, _, _, err := r.claim(tunnel.RegisterRequest{}); err != nil {
 		t.Fatalf("claim 1: %v", err)
 	}
@@ -279,7 +279,7 @@ func TestRegistryCapacityIsHardAtClaim(t *testing.T) {
 // TestRegistryReleaseFreesReservation verifies a failed-handshake reservation is
 // freed (and frees the cap slot), while release is a no-op for a bound session.
 func TestRegistryReleaseFreesReservation(t *testing.T) {
-	r := newRegistry("https://gw", 1, testSigner(t, ""))
+	r := newRegistry("https://gw", "", 1, testSigner(t, ""))
 	s, _, isNew, _ := r.claim(tunnel.RegisterRequest{})
 	if !isNew {
 		t.Fatal("want new")
@@ -291,7 +291,7 @@ func TestRegistryReleaseFreesReservation(t *testing.T) {
 	}
 
 	// release is a no-op once bound.
-	r2 := newRegistry("https://gw", 16, testSigner(t, ""))
+	r2 := newRegistry("https://gw", "", 16, testSigner(t, ""))
 	bs, _, _, _ := r2.claim(tunnel.RegisterRequest{})
 	r2.bind(bs, fakeTunnel(t))
 	r2.release(bs)
@@ -303,7 +303,7 @@ func TestRegistryReleaseFreesReservation(t *testing.T) {
 // TestRegistryReapsAbandonedReservation verifies the reaper backstop frees a
 // reservation whose handshake never completed.
 func TestRegistryReapsAbandonedReservation(t *testing.T) {
-	r := newRegistry("https://gw", 16, testSigner(t, ""))
+	r := newRegistry("https://gw", "", 16, testSigner(t, ""))
 	s, _, _, _ := r.claim(tunnel.RegisterRequest{}) // never bound, never released
 	// Within the reservation grace: kept.
 	r.reap(s.createdAt.Add(reservationGrace/2), sessionTTL)
@@ -318,7 +318,7 @@ func TestRegistryReapsAbandonedReservation(t *testing.T) {
 }
 
 func TestRegistryReapHonorsGraceTTL(t *testing.T) {
-	r := newRegistry("https://gw", 16, testSigner(t, ""))
+	r := newRegistry("https://gw", "", 16, testSigner(t, ""))
 	const ttl = 5 * time.Minute
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -43,18 +43,18 @@ func (s *service) SetConfig(_ context.Context, req *fleetgrpc.SetConfigRequest) 
 		return nil, status.Errorf(codes.Internal, "reload config: %v", err)
 	}
 
-	// Converge the remote-MCP tunnel to the saved settings. Reconcile is
+	// Converge the remote-gateway tunnel to the saved settings. Reconcile is
 	// non-blocking (it just records desired state and nudges the supervisor), so
 	// calling it while muWrite is held cannot deadlock. nil during tests that use
 	// newService() without a serve loop.
 	if s.remote != nil {
-		s.remote.Reconcile(saved.RemoteMcpSettings.Enabled, saved.RemoteMcpSettings.GatewayURL)
+		s.remote.Reconcile(saved.RemoteMcpSettings.Enabled, saved.RemoteMcpSettings.FleetEnabled, saved.RemoteMcpSettings.GatewayURL)
 	}
 
 	// The remote-gateway fields are the ones whose effects outlive this RPC (the
 	// tunnel supervisor reacts to them), so call them out; the manager logs the
 	// resulting connection transitions itself.
-	flog.Info("config updated", "remoteMcp", saved.RemoteMcpSettings.Enabled, "gateway", saved.RemoteMcpSettings.GatewayURL)
+	flog.Info("config updated", "remoteMcp", saved.RemoteMcpSettings.Enabled, "remoteFleet", saved.RemoteMcpSettings.FleetEnabled, "gateway", saved.RemoteMcpSettings.GatewayURL)
 
 	return &fleetgrpc.SetConfigReply{Config: configToProto(saved)}, nil
 }
@@ -74,8 +74,9 @@ func configToProto(c *state.Config) *fleetgrpc.Config {
 		Codespaces:     &fleetgrpc.CodespacesSettings{},
 		Browser:        &fleetgrpc.BrowserSettings{},
 		RemoteMcp: &fleetgrpc.RemoteMcpSettings{
-			Enabled:    c.RemoteMcpSettings.Enabled,
-			GatewayUrl: c.RemoteMcpSettings.GatewayURL,
+			Enabled:      c.RemoteMcpSettings.Enabled,
+			GatewayUrl:   c.RemoteMcpSettings.GatewayURL,
+			FleetEnabled: c.RemoteMcpSettings.FleetEnabled,
 		},
 		DefaultBackend: backendToProto(fleet.BackendType(c.DefaultBackend)),
 	}
@@ -203,6 +204,7 @@ func protoConfigToLegacy(pc *fleetgrpc.Config) *state.Config {
 	if rm := pc.GetRemoteMcp(); rm != nil {
 		c.RemoteMcpSettings.Enabled = rm.GetEnabled()
 		c.RemoteMcpSettings.GatewayURL = rm.GetGatewayUrl()
+		c.RemoteMcpSettings.FleetEnabled = rm.GetFleetEnabled()
 	}
 
 	c.DefaultBackend = backendProtoToString(pc.GetDefaultBackend())

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -110,7 +110,7 @@ func TestSetConfigRoundTripsRemoteMcp(t *testing.T) {
 
 	in := &fleetgrpc.Config{
 		Agent:     &fleetgrpc.AgentSettings{ToolSelection: "claude"},
-		RemoteMcp: &fleetgrpc.RemoteMcpSettings{Enabled: true, GatewayUrl: "https://gateway.example.com"},
+		RemoteMcp: &fleetgrpc.RemoteMcpSettings{Enabled: true, GatewayUrl: "https://gateway.example.com", FleetEnabled: true},
 	}
 	if _, err := svc.SetConfig(ctx, &fleetgrpc.SetConfigRequest{Config: in}); err != nil {
 		t.Fatalf("SetConfig: %v", err)
@@ -127,6 +127,9 @@ func TestSetConfigRoundTripsRemoteMcp(t *testing.T) {
 	if rm.GetGatewayUrl() != "https://gateway.example.com" {
 		t.Fatalf("gateway_url mismatch: %q", rm.GetGatewayUrl())
 	}
+	if !rm.GetFleetEnabled() {
+		t.Fatalf("fleet_enabled lost on round-trip")
+	}
 
 	// And the bytes on disk match what the legacy SaveConfig writes.
 	loaded, err := state.LoadConfig()
@@ -135,5 +138,8 @@ func TestSetConfigRoundTripsRemoteMcp(t *testing.T) {
 	}
 	if !loaded.RemoteMcpSettings.Enabled || loaded.RemoteMcpSettings.GatewayURL != "https://gateway.example.com" {
 		t.Fatalf("disk config lost remote-mcp settings: %+v", loaded.RemoteMcpSettings)
+	}
+	if !loaded.RemoteMcpSettings.FleetEnabled {
+		t.Fatalf("disk config lost fleet_enabled: %+v", loaded.RemoteMcpSettings)
 	}
 }

--- a/internal/server/grpc_remote_e2e_test.go
+++ b/internal/server/grpc_remote_e2e_test.go
@@ -145,7 +145,10 @@ func grpcStack(t *testing.T) (dial func(withToken bool) *grpc.ClientConn, token 
 		remote.WithGRPCListener(grpcLis),
 	)
 	go mgr.Run(ctx)
-	mgr.Reconcile(true, "https://gw.example.com")
+	// Both toggles on: remote MCP (the tunnel's base traffic) AND remote fleet
+	// (without which the grpc feature is no longer advertised, and every
+	// remote-control RPC under test here would be refused).
+	mgr.Reconcile(true, true, "https://gw.example.com")
 
 	// Wait for CONNECTED and derive the session id from the MCP public URL.
 	var publicURL string

--- a/internal/server/mcp_remote_e2e_test.go
+++ b/internal/server/mcp_remote_e2e_test.go
@@ -173,7 +173,7 @@ func remoteMCPStack(t *testing.T) (publicMCPURL, publicBase, token string, pool 
 		remote.WithDialFunc(registerDialFunc(grpcLn.Addr().String(), gwCreds)),
 	)
 	go mgr.Run(ctx)
-	mgr.Reconcile(true, "https://gw.example.com")
+	mgr.Reconcile(true, false, "https://gw.example.com")
 
 	// Wait for CONNECTED and the gateway-assigned public URL.
 	deadline := time.After(10 * time.Second)

--- a/internal/server/remote/manager.go
+++ b/internal/server/remote/manager.go
@@ -37,10 +37,19 @@ const (
 	handshakeTimeout = 15 * time.Second
 )
 
-// desiredState is the latest config the manager should converge to.
+// desiredState is the latest config the manager should converge to. mcp and
+// grpc are the two independent exposure toggles ("Enable Remote MCP" / "Enable
+// Remote Fleet"); the tunnel connects while EITHER is on, and each gates its own
+// traffic kind on that shared tunnel.
 type desiredState struct {
-	enabled    bool
+	mcp        bool
+	grpc       bool
 	gatewayURL string
+}
+
+// on reports whether the tunnel should be up at all.
+func (d desiredState) on() bool {
+	return (d.mcp || d.grpc) && d.gatewayURL != ""
 }
 
 // Manager supervises the outbound tunnel. Construct with NewManager and drive
@@ -88,9 +97,13 @@ func WithGRPCListener(lis *ChanListener) Option {
 }
 
 // features lists the tunnel capabilities this Manager requests in its
-// RegisterRequest. Only advertises FeatureGRPC when a gRPC listener is wired.
-func (m *Manager) features() []string {
-	if m.grpcLis != nil {
+// RegisterRequest for the attempt's desired state. FeatureGRPC is advertised
+// only when a gRPC listener is wired AND the user enabled remote fleet — NOT
+// negotiating the feature is what makes the gateway's gRPC endpoint dead for
+// this session (the gateway rejects fleet-session RPCs for it), so a disabled
+// daemon never sees incoming gRPC commands at all.
+func (m *Manager) features(d desiredState) []string {
+	if m.grpcLis != nil && d.grpc {
 		return []string{tunnel.FeatureGRPC}
 	}
 	return nil
@@ -116,13 +129,14 @@ func NewManager(mcpPort int, clientVersion string, publish func(*fleetgrpc.Remot
 	return m
 }
 
-// Reconcile records the desired config and nudges the supervisor. It is
-// NON-BLOCKING: it sets state, cancels any in-flight attempt so it re-evaluates,
-// and signals the loop — so it is safe to call while holding other locks (e.g.
-// the service's config-write lock in SetConfig).
-func (m *Manager) Reconcile(enabled bool, gatewayURL string) {
+// Reconcile records the desired config and nudges the supervisor. mcpEnabled
+// and fleetEnabled are the two exposure toggles (remote MCP / remote fleet
+// control). It is NON-BLOCKING: it sets state, cancels any in-flight attempt so
+// it re-evaluates, and signals the loop — so it is safe to call while holding
+// other locks (e.g. the service's config-write lock in SetConfig).
+func (m *Manager) Reconcile(mcpEnabled, fleetEnabled bool, gatewayURL string) {
 	m.mu.Lock()
-	m.desired = desiredState{enabled: enabled, gatewayURL: strings.TrimSpace(gatewayURL)}
+	m.desired = desiredState{mcp: mcpEnabled, grpc: fleetEnabled, gatewayURL: strings.TrimSpace(gatewayURL)}
 	cancel := m.attemptCancel
 	m.mu.Unlock()
 	if cancel != nil {
@@ -166,7 +180,7 @@ func (m *Manager) Run(ctx context.Context) {
 			prev = d
 		}
 
-		if !d.enabled || d.gatewayURL == "" {
+		if !d.on() {
 			cancel()
 			m.mu.Lock()
 			m.attemptCancel = nil
@@ -180,7 +194,7 @@ func (m *Manager) Run(ctx context.Context) {
 		}
 
 		m.publish(statusConnecting())
-		registered, err := m.connectAndServe(attemptCtx, d.gatewayURL)
+		registered, err := m.connectAndServe(attemptCtx, d)
 		cancel()
 
 		m.mu.Lock()
@@ -218,7 +232,8 @@ func (m *Manager) Run(ctx context.Context) {
 // until it drops or attemptCtx is cancelled. registered reports whether the
 // gateway accepted the registration (used to reset the backoff for an
 // established-then-dropped connection).
-func (m *Manager) connectAndServe(ctx context.Context, gatewayURL string) (registered bool, err error) {
+func (m *Manager) connectAndServe(ctx context.Context, d desiredState) (registered bool, err error) {
+	gatewayURL := d.gatewayURL
 	if m.mcpPort == 0 {
 		return false, fmt.Errorf("local MCP server is not running")
 	}
@@ -242,7 +257,7 @@ func (m *Manager) connectAndServe(ctx context.Context, gatewayURL string) (regis
 		SessionID:     prev.SessionID,
 		SessionToken:  prev.SessionToken,
 		ClientVersion: m.clientVersion,
-		Features:      m.features(),
+		Features:      m.features(d),
 	}
 	reply, err := tunnel.Handshake(conn, req, handshakeTimeout)
 	if err != nil {
@@ -253,16 +268,17 @@ func (m *Manager) connectAndServe(ctx context.Context, gatewayURL string) (regis
 	}
 
 	// Registered. Persist the sticky session (id + resume token) and report the
-	// public URL.
+	// public URLs.
 	registered = true
 	_ = saveSession(sessionFile{
-		SessionID:    reply.SessionID,
-		SessionToken: reply.SessionToken,
-		PublicURL:    reply.PublicURL,
-		GatewayURL:   gatewayURL,
+		SessionID:     reply.SessionID,
+		SessionToken:  reply.SessionToken,
+		PublicURL:     reply.PublicURL,
+		PublicGRPCURL: reply.PublicGRPCURL,
+		GatewayURL:    gatewayURL,
 	})
-	flog.Info("remote gateway connected", "gateway", gatewayURL, "publicURL", reply.PublicURL)
-	m.publish(statusConnected(reply.PublicURL))
+	flog.Info("remote gateway connected", "gateway", gatewayURL, "publicURL", reply.PublicURL, "publicGrpcURL", reply.PublicGRPCURL)
+	m.publish(statusConnected(reply.PublicURL, reply.PublicGRPCURL))
 
 	session, err := tunnel.ClientSession(conn, m.logOut)
 	if err != nil {
@@ -271,26 +287,33 @@ func (m *Manager) connectAndServe(ctx context.Context, gatewayURL string) (regis
 	defer session.Close()
 	// The serve loop unblocks when the session/conn closes — on a peer drop, or
 	// when stopOnCancel closes the conn on ctx cancel (shutdown / Reconcile
-	// teardown). Use the demuxing path only when the gateway negotiated gRPC AND
-	// we have a gRPC listener; otherwise the streams are untagged (legacy MCP).
+	// teardown). Use the demuxing path only when the gateway negotiated gRPC (only
+	// requested when remote fleet is enabled AND a gRPC listener is wired);
+	// otherwise the streams are untagged (legacy MCP wire). Either path serves a
+	// traffic kind only while its toggle is on — a toggle flip mid-connection
+	// lands here again via Reconcile's attempt cancel + reconnect.
 	if m.grpcLis != nil && tunnel.HasFeature(reply.Features, tunnel.FeatureGRPC) {
-		return registered, serveTunnel(session, m.mcpPort, m.grpcLis)
+		return registered, serveTunnel(session, m.mcpPort, m.grpcLis, d.mcp)
+	}
+	if !d.mcp {
+		// Remote-fleet-only, but the gateway did not negotiate gRPC (old gateway).
+		// Nothing may be served: park on the session, closing every stream the
+		// gateway pushes, until it drops or the attempt is cancelled.
+		return registered, serveReject(session)
 	}
 	return registered, serveProxy(session, m.mcpPort)
 }
 
 // logDesiredChange records a remote-gateway config transition in the event log:
-// enabled, reconfigured (URL change while enabled), or disabled. A change that
-// never turns the tunnel on (e.g. enabled with an empty URL) logs nothing.
+// enabled, reconfigured (URL or toggle change while on), or disabled. A change
+// that never turns the tunnel on (e.g. enabled with an empty URL) logs nothing.
 func logDesiredChange(prev, d desiredState) {
-	prevOn := prev.enabled && prev.gatewayURL != ""
-	on := d.enabled && d.gatewayURL != ""
 	switch {
-	case on && !prevOn:
-		flog.Info("remote gateway enabled", "gateway", d.gatewayURL)
-	case on && prevOn:
-		flog.Info("remote gateway reconfigured", "gateway", d.gatewayURL)
-	case prevOn:
+	case d.on() && !prev.on():
+		flog.Info("remote gateway enabled", "gateway", d.gatewayURL, "mcp", d.mcp, "fleet", d.grpc)
+	case d.on() && prev.on():
+		flog.Info("remote gateway reconfigured", "gateway", d.gatewayURL, "mcp", d.mcp, "fleet", d.grpc)
+	case prev.on():
 		flog.Info("remote gateway disabled")
 	}
 }

--- a/internal/server/remote/manager.go
+++ b/internal/server/remote/manager.go
@@ -234,8 +234,13 @@ func (m *Manager) Run(ctx context.Context) {
 // established-then-dropped connection).
 func (m *Manager) connectAndServe(ctx context.Context, d desiredState) (registered bool, err error) {
 	gatewayURL := d.gatewayURL
+	// The whole remote surface depends on the local MCP stack: the tunnel-facing
+	// gRPC server is only wired when MCP is up (its bearer token IS the MCP
+	// token), so with mcpPort == 0 even a remote-fleet-only tunnel could serve
+	// nothing. Fail the attempt — an explicit error in the settings page beats a
+	// "connected" tunnel that silently serves neither traffic kind.
 	if m.mcpPort == 0 {
-		return false, fmt.Errorf("local MCP server is not running")
+		return false, fmt.Errorf("local MCP server is not running (required for remote MCP and remote fleet)")
 	}
 
 	conn, err := m.dial(ctx, gatewayURL)

--- a/internal/server/remote/manager_test.go
+++ b/internal/server/remote/manager_test.go
@@ -60,6 +60,27 @@ func TestGRPCTarget(t *testing.T) {
 	}
 }
 
+// TestFeaturesGatedOnFleetEnabled pins the "Enable Remote Fleet" gate: the grpc
+// tunnel feature is requested ONLY when a gRPC listener is wired AND the user
+// enabled remote fleet. Not requesting it is what keeps the gateway's gRPC
+// endpoint dead for this daemon — the gateway refuses to route fleet-session
+// RPCs for a session that did not negotiate grpc.
+func TestFeaturesGatedOnFleetEnabled(t *testing.T) {
+	discard := func(*fleetgrpc.RemoteMcpStatus) {}
+	withLis := NewManager(1, "v", discard, WithGRPCListener(NewChanListener()))
+	noLis := NewManager(1, "v", discard)
+
+	if got := withLis.features(desiredState{mcp: true, grpc: true}); !tunnel.HasFeature(got, tunnel.FeatureGRPC) {
+		t.Fatalf("fleet enabled + listener wired should request grpc, got %v", got)
+	}
+	if got := withLis.features(desiredState{mcp: true, grpc: false}); len(got) != 0 {
+		t.Fatalf("fleet disabled must request no features, got %v", got)
+	}
+	if got := noLis.features(desiredState{mcp: true, grpc: true}); len(got) != 0 {
+		t.Fatalf("no gRPC listener must request no features, got %v", got)
+	}
+}
+
 func TestNextBackoffCaps(t *testing.T) {
 	d := initialBackoff
 	for i := 0; i < 20; i++ {
@@ -207,7 +228,7 @@ func TestManagerConnectsServesAndDisables(t *testing.T) {
 		if err := tunnel.ReadFrame(conn, &req); err != nil {
 			return
 		}
-		_ = tunnel.WriteFrame(conn, tunnel.RegisterReply{SessionID: "sess-A", SessionToken: "tok-A", PublicURL: "https://gw/mcp/sess-A"})
+		_ = tunnel.WriteFrame(conn, tunnel.RegisterReply{SessionID: "sess-A", SessionToken: "tok-A", PublicURL: "https://gw/mcp/sess-A", PublicGRPCURL: "https://gw:50051/grpc/sess-A"})
 		sess, err := tunnel.ServerSession(conn, io.Discard)
 		if err != nil {
 			return
@@ -232,11 +253,15 @@ func TestManagerConnectsServesAndDisables(t *testing.T) {
 	defer cancel()
 	go m.Run(ctx)
 
-	m.Reconcile(true, "https://gw.example.com")
+	m.Reconcile(true, false, "https://gw.example.com")
 
 	connected := waitForState(t, statusCh, fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED, 5*time.Second)
 	if connected.GetPublicUrl() != "https://gw/mcp/sess-A" {
 		t.Fatalf("public url = %q, want https://gw/mcp/sess-A", connected.GetPublicUrl())
+	}
+	// The gateway-assigned Public GRPC URL rides the same status.
+	if connected.GetPublicGrpcUrl() != "https://gw:50051/grpc/sess-A" {
+		t.Fatalf("public grpc url = %q, want https://gw:50051/grpc/sess-A", connected.GetPublicGrpcUrl())
 	}
 
 	// The tunnel actually carried a request, auth header intact.
@@ -249,13 +274,14 @@ func TestManagerConnectsServesAndDisables(t *testing.T) {
 		t.Fatal("gateway never served a request over the tunnel")
 	}
 
-	// Sticky session (id + resume token) persisted for reconnect.
-	if s := loadSession("https://gw.example.com"); s.SessionID != "sess-A" || s.SessionToken != "tok-A" || s.PublicURL != "https://gw/mcp/sess-A" {
+	// Sticky session (id + resume token + URLs) persisted for reconnect.
+	if s := loadSession("https://gw.example.com"); s.SessionID != "sess-A" || s.SessionToken != "tok-A" ||
+		s.PublicURL != "https://gw/mcp/sess-A" || s.PublicGRPCURL != "https://gw:50051/grpc/sess-A" {
 		t.Fatalf("session not persisted: %+v", s)
 	}
 
 	// Disable -> tears down to UNSPECIFIED.
-	m.Reconcile(false, "https://gw.example.com")
+	m.Reconcile(false, false, "https://gw.example.com")
 	waitForState(t, statusCh, fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_UNSPECIFIED, 5*time.Second)
 }
 
@@ -316,7 +342,7 @@ func TestManagerStickyReconnect(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go m.Run(ctx)
-	m.Reconcile(true, "https://gw.example.com")
+	m.Reconcile(true, false, "https://gw.example.com")
 
 	// First registration: no prior session id or resume token.
 	if got := waitForReg(t, regs, 5*time.Second); got.SessionID != "" || got.SessionToken != "" {
@@ -391,8 +417,8 @@ func TestManagerReconcileDisableConverges(t *testing.T) {
 	go m.Run(ctx)
 
 	for i := 0; i < 30; i++ {
-		m.Reconcile(true, "https://gw.example.com")
-		m.Reconcile(false, "https://gw.example.com")
+		m.Reconcile(true, false, "https://gw.example.com")
+		m.Reconcile(false, false, "https://gw.example.com")
 	}
 
 	// After the toggles settle, the LAST state observed must be UNSPECIFIED —
@@ -435,7 +461,7 @@ func TestManagerErrorsWhenMcpDown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go m.Run(ctx)
-	m.Reconcile(true, "https://gw.example.com")
+	m.Reconcile(true, false, "https://gw.example.com")
 
 	st := waitForState(t, statusCh, fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_ERROR, 5*time.Second)
 	if st.GetError() == "" {

--- a/internal/server/remote/proxy.go
+++ b/internal/server/remote/proxy.go
@@ -56,19 +56,37 @@ func serveProxy(session *yamux.Session, mcpPort int) error {
 	return srv.Serve(session)
 }
 
+// serveReject parks on a session that may serve NOTHING (remote fleet only, but
+// the gateway did not negotiate gRPC): every stream the gateway pushes is closed
+// unanswered. Keeping the session itself open preserves the sticky registration
+// until the user re-enables a traffic kind. Returns when the session errors.
+func serveReject(session *yamux.Session) error {
+	for {
+		stream, err := session.Accept()
+		if err != nil {
+			return err
+		}
+		_ = stream.Close()
+	}
+}
+
 // serveTunnel serves a session whose streams are TAG-prefixed (FeatureGRPC
 // negotiated): it reads each stream's tag and routes it. MCP streams feed a local
-// http.Server; gRPC streams feed grpcLis (the daemon's tunnel-facing gRPC server,
-// which is shared across reconnects and NOT closed here). Returns when the
-// session errors.
-func serveTunnel(session *yamux.Session, mcpPort int, grpcLis *ChanListener) error {
-	mcpLis := NewChanListener()
-	mcpSrv := &http.Server{Handler: mcpReverseProxy(mcpPort)}
-	// Closing the server closes mcpLis (so its Accept unblocks) and drops the
-	// per-connection MCP requests; grpcLis is NOT closed — it outlives this
-	// connection so reconnects reuse the same gRPC server.
-	defer mcpSrv.Close()
-	go func() { _ = mcpSrv.Serve(mcpLis) }()
+// http.Server — unless remote MCP is disabled (mcpOn false: a remote-fleet-only
+// tunnel), in which case they are rejected; gRPC streams feed grpcLis (the
+// daemon's tunnel-facing gRPC server, which is shared across reconnects and NOT
+// closed here). Returns when the session errors.
+func serveTunnel(session *yamux.Session, mcpPort int, grpcLis *ChanListener, mcpOn bool) error {
+	var mcpLis *ChanListener
+	if mcpOn {
+		mcpLis = NewChanListener()
+		mcpSrv := &http.Server{Handler: mcpReverseProxy(mcpPort)}
+		// Closing the server closes mcpLis (so its Accept unblocks) and drops the
+		// per-connection MCP requests; grpcLis is NOT closed — it outlives this
+		// connection so reconnects reuse the same gRPC server.
+		defer mcpSrv.Close()
+		go func() { _ = mcpSrv.Serve(mcpLis) }()
+	}
 
 	for {
 		stream, err := session.Accept()
@@ -80,18 +98,19 @@ func serveTunnel(session *yamux.Session, mcpPort int, grpcLis *ChanListener) err
 }
 
 // dispatchStream reads the leading tag byte and routes the (tag-stripped) stream
-// to the MCP or gRPC listener. An unreadable tag or unknown value closes the
-// stream without disturbing the others.
+// to the MCP or gRPC listener. A nil listener means that traffic kind is
+// disabled, so its streams are rejected. An unreadable tag or unknown value
+// closes the stream without disturbing the others.
 func dispatchStream(stream net.Conn, mcpLis, grpcLis *ChanListener) {
 	tag, err := tunnel.ReadTag(stream)
 	if err != nil {
 		_ = stream.Close()
 		return
 	}
-	switch tag {
-	case tunnel.TagMCP:
+	switch {
+	case tag == tunnel.TagMCP && mcpLis != nil:
 		mcpLis.Push(stream)
-	case tunnel.TagGRPC:
+	case tag == tunnel.TagGRPC && grpcLis != nil:
 		grpcLis.Push(stream)
 	default:
 		_ = stream.Close()

--- a/internal/server/remote/serve_tunnel_test.go
+++ b/internal/server/remote/serve_tunnel_test.go
@@ -34,7 +34,7 @@ func TestServeTunnelDemux(t *testing.T) {
 
 	grpcLis := NewChanListener()
 	defer grpcLis.Close()
-	go func() { _ = serveTunnel(fleetdSession, mcp.port(t), grpcLis) }()
+	go func() { _ = serveTunnel(fleetdSession, mcp.port(t), grpcLis, true) }()
 
 	// --- TagGRPC: the post-tag bytes must arrive intact on grpcLis. ---
 	gstream, err := gwSession.Open()
@@ -89,6 +89,75 @@ func TestServeTunnelDemux(t *testing.T) {
 	// The loop still serves MCP after the bad stream.
 	if body := mcpRoundTrip(t, gwSession, "Bearer after-bad"); body != "Bearer after-bad" {
 		t.Fatalf("mcp after unknown tag = %q", body)
+	}
+}
+
+// TestServeTunnelRejectsMcpWhenDisabled covers the remote-fleet-only tunnel
+// (Enable Remote Fleet on, Enable Remote MCP off): TagGRPC streams are still
+// routed to the gRPC listener, but TagMCP streams must be CLOSED unanswered —
+// the user did not expose MCP — and the loop must keep serving gRPC after one.
+func TestServeTunnelRejectsMcpWhenDisabled(t *testing.T) {
+	fleetdConn, gwConn := tcpPair(t)
+	fleetdSession, err := tunnel.ClientSession(fleetdConn, io.Discard)
+	if err != nil {
+		t.Fatalf("client session: %v", err)
+	}
+	defer fleetdSession.Close()
+	gwSession, err := tunnel.ServerSession(gwConn, io.Discard)
+	if err != nil {
+		t.Fatalf("server session: %v", err)
+	}
+	defer gwSession.Close()
+
+	grpcLis := NewChanListener()
+	defer grpcLis.Close()
+	go func() { _ = serveTunnel(fleetdSession, 0, grpcLis, false) }()
+
+	// --- TagMCP: closed unanswered (no HTTP response, the read just fails). ---
+	mstream, err := gwSession.Open()
+	if err != nil {
+		t.Fatalf("open mcp stream: %v", err)
+	}
+	if err := tunnel.WriteTag(mstream, tunnel.TagMCP); err != nil {
+		t.Fatalf("write mcp tag: %v", err)
+	}
+	_ = mstream.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if _, err := mstream.Read(make([]byte, 1)); err == nil {
+		t.Fatal("mcp stream should be closed when remote MCP is disabled")
+	}
+
+	// --- TagGRPC: still served after the rejected MCP stream. ---
+	gstream, err := gwSession.Open()
+	if err != nil {
+		t.Fatalf("open grpc stream: %v", err)
+	}
+	if err := tunnel.WriteTag(gstream, tunnel.TagGRPC); err != nil {
+		t.Fatalf("write grpc tag: %v", err)
+	}
+	if _, err := io.WriteString(gstream, "still-grpc"); err != nil {
+		t.Fatalf("write grpc bytes: %v", err)
+	}
+	got := make(chan string, 1)
+	go func() {
+		c, err := grpcLis.Accept()
+		if err != nil {
+			got <- "ERR:" + err.Error()
+			return
+		}
+		b := make([]byte, len("still-grpc"))
+		if _, err := io.ReadFull(c, b); err != nil {
+			got <- "READ:" + err.Error()
+			return
+		}
+		got <- string(b)
+	}()
+	select {
+	case s := <-got:
+		if s != "still-grpc" {
+			t.Fatalf("grpc stream payload = %q, want still-grpc", s)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("grpc-tagged stream never reached the gRPC listener")
 	}
 }
 

--- a/internal/server/remote/session.go
+++ b/internal/server/remote/session.go
@@ -21,7 +21,11 @@ type sessionFile struct {
 	// token against its signing key and hand back the same public URL.
 	SessionToken string `json:"session_token,omitempty"`
 	PublicURL    string `json:"public_url"`
-	GatewayURL   string `json:"gateway_url"`
+	// PublicGRPCURL is the gateway-assigned Public GRPC URL from the last
+	// registration ("" when the grpc feature was not negotiated or the gateway
+	// has no --public-grpc-url). Recorded for parity with PublicURL.
+	PublicGRPCURL string `json:"public_grpc_url,omitempty"`
+	GatewayURL    string `json:"gateway_url"`
 }
 
 // loadSession returns the persisted session IF it was issued for gatewayURL. A

--- a/internal/server/remote/status.go
+++ b/internal/server/remote/status.go
@@ -4,7 +4,8 @@ import "github.com/BenjaminBenetti/fleet-man/fleetgrpc"
 
 // status.go builds the fleetgrpc.RemoteMcpStatus values the manager publishes to
 // the hub (and thence to the TUI over Watch). The status is the ONLY channel for
-// the computed Public MCP URL — it is never persisted in Config.
+// the computed Public MCP URL and Public GRPC URL — they are never persisted in
+// Config.
 
 func statusDisabled() *fleetgrpc.RemoteMcpStatus {
 	return &fleetgrpc.RemoteMcpStatus{State: fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_UNSPECIFIED}
@@ -14,10 +15,11 @@ func statusConnecting() *fleetgrpc.RemoteMcpStatus {
 	return &fleetgrpc.RemoteMcpStatus{State: fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTING}
 }
 
-func statusConnected(publicURL string) *fleetgrpc.RemoteMcpStatus {
+func statusConnected(publicURL, publicGRPCURL string) *fleetgrpc.RemoteMcpStatus {
 	return &fleetgrpc.RemoteMcpStatus{
-		State:     fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
-		PublicUrl: publicURL,
+		State:         fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
+		PublicUrl:     publicURL,
+		PublicGrpcUrl: publicGRPCURL,
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -155,19 +155,20 @@ func Serve(ctx context.Context) error {
 		}
 	}
 
-	// Remote-MCP gateway tunnel: an outbound, OPT-IN connection that exposes the
-	// loopback MCP server (and, when negotiated, the gRPC server above) to the
-	// internet through a remote fleet gateway. Like MCP itself it is auxiliary —
-	// the supervisor stays idle until the config enables it, and a connect failure
-	// only affects remote access, never the local daemon. It publishes its status
-	// (incl. the gateway-assigned Public MCP URL) through the hub so the TUI
-	// settings page reflects it live.
+	// Remote gateway tunnel: an outbound, OPT-IN connection that exposes the
+	// loopback MCP server ("Enable Remote MCP") and/or the gRPC server above
+	// ("Enable Remote Fleet") to the internet through a remote fleet gateway.
+	// Like MCP itself it is auxiliary — the supervisor stays idle until the
+	// config enables a traffic kind, and a connect failure only affects remote
+	// access, never the local daemon. It publishes its status (incl. the
+	// gateway-assigned Public MCP URL / Public GRPC URL) through the hub so the
+	// TUI settings page reflects it live.
 	svc.remote = remote.NewManager(mcpPort, versionOrDev(), func(st *fleetgrpc.RemoteMcpStatus) {
 		svc.hub.post(func(h *hub) { h.broadcastRemoteMcpStatus(st) })
 	}, remoteOpts...)
 	go svc.remote.Run(hubCtx)
 	if cfg, err := state.LoadConfig(); err == nil {
-		svc.remote.Reconcile(cfg.RemoteMcpSettings.Enabled, cfg.RemoteMcpSettings.GatewayURL)
+		svc.remote.Reconcile(cfg.RemoteMcpSettings.Enabled, cfg.RemoteMcpSettings.FleetEnabled, cfg.RemoteMcpSettings.GatewayURL)
 	} else {
 		flog.Warn("remote mcp: load config", "err", err)
 	}

--- a/internal/state/remote_mcp_settings.go
+++ b/internal/state/remote_mcp_settings.go
@@ -1,16 +1,18 @@
 package state
 
 // RemoteMcpSettings holds the user's intent to expose this daemon's local MCP
-// server to the internet through a remote fleet gateway, so remote agents can
-// drive the fleet. The local MCP server itself (internal/server/mcp.go) is
-// unchanged and stays loopback-only; the gateway tunnel (a later PR) dials OUT
-// to GatewayURL and reverse-proxies inbound requests back to it.
+// server (Enabled) and/or its gRPC control surface (FleetEnabled) to the
+// internet through a remote fleet gateway. Both ride the SAME outbound tunnel to
+// GatewayURL; the two toggles are independent, so a user can expose MCP, remote
+// control, or both. The local MCP server itself (internal/server/mcp.go) is
+// unchanged and stays loopback-only; the gateway tunnel dials OUT to GatewayURL
+// and reverse-proxies inbound requests back to it.
 //
-// Only two fields are persisted here. The gateway-assigned "Public MCP URL" is
-// deliberately NOT stored: it is runtime state the server computes after it
-// connects and pushes to the TUI over the Watch stream (fleetgrpc.RemoteMcpStatus).
-// Keeping it out of Config is what stops SetConfig — which replaces the whole
-// Config — from clobbering it.
+// Only these fields are persisted here. The gateway-assigned "Public MCP URL" /
+// "Public GRPC URL" are deliberately NOT stored: they are runtime state the
+// server computes after it connects and pushes to the TUI over the Watch stream
+// (fleetgrpc.RemoteMcpStatus). Keeping them out of Config is what stops
+// SetConfig — which replaces the whole Config — from clobbering them.
 type RemoteMcpSettings struct {
 	// Enabled turns the remote-MCP gateway tunnel on. Plain bool (default
 	// off), matching the create-time *Mount flags: false == "never set" ==
@@ -22,4 +24,10 @@ type RemoteMcpSettings struct {
 	// gateway is fronted by a TLS-terminating proxy). Empty while Enabled means
 	// "enabled but not yet configured"; the tunnel manager treats that as a no-op.
 	GatewayURL string `json:"gateway_url,omitempty"`
+
+	// FleetEnabled ("Enable Remote Fleet") exposes the daemon's gRPC server
+	// through the gateway so a remote `fleet` binary can control this instance.
+	// When off, fleetd does not negotiate the grpc tunnel feature, so the
+	// gateway rejects any incoming gRPC commands aimed at this daemon.
+	FleetEnabled bool `json:"fleet_enabled,omitempty"`
 }

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -371,8 +371,9 @@ func configToProto(c *configutil.Config) *fleetgrpc.Config {
 		Codespaces:     &fleetgrpc.CodespacesSettings{},
 		Browser:        &fleetgrpc.BrowserSettings{},
 		RemoteMcp: &fleetgrpc.RemoteMcpSettings{
-			Enabled:    c.RemoteMcpSettings.Enabled,
-			GatewayUrl: c.RemoteMcpSettings.GatewayURL,
+			Enabled:      c.RemoteMcpSettings.Enabled,
+			GatewayUrl:   c.RemoteMcpSettings.GatewayURL,
+			FleetEnabled: c.RemoteMcpSettings.FleetEnabled,
 		},
 		DefaultBackend: backendStringToProto(c.DefaultBackend),
 	}
@@ -657,6 +658,7 @@ func protoConfigToLegacy(pc *fleetgrpc.Config) *configutil.Config {
 	if rm := pc.GetRemoteMcp(); rm != nil {
 		c.RemoteMcpSettings.Enabled = rm.GetEnabled()
 		c.RemoteMcpSettings.GatewayURL = rm.GetGatewayUrl()
+		c.RemoteMcpSettings.FleetEnabled = rm.GetFleetEnabled()
 	}
 	c.DefaultBackend = backendProtoToString(pc.GetDefaultBackend())
 	return c

--- a/internal/tui/client_test.go
+++ b/internal/tui/client_test.go
@@ -66,17 +66,23 @@ func TestConfigToProtoEncodesFullConfig(t *testing.T) {
 func TestRemoteMcpConfigRoundTripClient(t *testing.T) {
 	c := &state.Config{
 		AgentSettings:     state.AgentSettings{ToolSelection: state.AgentToolClaude},
-		RemoteMcpSettings: state.RemoteMcpSettings{Enabled: true, GatewayURL: "https://gateway.example.com"},
+		RemoteMcpSettings: state.RemoteMcpSettings{Enabled: true, GatewayURL: "https://gateway.example.com", FleetEnabled: true},
 	}
 
 	pc := configToProto(c)
 	if !pc.GetRemoteMcp().GetEnabled() || pc.GetRemoteMcp().GetGatewayUrl() != "https://gateway.example.com" {
 		t.Fatalf("configToProto lost remote-mcp: %v", pc.GetRemoteMcp())
 	}
+	if !pc.GetRemoteMcp().GetFleetEnabled() {
+		t.Fatalf("configToProto lost fleet_enabled: %v", pc.GetRemoteMcp())
+	}
 
 	back := protoConfigToLegacy(pc)
 	if !back.RemoteMcpSettings.Enabled || back.RemoteMcpSettings.GatewayURL != "https://gateway.example.com" {
 		t.Fatalf("protoConfigToLegacy lost remote-mcp: %+v", back.RemoteMcpSettings)
+	}
+	if !back.RemoteMcpSettings.FleetEnabled {
+		t.Fatalf("protoConfigToLegacy lost fleet_enabled: %+v", back.RemoteMcpSettings)
 	}
 }
 

--- a/internal/tui/page_settings.go
+++ b/internal/tui/page_settings.go
@@ -43,6 +43,7 @@ const (
 	settingsItemRemoteMcpGatewayURL = 701
 	settingsItemRemoteMcpCopyLocal  = 702 // copy local mcp.json snippet to clipboard
 	settingsItemRemoteMcpCopyRemote = 703 // copy gateway mcp.json snippet to clipboard
+	settingsItemRemoteFleetEnabled  = 704 // expose the gRPC control surface through the gateway
 
 	settingsItemToolStatusBase = 1000 // tool status rows start here
 	settingsItemDoctor         = 2000 // doctor action row
@@ -180,13 +181,14 @@ var settingsSections = []settingsSection{
 		Title: "Fleet MCP",
 		Items: func(config *configutil.Config) []int {
 			// Copy actions come first. The remote-copy action only appears
-			// once the gateway tunnel is enabled. The computed Public MCP URL
-			// is rendered inline as a read-only status line (not navigable).
+			// once the gateway tunnel is enabled. The computed Public MCP URL /
+			// Public GRPC URL are rendered inline as read-only status lines
+			// (not navigable).
 			items := []int{settingsItemRemoteMcpCopyLocal}
 			if config != nil && config.RemoteMcpSettings.Enabled {
 				items = append(items, settingsItemRemoteMcpCopyRemote)
 			}
-			items = append(items, settingsItemRemoteMcpEnabled, settingsItemRemoteMcpGatewayURL)
+			items = append(items, settingsItemRemoteMcpEnabled, settingsItemRemoteFleetEnabled, settingsItemRemoteMcpGatewayURL)
 			return items
 		},
 	},
@@ -386,6 +388,30 @@ func (settingsPage *settingsPage) toggleRemoteMcpEnabled(m *model) {
 	m.message = fmt.Sprintf("Remote MCP set to %s", label)
 }
 
+// toggleRemoteFleetEnabled flips the "Enable Remote Fleet" preference — exposing
+// this daemon's gRPC control surface through the gateway so a remote `fleet`
+// binary can drive it — and saves. Reverts on a save failure, mirroring the
+// other toggles. Unlike the MCP toggle it inserts no navigable rows, so the
+// cursor needs no re-pin.
+func (settingsPage *settingsPage) toggleRemoteFleetEnabled(m *model) {
+	if m.config == nil {
+		m.config = configutil.DefaultConfig()
+	}
+	current := m.config.RemoteMcpSettings.FleetEnabled
+	next := !current
+	m.config.RemoteMcpSettings.FleetEnabled = next
+	if err := setConfigRemote(m.config); err != nil {
+		m.config.RemoteMcpSettings.FleetEnabled = current
+		m.message = fmt.Sprintf("Failed to save settings: %v", err)
+		return
+	}
+	label := "off"
+	if next {
+		label = "on"
+	}
+	m.message = fmt.Sprintf("Remote Fleet set to %s", label)
+}
+
 // toggleAutoInstall toggles the dotfiles auto-install setting.
 func (settingsPage *settingsPage) toggleAutoInstall(m *model) {
 	if m.config == nil {
@@ -500,6 +526,36 @@ func remoteMcpPublicURL(m *model) string {
 	return m.remoteMcpStatus.GetPublicUrl()
 }
 
+// remoteGrpcStatusValue renders the read-only Public GRPC URL line from the same
+// pushed tunnel status as remoteMcpStatusValue (one tunnel carries both traffic
+// kinds, so they share connection state). A connected tunnel with no gRPC URL
+// means the gateway withheld it — it is old, runs without --public-grpc-url, or
+// registered this session before remote fleet was enabled (the reconnect that
+// negotiates grpc refreshes it).
+func remoteGrpcStatusValue(m *model) string {
+	st := m.remoteMcpStatus
+	if st == nil {
+		return dimStyle.Render("(not connected)")
+	}
+	switch st.GetState() {
+	case fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED:
+		if url := st.GetPublicGrpcUrl(); url != "" {
+			return statusRunningStyle.Render("connected") + "  " + url
+		}
+		return statusRunningStyle.Render("connected") + "  " + dimStyle.Render("(gateway provided no public gRPC URL)")
+	case fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTING:
+		return m.spinner.View() + " connecting…"
+	case fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_ERROR:
+		msg := st.GetError()
+		if msg == "" {
+			msg = "connection failed"
+		}
+		return statusCreatingStyle.Render("error") + "  " + dimStyle.Render(msg)
+	default: // UNSPECIFIED / not yet connected
+		return dimStyle.Render("(not connected)")
+	}
+}
+
 // localMcpConfigJSON returns the mcp.json snippet for the loopback MCP server,
 // matching the README. It uses the ${FLEET_MCP_URL}/${FLEET_MCP_TOKEN} env vars
 // written to ~/.fleet/mcp.env so the snippet survives port changes.
@@ -596,6 +652,8 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 				settingsPage.toggleBrowserAutoSwitch(m)
 			} else if item == settingsItemRemoteMcpEnabled {
 				settingsPage.toggleRemoteMcpEnabled(m)
+			} else if item == settingsItemRemoteFleetEnabled {
+				settingsPage.toggleRemoteFleetEnabled(m)
 			} else if item == settingsItemCoderPreset {
 				settingsPage.cycleCoderPreset(m, -1)
 			} else if item == settingsItemCodespacesMachine {
@@ -617,6 +675,8 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 				settingsPage.toggleBrowserAutoSwitch(m)
 			} else if item == settingsItemRemoteMcpEnabled {
 				settingsPage.toggleRemoteMcpEnabled(m)
+			} else if item == settingsItemRemoteFleetEnabled {
+				settingsPage.toggleRemoteFleetEnabled(m)
 			} else if item == settingsItemCoderPreset {
 				settingsPage.cycleCoderPreset(m, 1)
 			} else if item == settingsItemCodespacesMachine {
@@ -648,6 +708,10 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 			}
 			if item == settingsItemRemoteMcpEnabled {
 				settingsPage.toggleRemoteMcpEnabled(m)
+				return nil
+			}
+			if item == settingsItemRemoteFleetEnabled {
+				settingsPage.toggleRemoteFleetEnabled(m)
 				return nil
 			}
 			if item == settingsItemRemoteMcpCopyLocal {
@@ -1029,18 +1093,32 @@ func (settingsPage *settingsPage) viewSettings(m *model) string {
 			recordRow(settingsItemRemoteMcpEnabled, settingsPage.renderSettingsRow(m, currentItem == settingsItemRemoteMcpEnabled, "Enable Remote MCP", enabledValue))
 			listContent.WriteString("\n")
 
+			fleetEnabledValue := "[ off ]"
+			if config.RemoteMcpSettings.FleetEnabled {
+				fleetEnabledValue = "[ on ]"
+			}
+			fleetEnabledValue += "\n" + strings.Repeat(" ", 21) + dimStyle.Render("Allow remote `fleet` binary to control this instance through the gateway public url")
+			recordRow(settingsItemRemoteFleetEnabled, settingsPage.renderSettingsRow(m, currentItem == settingsItemRemoteFleetEnabled, "Enable Remote Fleet", fleetEnabledValue))
+			listContent.WriteString("\n")
+
 			gatewayValue := config.RemoteMcpSettings.GatewayURL
 			if gatewayValue == "" && !(settingsPage.editing && currentItem == settingsItemRemoteMcpGatewayURL) {
 				gatewayValue = dimStyle.Render("(not set)")
 			}
 			recordRow(settingsItemRemoteMcpGatewayURL, settingsPage.renderSettingsRow(m, currentItem == settingsItemRemoteMcpGatewayURL, "Gateway URL", gatewayValue))
 
-			// The computed Public MCP URL is read-only (not navigable): it is the
-			// gateway-assigned address, delivered over Watch, that external tools
-			// use to reach this fleet. Only shown once the feature is enabled.
+			// The computed Public MCP URL / Public GRPC URL are read-only (not
+			// navigable): they are the gateway-assigned addresses, delivered over
+			// Watch, that external tools / a remote `fleet` use to reach this
+			// fleet. Each is only shown once its feature is enabled.
 			if config.RemoteMcpSettings.Enabled {
 				listContent.WriteString("\n")
 				row := settingsPage.renderSettingsRow(m, false, "Public MCP URL", remoteMcpStatusValue(m))
+				listContent.WriteString(lipgloss.NewStyle().Width(contentWidth).Render(row))
+			}
+			if config.RemoteMcpSettings.FleetEnabled {
+				listContent.WriteString("\n")
+				row := settingsPage.renderSettingsRow(m, false, "Public GRPC URL", remoteGrpcStatusValue(m))
 				listContent.WriteString(lipgloss.NewStyle().Width(contentWidth).Render(row))
 			}
 

--- a/internal/tui/page_settings_test.go
+++ b/internal/tui/page_settings_test.go
@@ -55,6 +55,49 @@ func TestSettingsSectionIncludesRemoteMcp(t *testing.T) {
 	}
 }
 
+// TestSettingsSectionIncludesRemoteFleet confirms the "Enable Remote Fleet"
+// toggle is navigable right under "Enable Remote MCP", and that the read-only
+// Public GRPC URL line renders once the feature is enabled.
+func TestSettingsSectionIncludesRemoteFleet(t *testing.T) {
+	sp := newSettingsPage()
+	cfg := state.DefaultConfig()
+	cfg.RemoteMcpSettings.FleetEnabled = true
+	m := &model{
+		config:     cfg,
+		toolStatus: allToolsFound(),
+		spinner:    spinner.New(),
+	}
+
+	items := sp.visibleItems(m)
+	mcpAt, fleetAt := -1, -1
+	for i, id := range items {
+		switch id {
+		case settingsItemRemoteMcpEnabled:
+			mcpAt = i
+		case settingsItemRemoteFleetEnabled:
+			fleetAt = i
+		}
+	}
+	if fleetAt == -1 {
+		t.Fatal("remote-fleet toggle missing from settings nav")
+	}
+	if fleetAt != mcpAt+1 {
+		t.Fatalf("remote-fleet toggle should sit right under remote MCP: mcp=%d fleet=%d", mcpAt, fleetAt)
+	}
+
+	out := sp.viewSettings(m)
+	if !strings.Contains(out, "Enable Remote Fleet") {
+		t.Fatal("settings view missing the Enable Remote Fleet row")
+	}
+	if !strings.Contains(out, "Public GRPC URL") {
+		t.Fatal("settings view missing the computed Public GRPC URL row when enabled")
+	}
+	// MCP stays off here, so its computed URL row must NOT render.
+	if strings.Contains(out, "Public MCP URL") {
+		t.Fatal("Public MCP URL row rendered while remote MCP is disabled")
+	}
+}
+
 // TestCoderVariablesHintScopedToCoderParams guards the footer hint range: the
 // "${GIT_URL}" coder-variables hint must show only on coder PARAMETER rows, not
 // on the codespaces/browser/remote-mcp rows that sit in the numeric blocks below
@@ -109,6 +152,91 @@ func TestRemoteMcpStatusValueRendersStates(t *testing.T) {
 	}
 	if got := remoteMcpStatusValue(m); !strings.Contains(got, "error") || !strings.Contains(got, "dial tcp: refused") {
 		t.Fatalf("error: want 'error' + message, got %q", got)
+	}
+}
+
+// TestRemoteGrpcStatusValueRendersStates exercises the read-only Public GRPC URL
+// line for each tunnel state, including a connected tunnel whose gateway
+// withheld the gRPC URL (no --public-grpc-url / feature not negotiated).
+func TestRemoteGrpcStatusValueRendersStates(t *testing.T) {
+	m := &model{spinner: spinner.New()}
+
+	if got := remoteGrpcStatusValue(m); !strings.Contains(got, "not connected") {
+		t.Fatalf("nil status: want 'not connected', got %q", got)
+	}
+
+	m.remoteMcpStatus = &fleetgrpc.RemoteMcpStatus{
+		State:         fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
+		PublicUrl:     "https://gw.example.com/mcp/abc123",
+		PublicGrpcUrl: "https://gw.example.com:50051/grpc/abc123",
+	}
+	got := remoteGrpcStatusValue(m)
+	if !strings.Contains(got, "connected") || !strings.Contains(got, "https://gw.example.com:50051/grpc/abc123") {
+		t.Fatalf("connected: want 'connected' + grpc url, got %q", got)
+	}
+
+	// Connected but the gateway handed no gRPC URL.
+	m.remoteMcpStatus = &fleetgrpc.RemoteMcpStatus{
+		State:     fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
+		PublicUrl: "https://gw.example.com/mcp/abc123",
+	}
+	if got := remoteGrpcStatusValue(m); !strings.Contains(got, "no public gRPC URL") {
+		t.Fatalf("connected without grpc url: want the withheld-URL note, got %q", got)
+	}
+
+	m.remoteMcpStatus = &fleetgrpc.RemoteMcpStatus{State: fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTING}
+	if got := remoteGrpcStatusValue(m); !strings.Contains(got, "connecting") {
+		t.Fatalf("connecting: want 'connecting', got %q", got)
+	}
+
+	m.remoteMcpStatus = &fleetgrpc.RemoteMcpStatus{
+		State: fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_ERROR,
+		Error: "dial tcp: refused",
+	}
+	if got := remoteGrpcStatusValue(m); !strings.Contains(got, "error") || !strings.Contains(got, "dial tcp: refused") {
+		t.Fatalf("error: want 'error' + message, got %q", got)
+	}
+}
+
+// TestToggleRemoteFleetEnabledPersists confirms pressing enter on the Enable
+// Remote Fleet row flips the setting and persists it through the
+// setConfigRemote seam, leaving the MCP toggle untouched.
+func TestToggleRemoteFleetEnabledPersists(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	origSetConfig := setConfigRemote
+	setConfigRemote = func(c *state.Config) error { return state.SaveConfig(c) }
+	defer func() { setConfigRemote = origSetConfig }()
+
+	sp := newSettingsPage()
+	m := &model{
+		config:      state.DefaultConfig(),
+		toolStatus:  allToolsFound(),
+		currentPage: sp,
+		fleetPage:   newFleetPage(),
+		spinner:     spinner.New(),
+	}
+	sp.cursor = settingsPositionOf(sp, m, settingsItemRemoteFleetEnabled)
+
+	sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if !m.config.RemoteMcpSettings.FleetEnabled {
+		t.Fatal("fleet enabled should be true after toggle")
+	}
+	if m.config.RemoteMcpSettings.Enabled {
+		t.Fatal("toggling remote fleet must not flip remote MCP")
+	}
+	loaded, err := state.LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !loaded.RemoteMcpSettings.FleetEnabled {
+		t.Fatal("toggle did not persist to disk")
+	}
+
+	// And the cursor stays on the row (no rows were inserted/removed).
+	if got := sp.settingsCursorItem(m); got != settingsItemRemoteFleetEnabled {
+		t.Fatalf("cursor slid off the fleet toggle: got item %d", got)
 	}
 }
 

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -67,6 +67,11 @@ type RegisterRequest struct {
 type RegisterReply struct {
 	SessionID string `json:"session_id,omitempty"`
 	PublicURL string `json:"public_url,omitempty"`
+	// PublicGRPCURL is the address a remote `fleet` binary dials to control this
+	// daemon through the gateway (the "Public GRPC URL"). Only set when the grpc
+	// feature is negotiated AND the gateway is configured with a public gRPC base
+	// URL (--public-grpc-url); empty otherwise (incl. from an old gateway).
+	PublicGRPCURL string `json:"public_grpc_url,omitempty"`
 	// SessionToken is a JWT, signed with the gateway's session key, encoding
 	// this session's ids. fleetd persists it with the session id and presents
 	// both on reconnect, so the session (and its public URL) survives a gateway


### PR DESCRIPTION
Closes #136.

Adds an **Enable Remote Fleet** toggle right under **Enable Remote MCP** in Settings → Fleet MCP, with the sub-line *"Allow remote `fleet` binary to control this instance through the gateway public url"*. The toggle gates whether the gateway gRPC endpoint is live for this daemon; the two toggles are independent, so a user can expose MCP, remote control, or both (either one brings the shared tunnel up).

## How the gate works

- `remote.Manager` now reconciles `(mcpEnabled, fleetEnabled, gatewayURL)`. The `grpc` tunnel feature is **only advertised when remote fleet is enabled** — without the negotiated feature the gateway answers every `fleet-session` RPC for the session with `NotFound`, so fleetd rejects incoming gRPC commands from the gateway by construction.
- Defense in depth on the data path: `dispatchStream` closes `TagGRPC` streams when no gRPC listener is wired, and a remote-fleet-only tunnel (`mcp` off) closes `TagMCP` streams / parks on a reject loop against an old gateway. A toggle flip mid-connection cancels the attempt and re-handshakes with the new feature set.

## Public GRPC URL

- New gateway flag `--public-grpc-url` (e.g. `https://gw.example.com:50051`). A grpc-negotiating daemon is handed `<public-grpc-url>/grpc/<publicID>` in the register reply; the URL is **withheld** when grpc is not negotiated, and never minted when the flag is unset.
- The URL rides the existing `RemoteMcpStatus` Watch event (`public_grpc_url = 4`) and renders as a read-only **Public GRPC URL** row under Public MCP URL when the setting is on. The format is already parseable by `fleetclient.newGatewayEndpoint`, so it is the exact `FLEET_GATEWAY` value for a future remote fleet.

## Config plumbing

`RemoteMcpSettings.FleetEnabled` (`fleet_enabled = 3` in config.proto), mapped through both server and TUI converters; `SetConfig` reconciles the tunnel with the new toggle. Computed URLs stay out of Config, mirroring the Public MCP URL design.

## Tests

- Gateway: Public GRPC URL minted for grpc-negotiating daemons, withheld without negotiation, never minted without the flag.
- Remote manager: feature-gating unit test; connect test asserts the gRPC URL lands in the status + session file; demux test for TagMCP rejection on a remote-fleet-only tunnel.
- Config round-trips (server + TUI) and TUI toggle persistence/placement/rendering tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)