### PR TITLE
feat/version-chain-collapse — collapse a matched version chain to '<version> xN'

### DIFF
--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -34,9 +34,9 @@ func versionChain(m *model) string {
 		if gw == "" {
 			gw = "?"
 		}
-		return versionLabel(version.Version) + versionArrow + gw + versionArrow + versionLabel(m.serverVersion)
+		return joinVersions(versionLabel(version.Version), gw, versionLabel(m.serverVersion))
 	case fleetclient.IsRemote():
-		return versionLabel(version.Version) + versionArrow + versionLabel(m.serverVersion)
+		return joinVersions(versionLabel(version.Version), versionLabel(m.serverVersion))
 	default:
 		// Local daemon. Collapse to the TUI version alone when the daemon
 		// matches (or hasn't answered yet) — preserving the old header exactly,
@@ -45,8 +45,26 @@ func versionChain(m *model) string {
 		if m.serverVersion == "" || m.serverVersion == version.Version {
 			return version.Version
 		}
-		return versionLabel(version.Version) + versionArrow + versionLabel(m.serverVersion)
+		return joinVersions(versionLabel(version.Version), versionLabel(m.serverVersion))
 	}
+}
+
+// joinVersions renders the chain hops as "a → b → c", but collapses a chain
+// whose hops are ALL identical to "<version> xN" (e.g. tui == gateway == fleetd
+// all on v1.0.19-beta renders "v1.0.19-beta x3") — when every hop is in lockstep
+// the arrow form is just noise. A single hop renders bare (no "x1").
+func joinVersions(hops ...string) string {
+	allSame := len(hops) > 1
+	for _, h := range hops[1:] {
+		if h != hops[0] {
+			allSame = false
+			break
+		}
+	}
+	if allSame {
+		return fmt.Sprintf("%s x%d", hops[0], len(hops))
+	}
+	return strings.Join(hops, versionArrow)
 }
 
 // versionLabel maps an empty (unset, dev-build) version to "dev" so a chain hop

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -54,6 +54,9 @@ func versionChain(m *model) string {
 // all on v1.0.19-beta renders "v1.0.19-beta x3") — when every hop is in lockstep
 // the arrow form is just noise. A single hop renders bare (no "x1").
 func joinVersions(hops ...string) string {
+	if len(hops) == 0 {
+		return ""
+	}
 	allSame := len(hops) > 1
 	for _, h := range hops[1:] {
 		if h != hops[0] {

--- a/internal/tui/render_test.go
+++ b/internal/tui/render_test.go
@@ -47,6 +47,23 @@ func TestVersionChain(t *testing.T) {
 			want: "v1.3.0 → v1.2.5 → v1.2.0",
 		},
 		{
+			name:    "gateway all three identical collapses to xN",
+			gateway: "http://gw.example/abc",
+			tui:     "v1.0.19-beta", fleetd: "v1.0.19-beta", gw: "v1.0.19-beta", gwStatusPresent: true,
+			want: "v1.0.19-beta x3",
+		},
+		{
+			name:    "gateway two ends match but gateway differs stays expanded",
+			gateway: "http://gw.example/abc",
+			tui:     "v1.0.19-beta", fleetd: "v1.0.19-beta", gw: "v1.0.18-beta", gwStatusPresent: true,
+			want: "v1.0.19-beta → v1.0.18-beta → v1.0.19-beta",
+		},
+		{
+			name:   "remote server both identical collapses to xN",
+			server: "host:50051",
+			tui:    "v1.0.19-beta", fleetd: "v1.0.19-beta", want: "v1.0.19-beta x2",
+		},
+		{
 			name:    "old gateway (no version, nil status) shows ? for the unknown hop",
 			gateway: "http://gw.example/abc",
 			tui:     "v1.3.0", fleetd: "v1.2.0", gwStatusPresent: false,

--- a/internal/tui/render_test.go
+++ b/internal/tui/render_test.go
@@ -97,3 +97,20 @@ func TestVersionChain(t *testing.T) {
 		})
 	}
 }
+
+// TestJoinVersionsEdges covers joinVersions directly for the degenerate arg
+// counts the chain callers never hit but which must not panic or emit "x1".
+func TestJoinVersionsEdges(t *testing.T) {
+	if got := joinVersions(); got != "" {
+		t.Fatalf("joinVersions() = %q, want empty (and no panic)", got)
+	}
+	if got := joinVersions("v1"); got != "v1" {
+		t.Fatalf("joinVersions(single) = %q, want bare \"v1\" (not \"v1 x1\")", got)
+	}
+	if got := joinVersions("v1", "v1"); got != "v1 x2" {
+		t.Fatalf("joinVersions(two same) = %q, want \"v1 x2\"", got)
+	}
+	if got := joinVersions("v1", "v2"); got != "v1 → v2" {
+		t.Fatalf("joinVersions(two diff) = %q, want \"v1 → v2\"", got)
+	}
+}


### PR DESCRIPTION
## Summary

Small follow-up to the control-chain version header (#162). When every hop is on the same build — the healthy, in-sync case — the arrow form is just noise:

- before: `v1.0.19-beta → v1.0.19-beta → v1.0.19-beta`
- after: `v1.0.19-beta x3`

A matched two-hop chain (remote `FLEET_SERVER`) collapses to `… x2` the same way. Any divergence keeps the full arrow form so skew still stands out — including an old gateway's `?` hop (`v2.0.0 → ? → v2.0.0` is not collapsed). The local single-version header is unchanged.

Verified live (all three hops on v2.0.0 → header shows `v2.0.0 x3`) and with unit tests covering x3, x2, and the non-collapse cases (mixed versions, and matched ends around a differing gateway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)