### PR TITLE
feat/version-chain-display — show tui → gateway → fleetd versions in the header

### DIFF
--- a/fleetgrpc/watch.pb.go
+++ b/fleetgrpc/watch.pb.go
@@ -383,8 +383,13 @@ type RemoteMcpStatus struct {
 	PublicUrl     string                 `protobuf:"bytes,2,opt,name=public_url,json=publicUrl,proto3" json:"public_url,omitempty"`
 	Error         string                 `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`
 	PublicGrpcUrl string                 `protobuf:"bytes,4,opt,name=public_grpc_url,json=publicGrpcUrl,proto3" json:"public_grpc_url,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// gateway_version is the build version the gateway reported in its register
+	// reply (empty from an old gateway that predates the field, or while not
+	// CONNECTED). Surfaced so a remote TUI can render the version of every hop in
+	// the control chain (tui -> gateway -> fleetd) and spot version skew.
+	GatewayVersion string `protobuf:"bytes,5,opt,name=gateway_version,json=gatewayVersion,proto3" json:"gateway_version,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *RemoteMcpStatus) Reset() {
@@ -441,6 +446,13 @@ func (x *RemoteMcpStatus) GetError() string {
 func (x *RemoteMcpStatus) GetPublicGrpcUrl() string {
 	if x != nil {
 		return x.PublicGrpcUrl
+	}
+	return ""
+}
+
+func (x *RemoteMcpStatus) GetGatewayVersion() string {
+	if x != nil {
+		return x.GatewayVersion
 	}
 	return ""
 }
@@ -714,13 +726,14 @@ const file_watch_proto_rawDesc = "" +
 	"\x0fruntime_changed\x18\a \x01(\v2\x19.fleetgrpc.RuntimeChangedH\x00R\x0eruntimeChanged\x12H\n" +
 	"\x11remote_mcp_status\x18\b \x01(\v2\x1a.fleetgrpc.RemoteMcpStatusH\x00R\x0fremoteMcpStatus\x122\n" +
 	"\tfile_copy\x18\t \x01(\v2\x13.fleetgrpc.FileCopyH\x00R\bfileCopyB\x06\n" +
-	"\x04kind\"\x9e\x01\n" +
+	"\x04kind\"\xc7\x01\n" +
 	"\x0fRemoteMcpStatus\x12.\n" +
 	"\x05state\x18\x01 \x01(\x0e2\x18.fleetgrpc.RemoteMcpConnR\x05state\x12\x1d\n" +
 	"\n" +
 	"public_url\x18\x02 \x01(\tR\tpublicUrl\x12\x14\n" +
 	"\x05error\x18\x03 \x01(\tR\x05error\x12&\n" +
-	"\x0fpublic_grpc_url\x18\x04 \x01(\tR\rpublicGrpcUrl\"6\n" +
+	"\x0fpublic_grpc_url\x18\x04 \x01(\tR\rpublicGrpcUrl\x12'\n" +
+	"\x0fgateway_version\x18\x05 \x01(\tR\x0egatewayVersion\"6\n" +
 	"\fStateChanged\x12&\n" +
 	"\x05state\x18\x01 \x01(\v2\x10.fleetgrpc.StateR\x05state\"F\n" +
 	"\x0eRuntimeChanged\x124\n" +

--- a/fleetgrpc/watch.proto
+++ b/fleetgrpc/watch.proto
@@ -96,6 +96,11 @@ message RemoteMcpStatus {
   string public_url = 2;
   string error = 3;
   string public_grpc_url = 4;
+  // gateway_version is the build version the gateway reported in its register
+  // reply (empty from an old gateway that predates the field, or while not
+  // CONNECTED). Surfaced so a remote TUI can render the version of every hop in
+  // the control chain (tui -> gateway -> fleetd) and spot version skew.
+  string gateway_version = 5;
 }
 
 // StateChanged is pushed whenever the authoritative PERSISTED model mutates. It

--- a/internal/cli/gateway.go
+++ b/internal/cli/gateway.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/gateway"
+	"github.com/BenjaminBenetti/fleet-man/internal/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -46,6 +47,9 @@ func newGatewayCmd() *cobra.Command {
 			return applyGatewayEnv(cmd.Flags())
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			// The gateway binary is the fleet binary, built with the same version
+			// ldflags; pass that through so it can report its version to daemons.
+			cfg.Version = version.Version
 			return gateway.Serve(cmd.Context(), cfg)
 		},
 	}

