### PR TITLE
fix: reject spaces in instance names on create, clone, and rename (#143)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"bcc7cb75-9720-44f2-867b-e8c15121637b","pid":44318,"procStart":"43977434","acquiredAt":1780631320803}
+{"sessionId":"a8e2a80e-1f89-4079-8b31-faaea1b3d495","pid":84623,"procStart":"104108913","acquiredAt":1781232824486}

--- a/internal/fleet/instance.go
+++ b/internal/fleet/instance.go
@@ -6,8 +6,9 @@ import "time"
 //
 // Name is the stable identifier used for container names, workspace paths,
 // tmux session prefixes, and CLI lookups — it never changes after creation.
-// DisplayName is the user-facing label shown in the TUI; it may be edited
-// freely without touching any underlying resources.
+// DisplayName is the user-facing label shown in the TUI; editing it never
+// touches underlying resources, but like Name it must satisfy
+// ValidateInstanceName.
 type Instance struct {
 	Name         string         `json:"name"`
 	DisplayName  string         `json:"display_name,omitempty"`

--- a/internal/fleet/validate_instance_name.go
+++ b/internal/fleet/validate_instance_name.go
@@ -1,0 +1,22 @@
+package fleet
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// ValidateInstanceName rejects names that cannot be embedded verbatim in the
+// places an instance name ends up: container names, workspace paths, and tmux
+// session prefixes. Every path that accepts a name — create, clone, and the
+// display-name edit (rename) — calls this so the rule has a single source of
+// truth (issue #143).
+func ValidateInstanceName(name string) error {
+	if name == "" {
+		return fmt.Errorf("instance name must not be empty")
+	}
+	if strings.ContainsFunc(name, unicode.IsSpace) {
+		return fmt.Errorf("instance name %q must not contain spaces", name)
+	}
+	return nil
+}

--- a/internal/fleet/validate_instance_name_test.go
+++ b/internal/fleet/validate_instance_name_test.go
@@ -1,0 +1,32 @@
+package fleet
+
+import "testing"
+
+func TestValidateInstanceName(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{name: "agent-1"},
+		{name: "Agent_1"},
+		{name: "auth.fix"},
+		{name: "", wantErr: true},
+		{name: "my agent", wantErr: true},
+		{name: " agent-1", wantErr: true},
+		{name: "agent-1 ", wantErr: true},
+		{name: "agent\t1", wantErr: true},
+		{name: "agent\n1", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateInstanceName(tt.name)
+			if tt.wantErr && err == nil {
+				t.Fatalf("ValidateInstanceName(%q) = nil, want error", tt.name)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("ValidateInstanceName(%q) = %v, want nil", tt.name, err)
+			}
+		})
+	}
+}

