### PR TITLE
fix(startup): install Codex as a static binary — drop the npm dependency (#145)

### DIFF
--- a/integration/tests/430_install_codex.sh
+++ b/integration/tests/430_install_codex.sh
@@ -1,22 +1,26 @@
 #!/usr/bin/env bash
-# Description: Codex CLI is installed in the container by the startup script.
+# Description: Codex CLI is installed by the startup script on an image WITHOUT node/npm.
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
 itest_begin
 
-setup_agent_test
-seed_fleet_settings "${FIXTURE_REPO_NAME}" false true /home/node
+# Deliberately uses the default debian-base fixture (no node/npm): the
+# regression behind issue #145 was the npm-based codex install silently
+# failing on exactly this image class. The standalone installer needs
+# only curl + tar. The node-image path stays covered by 440_install_both.
+setup_test
+seed_fleet_settings "${FIXTURE_REPO_NAME}" false true /home/vscode
 
-info "fleet up alpha (codex install enabled)"
+info "fleet up alpha (codex install enabled, no-node image)"
 fleet_up alpha
 
 info "asserting startup script log was created"
-"${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- test -f /home/node/.fleet/startup/codex.log \
+"${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- test -f /home/vscode/.fleet/startup/codex.log \
   || fail "codex.log was not created — startup runner did not execute"
 
 info "codex.log contents:"
-"${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- cat /home/node/.fleet/startup/codex.log || true
+"${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- cat /home/vscode/.fleet/startup/codex.log || true
 
 info "asserting codex binary is on the user's PATH"
 codex_path=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- bash -lc 'command -v codex' 2>&1) \

--- a/internal/startup/codex_script.go
+++ b/internal/startup/codex_script.go
@@ -56,7 +56,7 @@ case "$(uname -m)" in
     ;;
 esac
 
-scratch=$(mktemp -d)
+scratch=$(mktemp -d) || exit 1
 trap 'rm -rf "$scratch"' EXIT
 
 attempt=1

--- a/internal/startup/codex_script.go
+++ b/internal/startup/codex_script.go
@@ -4,9 +4,35 @@ package startup
 // on PATH inside the container. Idempotent: short-circuits if `codex`
 // is already resolvable (e.g. baked into the image).
 //
-// Install method: npm. The Codex CLI ships as @openai/codex on npm
-// and Node.js is present in essentially every Microsoft devcontainer
-// base image, so this avoids the curl-piped-bash route.
+// Install method: the static musl binary from the latest GitHub
+// release, unpacked into ~/.local/bin/codex — the same directory the
+// Claude Code installer targets, so codex is visible in exactly the
+// shells claude is. Needs only curl + tar.
+//
+// Two distribution channels were rejected (issue #145):
+//   - npm (@openai/codex): silently broke on any image without
+//     Node.js — npm-less images exited 127, root-owned system Node
+//     hit EACCES on `npm -g`, and nvm-based installs landed the
+//     binary somewhere only nvm-initialized shells could see.
+//   - OpenAI's official installer (chatgpt.com/codex/install.sh):
+//     its SHA256SUMS lookup uses an awk interval regex ({64}) that
+//     mawk — the default awk on Debian/Ubuntu base images — does not
+//     support, so it aborts with "Could not find SHA-256 digest" on
+//     exactly the npm-less images this script needs to cover. It also
+//     unpacks its payload under ~/.codex, this fleet's SHARED Codex
+//     mount (see dirMountSpecsFor), which the direct download avoids
+//     entirely — no shared-mount writes means no #149-class install
+//     races between concurrently provisioning instances.
+//
+// The release tarball contains a single statically-linked
+// (musl-target) binary, so it runs on any Linux regardless of libc.
+// ~/.local/bin is appended to ~/.profile when no .local/bin entry is
+// present so login shells resolve codex even on images whose stock
+// .profile lacks the conventional Debian snippet.
+//
+// As defense in depth the install is attempted up to three times, and
+// an attempt only counts as success once the installed binary answers
+// `--version`, matching claudeCodeScript.
 func codexScript() Script {
 	return Script{
 		Name: "codex",
@@ -14,11 +40,46 @@ func codexScript() Script {
   echo "codex already installed: $(codex --version 2>/dev/null || echo unknown)"
   exit 0
 fi
-if ! command -v npm >/dev/null 2>&1; then
-  echo "npm is required to install Codex but was not found on PATH"
-  exit 127
-fi
-echo "installing Codex via npm..."
-npm install -g @openai/codex`,
+for tool in curl tar; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "$tool is required to install Codex but was not found on PATH"
+    exit 127
+  fi
+done
+
+case "$(uname -m)" in
+  x86_64 | amd64)  target="x86_64-unknown-linux-musl" ;;
+  aarch64 | arm64) target="aarch64-unknown-linux-musl" ;;
+  *)
+    echo "unsupported architecture for Codex install: $(uname -m)"
+    exit 1
+    ;;
+esac
+
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+
+attempt=1
+while :; do
+  echo "installing Codex from the GitHub release (attempt $attempt of 3)..."
+  if curl -fsSL "https://github.com/openai/codex/releases/latest/download/codex-$target.tar.gz" -o "$scratch/codex.tar.gz" &&
+    tar -xzf "$scratch/codex.tar.gz" -C "$scratch"; then
+    mkdir -p "$HOME/.local/bin"
+    cp "$scratch/codex-$target" "$HOME/.local/bin/codex"
+    chmod 0755 "$HOME/.local/bin/codex"
+    if "$HOME/.local/bin/codex" --version >/dev/null 2>&1; then
+      echo "codex installed: $("$HOME/.local/bin/codex" --version)"
+      grep -qs '\.local/bin' "$HOME/.profile" ||
+        printf '\nexport PATH="$HOME/.local/bin:$PATH"\n' >>"$HOME/.profile"
+      exit 0
+    fi
+  fi
+  if [ "$attempt" -ge 3 ]; then
+    echo "Codex install failed after 3 attempts"
+    exit 1
+  fi
+  attempt=$((attempt + 1))
+  sleep 2
+done`,
 	}
 }

--- a/internal/startup/codex_script_test.go
+++ b/internal/startup/codex_script_test.go
@@ -1,0 +1,232 @@
+package startup
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// codexScriptEnv is the sandbox a single test run of the codex script
+// body executes in: an isolated HOME, an isolated TMPDIR (so the
+// download scratch dir is observable), and a stub bin dir that shadows
+// curl and sleep on PATH.
+type codexScriptEnv struct {
+	home    string
+	tmpDir  string
+	stubBin string
+	counter string
+}
+
+// newCodexScriptEnv builds the sandbox. failures is the number of leading
+// curl download attempts that must fail: the stub curl exits 1 (a failed
+// download) for the first `failures` calls and afterwards writes a
+// faithful release tarball — a gzipped tar holding the single
+// codex-<target> static binary — to curl's -o destination. The stub
+// counts every call in a counter file so tests can assert attempts.
+func newCodexScriptEnv(t *testing.T, failures string) *codexScriptEnv {
+	t.Helper()
+	env := &codexScriptEnv{
+		home:    t.TempDir(),
+		tmpDir:  t.TempDir(),
+		stubBin: t.TempDir(),
+	}
+	env.counter = filepath.Join(env.stubBin, "curl-calls")
+
+	writeStub(t, env.stubBin, "curl", `#!/bin/sh
+count=$(cat "`+env.counter+`" 2>/dev/null || echo 0)
+count=$((count + 1))
+echo "$count" > "`+env.counter+`"
+out=""
+while [ $# -gt 0 ]; do
+  if [ "$1" = "-o" ]; then out="$2"; shift; fi
+  shift
+done
+if [ "$count" -le "`+failures+`" ]; then
+  echo "curl: (23) Failure writing output to destination" >&2
+  exit 1
+fi
+case "$(uname -m)" in
+  x86_64 | amd64)  target="x86_64-unknown-linux-musl" ;;
+  aarch64 | arm64) target="aarch64-unknown-linux-musl" ;;
+esac
+stage=$(mktemp -d)
+printf '#!/bin/sh\necho "codex-cli 1.0.0"\n' > "$stage/codex-$target"
+chmod +x "$stage/codex-$target"
+tar -czf "$out" -C "$stage" "codex-$target"
+rm -rf "$stage"
+`)
+	// Stub sleep so the retry backoff doesn't slow the test down.
+	writeStub(t, env.stubBin, "sleep", "#!/bin/sh\nexit 0\n")
+	return env
+}
+
+// run executes the codex script body under sh with the sandbox
+// environment. PATH deliberately excludes the host's /usr/local/bin etc.
+// so a codex binary on the developer's machine can't short-circuit the
+// install path under test.
+func (env *codexScriptEnv) run(t *testing.T) (string, error) {
+	t.Helper()
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh not available on this host: %v", err)
+	}
+	cmd := exec.Command(sh, "-c", codexScript().Body)
+	cmd.Env = []string{
+		"PATH=" + env.stubBin + ":/usr/bin:/bin",
+		"HOME=" + env.home,
+		"TMPDIR=" + env.tmpDir,
+	}
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// curlCalls reports how many times the stub curl was invoked.
+func (env *codexScriptEnv) curlCalls(t *testing.T) string {
+	t.Helper()
+	content, err := os.ReadFile(env.counter)
+	if os.IsNotExist(err) {
+		return "0"
+	}
+	if err != nil {
+		t.Fatalf("read curl counter: %v", err)
+	}
+	return strings.TrimSpace(string(content))
+}
+
+// TestCodexScript_InstallsStandaloneBinary is the regression test for
+// issue #145: the install must depend on nothing beyond curl + tar (the
+// sandbox PATH has no node/npm/gawk), must leave a runnable binary at
+// the real ~/.local/bin/codex, must keep every write out of ~/.codex
+// (the fleet's shared mount), and must wire ~/.local/bin into
+// ~/.profile for login shells.
+func TestCodexScript_InstallsStandaloneBinary(t *testing.T) {
+	env := newCodexScriptEnv(t, "0")
+
+	out, err := env.run(t)
+	if err != nil {
+		t.Fatalf("script exited non-zero: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "codex installed: codex-cli 1.0.0") {
+		t.Errorf("output missing install confirmation:\n%s", out)
+	}
+
+	launcher := filepath.Join(env.home, ".local", "bin", "codex")
+	version, err := exec.Command(launcher, "--version").Output()
+	if err != nil {
+		t.Fatalf("installed codex --version failed: %v", err)
+	}
+	if got := strings.TrimSpace(string(version)); got != "codex-cli 1.0.0" {
+		t.Errorf("codex --version = %q, want %q", got, "codex-cli 1.0.0")
+	}
+
+	// The shared mount (real ~/.codex) must be untouched by the install.
+	if _, err := os.Stat(filepath.Join(env.home, ".codex")); !os.IsNotExist(err) {
+		t.Errorf("install wrote to ~/.codex (the shared mount): stat err = %v", err)
+	}
+
+	// Login shells must find ~/.local/bin.
+	profile, err := os.ReadFile(filepath.Join(env.home, ".profile"))
+	if err != nil {
+		t.Fatalf("read ~/.profile: %v", err)
+	}
+	if !strings.Contains(string(profile), `.local/bin`) {
+		t.Errorf("~/.profile not wired for ~/.local/bin:\n%s", profile)
+	}
+
+	// The trap must have removed the download scratch dir.
+	leftovers, err := os.ReadDir(env.tmpDir)
+	if err != nil {
+		t.Fatalf("read tmpdir: %v", err)
+	}
+	if len(leftovers) != 0 {
+		t.Errorf("download scratch dir not cleaned up: %v", leftovers)
+	}
+}
+
+// TestCodexScript_SkipsProfileAppendWhenAlreadyWired asserts the
+// ~/.profile guard: a profile that already references .local/bin (the
+// stock Debian snippet, or a previous install) must not gain a
+// duplicate PATH line.
+func TestCodexScript_SkipsProfileAppendWhenAlreadyWired(t *testing.T) {
+	env := newCodexScriptEnv(t, "0")
+	stock := "PATH=\"$HOME/.local/bin:$PATH\"\n"
+	if err := os.WriteFile(filepath.Join(env.home, ".profile"), []byte(stock), 0o644); err != nil {
+		t.Fatalf("seed ~/.profile: %v", err)
+	}
+
+	out, err := env.run(t)
+	if err != nil {
+		t.Fatalf("script exited non-zero: %v\noutput: %s", err, out)
+	}
+	profile, err := os.ReadFile(filepath.Join(env.home, ".profile"))
+	if err != nil {
+		t.Fatalf("read ~/.profile: %v", err)
+	}
+	if string(profile) != stock {
+		t.Errorf("~/.profile modified despite existing .local/bin entry:\n%s", profile)
+	}
+}
+
+// TestCodexScript_RetriesTransientFailure simulates a transient download
+// failure on the first two attempts and asserts the retry loop self-heals.
+func TestCodexScript_RetriesTransientFailure(t *testing.T) {
+	env := newCodexScriptEnv(t, "2")
+
+	out, err := env.run(t)
+	if err != nil {
+		t.Fatalf("script exited non-zero: %v\noutput: %s", err, out)
+	}
+	if got := env.curlCalls(t); got != "3" {
+		t.Errorf("curl invoked %s times, want 3 (two failures + one success)", got)
+	}
+	if _, err := os.Stat(filepath.Join(env.home, ".local", "bin", "codex")); err != nil {
+		t.Errorf("binary missing after retried install: %v", err)
+	}
+}
+
+// TestCodexScript_GivesUpAfterThreeAttempts asserts the retry loop is
+// bounded and surfaces a non-zero exit (which the runner reports as a
+// warning) once all attempts are exhausted.
+func TestCodexScript_GivesUpAfterThreeAttempts(t *testing.T) {
+	env := newCodexScriptEnv(t, "99")
+
+	out, err := env.run(t)
+	if err == nil {
+		t.Fatalf("script exited zero despite persistent install failure\noutput: %s", out)
+	}
+	if !strings.Contains(out, "failed after 3 attempts") {
+		t.Errorf("output missing give-up message:\n%s", out)
+	}
+	if got := env.curlCalls(t); got != "3" {
+		t.Errorf("curl invoked %s times, want exactly 3", got)
+	}
+	// Even on failure the download scratch dir must be cleaned up.
+	leftovers, err := os.ReadDir(env.tmpDir)
+	if err != nil {
+		t.Fatalf("read tmpdir: %v", err)
+	}
+	if len(leftovers) != 0 {
+		t.Errorf("download scratch dir not cleaned up: %v", leftovers)
+	}
+}
+
+// TestCodexScript_SkipsWhenAlreadyInstalled asserts the idempotency
+// short-circuit: with a codex already on PATH the script must not
+// download anything at all.
+func TestCodexScript_SkipsWhenAlreadyInstalled(t *testing.T) {
+	env := newCodexScriptEnv(t, "0")
+	writeStub(t, env.stubBin, "codex", "#!/bin/sh\necho \"codex-cli 9.9.9\"\n")
+
+	out, err := env.run(t)
+	if err != nil {
+		t.Fatalf("script exited non-zero: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "already installed") {
+		t.Errorf("output missing already-installed short-circuit:\n%s", out)
+	}
+	if got := env.curlCalls(t); got != "0" {
+		t.Errorf("curl invoked %s times, want 0", got)
+	}
+}

--- a/skills/DOCTOR.md
+++ b/skills/DOCTOR.md
@@ -341,7 +341,7 @@ done
 
 If the user wants to install one:
 - **Claude Code:** `npm install -g @anthropic-ai/claude-code`
-- **Codex:** `npm install -g @openai/codex`
+- **Codex:** `npm install -g @openai/codex` (with node), or the static binary from https://github.com/openai/codex/releases (no node needed; the official install.sh needs gawk — it breaks on mawk-default images)
 - **Auggie (Augment Code):** `npm install -g @augmentcode/auggie`
 - **Gemini:** See Google's latest CLI install instructions
 - **Copilot:** `gh extension install github/gh-copilot`


### PR DESCRIPTION
## Summary

Fixes the install half of #145 ("Codex auto install broken"). The codex startup script required npm, so any image without Node.js (debian base, python, go, …) silently exited 127 — the failure only landed in `~/.fleet/startup/codex.log` and the instance warn file, so to the user codex simply never appeared, while Claude Code (curl-based standalone install) worked everywhere.

The new script downloads the statically-linked musl binary straight from the latest GitHub release into `~/.local/bin/codex` — the same directory the Claude Code installer targets — needing only `curl` + `tar`:

- `~/.local/bin` is appended to `~/.profile` when no `.local/bin` entry exists, so login shells resolve codex even on images without the stock Debian snippet.
- Retry-and-verify defense matching the Claude Code script (#154): up to 3 attempts, success only once the installed binary answers `--version`.
- Everything stays **off the shared `~/.codex` mount** — no #149-class install race between concurrently provisioning instances.

## Why not the official installer or npm

- **OpenAI's `chatgpt.com/codex/install.sh`**: its SHA256SUMS lookup uses an awk interval regex (`{64}`) that **mawk — the default awk on Debian/Ubuntu images — does not support**, so it aborts with "Could not find SHA-256 digest" on exactly the npm-less images this fix targets (reproduced end-to-end). It also unpacks its payload under `~/.codex`, the fleet's shared mount.
- **npm (`@openai/codex`)**: exits 127 without node; hits EACCES on root-owned system Node; under nvm, lands the binary somewhere only nvm-initialized shells can see.

## Testing

- New `internal/startup/codex_script_test.go` (5 tests, mirrors the claude script tests): no-node/no-gawk sandbox install, shared-mount untouched, `~/.profile` wiring + no-duplicate guard, bounded retry loop, idempotency short-circuit.
- `integration/tests/430_install_codex.sh` now runs on the **default debian-base fixture (no node/npm)** — the image class the npm route silently broke on. Ran locally: codex 0.139.0 installs, `bash -lc 'command -v codex'` → `/home/vscode/.local/bin/codex`. The node-image path stays covered by `440_install_both.sh`.
- Real-environment proof: script body executed under `env -i PATH=/usr/bin:/bin` (no node, mawk-only) — codex 0.139.0 installed and runnable, `~/.codex` untouched.

The settings relabel side-note from #145 (drop trailing "mount" from the toggle labels) is intentionally not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)