--- a/internal/fleetclient/dial.go
+++ b/internal/fleetclient/dial.go
@@ -14,12 +14,18 @@ import (
 // Conn is a connected fleet client. Service() returns the gRPC client; callers
 // never see the socket, address, or transport.
 type Conn struct {
-	conn *grpc.ClientConn
-	svc  fleetgrpc.FleetServiceClient
+	conn          *grpc.ClientConn
+	svc           fleetgrpc.FleetServiceClient
+	serverVersion string
 }
 
 // Service returns the fleet service client for issuing RPCs.
 func (c *Conn) Service() fleetgrpc.FleetServiceClient { return c.svc }
+
+// ServerVersion returns the daemon's build version, learned from the Hello
+// handshake run at Dial time (the daemon reached THROUGH a gateway, when remote,
+// so this is fleetd's version, not the gateway's). Empty for a dev-build daemon.
+func (c *Conn) ServerVersion() string { return c.serverVersion }
 
 // Close releases the underlying connection.
 func (c *Conn) Close() error { return c.conn.Close() }
@@ -90,7 +96,7 @@ func dialEndpoint(ctx context.Context, ep Endpoint) (*Conn, error) {
 			return nil, fmt.Errorf("fleet server unreachable after restart: %w", err)
 		}
 	}
-	return &Conn{conn: conn, svc: svc}, nil
+	return &Conn{conn: conn, svc: svc, serverVersion: reply.GetServerVersion()}, nil
 }
 
 func hello(ctx context.Context, svc fleetgrpc.FleetServiceClient) (*fleetgrpc.HelloReply, error) {

--- a/internal/fleetclient/endpoint.go
+++ b/internal/fleetclient/endpoint.go
@@ -83,6 +83,14 @@ func IsRemote() bool {
 	return os.Getenv("FLEET_GATEWAY") != "" || os.Getenv("FLEET_SERVER") != ""
 }
 
+// IsGateway reports whether the client reaches the daemon THROUGH a fleet
+// gateway (FLEET_GATEWAY set), as opposed to a direct remote TCP target
+// (FLEET_SERVER) or the local socket. Only a gateway connection has a gateway
+// version to show in the control chain.
+func IsGateway() bool {
+	return os.Getenv("FLEET_GATEWAY") != ""
+}
+
 // gatewayToken resolves the bearer token for a gateway endpoint: FLEET_TOKEN, or
 // the on-disk MCP token (so a user on the same host as their daemon need only
 // supply the URL).

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -98,6 +98,7 @@ type Config struct {
 	TLSKey        string // path to the TLS private key (PEM). Optional; both TLSCert and TLSKey together enable TLS.
 	MaxSessions   int    // cap on concurrent tunnels. Default 1024.
 	SessionKey    string // secret key signing session-resume tokens (token.go). Empty = a random per-boot key, so session URLs do not survive a gateway restart.
+	Version       string // gateway build version, echoed to fleetd in the register reply for diagnostics. Empty = unset (dev build).
 }
 
 // Server is a configured gateway. Build with New, then Run. tlsConfig is nil when

--- a/internal/gateway/gateway_e2e_test.go
+++ b/internal/gateway/gateway_e2e_test.go
@@ -289,6 +289,36 @@ func TestGatewayEndToEnd(t *testing.T) {
 	}
 }
 