--- a/internal/server/jobs.go
+++ b/internal/server/jobs.go
@@ -440,6 +440,9 @@ func (s *service) startCreateInstanceJob(req *fleetgrpc.CreateInstanceRequest) (
 	if fleetName == "" || instanceName == "" {
 		return nil, status.Error(codes.InvalidArgument, "fleet and instance are required")
 	}
+	if err := fleet.ValidateInstanceName(instanceName); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	backendType := s.resolveBackend(req.GetBackend())
 	wsDir := filepath.Join(state.WorkspacesDir(), fleetName, instanceName, fleetName)
@@ -502,6 +505,9 @@ func (s *service) startCloneInstanceJob(req *fleetgrpc.CloneInstanceRequest) (*j
 	srcName, destName := req.GetSourceInstance(), req.GetNewInstance()
 	if fleetName == "" || srcName == "" || destName == "" {
 		return nil, status.Error(codes.InvalidArgument, "fleet, source_instance and new_instance are required")
+	}
+	if err := fleet.ValidateInstanceName(destName); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	wsDir := filepath.Join(state.WorkspacesDir(), fleetName, destName, fleetName)

--- a/internal/server/jobs.go
+++ b/internal/server/jobs.go
@@ -509,6 +509,11 @@ func (s *service) startCloneInstanceJob(req *fleetgrpc.CloneInstanceRequest) (*j
 	if err := fleet.ValidateInstanceName(destName); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	if req.GetNewDisplayName() != "" {
+		if err := fleet.ValidateInstanceName(req.GetNewDisplayName()); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+	}
 
 	wsDir := filepath.Join(state.WorkspacesDir(), fleetName, destName, fleetName)
 	err := state.Update(func(st *state.State) error {

--- a/internal/server/jobs_test.go
+++ b/internal/server/jobs_test.go
@@ -142,6 +142,46 @@ func TestCreateInstanceRejectsDuplicate(t *testing.T) {
 	}
 }
 
+func TestCreateInstanceRejectsSpaceInName(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Remote: "git@x:a.git"},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+
+	stream, err := client.CreateInstance(context.Background(), &fleetgrpc.CreateInstanceRequest{Fleet: "alpha", Instance: "my agent"})
+	if err != nil {
+		t.Fatalf("CreateInstance call: %v", err)
+	}
+	_, err = stream.Recv()
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("want InvalidArgument, got %v", err)
+	}
+}
+
+func TestCloneInstanceRejectsSpaceInName(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Remote: "git@x:a.git", Instances: []*fleet.Instance{{Name: "i1"}}},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+
+	stream, err := client.CloneInstance(context.Background(), &fleetgrpc.CloneInstanceRequest{Fleet: "alpha", SourceInstance: "i1", NewInstance: "i 2"})
+	if err != nil {
+		t.Fatalf("CloneInstance call: %v", err)
+	}
+	_, err = stream.Recv()
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("want InvalidArgument, got %v", err)
+	}
+}
+
 func TestStartStopJobs(t *testing.T) {
 	isolateFleetDir(t)
 	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{

--- a/internal/server/jobs_test.go
+++ b/internal/server/jobs_test.go
@@ -180,6 +180,16 @@ func TestCloneInstanceRejectsSpaceInName(t *testing.T) {
 	if status.Code(err) != codes.InvalidArgument {
 		t.Fatalf("want InvalidArgument, got %v", err)
 	}
+
+	// The optional new display name follows the same rule.
+	stream, err = client.CloneInstance(context.Background(), &fleetgrpc.CloneInstanceRequest{Fleet: "alpha", SourceInstance: "i1", NewInstance: "i2", NewDisplayName: ptr("i 2")})
+	if err != nil {
+		t.Fatalf("CloneInstance call: %v", err)
+	}
+	_, err = stream.Recv()
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("want InvalidArgument, got %v", err)
+	}
 }
 
 func TestStartStopJobs(t *testing.T) {

--- a/internal/server/mutations.go
+++ b/internal/server/mutations.go
@@ -149,8 +149,15 @@ func (s *service) SetFleetSettings(_ context.Context, req *fleetgrpc.SetFleetSet
 // SetInstanceMetadata updates user-facing labels (display name, color, tag)
 // without touching resources. Only the fields present in the request are
 // changed; an explicit empty string (e.g. clearing a tag) is distinguished from
-// "leave unchanged" by the proto presence bit.
+// "leave unchanged" by the proto presence bit. A non-empty display name (the
+// rename path) must satisfy fleet.ValidateInstanceName; an empty one clears
+// the override so the instance falls back to its immutable Name.
 func (s *service) SetInstanceMetadata(_ context.Context, req *fleetgrpc.SetInstanceMetadataRequest) (*fleetgrpc.MutationReply, error) {
+	if req.DisplayName != nil && req.GetDisplayName() != "" {
+		if err := fleet.ValidateInstanceName(req.GetDisplayName()); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+	}
 	snapshot, err := s.mutate(func(st *state.State) error {
 		f, ok := st.Fleets[req.GetFleet()]
 		if !ok {

--- a/internal/server/mutations_test.go
+++ b/internal/server/mutations_test.go
@@ -225,6 +225,36 @@ func TestSetInstanceMetadataUpdatesOnlyProvidedFields(t *testing.T) {
 	}
 }
 
+func TestSetInstanceMetadataRejectsDisplayNameWithSpaces(t *testing.T) {
+	isolateFleetDir(t)
+	svc := newService()
+	ctx := context.Background()
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Instances: []*fleet.Instance{{Name: "i1", DisplayName: "orig"}}},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	_, err := svc.SetInstanceMetadata(ctx, &fleetgrpc.SetInstanceMetadataRequest{
+		Fleet: "alpha", Instance: "i1", DisplayName: ptr("new name"),
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("want InvalidArgument, got %v", err)
+	}
+	st, _ := state.Load()
+	if got := st.Fleets["alpha"].Instances[0].DisplayName; got != "orig" {
+		t.Fatalf("DisplayName = %q, want unchanged %q", got, "orig")
+	}
+
+	// An explicit empty string clears the override (falls back to Name) and
+	// must stay allowed.
+	if _, err := svc.SetInstanceMetadata(ctx, &fleetgrpc.SetInstanceMetadataRequest{
+		Fleet: "alpha", Instance: "i1", DisplayName: ptr(""),
+	}); err != nil {
+		t.Fatalf("clear display name: %v", err)
+	}
+}
+
 func TestGroupLayoutSetAndDelete(t *testing.T) {
 	isolateFleetDir(t)
 	svc := newService()

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -571,10 +571,9 @@ func (fleetPage *fleetPage) submitAddInstance(m *model) tea.Cmd {
 		fleetPage.blurDialogFields()
 		return nil
 	}
+	// Keep the dialog open so the user can correct the name in place.
 	if err := fleet.ValidateInstanceName(name); err != nil {
 		m.message = err.Error()
-		fleetPage.mode = viewNormal
-		fleetPage.blurDialogFields()
 		return nil
 	}
 
@@ -2190,10 +2189,9 @@ func (fleetPage *fleetPage) saveCloneInstance(m *model) tea.Cmd {
 		fleetPage.blurDialogFields()
 		return nil
 	}
+	// Keep the dialog open so the user can correct the name in place.
 	if err := fleet.ValidateInstanceName(destName); err != nil {
 		m.message = err.Error()
-		fleetPage.mode = viewNormal
-		fleetPage.blurDialogFields()
 		return nil
 	}
 

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -571,6 +571,12 @@ func (fleetPage *fleetPage) submitAddInstance(m *model) tea.Cmd {
 		fleetPage.blurDialogFields()
 		return nil
 	}
+	if err := fleet.ValidateInstanceName(name); err != nil {
+		m.message = err.Error()
+		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
+		return nil
+	}
 
 	fleetName := fleetPage.dialogFleet
 	f, ok := m.st.Fleets[fleetName]
@@ -727,6 +733,10 @@ func (fleetPage *fleetPage) saveInstanceEdits(m *model) tea.Cmd {
 	displayName := strings.TrimSpace(fleetPage.textInput.Value())
 	if displayName == "" {
 		m.message = "Name cannot be empty"
+		return nil
+	}
+	if err := fleet.ValidateInstanceName(displayName); err != nil {
+		m.message = err.Error()
 		return nil
 	}
 
@@ -2176,6 +2186,12 @@ func (fleetPage *fleetPage) saveCloneInstance(m *model) tea.Cmd {
 	destName := strings.TrimSpace(fleetPage.textInput.Value())
 	if destName == "" {
 		m.message = "Name cannot be empty"
+		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
+		return nil
+	}
+	if err := fleet.ValidateInstanceName(destName); err != nil {
+		m.message = err.Error()
 		fleetPage.mode = viewNormal
 		fleetPage.blurDialogFields()
 		return nil

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -671,6 +671,38 @@ func TestEditInstanceRejectsEmptyName(t *testing.T) {
 	}
 }
 
+func TestEditInstanceRejectsNameWithSpaces(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	inst := &fleet.Instance{Name: "agent-1", DisplayName: "agent-1", Status: fleet.StatusRunning}
+	fp := newFleetPage()
+	fp.rows = []row{{kind: rowInstance, fleetName: "alpha", instance: inst}}
+	m := &model{
+		st: &state.State{
+			Fleets: map[string]*fleet.Fleet{
+				"alpha": {Name: "alpha", Instances: []*fleet.Instance{inst}},
+			},
+		},
+		fleetPage: fp,
+	}
+
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	// Activate the name field, then submit a value containing a space.
+	fp.updateAddInstance(m, tea.KeyMsg{Type: tea.KeyEnter})
+	fp.textInput.SetValue("auth fix")
+	fp.updateAddInstance(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if inst.DisplayName != "agent-1" {
+		t.Fatalf("DisplayName = %q, want unchanged %q", inst.DisplayName, "agent-1")
+	}
+	if !strings.Contains(m.message, "must not contain spaces") {
+		t.Fatalf("message = %q, want spaces rejection message", m.message)
+	}
+	if fp.mode != viewAddInstance {
+		t.Fatalf("dialog closed prematurely; mode = %v", fp.mode)
+	}
+}
+
 // stubFleetSettingsSave makes the instant-save RPC a no-op for tests: the dialog
 // mutates m.st in-memory before calling it, so a nil return means "saved" with
 // no real RPC and no revert.


### PR DESCRIPTION
Closes #143.

Instance names flow verbatim into container names, workspace paths, and tmux session prefixes, so a name containing whitespace breaks downstream tooling. This PR makes fleet reject such names on every path that accepts one.

## What changed

- **`internal/fleet/validate_instance_name.go`** — new `fleet.ValidateInstanceName(name)`: rejects empty names and any name containing whitespace (`unicode.IsSpace`, so tabs/newlines too) with the error `instance name "..." must not contain spaces`. Single source of truth for the rule.
- **Server (authoritative):**
  - `startCreateInstanceJob` rejects instance names with spaces (`InvalidArgument`) — covers the CLI `fleet up`, TUI, and MCP `fleet_up` paths.
  - `startCloneInstanceJob` rejects clone destination names with spaces — covers `fleet clone` and MCP.
  - `SetInstanceMetadata` rejects a non-empty display name with spaces (the rename path; `Name` itself is immutable). An explicit empty string still clears the override and falls back to `Name`.
- **TUI (UX mirror):** the add-instance, clone, and edit (rename) dialogs validate locally and show the same message immediately.
- The web UI is a prebuilt static bundle with no name-input forms, so no change there.

## Tests

- `TestValidateInstanceName` table test (valid names pass; space/tab/newline/leading/trailing whitespace and empty are rejected).
- `TestCreateInstanceRejectsSpaceInName`, `TestCloneInstanceRejectsSpaceInName` (gRPC, `InvalidArgument`).
- `TestSetInstanceMetadataRejectsDisplayNameWithSpaces` (rejection leaves state unchanged; empty-string clear still allowed).
- `TestEditInstanceRejectsNameWithSpaces` (TUI edit dialog keeps the dialog open and shows the rejection message).

`make test` (lint + full unit suite) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)