+// TestGatewayReportsVersionInRegisterReply verifies the gateway echoes its
+// configured build version in the register reply, so fleetd can surface it to
+// remote TUIs for control-chain version diagnostics. An unset version yields an
+// empty field (how an old gateway predating the feature already behaves).
+func TestGatewayReportsVersionInRegisterReply(t *testing.T) {
+	const publicBase = "http://gw.example.com"
+	s := &Server{
+		cfg:       Config{PublicURL: publicBase, MaxSessions: 64, Version: "gw-9.9.9"},
+		reg:       newRegistry(publicBase, "", 64, testSigner(t, "")),
+		tlsConfig: nil,
+		log:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	publicLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("public listen: %v", err)
+	}
+	grpcLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("grpc listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = s.ServeListeners(ctx, publicLn, grpcLn) }()
+
+	reply := dialFleetdPlain(t, grpcLn.Addr().String(), "")
+	if reply.GatewayVersion != "gw-9.9.9" {
+		t.Fatalf("RegisterReply.GatewayVersion = %q, want gw-9.9.9", reply.GatewayVersion)
+	}
+}
+
 // TestGatewayEndToEndPlainHTTP is TestGatewayEndToEnd with no TLS anywhere: a
 // plaintext control dial and a plain-HTTP public client. It proves the full
 // reverse-proxy path — plain control handshake + yamux + plain public HTTP +

--- a/internal/gateway/register.go
+++ b/internal/gateway/register.go
@@ -101,6 +101,10 @@ func (s *Server) bindTunnel(ctx context.Context, conn net.Conn, remote string) e
 		reply.PublicGRPCURL = ""
 	}
 
+	// Echo the gateway's build version so fleetd can surface it (over
+	// RemoteMcpStatus) to remote TUIs for control-chain version diagnostics.
+	reply.GatewayVersion = s.cfg.Version
+
 	if err := tunnel.WriteFrame(conn, reply); err != nil {
 		if isNew {
 			s.reg.release(sess)

--- a/internal/server/remote/manager.go
+++ b/internal/server/remote/manager.go
@@ -294,8 +294,8 @@ func (m *Manager) connectAndServe(ctx context.Context, d desiredState) (register
 		PublicGRPCURL: reply.PublicGRPCURL,
 		GatewayURL:    gatewayURL,
 	})
-	flog.Info("remote gateway connected", "gateway", gatewayURL, "publicURL", reply.PublicURL, "publicGrpcURL", reply.PublicGRPCURL)
-	m.publish(statusConnected(reply.PublicURL, reply.PublicGRPCURL))
+	flog.Info("remote gateway connected", "gateway", gatewayURL, "publicURL", reply.PublicURL, "publicGrpcURL", reply.PublicGRPCURL, "gatewayVersion", reply.GatewayVersion)
+	m.publish(statusConnected(reply.PublicURL, reply.PublicGRPCURL, reply.GatewayVersion))
 
 	session, err := tunnel.ClientSession(conn, m.logOut)
 	if err != nil {

--- a/internal/server/remote/manager_test.go
+++ b/internal/server/remote/manager_test.go
@@ -228,7 +228,7 @@ func TestManagerConnectsServesAndDisables(t *testing.T) {
 		if err := tunnel.ReadFrame(conn, &req); err != nil {
 			return
 		}
-		_ = tunnel.WriteFrame(conn, tunnel.RegisterReply{SessionID: "sess-A", SessionToken: "tok-A", PublicURL: "https://gw/mcp/sess-A", PublicGRPCURL: "https://gw:50051/grpc/sess-A"})
+		_ = tunnel.WriteFrame(conn, tunnel.RegisterReply{SessionID: "sess-A", SessionToken: "tok-A", PublicURL: "https://gw/mcp/sess-A", PublicGRPCURL: "https://gw:50051/grpc/sess-A", GatewayVersion: "gw-7.0.0"})
 		sess, err := tunnel.ServerSession(conn, io.Discard)
 		if err != nil {
 			return
@@ -262,6 +262,11 @@ func TestManagerConnectsServesAndDisables(t *testing.T) {
 	// The gateway-assigned Public GRPC URL rides the same status.
 	if connected.GetPublicGrpcUrl() != "https://gw:50051/grpc/sess-A" {
 		t.Fatalf("public grpc url = %q, want https://gw:50051/grpc/sess-A", connected.GetPublicGrpcUrl())
+	}
+	// The gateway's reported build version rides the same status (so a remote
+	// TUI can show the control-chain versions).
+	if connected.GetGatewayVersion() != "gw-7.0.0" {
+		t.Fatalf("gateway version = %q, want gw-7.0.0", connected.GetGatewayVersion())
 	}
 
 	// The tunnel actually carried a request, auth header intact.

--- a/internal/server/remote/status.go
+++ b/internal/server/remote/status.go
@@ -15,11 +15,12 @@ func statusConnecting() *fleetgrpc.RemoteMcpStatus {
 	return &fleetgrpc.RemoteMcpStatus{State: fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTING}
 }
 
-func statusConnected(publicURL, publicGRPCURL string) *fleetgrpc.RemoteMcpStatus {
+func statusConnected(publicURL, publicGRPCURL, gatewayVersion string) *fleetgrpc.RemoteMcpStatus {
 	return &fleetgrpc.RemoteMcpStatus{
-		State:         fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
-		PublicUrl:     publicURL,
-		PublicGrpcUrl: publicGRPCURL,
+		State:          fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
+		PublicUrl:      publicURL,
+		PublicGrpcUrl:  publicGRPCURL,
+		GatewayVersion: gatewayVersion,
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -45,6 +45,12 @@ type model struct {
 	// settings page renders it read-only; nil means "no status received yet".
 	remoteMcpStatus *fleetgrpc.RemoteMcpStatus
 
+	// serverVersion is the connected daemon's build version, learned from the
+	// Hello handshake on each (re)connect (see serverInfoMsg). Empty until the
+	// first connect, or for a dev-build daemon. Rendered in the header's
+	// control-chain version string (see versionChain).
+	serverVersion string
+
 	// Fleet Armada: the registry of remote fleets (loaded from the LOCAL
 	// daemon — see armada_client.go), the latest ping outcome per remote URL,
 	// and whether the settings-page status-sweep tick is armed (guards against
@@ -754,6 +760,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// state + computed Public MCP URL). Cache it for the settings page to
 		// render; a redraw picks it up on the next frame.
 		m.remoteMcpStatus = msg.status
+		return m, spinCmd
+
+	case serverInfoMsg:
+		if msg.gen != m.watchGen {
+			return m, spinCmd
+		}
+		// The daemon's version learned at (re)connect; render it in the header's
+		// control-chain version string.
+		m.serverVersion = msg.serverVersion
 		return m, spinCmd
 
 	case watchErrMsg, watchClosedMsg:

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -13,7 +13,6 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/devcontainersetup"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/gitutil"
-	"github.com/BenjaminBenetti/fleet-man/internal/version"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -1203,8 +1202,8 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 		rendered = strings.Join(lines, "\n")
 	}
 	b.WriteString(rendered)
-	if version.Version != "" {
-		b.WriteString(" " + dimStyle.Render(version.Version))
+	if chain := versionChain(m); chain != "" {
+		b.WriteString(" " + dimStyle.Render(chain))
 	}
 	if m.updateAvailable != "" {
 		b.WriteString("  " + updateStyle.Render(fmt.Sprintf("A new version: %s is available ⚡ Settings to update", m.updateAvailable)))

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -6,8 +6,57 @@ import (
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetclient"
+	"github.com/BenjaminBenetti/fleet-man/internal/version"
 	"github.com/charmbracelet/lipgloss"
 )
+
+// versionArrow separates hops in the control-chain version string.
+const versionArrow = " → "
+
+// versionChain renders the build versions of every hop in the control chain so
+// version skew (a stale TUI, gateway, or daemon) is visible at a glance:
+//
+//   - local daemon, versions match (the common case — fleetd auto-upgrades to
+//     the client): just "<tui>" (unchanged from the old single-version header;
+//     a dev build with no version still renders nothing).
+//   - local daemon, versions differ: "<tui> → <fleetd>".
+//   - remote via a gateway: "<tui> → <gateway> → <fleetd>".
+//   - remote via FLEET_SERVER (no gateway): "<tui> → <fleetd>".
+//
+// An empty gateway version (an old gateway predating the version field, or the
+// status not yet received) renders as "?" so the unknown hop stands out rather
+// than being masked.
+func versionChain(m *model) string {
+	switch {
+	case fleetclient.IsGateway():
+		gw := m.remoteMcpStatus.GetGatewayVersion()
+		if gw == "" {
+			gw = "?"
+		}
+		return versionLabel(version.Version) + versionArrow + gw + versionArrow + versionLabel(m.serverVersion)
+	case fleetclient.IsRemote():
+		return versionLabel(version.Version) + versionArrow + versionLabel(m.serverVersion)
+	default:
+		// Local daemon. Collapse to the TUI version alone when the daemon
+		// matches (or hasn't answered yet) — preserving the old header exactly,
+		// including rendering nothing for a versionless dev build — and only
+		// expand to show the daemon version when they actually diverge.
+		if m.serverVersion == "" || m.serverVersion == version.Version {
+			return version.Version
+		}
+		return versionLabel(version.Version) + versionArrow + versionLabel(m.serverVersion)
+	}
+}
+
+// versionLabel maps an empty (unset, dev-build) version to "dev" so a chain hop
+// always renders a token.
+func versionLabel(v string) string {
+	if v == "" {
+		return "dev"
+	}
+	return v
+}
 
 func renderHelp(width int, helpKeys []string) string {
 	maxW := width

--- a/internal/tui/render_test.go
+++ b/internal/tui/render_test.go
@@ -1,0 +1,82 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/version"
+)
+
+// TestVersionChain covers the control-chain version header rendering: local
+// (collapsed when matched), remote-server (two hops), and gateway (three hops),
+// including the "?" placeholder for an old gateway that reports no version and
+// the "dev" label for a versionless build.
+func TestVersionChain(t *testing.T) {
+	cases := []struct {
+		name            string
+		gateway, server string // FLEET_GATEWAY / FLEET_SERVER env
+		tui, fleetd, gw string // version values
+		gwStatusPresent bool   // whether a RemoteMcpStatus is set (vs nil)
+		want            string
+	}{
+		{
+			name: "local exact match collapses to tui only",
+			tui:  "v1.2.3", fleetd: "v1.2.3", want: "v1.2.3",
+		},
+		{
+			name: "local daemon not yet known collapses to tui only",
+			tui:  "v1.2.3", fleetd: "", want: "v1.2.3",
+		},
+		{
+			name: "local dev build with matching daemon renders nothing",
+			tui:  "", fleetd: "", want: "",
+		},
+		{
+			name: "local mismatch expands to tui then fleetd",
+			tui:  "v1.2.3", fleetd: "v1.2.0", want: "v1.2.3 → v1.2.0",
+		},
+		{
+			name:   "remote server (no gateway) is two hops",
+			server: "host:50051",
+			tui:    "v1.2.3", fleetd: "v1.2.0", want: "v1.2.3 → v1.2.0",
+		},
+		{
+			name:    "gateway is three hops",
+			gateway: "http://gw.example/abc",
+			tui:     "v1.3.0", fleetd: "v1.2.0", gw: "v1.2.5", gwStatusPresent: true,
+			want: "v1.3.0 → v1.2.5 → v1.2.0",
+		},
+		{
+			name:    "old gateway (no version, nil status) shows ? for the unknown hop",
+			gateway: "http://gw.example/abc",
+			tui:     "v1.3.0", fleetd: "v1.2.0", gwStatusPresent: false,
+			want: "v1.3.0 → ? → v1.2.0",
+		},
+		{
+			name:    "gateway with dev-build daemon labels the empty hops",
+			gateway: "http://gw.example/abc",
+			tui:     "", fleetd: "", gw: "gw-1", gwStatusPresent: true,
+			want: "dev → gw-1 → dev",
+		},
+	}
+
+	orig := version.Version
+	t.Cleanup(func() { version.Version = orig })
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("FLEET_GATEWAY", tc.gateway)
+			t.Setenv("FLEET_SERVER", tc.server)
+			version.Version = tc.tui
+
+			m := &model{serverVersion: tc.fleetd}
+			if tc.gwStatusPresent {
+				m.remoteMcpStatus = &fleetgrpc.RemoteMcpStatus{GatewayVersion: tc.gw}
+			}
+
+			if got := versionChain(m); got != tc.want {
+				t.Fatalf("versionChain = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tui/watch.go
+++ b/internal/tui/watch.go
@@ -109,6 +109,14 @@ type remoteMcpStatusMsg struct {
 	status *fleetgrpc.RemoteMcpStatus
 	gen    int
 }
+
+// serverInfoMsg carries the daemon version learned at Dial time (Hello
+// handshake), sent on every successful (re)connect so the header can render the
+// control-chain versions.
+type serverInfoMsg struct {
+	serverVersion string
+	gen           int
+}
 type watchErrMsg struct{ err error }
 type watchClosedMsg struct{ err error }
 
@@ -157,6 +165,11 @@ func watchOnce(ctx context.Context, program *tea.Program, gen int) bool {
 		return false
 	}
 	defer conn.Close()
+
+	// Surface the daemon's version (from Dial's Hello handshake) so the header
+	// can render the control-chain versions. Reached through the gateway when
+	// remote, so this is always fleetd's version.
+	program.Send(serverInfoMsg{serverVersion: conn.ServerVersion(), gen: gen})
 
 	stream, err := conn.Service().Watch(ctx, &fleetgrpc.WatchRequest{
 		IncludeInitialState: true,

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -82,6 +82,10 @@ type RegisterReply struct {
 	// Features is the negotiated set: the intersection of what fleetd requested
 	// and what the gateway supports. Absent (old gateway) means MCP-only.
 	Features []string `json:"features,omitempty"`
+	// GatewayVersion is the gateway's build version, for diagnostics: fleetd
+	// surfaces it to remote TUIs (over RemoteMcpStatus) so the whole control
+	// chain's versions are visible. Empty from an old gateway predating the field.
+	GatewayVersion string `json:"gateway_version,omitempty"`
 }
 
 // FeatureGRPC negotiates tunneling the daemon's gRPC server alongside MCP. When


### PR DESCRIPTION
## Summary

Multi-TUI and remote-fleet setups make it easy to end up with version skew between the **client**, the **gateway**, and the **daemon** — and skew is a prime suspect for the kind of state-desync symptoms tracked in #158 (one stale binary in the chain can corrupt shared state for everyone). Today only the client's own version is shown, so skew is invisible.

This surfaces every hop's build version in the fleet-list header:

- **local daemon, versions match** (the common case under fleetd's auto-upgrade): just `<tui>` — unchanged from the old single-version header; a versionless dev build still renders nothing.
- **local daemon, versions differ:** `<tui> → <fleetd>`
- **remote via a gateway:** `<tui> → <gateway> → <fleetd>`
- **remote via `FLEET_SERVER` (no gateway):** `<tui> → <fleetd>`

An **old gateway** that predates the new version field renders its hop as `?`, so a stale gateway stands out at a glance instead of being silently masked.

### How it's wired

- The gateway echoes its build version in the tunnel `RegisterReply` (new `GatewayVersion` field, fed from the fleet binary's version ldflag via the gateway `Config`).
- fleetd carries it into the `RemoteMcpStatus` it already pushes over Watch (new `gateway_version` proto field).
- The TUI captures the daemon version from the existing **Hello** handshake (now surfaced on `fleetclient.Conn`) and renders the chain.

Fully backward compatible: an old gateway omits the reply field, an old daemon omits the status field, and the header degrades to `?` or fewer hops rather than breaking.

### Verified live

Built versioned binaries and ran the full gateway path in containers:
- local matched → `v2.0.0`
- gateway (versioned) → `v2.0.0 → gw-OLD-1.0 → v2.0.0`
- genuine pre-#142 gateway (sends no version) → `v2.0.0 → ? → v2.0.0`

Plus unit tests for the chain rendering (all branches incl. `?`/`dev` fallbacks), the gateway register-reply field, and the daemon→status propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)