### PR TITLE
feat(tui): layout presets — capture, edit, and apply session pane layouts (#150)

### DIFF
--- a/fleetgrpc/domain.pb.go
+++ b/fleetgrpc/domain.pb.go
@@ -395,7 +395,12 @@ type FleetSettings struct {
 	// Code CLI — keeps its login session and settings there) plus the Auggie
 	// auto-install startup script. Plain bool like the other *Mount flags:
 	// false == "never set" == disabled.
-	AuggieMount   bool `protobuf:"varint,10,opt,name=auggie_mount,json=auggieMount,proto3" json:"auggie_mount,omitempty"`
+	AuggieMount bool `protobuf:"varint,10,opt,name=auggie_mount,json=auggieMount,proto3" json:"auggie_mount,omitempty"`
+	// layout_presets is the fleet's list of saved session-layout templates
+	// (issue #150). repeated message: an empty list (the default) means no
+	// presets. Names are unique within the list (the server normalizes and
+	// rejects duplicates, like custom_mounts).
+	LayoutPresets []*LayoutPreset `protobuf:"bytes,11,rep,name=layout_presets,json=layoutPresets,proto3" json:"layout_presets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -500,6 +505,83 @@ func (x *FleetSettings) GetAuggieMount() bool {
 	return false
 }
 
+func (x *FleetSettings) GetLayoutPresets() []*LayoutPreset {
+	if x != nil {
+		return x.LayoutPresets
+	}
+	return nil
+}
+
+// LayoutPreset mirrors internal/fleet.LayoutPreset — a saved pane-layout
+// template the user can apply when creating a new session (Tab in the
+// new-session dialog). It is captured FROM a live session group: layout is the
+// outer-tmux window_layout string the group save/restore mechanism already
+// persists (GroupLayout.layout; leaf 0 is the fleet TUI pane), and
+// pane_commands holds one bash command per NON-TUI pane in position order (top
+// then left — the same ordering GroupLayout.sessions uses), "" meaning a plain
+// shell. len(pane_commands) IS the pane count; an empty layout string means "no
+// captured geometry" and restores as the default stacked split, exactly like a
+// GroupLayout with no layout.
+type LayoutPreset struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Layout        string                 `protobuf:"bytes,2,opt,name=layout,proto3" json:"layout,omitempty"`
+	PaneCommands  []string               `protobuf:"bytes,3,rep,name=pane_commands,json=paneCommands,proto3" json:"pane_commands,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LayoutPreset) Reset() {
+	*x = LayoutPreset{}
+	mi := &file_domain_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LayoutPreset) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LayoutPreset) ProtoMessage() {}
+
+func (x *LayoutPreset) ProtoReflect() protoreflect.Message {
+	mi := &file_domain_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LayoutPreset.ProtoReflect.Descriptor instead.
+func (*LayoutPreset) Descriptor() ([]byte, []int) {
+	return file_domain_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *LayoutPreset) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *LayoutPreset) GetLayout() string {
+	if x != nil {
+		return x.Layout
+	}
+	return ""
+}
+
+func (x *LayoutPreset) GetPaneCommands() []string {
+	if x != nil {
+		return x.PaneCommands
+	}
+	return nil
+}
+
 // Fleet mirrors internal/fleet.Fleet. Settings is a NESTED message (not inlined)
 // so FleetSettings' tri-state presence stays self-contained; a nil Settings ==
 // zero settings. Instances ([]*Instance) -> repeated.
@@ -515,7 +597,7 @@ type Fleet struct {
 
 func (x *Fleet) Reset() {
 	*x = Fleet{}
-	mi := &file_domain_proto_msgTypes[2]
+	mi := &file_domain_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -527,7 +609,7 @@ func (x *Fleet) String() string {
 func (*Fleet) ProtoMessage() {}
 
 func (x *Fleet) ProtoReflect() protoreflect.Message {
-	mi := &file_domain_proto_msgTypes[2]
+	mi := &file_domain_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -540,7 +622,7 @@ func (x *Fleet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Fleet.ProtoReflect.Descriptor instead.
 func (*Fleet) Descriptor() ([]byte, []int) {
-	return file_domain_proto_rawDescGZIP(), []int{2}
+	return file_domain_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Fleet) GetName() string {
@@ -589,7 +671,7 @@ type GroupLayout struct {
 
 func (x *GroupLayout) Reset() {
 	*x = GroupLayout{}
-	mi := &file_domain_proto_msgTypes[3]
+	mi := &file_domain_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -601,7 +683,7 @@ func (x *GroupLayout) String() string {
 func (*GroupLayout) ProtoMessage() {}
 
 func (x *GroupLayout) ProtoReflect() protoreflect.Message {
-	mi := &file_domain_proto_msgTypes[3]
+	mi := &file_domain_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -614,7 +696,7 @@ func (x *GroupLayout) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GroupLayout.ProtoReflect.Descriptor instead.
 func (*GroupLayout) Descriptor() ([]byte, []int) {
-	return file_domain_proto_rawDescGZIP(), []int{3}
+	return file_domain_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *GroupLayout) GetGroupId() string {
@@ -666,7 +748,7 @@ type State struct {
 
 func (x *State) Reset() {
 	*x = State{}
-	mi := &file_domain_proto_msgTypes[4]
+	mi := &file_domain_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -678,7 +760,7 @@ func (x *State) String() string {
 func (*State) ProtoMessage() {}
 
 func (x *State) ProtoReflect() protoreflect.Message {
-	mi := &file_domain_proto_msgTypes[4]
+	mi := &file_domain_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -691,7 +773,7 @@ func (x *State) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use State.ProtoReflect.Descriptor instead.
 func (*State) Descriptor() ([]byte, []int) {
-	return file_domain_proto_rawDescGZIP(), []int{4}
+	return file_domain_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *State) GetFleets() map[string]*Fleet {
@@ -743,7 +825,7 @@ const file_domain_proto_rawDesc = "" +
 	"\x06_errorB\x06\n" +
 	"\x04_tagB\b\n" +
 	"\x06_colorB\t\n" +
-	"\a_branchJ\x04\b\x0e\x10\x1f\"\xba\x03\n" +
+	"\a_branchJ\x04\b\x0e\x10\x1f\"\xfa\x03\n" +
 	"\rFleetSettings\x12*\n" +
 	"\x11claude_code_mount\x18\x01 \x01(\bR\x0fclaudeCodeMount\x12\x1f\n" +
 	"\vcodex_mount\x18\x02 \x01(\bR\n" +
@@ -756,9 +838,14 @@ const file_domain_proto_rawDesc = "" +
 	"\x10deb_cache_server\x18\b \x01(\bR\x0edebCacheServer\x12,\n" +
 	"\x12image_cache_server\x18\t \x01(\bR\x10imageCacheServer\x12!\n" +
 	"\fauggie_mount\x18\n" +
-	" \x01(\bR\vauggieMountB\v\n" +
+	" \x01(\bR\vauggieMount\x12>\n" +
+	"\x0elayout_presets\x18\v \x03(\v2\x17.fleetgrpc.LayoutPresetR\rlayoutPresetsB\v\n" +
 	"\t_home_dirB\x16\n" +
-	"\x14_prefer_fleet_launch\"\xa2\x01\n" +
+	"\x14_prefer_fleet_launch\"_\n" +
+	"\fLayoutPreset\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
+	"\x06layout\x18\x02 \x01(\tR\x06layout\x12#\n" +
+	"\rpane_commands\x18\x03 \x03(\tR\fpaneCommands\"\xa2\x01\n" +
 	"\x05Fleet\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
 	"\x06remote\x18\x02 \x01(\tR\x06remote\x124\n" +
@@ -811,34 +898,36 @@ func file_domain_proto_rawDescGZIP() []byte {
 }
 
 var file_domain_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_domain_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_domain_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_domain_proto_goTypes = []any{
 	(InstanceStatus)(0),           // 0: fleetgrpc.InstanceStatus
 	(BackendType)(0),              // 1: fleetgrpc.BackendType
 	(*Instance)(nil),              // 2: fleetgrpc.Instance
 	(*FleetSettings)(nil),         // 3: fleetgrpc.FleetSettings
-	(*Fleet)(nil),                 // 4: fleetgrpc.Fleet
-	(*GroupLayout)(nil),           // 5: fleetgrpc.GroupLayout
-	(*State)(nil),                 // 6: fleetgrpc.State
-	nil,                           // 7: fleetgrpc.State.FleetsEntry
-	nil,                           // 8: fleetgrpc.State.GroupLayoutsEntry
-	(*timestamppb.Timestamp)(nil), // 9: google.protobuf.Timestamp
+	(*LayoutPreset)(nil),          // 4: fleetgrpc.LayoutPreset
+	(*Fleet)(nil),                 // 5: fleetgrpc.Fleet
+	(*GroupLayout)(nil),           // 6: fleetgrpc.GroupLayout
+	(*State)(nil),                 // 7: fleetgrpc.State
+	nil,                           // 8: fleetgrpc.State.FleetsEntry
+	nil,                           // 9: fleetgrpc.State.GroupLayoutsEntry
+	(*timestamppb.Timestamp)(nil), // 10: google.protobuf.Timestamp
 }
 var file_domain_proto_depIdxs = []int32{
-	9, // 0: fleetgrpc.Instance.created_at:type_name -> google.protobuf.Timestamp
-	0, // 1: fleetgrpc.Instance.status:type_name -> fleetgrpc.InstanceStatus
-	1, // 2: fleetgrpc.Instance.backend:type_name -> fleetgrpc.BackendType
-	3, // 3: fleetgrpc.Fleet.settings:type_name -> fleetgrpc.FleetSettings
-	2, // 4: fleetgrpc.Fleet.instances:type_name -> fleetgrpc.Instance
-	7, // 5: fleetgrpc.State.fleets:type_name -> fleetgrpc.State.FleetsEntry
-	8, // 6: fleetgrpc.State.group_layouts:type_name -> fleetgrpc.State.GroupLayoutsEntry
-	4, // 7: fleetgrpc.State.FleetsEntry.value:type_name -> fleetgrpc.Fleet
-	5, // 8: fleetgrpc.State.GroupLayoutsEntry.value:type_name -> fleetgrpc.GroupLayout
-	9, // [9:9] is the sub-list for method output_type
-	9, // [9:9] is the sub-list for method input_type
-	9, // [9:9] is the sub-list for extension type_name
-	9, // [9:9] is the sub-list for extension extendee
-	0, // [0:9] is the sub-list for field type_name
+	10, // 0: fleetgrpc.Instance.created_at:type_name -> google.protobuf.Timestamp
+	0,  // 1: fleetgrpc.Instance.status:type_name -> fleetgrpc.InstanceStatus
+	1,  // 2: fleetgrpc.Instance.backend:type_name -> fleetgrpc.BackendType
+	4,  // 3: fleetgrpc.FleetSettings.layout_presets:type_name -> fleetgrpc.LayoutPreset
+	3,  // 4: fleetgrpc.Fleet.settings:type_name -> fleetgrpc.FleetSettings
+	2,  // 5: fleetgrpc.Fleet.instances:type_name -> fleetgrpc.Instance
+	8,  // 6: fleetgrpc.State.fleets:type_name -> fleetgrpc.State.FleetsEntry
+	9,  // 7: fleetgrpc.State.group_layouts:type_name -> fleetgrpc.State.GroupLayoutsEntry
+	5,  // 8: fleetgrpc.State.FleetsEntry.value:type_name -> fleetgrpc.Fleet
+	6,  // 9: fleetgrpc.State.GroupLayoutsEntry.value:type_name -> fleetgrpc.GroupLayout
+	10, // [10:10] is the sub-list for method output_type
+	10, // [10:10] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_domain_proto_init() }
@@ -848,14 +937,14 @@ func file_domain_proto_init() {
 	}
 	file_domain_proto_msgTypes[0].OneofWrappers = []any{}
 	file_domain_proto_msgTypes[1].OneofWrappers = []any{}
-	file_domain_proto_msgTypes[4].OneofWrappers = []any{}
+	file_domain_proto_msgTypes[5].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_domain_proto_rawDesc), len(file_domain_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   7,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/fleetgrpc/domain.proto
+++ b/fleetgrpc/domain.proto
@@ -178,6 +178,27 @@ message FleetSettings {
   // auto-install startup script. Plain bool like the other *Mount flags:
   // false == "never set" == disabled.
   bool auggie_mount = 10;
+  // layout_presets is the fleet's list of saved session-layout templates
+  // (issue #150). repeated message: an empty list (the default) means no
+  // presets. Names are unique within the list (the server normalizes and
+  // rejects duplicates, like custom_mounts).
+  repeated LayoutPreset layout_presets = 11;
+}
+
+// LayoutPreset mirrors internal/fleet.LayoutPreset — a saved pane-layout
+// template the user can apply when creating a new session (Tab in the
+// new-session dialog). It is captured FROM a live session group: layout is the
+// outer-tmux window_layout string the group save/restore mechanism already
+// persists (GroupLayout.layout; leaf 0 is the fleet TUI pane), and
+// pane_commands holds one bash command per NON-TUI pane in position order (top
+// then left — the same ordering GroupLayout.sessions uses), "" meaning a plain
+// shell. len(pane_commands) IS the pane count; an empty layout string means "no
+// captured geometry" and restores as the default stacked split, exactly like a
+// GroupLayout with no layout.
+message LayoutPreset {
+  string name = 1;
+  string layout = 2;
+  repeated string pane_commands = 3;
 }
 
 // Fleet mirrors internal/fleet.Fleet. Settings is a NESTED message (not inlined)

--- a/integration/tests/290_tui_layout_preset.sh
+++ b/integration/tests/290_tui_layout_preset.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Description: Layout presets (issue #150) — capture a preset from a live session, then create a templated session whose pane command auto-runs
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+info "spawning TUI"
+tui_spawn
+tui_wait_for "alpha" 15
+tui_wait_for "○ idle" 60
+
+info "expanding the instance session list"
+tui_send j
+sleep 0.5
+tui_send Space
+tui_wait_for "+ new session" 15
+
+# ---------------------------------------------------------------------------
+# Phase 1 — create the source session the preset will be captured from.
+# ---------------------------------------------------------------------------
+info "creating source session 'src'"
+tui_send a
+tui_wait_for "session-name (or empty for auto)" 5
+tui_send_text "src"
+sleep 0.3
+tui_send Enter
+tui_wait_for "Session created" 15
+tui_wait_for "○ src" 15
+
+# ---------------------------------------------------------------------------
+# Phase 2 — capture a preset from it in the edit-fleet Layouts section.
+# ---------------------------------------------------------------------------
+info "opening the edit-fleet dialog"
+tui_send k
+sleep 0.3
+tui_send e
+tui_wait_for "Edit fleet" 5
+tui_assert_contains "Layouts (0)" "Layouts section header missing"
+
+info "expanding Layouts and starting preset creation"
+for _ in 1 2 3 4 5 6; do tui_send j; sleep 0.1; done
+tui_send l
+tui_wait_for "+ Layout Preset" 5
+tui_send j
+sleep 0.2
+tui_send Enter
+tui_wait_for "Capture the layout of:" 5
+tui_assert_contains "alpha / src" "source session candidate missing"
+
+info "capturing the session and assigning the pane command"
+tui_send Enter
+# The gating text wraps inside the 50-col dialog box — match a one-line prefix.
+tui_wait_for "Assign startup commands" 5
+tui_send Enter
+tui_wait_for "Pane 1 command:" 5
+tui_send_text "echo preset-pane-ready"
+sleep 0.3
+tui_send Enter
+tui_wait_for "[ create ]" 5
+
+info "creating the preset"
+tui_send Enter
+tui_wait_for "Layouts (1)" 10
+tui_assert_contains "src (1 pane)" "saved preset row missing"
+
+info "preset persisted to fleet settings"
+assert_file_exists "${HOME}/.fleet/state.json"
+state=$(cat "${HOME}/.fleet/state.json")
+assert_contains "${state}" '"layoutPresets"' "state.json missing layoutPresets"
+assert_contains "${state}" 'preset-pane-ready' "state.json missing the pane command"
+
+info "closing the edit-fleet dialog"
+tui_send Escape
+sleep 0.5
+
+# ---------------------------------------------------------------------------
+# Phase 3 — create a new session from the template via Tab cycling.
+# ---------------------------------------------------------------------------
+info "opening the New session dialog on the instance"
+tui_send j
+sleep 0.3
+tui_send a
+tui_wait_for "Template:" 5
+tui_assert_contains "(none)" "template should default to none"
+
+info "Tab-selecting the preset and naming the session"
+tui_send Tab
+tui_wait_for "src (1 pane)" 5
+tui_send_text "fromtpl"
+sleep 0.3
+tui_send Enter
+tui_wait_for "Session fromtpl created (1 pane)" 20
+tui_wait_for "○ fromtpl" 15
+
+info "templated session records a group layout in state.json"
+deadline=$(( $(date +%s) + 10 ))
+ok=""
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  if grep -q '"fromtpl"' "${HOME}/.fleet/state.json" 2>/dev/null; then
+    ok=1
+    break
+  fi
+  sleep 0.5
+done
+[ -n "${ok}" ] || fail "state.json never recorded the fromtpl group layout"
+
+# ---------------------------------------------------------------------------
+# Phase 4 — the preset's startup command actually ran in the new pane.
+# ---------------------------------------------------------------------------
+info "verifying the startup command ran inside the inner session"
+deadline=$(( $(date +%s) + 20 ))
+ok=""
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- tmux capture-pane -p -t '=alpha~fromtpl:' 2>/dev/null || true)
+  if printf '%s' "${out}" | grep -q "preset-pane-ready"; then
+    ok=1
+    break
+  fi
+  sleep 1
+done
+if [ -z "${ok}" ]; then
+  printf -- '--- inner pane capture ---\n%s\n--- end ---\n' "${out:-}" >&2
+  fail "preset startup command output not found in the templated session"
+fi
+
+pass "TUI layout preset capture + templated session creation"

--- a/integration/tests/290_tui_layout_preset.sh
+++ b/integration/tests/290_tui_layout_preset.sh
@@ -54,16 +54,19 @@ tui_assert_contains "alpha / src" "source session candidate missing"
 
 info "capturing the session and assigning the pane command"
 tui_send Enter
-# The gating text wraps inside the 50-col dialog box — match a one-line prefix.
-tui_wait_for "Assign startup commands" 5
+# Edit stage: focus starts on pane 1; [ save ] is always offered (no gating).
+tui_wait_for "pane 1:" 5
+tui_assert_contains "[ save ]" "save button should always be shown"
 tui_send Enter
 tui_wait_for "Pane 1 command:" 5
 tui_send_text "echo preset-pane-ready"
 sleep 0.3
 tui_send Enter
-tui_wait_for "[ create ]" 5
+# Single pane: setting its command advances focus to [ save ].
+tui_wait_for "[ save ]" 5
+sleep 0.3
 
-info "creating the preset"
+info "saving the preset"
 tui_send Enter
 tui_wait_for "Layouts (1)" 10
 tui_assert_contains "src (1 pane)" "saved preset row missing"

--- a/integration/tests/290_tui_layout_preset.sh
+++ b/integration/tests/290_tui_layout_preset.sh
@@ -89,11 +89,11 @@ tui_send j
 sleep 0.3
 tui_send a
 tui_wait_for "Template:" 5
-tui_assert_contains "(none)" "template should default to none"
+tui_assert_contains "[ none ]" "template should default to the bracketed [ none ] cycle option"
 
 info "Tab-selecting the preset and naming the session"
 tui_send Tab
-tui_wait_for "src (1 pane)" 5
+tui_wait_for "[ src ]" 5
 tui_send_text "fromtpl"
 sleep 0.3
 tui_send Enter

--- a/integration/tests/291_tui_layout_preset_restart.sh
+++ b/integration/tests/291_tui_layout_preset_restart.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Description: Layout presets survive a full fleetd restart (issue #150 persistence) — create a preset, kill the daemon + TUI, relaunch, and confirm the preset is still there.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+info "spawning TUI"
+tui_spawn
+tui_wait_for "alpha" 15
+tui_wait_for "○ idle" 60
+
+info "expanding the instance session list"
+tui_send j
+sleep 0.5
+tui_send Space
+tui_wait_for "+ new session" 15
+
+info "creating source session 'src'"
+tui_send a
+tui_wait_for "session-name (or empty for auto)" 5
+tui_send_text "src"
+sleep 0.3
+tui_send Enter
+tui_wait_for "Session created" 15
+tui_wait_for "○ src" 15
+
+info "opening the edit-fleet dialog and capturing a preset"
+tui_send k
+sleep 0.3
+tui_send e
+tui_wait_for "Edit fleet" 5
+for _ in 1 2 3 4 5 6; do tui_send j; sleep 0.1; done
+tui_send l
+tui_wait_for "+ Layout Preset" 5
+tui_send j
+sleep 0.2
+tui_send Enter
+tui_wait_for "Capture the layout of:" 5
+tui_send Enter
+tui_wait_for "pane 1:" 5
+tui_send Enter
+tui_wait_for "Pane 1 command:" 5
+tui_send_text "echo persisted-across-restart"
+sleep 0.3
+tui_send Enter
+tui_wait_for "[ save ]" 5
+sleep 0.3
+tui_send Enter
+tui_wait_for "Layouts (1)" 10
+
+info "preset is in state.json before restart"
+assert_file_exists "${HOME}/.fleet/state.json"
+assert_contains "$(cat "${HOME}/.fleet/state.json")" 'persisted-across-restart' \
+  "state.json missing the preset command before restart"
+
+# ---------------------------------------------------------------------------
+# Fully close fleet: kill the TUI AND the fleetd daemon (the user's scenario).
+# Reopening then auto-spawns a FRESH daemon that must load the preset back from
+# state.json and serve it to the reconnecting TUI.
+# ---------------------------------------------------------------------------
+info "killing the TUI and the fleetd daemon"
+tui_kill
+pkill -f "${FLEET_BIN} server" 2>/dev/null || true
+# Wait for the daemon socket to disappear so the relaunch truly respawns a
+# fresh process. If it never goes away the kill was a no-op and this test would
+# silently degrade into "reconnect to the same daemon" — fail loudly instead,
+# so a green result always means a real cold reload from state.json.
+deadline=$(( $(date +%s) + 15 ))
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  [ -S "${HOME}/.fleet/fleet.sock" ] || break
+  sleep 0.25
+done
+if [ -S "${HOME}/.fleet/fleet.sock" ]; then
+  fail "fleetd socket still present — daemon was not killed, restart not exercised"
+fi
+info "daemon is down (socket gone); the relaunch will spawn a fresh one"
+
+info "relaunching the TUI (respawns a fresh daemon from state.json)"
+tui_spawn
+tui_wait_for "alpha" 30
+tui_wait_for "○ idle" 60
+
+info "opening edit-fleet again — the preset must still be there"
+tui_send e
+tui_wait_for "Edit fleet" 5
+tui_assert_contains "Layouts (1)" "preset count lost after restart — the layout preset did not persist"
+
+info "expanding Layouts to confirm the preset row survived"
+for _ in 1 2 3 4 5 6; do tui_send j; sleep 0.1; done
+tui_send l
+sleep 0.5
+tui_assert_contains "src (1 pane)" "preset row missing after restart"
+
+pass "layout preset survived a full fleetd restart"

--- a/internal/fleet/fleet_settings.go
+++ b/internal/fleet/fleet_settings.go
@@ -106,6 +106,14 @@ type FleetSettings struct {
 	// back to "/home/vscode" if it stays empty at provisioning time.
 	HomeDir string `json:"homeDir,omitempty"`
 
+	// LayoutPresets is the fleet's list of saved session-layout templates
+	// (issue #150). Each preset pairs a captured outer-tmux pane layout with
+	// per-pane startup commands; the new-session dialog Tab-cycles them and
+	// applies the selection at creation time. Entries are validated/normalized
+	// (see NormalizeLayoutPresets) before persisting. Empty (the default)
+	// means no presets.
+	LayoutPresets []LayoutPreset `json:"layoutPresets,omitempty"`
+
 	// PreferFleetLaunch controls which page the built-in browser opens to
 	// when a workspace's devcontainer.json configures BOTH a
 	// customizations.fleet.browser.initialUrl AND a fleetLaunch block.

--- a/internal/fleet/layout_preset.go
+++ b/internal/fleet/layout_preset.go
@@ -1,0 +1,85 @@
+package fleet
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Layout presets (issue #150) are saved pane-layout templates a user can apply
+// when creating a new session. A preset is captured FROM a live session group:
+// Layout is the outer-tmux window_layout string the group save/restore
+// mechanism already persists (state.GroupLayout.Layout — leaf 0 is the fleet
+// TUI pane), and PaneCommands holds one bash command per non-TUI pane in
+// position order (top then left, the same ordering GroupLayout.Sessions uses).
+// As with custom mounts, the TUI validates for immediate UX feedback and the
+// server validates authoritatively in SetFleetSettings, both through the one
+// definition below.
+
+// maxLayoutPresetPanes bounds a preset's pane count. The outer tmux window
+// cannot usefully hold more panes than this, and the bound keeps a corrupt or
+// hostile settings write from minting an absurd number of sessions on apply.
+const maxLayoutPresetPanes = 32
+
+// LayoutPreset is one saved session-layout template.
+type LayoutPreset struct {
+	// Name is the user-chosen label shown when Tab-cycling templates in the
+	// new-session dialog. Unique within a fleet's preset list.
+	Name string `json:"name"`
+
+	// Layout is the captured outer-tmux window_layout string ("" when the
+	// source group had no captured geometry; applying such a preset falls back
+	// to the default stacked split, exactly like a GroupLayout with no layout).
+	Layout string `json:"layout,omitempty"`
+
+	// PaneCommands holds the startup command for each non-TUI pane in position
+	// order (top then left). "" means the pane opens a plain shell. The slice
+	// length IS the preset's pane count.
+	PaneCommands []string `json:"paneCommands"`
+}
+
+// PaneCount returns the number of session panes the preset creates.
+func (p LayoutPreset) PaneCount() int { return len(p.PaneCommands) }
+
+// NormalizeLayoutPreset validates a single preset and returns its canonical
+// form: the name is whitespace-trimmed and must be non-empty, and the preset
+// must have between 1 and maxLayoutPresetPanes pane commands (a preset with no
+// panes would create nothing). Commands themselves are arbitrary bash run
+// inside the user's own instance, so they are deliberately not inspected.
+func NormalizeLayoutPreset(p LayoutPreset) (LayoutPreset, error) {
+	p.Name = strings.TrimSpace(p.Name)
+	if p.Name == "" {
+		return LayoutPreset{}, fmt.Errorf("layout preset name is empty")
+	}
+	if len(p.PaneCommands) == 0 {
+		return LayoutPreset{}, fmt.Errorf("layout preset %q has no panes", p.Name)
+	}
+	if len(p.PaneCommands) > maxLayoutPresetPanes {
+		return LayoutPreset{}, fmt.Errorf("layout preset %q has %d panes (max %d)", p.Name, len(p.PaneCommands), maxLayoutPresetPanes)
+	}
+	return p, nil
+}
+
+// NormalizeLayoutPresets validates every entry and returns the normalized list
+// (input order preserved). An empty or nil input yields a nil slice and no
+// error. A duplicate name — after trimming — is an error rather than a silent
+// dedup: unlike custom mounts, two presets with one name are not redundant
+// no-ops, they are ambiguous, so the whole update is rejected.
+func NormalizeLayoutPresets(in []LayoutPreset) ([]LayoutPreset, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	out := make([]LayoutPreset, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, raw := range in {
+		norm, err := NormalizeLayoutPreset(raw)
+		if err != nil {
+			return nil, err
+		}
+		if _, dup := seen[norm.Name]; dup {
+			return nil, fmt.Errorf("duplicate layout preset name %q", norm.Name)
+		}
+		seen[norm.Name] = struct{}{}
+		out = append(out, norm)
+	}
+	return out, nil
+}

--- a/internal/fleet/layout_preset_test.go
+++ b/internal/fleet/layout_preset_test.go
@@ -1,0 +1,75 @@
+package fleet
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeLayoutPresetTrimsName(t *testing.T) {
+	p, err := NormalizeLayoutPreset(LayoutPreset{Name: "  dev  ", PaneCommands: []string{"npm run dev"}})
+	if err != nil {
+		t.Fatalf("NormalizeLayoutPreset: %v", err)
+	}
+	if p.Name != "dev" {
+		t.Fatalf("name not trimmed: %q", p.Name)
+	}
+}
+
+func TestNormalizeLayoutPresetRejectsEmptyName(t *testing.T) {
+	if _, err := NormalizeLayoutPreset(LayoutPreset{Name: "   ", PaneCommands: []string{""}}); err == nil {
+		t.Fatal("want error for empty name")
+	}
+}
+
+func TestNormalizeLayoutPresetRejectsNoPanes(t *testing.T) {
+	if _, err := NormalizeLayoutPreset(LayoutPreset{Name: "dev"}); err == nil {
+		t.Fatal("want error for zero panes")
+	}
+}
+
+func TestNormalizeLayoutPresetRejectsTooManyPanes(t *testing.T) {
+	if _, err := NormalizeLayoutPreset(LayoutPreset{Name: "dev", PaneCommands: make([]string, maxLayoutPresetPanes+1)}); err == nil {
+		t.Fatal("want error for too many panes")
+	}
+}
+
+func TestNormalizeLayoutPresetAllowsEmptyCommands(t *testing.T) {
+	// "" per pane means a plain shell — explicitly legal.
+	p, err := NormalizeLayoutPreset(LayoutPreset{Name: "dev", PaneCommands: []string{"", ""}})
+	if err != nil {
+		t.Fatalf("NormalizeLayoutPreset: %v", err)
+	}
+	if p.PaneCount() != 2 {
+		t.Fatalf("pane count = %d, want 2", p.PaneCount())
+	}
+}
+
+func TestNormalizeLayoutPresetsEmptyInputIsNil(t *testing.T) {
+	out, err := NormalizeLayoutPresets(nil)
+	if err != nil || out != nil {
+		t.Fatalf("want (nil, nil), got (%v, %v)", out, err)
+	}
+}
+
+func TestNormalizeLayoutPresetsRejectsDuplicateNames(t *testing.T) {
+	_, err := NormalizeLayoutPresets([]LayoutPreset{
+		{Name: "dev", PaneCommands: []string{""}},
+		{Name: " dev ", PaneCommands: []string{""}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("want duplicate-name error, got %v", err)
+	}
+}
+
+func TestNormalizeLayoutPresetsPreservesOrder(t *testing.T) {
+	out, err := NormalizeLayoutPresets([]LayoutPreset{
+		{Name: "b", PaneCommands: []string{"x"}},
+		{Name: "a", PaneCommands: []string{"y", "z"}},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeLayoutPresets: %v", err)
+	}
+	if len(out) != 2 || out[0].Name != "b" || out[1].Name != "a" {
+		t.Fatalf("order not preserved: %v", out)
+	}
+}

--- a/internal/server/convert.go
+++ b/internal/server/convert.go
@@ -57,6 +57,7 @@ func fleetSettingsToProto(s fleet.FleetSettings) *fleetgrpc.FleetSettings {
 		CustomMounts:     s.CustomMounts,
 		DebCacheServer:   s.DebCacheServer,
 		ImageCacheServer: s.ImageCacheServer,
+		LayoutPresets:    layoutPresetsToProto(s.LayoutPresets),
 	}
 	if s.HomeDir != "" {
 		ps.HomeDir = strptr(s.HomeDir)
@@ -65,6 +66,21 @@ func fleetSettingsToProto(s fleet.FleetSettings) *fleetgrpc.FleetSettings {
 		ps.PreferFleetLaunch = boolptr(*s.PreferFleetLaunch)
 	}
 	return ps
+}
+
+func layoutPresetsToProto(in []fleet.LayoutPreset) []*fleetgrpc.LayoutPreset {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*fleetgrpc.LayoutPreset, 0, len(in))
+	for _, p := range in {
+		out = append(out, &fleetgrpc.LayoutPreset{
+			Name:         p.Name,
+			Layout:       p.Layout,
+			PaneCommands: p.PaneCommands,
+		})
+	}
+	return out
 }
 
 func instanceToProto(i *fleet.Instance) *fleetgrpc.Instance {

--- a/internal/server/mutations.go
+++ b/internal/server/mutations.go
@@ -130,6 +130,13 @@ func (s *service) SetFleetSettings(_ context.Context, req *fleetgrpc.SetFleetSet
 		return nil, status.Errorf(codes.InvalidArgument, "invalid custom mount: %v", err)
 	}
 	settings.CustomMounts = normalizedMounts
+	// Same trust boundary for layout presets: reject empty/duplicate names and
+	// pane-less presets here so a malformed list never reaches state.json.
+	normalizedPresets, err := fleet.NormalizeLayoutPresets(settings.LayoutPresets)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid layout preset: %v", err)
+	}
+	settings.LayoutPresets = normalizedPresets
 
 	snapshot, err := s.mutate(func(st *state.State) error {
 		f, ok := st.Fleets[req.GetFleet()]
@@ -261,10 +268,28 @@ func protoFleetSettingsToLegacy(ps *fleetgrpc.FleetSettings) fleet.FleetSettings
 	s.CustomMounts = ps.GetCustomMounts()
 	s.DebCacheServer = ps.GetDebCacheServer()
 	s.ImageCacheServer = ps.GetImageCacheServer()
+	s.LayoutPresets = protoLayoutPresetsToLegacy(ps.GetLayoutPresets())
 	s.HomeDir = ps.GetHomeDir()
 	if ps.PreferFleetLaunch != nil {
 		v := ps.GetPreferFleetLaunch()
 		s.PreferFleetLaunch = &v
 	}
 	return s
+}
+
+// protoLayoutPresetsToLegacy maps the repeated proto LayoutPreset back to the
+// legacy slice (nil for an empty list, matching the `,omitempty` JSON tag).
+func protoLayoutPresetsToLegacy(in []*fleetgrpc.LayoutPreset) []fleet.LayoutPreset {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]fleet.LayoutPreset, 0, len(in))
+	for _, p := range in {
+		out = append(out, fleet.LayoutPreset{
+			Name:         p.GetName(),
+			Layout:       p.GetLayout(),
+			PaneCommands: p.GetPaneCommands(),
+		})
+	}
+	return out
 }

--- a/internal/server/mutations_test.go
+++ b/internal/server/mutations_test.go
@@ -185,6 +185,71 @@ func TestSetFleetSettingsCustomMounts(t *testing.T) {
 	}
 }
 
+// TestSetFleetSettingsLayoutPresets verifies layout presets round-trip through
+// the RPC + state.json (name, layout string, per-pane commands — including the
+// empty "plain shell" command) and that the server rejects invalid lists with
+// InvalidArgument, like custom mounts.
+func TestSetFleetSettingsLayoutPresets(t *testing.T) {
+	isolateFleetDir(t)
+	svc := newService()
+	ctx := context.Background()
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{"alpha": {Name: "alpha"}}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	layout := "a0c2,208x58,0,0{104x58,0,0,0,103x58,105,0[103x29,105,0,1,103x28,105,30,2]}"
+	reply, err := svc.SetFleetSettings(ctx, &fleetgrpc.SetFleetSettingsRequest{
+		Fleet: "alpha",
+		Settings: &fleetgrpc.FleetSettings{
+			LayoutPresets: []*fleetgrpc.LayoutPreset{
+				{Name: " app-run ", Layout: layout, PaneCommands: []string{"npm run dev", ""}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SetFleetSettings: %v", err)
+	}
+	got := reply.GetState().GetFleets()["alpha"].GetSettings().GetLayoutPresets()
+	if len(got) != 1 || got[0].GetName() != "app-run" || got[0].GetLayout() != layout {
+		t.Fatalf("presets in reply = %v", got)
+	}
+	if cmds := got[0].GetPaneCommands(); len(cmds) != 2 || cmds[0] != "npm run dev" || cmds[1] != "" {
+		t.Fatalf("pane commands = %v", got[0].GetPaneCommands())
+	}
+
+	// Persisted through the legacy state.json mapper.
+	st, _ := state.Load()
+	presets := st.Fleets["alpha"].Settings.LayoutPresets
+	if len(presets) != 1 || presets[0].Name != "app-run" || presets[0].Layout != layout || len(presets[0].PaneCommands) != 2 {
+		t.Fatalf("persisted presets = %+v", presets)
+	}
+
+	// Duplicate names are rejected before persisting.
+	if _, err := svc.SetFleetSettings(ctx, &fleetgrpc.SetFleetSettingsRequest{
+		Fleet: "alpha",
+		Settings: &fleetgrpc.FleetSettings{LayoutPresets: []*fleetgrpc.LayoutPreset{
+			{Name: "x", PaneCommands: []string{""}},
+			{Name: "x", PaneCommands: []string{""}},
+		}},
+	}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("want InvalidArgument for duplicate preset names, got %v", err)
+	}
+
+	// A pane-less preset is rejected.
+	if _, err := svc.SetFleetSettings(ctx, &fleetgrpc.SetFleetSettingsRequest{
+		Fleet:    "alpha",
+		Settings: &fleetgrpc.FleetSettings{LayoutPresets: []*fleetgrpc.LayoutPreset{{Name: "x"}}},
+	}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("want InvalidArgument for pane-less preset, got %v", err)
+	}
+
+	// The rejected updates left the valid preset intact.
+	st, _ = state.Load()
+	if presets := st.Fleets["alpha"].Settings.LayoutPresets; len(presets) != 1 || presets[0].Name != "app-run" {
+		t.Fatalf("persisted presets after rejects = %+v", presets)
+	}
+}
+
 func TestSetInstanceMetadataUpdatesOnlyProvidedFields(t *testing.T) {
 	isolateFleetDir(t)
 	svc := newService()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -109,6 +109,14 @@ type model struct {
 	// across instances that share a session or group name.
 	sessionStore *SessionStore
 
+	// recentGroupLayouts stamps group-layout keys recorded ahead of session
+	// discovery (a group minted from a layout preset records its layout the
+	// moment the sessions are created, up to ~1s before the server's session
+	// poll sees them). pruneSavedGroupsForInstance skips keys younger than
+	// the grace window so a runtime push from that gap cannot delete the
+	// just-recorded layout as "not live".
+	recentGroupLayouts map[string]time.Time
+
 	// Split pane mode: when fleet runs inside a host tmux session,
 	// pressing enter opens the instance shell in a right-side pane
 	// instead of suspending the TUI.
@@ -165,18 +173,19 @@ func newModel() model {
 	agentSpinnerModel.Style = agentWorkingStyle
 
 	m := model{
-		creating:      make(map[string]bool),
-		runtime:       make(map[string]*fleetgrpc.InstanceRuntime),
-		portForwards:  portforward.NewManager(),
-		activeBrowser: make(map[string]string),
-		sessionStore:  NewSessionStore(),
-		spinner:       spinnerModel,
-		agentSpinner:  agentSpinnerModel,
-		inHostTmux:    os.Getenv("TMUX") != "",
-		armadaStatus:  make(map[string]armadaStatus),
-		bootGateway:   os.Getenv("FLEET_GATEWAY"),
-		bootToken:     os.Getenv("FLEET_TOKEN"),
-		bootServer:    os.Getenv("FLEET_SERVER"),
+		creating:           make(map[string]bool),
+		runtime:            make(map[string]*fleetgrpc.InstanceRuntime),
+		portForwards:       portforward.NewManager(),
+		activeBrowser:      make(map[string]string),
+		sessionStore:       NewSessionStore(),
+		recentGroupLayouts: make(map[string]time.Time),
+		spinner:            spinnerModel,
+		agentSpinner:       agentSpinnerModel,
+		inHostTmux:         os.Getenv("TMUX") != "",
+		armadaStatus:       make(map[string]armadaStatus),
+		bootGateway:        os.Getenv("FLEET_GATEWAY"),
+		bootToken:          os.Getenv("FLEET_TOKEN"),
+		bootServer:         os.Getenv("FLEET_SERVER"),
 	}
 
 	// Create the fleet page (persistent — background handlers reference it)
@@ -317,12 +326,58 @@ func (m *model) pruneSavedGroupsForInstance(ref InstanceRef) {
 		if savedLayout.InstanceName != ref.Instance {
 			continue
 		}
+		// A layout recorded moments ago (preset-backed creation) may predate
+		// the discovery snapshot that is about to judge it; give the server's
+		// session poll time to catch up before treating it as dead.
+		if recordedAt, ok := m.recentGroupLayouts[key]; ok {
+			if time.Since(recordedAt) < groupLayoutPruneGrace {
+				continue
+			}
+			delete(m.recentGroupLayouts, key)
+		}
 		if !live[savedLayout.GroupID] {
 			delete(m.fleetPage.savedGroups, key)
 			delete(m.st.GroupLayouts, key)
 			_ = deleteGroupLayoutRemote(savedLayout.InstanceName, savedLayout.GroupID)
 		}
 	}
+}
+
+// groupLayoutPruneGrace is how long a freshly recorded group layout is immune
+// from pruning while the server's ~1s session poll catches up to sessions the
+// TUI just created.
+const groupLayoutPruneGrace = 15 * time.Second
+
+// recordPresetGroupLayout persists the saved-group snapshot for a group just
+// minted from a layout preset — the same bookkeeping saveCurrentGroupLayout
+// does for a live split — so opening the new session restores the preset's
+// pane geometry and session-to-pane mapping.
+func (m *model) recordPresetGroupLayout(msg presetSessionsCreatedMsg) {
+	key := computeGroupKey(msg.ref.Instance, msg.groupID)
+	m.fleetPage.savedGroups[key] = savedGroup{
+		GroupID:      msg.groupID,
+		InstanceName: msg.ref.Instance,
+		Sessions:     msg.sessions,
+		Layout:       msg.layout,
+		PaneCount:    len(msg.sessions),
+	}
+	m.recentGroupLayouts[key] = time.Now()
+
+	if m.st == nil {
+		return
+	}
+	if m.st.GroupLayouts == nil {
+		m.st.GroupLayouts = make(map[string]configutil.GroupLayout)
+	}
+	layout := configutil.GroupLayout{
+		GroupID:      msg.groupID,
+		InstanceName: msg.ref.Instance,
+		Sessions:     msg.sessions,
+		Layout:       msg.layout,
+		PaneCount:    len(msg.sessions),
+	}
+	m.st.GroupLayouts[key] = layout
+	_ = setGroupLayoutRemote(layout)
 }
 
 // migrateRenamedSession rewrites the in-memory references that pointed at a
@@ -960,6 +1015,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// The new session appears on the next ~1s runtime tick; nudge from the
 		// current runtime cache so the list reflects what's already known.
+		m.refreshSessionsFromRuntime(msg.ref)
+
+	case presetSessionsCreatedMsg:
+		if msg.err != nil {
+			m.message = fmt.Sprintf("Failed to create session: %v", msg.err)
+		} else {
+			m.message = fmt.Sprintf("Session %s created (%s)", msg.groupID, paneCountLabel(len(msg.sessions)))
+			m.recordPresetGroupLayout(msg)
+		}
 		m.refreshSessionsFromRuntime(msg.ref)
 
 	case sessionRenamedMsg:

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -394,6 +394,7 @@ func fleetSettingsToProto(s fleet.FleetSettings) *fleetgrpc.FleetSettings {
 		CustomMounts:     s.CustomMounts,
 		DebCacheServer:   s.DebCacheServer,
 		ImageCacheServer: s.ImageCacheServer,
+		LayoutPresets:    layoutPresetsToProto(s.LayoutPresets),
 	}
 	if s.HomeDir != "" {
 		ps.HomeDir = &s.HomeDir
@@ -403,6 +404,36 @@ func fleetSettingsToProto(s fleet.FleetSettings) *fleetgrpc.FleetSettings {
 		ps.PreferFleetLaunch = &v
 	}
 	return ps
+}
+
+func layoutPresetsToProto(in []fleet.LayoutPreset) []*fleetgrpc.LayoutPreset {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*fleetgrpc.LayoutPreset, 0, len(in))
+	for _, p := range in {
+		out = append(out, &fleetgrpc.LayoutPreset{
+			Name:         p.Name,
+			Layout:       p.Layout,
+			PaneCommands: p.PaneCommands,
+		})
+	}
+	return out
+}
+
+func protoLayoutPresetsToLegacy(in []*fleetgrpc.LayoutPreset) []fleet.LayoutPreset {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]fleet.LayoutPreset, 0, len(in))
+	for _, p := range in {
+		out = append(out, fleet.LayoutPreset{
+			Name:         p.GetName(),
+			Layout:       p.GetLayout(),
+			PaneCommands: p.GetPaneCommands(),
+		})
+	}
+	return out
 }
 
 func configToProto(c *configutil.Config) *fleetgrpc.Config {
@@ -579,6 +610,7 @@ func protoFleetToLegacy(pf *fleetgrpc.Fleet) *fleet.Fleet {
 			CustomMounts:     ps.GetCustomMounts(),
 			DebCacheServer:   ps.GetDebCacheServer(),
 			ImageCacheServer: ps.GetImageCacheServer(),
+			LayoutPresets:    protoLayoutPresetsToLegacy(ps.GetLayoutPresets()),
 			HomeDir:          ps.GetHomeDir(),
 		}
 		if ps.PreferFleetLaunch != nil {

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -1288,6 +1288,7 @@ func (fleetPage *fleetPage) moveEditFleetRow(delta int) {
 	fleetPage.dialogCacheButtonFocused = false
 	fleetPage.dialogDeleteCacheConfirm = false
 	fleetPage.dialogMountRemoveConfirm = false
+	fleetPage.dialogPresetRemoveFocused = false
 	fleetPage.dialogPresetRemoveConfirm = false
 	fleetPage.syncEditFleetFocus()
 }
@@ -1389,6 +1390,7 @@ func (fleetPage *fleetPage) openEditFleetDialog(m *model) tea.Cmd {
 	fleetPage.customMountInput.Blur()
 	fleetPage.dialogLayoutsExpanded = false
 	fleetPage.dialogLayoutPresets = slices.Clone(f.Settings.LayoutPresets)
+	fleetPage.dialogPresetRemoveFocused = false
 	fleetPage.dialogPresetRemoveConfirm = false
 	fleetPage.lpFlow = nil
 
@@ -1767,9 +1769,11 @@ func (fleetPage *fleetPage) updateCustomMountRow(m *model, keyMsg tea.KeyMsg) te
 }
 
 // updateLayoutPresetRow handles a key press while the cursor is on one of the
-// dynamic layout-preset child rows: an existing preset (enter opens the
-// preview/command editor, x/d removes it behind a two-step confirm) or the
-// "+ Layout Preset" row (enter starts the capture flow).
+// dynamic layout-preset child rows. An existing preset row works exactly like a
+// Caching cache row: the row's primary action (Enter) opens the editor, and the
+// [remove] button is a horizontal sub-cursor reached with →/l — Enter there
+// arms a "[remove?]" confirm, a second Enter performs the removal, and ←/h
+// returns to the row. The "+ Layout Preset" row just starts the capture flow.
 func (fleetPage *fleetPage) updateLayoutPresetRow(m *model, keyMsg tea.KeyMsg) tea.Cmd {
 	idx := fleetPage.dialogRow - editFleetRowLayoutPresetBase
 	if idx == len(fleetPage.dialogLayoutPresets) {
@@ -1781,19 +1785,25 @@ func (fleetPage *fleetPage) updateLayoutPresetRow(m *model, keyMsg tea.KeyMsg) t
 		return nil
 	}
 	switch keyMsg.String() {
-	case "enter", "e":
+	case "right", "l":
+		fleetPage.dialogPresetRemoveFocused = true
+		return nil
+	case "left", "h":
+		fleetPage.dialogPresetRemoveFocused = false
 		fleetPage.dialogPresetRemoveConfirm = false
+		return nil
+	case "enter", " ":
+		if fleetPage.dialogPresetRemoveFocused {
+			if !fleetPage.dialogPresetRemoveConfirm {
+				fleetPage.dialogPresetRemoveConfirm = true // first Enter: arm confirm
+				return nil
+			}
+			fleetPage.dialogPresetRemoveConfirm = false // second Enter: remove
+			return fleetPage.removeLayoutPreset(m, idx)
+		}
+		// Row focused (not the remove button) → open the editor.
 		fleetPage.openLayoutPresetEdit(idx)
 		return nil
-	case "x", "d":
-		// Two-step confirm, mirroring the custom-mount [remove?] flow. Esc
-		// disarms via the dialog's top-level esc handler; row moves clear it.
-		if !fleetPage.dialogPresetRemoveConfirm {
-			fleetPage.dialogPresetRemoveConfirm = true
-			return nil
-		}
-		fleetPage.dialogPresetRemoveConfirm = false
-		return fleetPage.removeLayoutPreset(m, idx)
 	}
 	return nil
 }

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -2309,8 +2309,20 @@ func (fleetPage *fleetPage) updateCreateSession(m *model, msg tea.Msg) tea.Cmd {
 func (fleetPage *fleetPage) saveCreateSession(m *model) tea.Cmd {
 	name := strings.TrimSpace(fleetPage.textInput.Value())
 	ref := InstanceRef{Fleet: fleetPage.dialogFleet, Instance: fleetPage.dialogInst}
+
+	// Resolve the Tab-selected template (if any) up front so an empty name can
+	// default to the template's name rather than the generic "session-N".
+	var preset *fleet.LayoutPreset
+	if fleetPage.dialogPresetIdx >= 0 && fleetPage.dialogPresetIdx < len(fleetPage.dialogPresets) {
+		preset = &fleetPage.dialogPresets[fleetPage.dialogPresetIdx]
+	}
+
 	if name == "" {
-		name = nextSessionName(m.sessionStore.Sessions(ref))
+		if preset != nil {
+			name = preset.Name // default to the template's name
+		} else {
+			name = nextSessionName(m.sessionStore.Sessions(ref))
+		}
 	}
 	name = SanitizeSessionName(name)
 
@@ -2331,9 +2343,8 @@ func (fleetPage *fleetPage) saveCreateSession(m *model) tea.Cmd {
 	fullName := GroupSessionName(sanitized, name)
 
 	// A template was Tab-selected: mint the whole group — one session per
-	// pane, the user's name as the group ID — and run each pane's command.
-	if fleetPage.dialogPresetIdx >= 0 && fleetPage.dialogPresetIdx < len(fleetPage.dialogPresets) {
-		preset := fleetPage.dialogPresets[fleetPage.dialogPresetIdx]
+	// pane, the resolved name as the group ID — and run each pane's command.
+	if preset != nil {
 		sessions := make([]string, 0, preset.PaneCount())
 		sessions = append(sessions, fullName)
 		for i := 1; i < preset.PaneCount(); i++ {
@@ -2342,7 +2353,7 @@ func (fleetPage *fleetPage) saveCreateSession(m *model) tea.Cmd {
 		fleetPage.mode = viewNormal
 		fleetPage.blurDialogFields()
 		m.message = fmt.Sprintf("Creating session %s from %s...", name, preset.Name)
-		return createSessionGroupFromPresetCmd(ref, name, sessions, preset)
+		return createSessionGroupFromPresetCmd(ref, name, sessions, *preset)
 	}
 
 	fleetPage.mode = viewNormal

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -1135,6 +1135,7 @@ const (
 	editFleetRowAuggie
 	editFleetRowHomeDir
 	editFleetRowPreferFleetLaunch
+	editFleetRowLayouts      // collapsible section header (issue #150)
 	editFleetRowCustomMounts // collapsible section header
 	editFleetRowCaching      // collapsible section header
 	editFleetRowBuildkit     // child of Caching; only navigable when expanded
@@ -1149,14 +1150,31 @@ const (
 // at base+len(customMounts) is the "+ Add mount" affordance.
 const editFleetRowCustomMountBase = 1000
 
+// editFleetRowLayoutPresetBase is the start of the dynamic layout-preset child
+// rows, a second dynamic band above the custom-mount one. Row base+i is the
+// i-th existing preset; the row at base+len(presets) is "+ Layout Preset".
+const editFleetRowLayoutPresetBase = 2000
+
 // isCustomMountChildRow reports whether row is one of the dynamic custom-mount
 // child rows (an existing mount or the "+ Add mount" row).
-func isCustomMountChildRow(row int) bool { return row >= editFleetRowCustomMountBase }
+func isCustomMountChildRow(row int) bool {
+	return row >= editFleetRowCustomMountBase && row < editFleetRowLayoutPresetBase
+}
+
+// isLayoutPresetChildRow reports whether row is one of the dynamic
+// layout-preset child rows (an existing preset or the "+ Layout Preset" row).
+func isLayoutPresetChildRow(row int) bool { return row >= editFleetRowLayoutPresetBase }
 
 // customMountAddRow returns the row id of the "+ Add mount" affordance, which
 // always sits just past the last existing custom mount.
 func (fleetPage *fleetPage) customMountAddRow() int {
 	return editFleetRowCustomMountBase + len(fleetPage.dialogCustomMounts)
+}
+
+// layoutPresetAddRow returns the row id of the "+ Layout Preset" affordance,
+// which always sits just past the last existing preset.
+func (fleetPage *fleetPage) layoutPresetAddRow() int {
+	return editFleetRowLayoutPresetBase + len(fleetPage.dialogLayoutPresets)
 }
 
 // cacheKind identifies one of the three caches that share the Caching section's
@@ -1227,8 +1245,15 @@ func (fleetPage *fleetPage) visibleEditFleetRows() []int {
 		editFleetRowAuggie,
 		editFleetRowHomeDir,
 		editFleetRowPreferFleetLaunch,
-		editFleetRowCustomMounts,
+		editFleetRowLayouts,
 	}
+	if fleetPage.dialogLayoutsExpanded {
+		for i := range fleetPage.dialogLayoutPresets {
+			rows = append(rows, editFleetRowLayoutPresetBase+i)
+		}
+		rows = append(rows, fleetPage.layoutPresetAddRow())
+	}
+	rows = append(rows, editFleetRowCustomMounts)
 	if fleetPage.dialogCustomMountsExpanded {
 		for i := range fleetPage.dialogCustomMounts {
 			rows = append(rows, editFleetRowCustomMountBase+i)
@@ -1263,6 +1288,7 @@ func (fleetPage *fleetPage) moveEditFleetRow(delta int) {
 	fleetPage.dialogCacheButtonFocused = false
 	fleetPage.dialogDeleteCacheConfirm = false
 	fleetPage.dialogMountRemoveConfirm = false
+	fleetPage.dialogPresetRemoveConfirm = false
 	fleetPage.syncEditFleetFocus()
 }
 
@@ -1361,6 +1387,10 @@ func (fleetPage *fleetPage) openEditFleetDialog(m *model) tea.Cmd {
 	fleetPage.dialogMountRemoveConfirm = false
 	fleetPage.customMountInput.SetValue("")
 	fleetPage.customMountInput.Blur()
+	fleetPage.dialogLayoutsExpanded = false
+	fleetPage.dialogLayoutPresets = slices.Clone(f.Settings.LayoutPresets)
+	fleetPage.dialogPresetRemoveConfirm = false
+	fleetPage.lpFlow = nil
 
 	fleetPage.homedirInput.SetValue(f.Settings.HomeDir)
 	fleetPage.homedirInput.Blur()
@@ -1448,6 +1478,10 @@ func (fleetPage *fleetPage) updateEditFleet(m *model, msg tea.Msg) tea.Cmd {
 			fleetPage.dialogMountRemoveConfirm = false
 			return nil
 		}
+		if fleetPage.dialogPresetRemoveConfirm {
+			fleetPage.dialogPresetRemoveConfirm = false
+			return nil
+		}
 		fleetPage.closeEditFleet(m)
 		return nil
 	}
@@ -1456,6 +1490,11 @@ func (fleetPage *fleetPage) updateEditFleet(m *model, msg tea.Msg) tea.Cmd {
 	// handled separately since their row ids are not compile-time constants.
 	if isCustomMountChildRow(fleetPage.dialogRow) {
 		return fleetPage.updateCustomMountRow(m, keyMsg)
+	}
+	// Likewise the dynamic layout-preset child rows (existing presets + the
+	// "+ Layout Preset" row).
+	if isLayoutPresetChildRow(fleetPage.dialogRow) {
+		return fleetPage.updateLayoutPresetRow(m, keyMsg)
 	}
 
 	// Row-specific actions.
@@ -1476,6 +1515,16 @@ func (fleetPage *fleetPage) updateEditFleet(m *model, msg tea.Msg) tea.Cmd {
 			fleetPage.dialogCustomMountsExpanded = true
 		case "left", "h":
 			fleetPage.dialogCustomMountsExpanded = false
+		}
+		return nil
+	case editFleetRowLayouts:
+		switch keyMsg.String() {
+		case " ", "enter":
+			fleetPage.dialogLayoutsExpanded = !fleetPage.dialogLayoutsExpanded
+		case "right", "l":
+			fleetPage.dialogLayoutsExpanded = true
+		case "left", "h":
+			fleetPage.dialogLayoutsExpanded = false
 		}
 		return nil
 	case editFleetRowCaching:
@@ -1717,6 +1766,57 @@ func (fleetPage *fleetPage) updateCustomMountRow(m *model, keyMsg tea.KeyMsg) te
 	return nil
 }
 
+// updateLayoutPresetRow handles a key press while the cursor is on one of the
+// dynamic layout-preset child rows: an existing preset (enter opens the
+// preview/command editor, x/d removes it behind a two-step confirm) or the
+// "+ Layout Preset" row (enter starts the capture flow).
+func (fleetPage *fleetPage) updateLayoutPresetRow(m *model, keyMsg tea.KeyMsg) tea.Cmd {
+	idx := fleetPage.dialogRow - editFleetRowLayoutPresetBase
+	if idx == len(fleetPage.dialogLayoutPresets) {
+		// The "+ Layout Preset" row.
+		switch keyMsg.String() {
+		case "enter", " ":
+			fleetPage.openLayoutPresetCreate(m)
+		}
+		return nil
+	}
+	switch keyMsg.String() {
+	case "enter", "e":
+		fleetPage.dialogPresetRemoveConfirm = false
+		fleetPage.openLayoutPresetEdit(idx)
+		return nil
+	case "x", "d":
+		// Two-step confirm, mirroring the custom-mount [remove?] flow. Esc
+		// disarms via the dialog's top-level esc handler; row moves clear it.
+		if !fleetPage.dialogPresetRemoveConfirm {
+			fleetPage.dialogPresetRemoveConfirm = true
+			return nil
+		}
+		fleetPage.dialogPresetRemoveConfirm = false
+		return fleetPage.removeLayoutPreset(m, idx)
+	}
+	return nil
+}
+
+// removeLayoutPreset drops the idx-th preset and persists (instant-save),
+// reverting on RPC failure and keeping the cursor in range afterward.
+func (fleetPage *fleetPage) removeLayoutPreset(m *model, idx int) tea.Cmd {
+	if idx < 0 || idx >= len(fleetPage.dialogLayoutPresets) {
+		return nil
+	}
+	prev := fleetPage.dialogLayoutPresets
+	fleetPage.dialogLayoutPresets = slices.Delete(slices.Clone(prev), idx, idx+1)
+	if err := fleetPage.persistFleetSettings(m); err != nil {
+		fleetPage.dialogLayoutPresets = prev
+		m.message = fmt.Sprintf("Failed to save: %v", err)
+		return nil
+	}
+	if fleetPage.dialogRow > fleetPage.layoutPresetAddRow() {
+		fleetPage.dialogRow = fleetPage.layoutPresetAddRow()
+	}
+	return nil
+}
+
 // beginAddMount enters the add-custom-mount text sub-mode with a blank input.
 func (fleetPage *fleetPage) beginAddMount() {
 	fleetPage.dialogAddingMount = true
@@ -1878,6 +1978,7 @@ func (fleetPage *fleetPage) persistFleetSettings(m *model) error {
 	f.Settings.AuggieMount = fleetPage.dialogAuggieMount
 	f.Settings.BuildkitServer = fleetPage.dialogBuildkitServer
 	f.Settings.CustomMounts = fleetPage.dialogCustomMounts
+	f.Settings.LayoutPresets = fleetPage.dialogLayoutPresets
 	f.Settings.DebCacheServer = fleetPage.dialogDebCache
 	f.Settings.ImageCacheServer = fleetPage.dialogImageCache
 	if fleetPage.dialogPreferFleetLaunchSet {
@@ -2120,9 +2221,50 @@ func (fleetPage *fleetPage) updateCodespacesLimit(m *model, msg tea.Msg) tea.Cmd
 // ===========================================
 
 // updateCreateSession handles the dialog for creating a new tmux session.
+// openCreateSessionDialog opens the new-session dialog for an instance,
+// snapshotting the fleet's layout presets for Tab cycling (none selected by
+// default — a plain single session).
+func (fleetPage *fleetPage) openCreateSessionDialog(m *model, fleetName string, instance *fleet.Instance) tea.Cmd {
+	fleetPage.mode = viewCreateSession
+	fleetPage.dialogFleet = fleetName
+	fleetPage.dialogInst = instance.Name
+	fleetPage.dialogPresets = nil
+	if f, ok := m.st.Fleets[fleetName]; ok {
+		fleetPage.dialogPresets = f.Settings.LayoutPresets
+	}
+	fleetPage.dialogPresetIdx = -1
+	fleetPage.textInput.SetValue("")
+	fleetPage.textInput.Placeholder = "session-name (or empty for auto)"
+	fleetPage.textInput.CharLimit = 64
+	return fleetPage.activateTextInput()
+}
+
+// cyclePresetTemplate steps the new-session dialog's template selection:
+// -1 (none) → preset 0 → … → preset N-1 → back to none, mirroring how the
+// add-instance dialog Tab-cycles backends.
+func (fleetPage *fleetPage) cyclePresetTemplate(direction int) {
+	n := len(fleetPage.dialogPresets)
+	if n == 0 {
+		return
+	}
+	// Shift the -1..n-1 range to 0..n and cycle modulo n+1.
+	fleetPage.dialogPresetIdx = (fleetPage.dialogPresetIdx+1+direction+n+1)%(n+1) - 1
+}
+
 func (fleetPage *fleetPage) updateCreateSession(m *model, msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		// Tab cycles the layout-preset template in both navigation and
+		// text-entry states (the dialog's only text field never uses Tab).
+		switch msg.String() {
+		case "tab":
+			fleetPage.cyclePresetTemplate(1)
+			return nil
+		case "shift+tab":
+			fleetPage.cyclePresetTemplate(-1)
+			return nil
+		}
+
 		if fleetPage.dialogFieldActive {
 			switch msg.String() {
 			case "enter":
@@ -2177,6 +2319,21 @@ func (fleetPage *fleetPage) saveCreateSession(m *model) tea.Cmd {
 
 	sanitized := SanitizeSessionName(instance.Name)
 	fullName := GroupSessionName(sanitized, name)
+
+	// A template was Tab-selected: mint the whole group — one session per
+	// pane, the user's name as the group ID — and run each pane's command.
+	if fleetPage.dialogPresetIdx >= 0 && fleetPage.dialogPresetIdx < len(fleetPage.dialogPresets) {
+		preset := fleetPage.dialogPresets[fleetPage.dialogPresetIdx]
+		sessions := make([]string, 0, preset.PaneCount())
+		sessions = append(sessions, fullName)
+		for i := 1; i < preset.PaneCount(); i++ {
+			sessions = append(sessions, NewGroupPaneSessionName(sanitized, name))
+		}
+		fleetPage.mode = viewNormal
+		fleetPage.blurDialogFields()
+		m.message = fmt.Sprintf("Creating session %s from %s...", name, preset.Name)
+		return createSessionGroupFromPresetCmd(ref, name, sessions, preset)
+	}
 
 	fleetPage.mode = viewNormal
 	fleetPage.blurDialogFields()

--- a/internal/tui/layout_preset_dialog.go
+++ b/internal/tui/layout_preset_dialog.go
@@ -1,0 +1,632 @@
+package tui
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// layout_preset_dialog.go implements the layout-preset creation/edit flow
+// (issue #150), opened from the edit-fleet dialog's Layouts section. Creation
+// is two stages: pick a live session group to capture (its saved outer-tmux
+// layout is the template geometry), then assign a startup command to every
+// pane in a navigable preview and name the preset. Editing an existing preset
+// reuses stage two with the commands pre-assigned.
+
+type layoutPresetStage int
+
+const (
+	lpStagePick layoutPresetStage = iota // choosing the source session group
+	lpStageEdit                          // preview + per-pane commands + name
+)
+
+// Focus stops in the edit stage, in navigation order: the name row, one stop
+// per session pane (slot order = position order), then the buttons.
+const (
+	lpFocusName = 0
+	// pane slots occupy 1..paneCount; the buttons follow.
+)
+
+// lpCandidate is one capturable session group shown in the pick stage.
+type lpCandidate struct {
+	instance  string // instance Name (stable identifier)
+	display   string // "<instance display> / <group>" per the issue spec
+	groupName string // the group's display name; seeds the preset name
+	layout    string // saved outer-tmux layout ("" when never captured)
+	paneCount int
+}
+
+// layoutPresetFlow holds all state for one open preset flow. It lives on
+// fleetPage only while mode == viewLayoutPreset and is rebuilt on every open.
+type layoutPresetFlow struct {
+	stage   layoutPresetStage
+	editIdx int // index into dialogLayoutPresets being edited; -1 = creating
+
+	// Pick stage.
+	candidates []lpCandidate
+	pickCursor int
+
+	// Edit stage.
+	layout         string       // tmux layout string the preset will carry
+	rects          []layoutRect // parsed leaves; rects[0] is the TUI pane
+	order          []int        // rect index per slot, position-sorted
+	commands       []string     // per-slot startup command ("" = plain shell)
+	assigned       []bool       // per-slot: the user confirmed this pane's command
+	focus          int
+	editingName    bool
+	nameBeforeEdit string // restored when a name edit is escaped
+	editingCmd     bool
+	nameInput      textinput.Model
+	cmdInput       textinput.Model
+	errMsg         string // inline validation error
+}
+
+func (lp *layoutPresetFlow) paneCount() int { return len(lp.order) }
+
+func (lp *layoutPresetFlow) focusCancel() int  { return 1 + lp.paneCount() }
+func (lp *layoutPresetFlow) focusConfirm() int { return 2 + lp.paneCount() }
+
+// focusedSlot returns the pane slot the focus is on, or -1 when the focus is
+// on the name row or the buttons.
+func (lp *layoutPresetFlow) focusedSlot() int {
+	if lp.focus >= 1 && lp.focus <= lp.paneCount() {
+		return lp.focus - 1
+	}
+	return -1
+}
+
+func (lp *layoutPresetFlow) allAssigned() bool {
+	for _, a := range lp.assigned {
+		if !a {
+			return false
+		}
+	}
+	return true
+}
+
+// openLayoutPresetCreate opens the flow at the pick stage. Returns false (with
+// a user message) when the fleet has no active sessions to capture from.
+func (fleetPage *fleetPage) openLayoutPresetCreate(m *model) bool {
+	candidates := fleetPage.collectLayoutPresetCandidates(m, fleetPage.dialogFleet)
+	if len(candidates) == 0 {
+		m.message = "No active sessions to capture a layout from"
+		return false
+	}
+	fleetPage.lpFlow = &layoutPresetFlow{
+		stage:      lpStagePick,
+		editIdx:    -1,
+		candidates: candidates,
+	}
+	fleetPage.mode = viewLayoutPreset
+	return true
+}
+
+// openLayoutPresetEdit opens the flow directly at the edit stage for the idx-th
+// existing preset in the dialog's working copy.
+func (fleetPage *fleetPage) openLayoutPresetEdit(idx int) {
+	if idx < 0 || idx >= len(fleetPage.dialogLayoutPresets) {
+		return
+	}
+	preset := fleetPage.dialogLayoutPresets[idx]
+	lp := &layoutPresetFlow{
+		stage:   lpStageEdit,
+		editIdx: idx,
+	}
+	lp.initEditStage(preset.Layout, preset.PaneCount(), preset.Name, slices.Clone(preset.PaneCommands), true)
+	fleetPage.lpFlow = lp
+	fleetPage.mode = viewLayoutPreset
+}
+
+// collectLayoutPresetCandidates lists every live session group across the
+// fleet's instances, labeled "<instance> / <group>". A group that has a saved
+// outer-tmux layout (the same snapshot group restore uses) carries that
+// geometry; one that was never opened as a split has none and falls back to
+// the default stacked arrangement.
+func (fleetPage *fleetPage) collectLayoutPresetCandidates(m *model, fleetName string) []lpCandidate {
+	f, ok := m.st.Fleets[fleetName]
+	if !ok {
+		return nil
+	}
+	var out []lpCandidate
+	for _, inst := range f.Instances {
+		ref := InstanceRef{Fleet: fleetName, Instance: inst.Name}
+		sessions := m.runtimeSessions(ref)
+		if len(sessions) == 0 {
+			continue
+		}
+		sanitized := SanitizeSessionName(inst.Name)
+		for _, g := range groupSessions(sanitized, sessions) {
+			paneCount := len(g.Sessions)
+			layout := ""
+			if sg, ok := fleetPage.savedGroups[computeGroupKey(inst.Name, g.GroupID)]; ok {
+				layout = sg.Layout
+				paneCount = savedGroupPaneCount(sg)
+			}
+			out = append(out, lpCandidate{
+				instance:  inst.Name,
+				display:   inst.GetDisplayName() + " / " + g.GroupID,
+				groupName: g.GroupID,
+				layout:    layout,
+				paneCount: paneCount,
+			})
+		}
+	}
+	return out
+}
+
+// initEditStage populates the edit-stage state from a layout string + pane
+// count. When the layout fails to parse — or disagrees with the pane count —
+// the geometry falls back to the synthesized stack that applying a layout-less
+// preset would actually produce, so the preview never lies about the result.
+func (lp *layoutPresetFlow) initEditStage(layout string, paneCount int, name string, commands []string, preAssigned bool) {
+	if paneCount < 1 {
+		paneCount = 1
+	}
+	lp.layout = layout
+	lp.rects = nil
+	if layout != "" {
+		if rects, err := parseTmuxLayout(layout); err == nil && len(rects)-1 == paneCount {
+			lp.rects = rects
+		}
+	}
+	if lp.rects == nil {
+		lp.rects = synthesizedStackRects(paneCount)
+		lp.layout = ""
+	}
+	lp.order = orderRectsByPosition(lp.rects)
+
+	if len(commands) != paneCount {
+		resized := make([]string, paneCount)
+		copy(resized, commands)
+		commands = resized
+	}
+	lp.commands = commands
+	lp.assigned = make([]bool, paneCount)
+	if preAssigned {
+		for i := range lp.assigned {
+			lp.assigned[i] = true
+		}
+	}
+
+	lp.nameInput = textinput.New()
+	lp.nameInput.Placeholder = "preset-name"
+	lp.nameInput.CharLimit = 64
+	lp.nameInput.SetValue(name)
+	lp.cmdInput = textinput.New()
+	lp.cmdInput.Placeholder = "bash command (empty for plain shell)"
+	lp.cmdInput.CharLimit = 512
+
+	lp.stage = lpStageEdit
+	lp.focus = 1 // first pane: assigning commands is the main task
+	lp.editingName = false
+	lp.editingCmd = false
+	lp.errMsg = ""
+}
+
+// paneCountLabel formats a pane count for display ("1 pane", "3 panes").
+func paneCountLabel(n int) string {
+	if n == 1 {
+		return "1 pane"
+	}
+	return fmt.Sprintf("%d panes", n)
+}
+
+// uniquePresetName seeds the name field from the captured group's name,
+// suffixing -2, -3, … when that name is already taken by another preset.
+func uniquePresetName(base string, presets []fleet.LayoutPreset, skipIdx int) string {
+	base = strings.TrimSpace(base)
+	if base == "" {
+		base = "layout"
+	}
+	taken := func(name string) bool {
+		for i, p := range presets {
+			if i != skipIdx && p.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+	if !taken(base) {
+		return base
+	}
+	for n := 2; ; n++ {
+		candidate := fmt.Sprintf("%s-%d", base, n)
+		if !taken(candidate) {
+			return candidate
+		}
+	}
+}
+
+// closeLayoutPresetFlow abandons the flow and returns to the edit-fleet
+// dialog, leaving the Layouts section expanded with the cursor where the user
+// left it.
+func (fleetPage *fleetPage) closeLayoutPresetFlow() {
+	fleetPage.lpFlow = nil
+	fleetPage.mode = viewEditFleet
+}
+
+// updateLayoutPreset handles all input while the preset flow is open.
+func (fleetPage *fleetPage) updateLayoutPreset(m *model, msg tea.Msg) tea.Cmd {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return nil
+	}
+	lp := fleetPage.lpFlow
+	if lp == nil {
+		// Defensive: a stray message after close.
+		fleetPage.mode = viewEditFleet
+		return nil
+	}
+	if lp.stage == lpStagePick {
+		return fleetPage.updateLayoutPresetPick(lp, keyMsg)
+	}
+	return fleetPage.updateLayoutPresetEdit(m, lp, keyMsg)
+}
+
+func (fleetPage *fleetPage) updateLayoutPresetPick(lp *layoutPresetFlow, keyMsg tea.KeyMsg) tea.Cmd {
+	switch keyMsg.String() {
+	case "up", "k":
+		lp.pickCursor = (lp.pickCursor - 1 + len(lp.candidates)) % len(lp.candidates)
+	case "down", "j", "tab":
+		lp.pickCursor = (lp.pickCursor + 1) % len(lp.candidates)
+	case "enter", " ":
+		c := lp.candidates[lp.pickCursor]
+		name := uniquePresetName(c.groupName, fleetPage.dialogLayoutPresets, -1)
+		lp.initEditStage(c.layout, c.paneCount, name, nil, false)
+	case "esc", "q", "Q", "ctrl+c":
+		fleetPage.closeLayoutPresetFlow()
+	}
+	return nil
+}
+
+func (fleetPage *fleetPage) updateLayoutPresetEdit(m *model, lp *layoutPresetFlow, keyMsg tea.KeyMsg) tea.Cmd {
+	// Name text sub-mode.
+	if lp.editingName {
+		switch keyMsg.String() {
+		case "enter":
+			lp.editingName = false
+			lp.nameInput.Blur()
+			return nil
+		case "esc":
+			// Discard the uncommitted edit, matching the home-dir field.
+			lp.nameInput.SetValue(lp.nameBeforeEdit)
+			lp.editingName = false
+			lp.nameInput.Blur()
+			return nil
+		case "ctrl+c":
+			fleetPage.closeLayoutPresetFlow()
+			return nil
+		}
+		lp.errMsg = ""
+		var cmd tea.Cmd
+		lp.nameInput, cmd = lp.nameInput.Update(keyMsg)
+		return cmd
+	}
+
+	// Pane-command text sub-mode.
+	if lp.editingCmd {
+		slot := lp.focusedSlot()
+		switch keyMsg.String() {
+		case "enter":
+			if slot >= 0 {
+				lp.commands[slot] = strings.TrimSpace(lp.cmdInput.Value())
+				lp.assigned[slot] = true
+			}
+			lp.editingCmd = false
+			lp.cmdInput.Blur()
+			lp.advanceToNextUnassigned()
+			return nil
+		case "esc":
+			lp.editingCmd = false
+			lp.cmdInput.Blur()
+			return nil
+		case "ctrl+c":
+			fleetPage.closeLayoutPresetFlow()
+			return nil
+		}
+		var cmd tea.Cmd
+		lp.cmdInput, cmd = lp.cmdInput.Update(keyMsg)
+		return cmd
+	}
+
+	// Navigation.
+	switch keyMsg.String() {
+	case "esc", "q", "Q", "ctrl+c":
+		fleetPage.closeLayoutPresetFlow()
+		return nil
+
+	case "up", "k":
+		lp.moveFocus(-1)
+		return nil
+
+	case "down", "j", "tab":
+		lp.moveFocus(1)
+		return nil
+
+	case "left", "h":
+		// Between the buttons, left/right move sideways; on panes they step
+		// through the slots (position order, so this walks the layout).
+		if lp.focus == lp.focusConfirm() {
+			lp.focus = lp.focusCancel()
+		} else if lp.focusedSlot() > 0 {
+			lp.focus--
+		}
+		return nil
+
+	case "right", "l":
+		if lp.focus == lp.focusCancel() && lp.confirmVisible() {
+			lp.focus = lp.focusConfirm()
+		} else if s := lp.focusedSlot(); s >= 0 && s < lp.paneCount()-1 {
+			lp.focus++
+		}
+		return nil
+
+	case "enter", " ":
+		return fleetPage.activateLayoutPresetFocus(m, lp)
+	}
+
+	// Start typing directly on the name row or a pane row, matching the
+	// home-dir / add-mount convention.
+	if isDialogTextKey(keyMsg) {
+		if lp.focus == lpFocusName {
+			lp.beginEditName()
+			blinkCmd := lp.nameInput.Cursor.BlinkCmd()
+			var inputCmd tea.Cmd
+			lp.nameInput, inputCmd = lp.nameInput.Update(keyMsg)
+			return tea.Batch(blinkCmd, inputCmd)
+		}
+		if slot := lp.focusedSlot(); slot >= 0 {
+			lp.beginEditCommand(slot)
+			blinkCmd := lp.cmdInput.Cursor.BlinkCmd()
+			var inputCmd tea.Cmd
+			lp.cmdInput, inputCmd = lp.cmdInput.Update(keyMsg)
+			return tea.Batch(blinkCmd, inputCmd)
+		}
+	}
+	return nil
+}
+
+// confirmVisible reports whether the [create]/[save] button is shown: every
+// pane must have been assigned a command first (the issue's gating text).
+func (lp *layoutPresetFlow) confirmVisible() bool { return lp.allAssigned() }
+
+// moveFocus steps through the visible focus stops (name → panes → buttons),
+// wrapping, and skipping the confirm button while it is hidden.
+func (lp *layoutPresetFlow) moveFocus(delta int) {
+	maxFocus := lp.focusCancel()
+	if lp.confirmVisible() {
+		maxFocus = lp.focusConfirm()
+	}
+	lp.focus = (lp.focus + delta + maxFocus + 1) % (maxFocus + 1)
+}
+
+// advanceToNextUnassigned moves the focus to the next pane the user has not
+// yet visited; once all are assigned it lands on the confirm button, so the
+// happy path is enter → type command → enter, repeated, then enter to create.
+func (lp *layoutPresetFlow) advanceToNextUnassigned() {
+	for i := range lp.assigned {
+		if !lp.assigned[i] {
+			lp.focus = 1 + i
+			return
+		}
+	}
+	lp.focus = lp.focusConfirm()
+}
+
+func (lp *layoutPresetFlow) beginEditName() {
+	lp.editingName = true
+	lp.nameBeforeEdit = lp.nameInput.Value()
+	lp.errMsg = ""
+	lp.nameInput.Focus()
+}
+
+func (lp *layoutPresetFlow) beginEditCommand(slot int) {
+	lp.editingCmd = true
+	lp.errMsg = ""
+	lp.cmdInput.SetValue(lp.commands[slot])
+	lp.cmdInput.Focus()
+}
+
+// activateLayoutPresetFocus handles enter/space on the current focus stop.
+func (fleetPage *fleetPage) activateLayoutPresetFocus(m *model, lp *layoutPresetFlow) tea.Cmd {
+	switch {
+	case lp.focus == lpFocusName:
+		lp.beginEditName()
+		return lp.nameInput.Cursor.BlinkCmd()
+	case lp.focusedSlot() >= 0:
+		lp.beginEditCommand(lp.focusedSlot())
+		return lp.cmdInput.Cursor.BlinkCmd()
+	case lp.focus == lp.focusCancel():
+		fleetPage.closeLayoutPresetFlow()
+		return nil
+	case lp.focus == lp.focusConfirm() && lp.confirmVisible():
+		return fleetPage.commitLayoutPreset(m, lp)
+	}
+	return nil
+}
+
+// commitLayoutPreset validates and persists the preset (instant-save like the
+// rest of the edit-fleet dialog), then returns to the Layouts section with the
+// cursor on the saved preset's row.
+func (fleetPage *fleetPage) commitLayoutPreset(m *model, lp *layoutPresetFlow) tea.Cmd {
+	name := strings.TrimSpace(lp.nameInput.Value())
+	if name == "" {
+		lp.errMsg = "preset name is required"
+		lp.focus = lpFocusName
+		return nil
+	}
+	for i, p := range fleetPage.dialogLayoutPresets {
+		if i != lp.editIdx && p.Name == name {
+			lp.errMsg = fmt.Sprintf("a preset named %q already exists", name)
+			lp.focus = lpFocusName
+			return nil
+		}
+	}
+
+	preset := fleet.LayoutPreset{
+		Name:         name,
+		Layout:       lp.layout,
+		PaneCommands: slices.Clone(lp.commands),
+	}
+
+	prev := fleetPage.dialogLayoutPresets
+	next := slices.Clone(prev)
+	savedIdx := lp.editIdx
+	if savedIdx >= 0 && savedIdx < len(next) {
+		next[savedIdx] = preset
+	} else {
+		next = append(next, preset)
+		savedIdx = len(next) - 1
+	}
+	fleetPage.dialogLayoutPresets = next
+	if err := fleetPage.persistFleetSettings(m); err != nil {
+		fleetPage.dialogLayoutPresets = prev
+		m.message = fmt.Sprintf("Failed to save: %v", err)
+		return nil
+	}
+
+	fleetPage.lpFlow = nil
+	fleetPage.mode = viewEditFleet
+	fleetPage.dialogLayoutsExpanded = true
+	fleetPage.dialogRow = editFleetRowLayoutPresetBase + savedIdx
+	return nil
+}
+
+// ===========================================
+// Rendering
+// ===========================================
+
+// renderLayoutPresetDialog builds the dialog body for the current stage.
+func (fleetPage *fleetPage) renderLayoutPresetDialog() string {
+	lp := fleetPage.lpFlow
+	if lp == nil {
+		return ""
+	}
+	if lp.stage == lpStagePick {
+		return lp.renderPickStage()
+	}
+	return lp.renderEditStage()
+}
+
+func (lp *layoutPresetFlow) renderPickStage() string {
+	var d strings.Builder
+	d.WriteString(dialogTitle.Render("New layout preset"))
+	d.WriteString("\n\n")
+	d.WriteString(dialogLabel.Render("Capture the layout of:"))
+	d.WriteString("\n\n")
+	for i, c := range lp.candidates {
+		if i == lp.pickCursor {
+			d.WriteString(cursorStyle.Render("> ") + selectedStyle.Render(c.display))
+		} else {
+			d.WriteString("  " + dialogLabel.Render(c.display))
+		}
+		if c.paneCount > 1 {
+			d.WriteString(dimStyle.Render("  (" + paneCountLabel(c.paneCount) + ")"))
+		}
+		d.WriteString("\n")
+	}
+	d.WriteString("\n")
+	d.WriteString(dialogHint.Render("[j/k] Select  [enter] Capture  [q/esc] Cancel"))
+	return d.String()
+}
+
+func (lp *layoutPresetFlow) renderEditStage() string {
+	marker := func(focused bool) string {
+		if focused {
+			return cursorStyle.Render("> ")
+		}
+		return "  "
+	}
+
+	var d strings.Builder
+	title := "New layout preset"
+	if lp.editIdx >= 0 {
+		title = "Edit layout preset"
+	}
+	d.WriteString(dialogTitle.Render(title))
+	d.WriteString("\n\n")
+
+	// Name row.
+	var nameField string
+	if lp.editingName {
+		nameField = lp.nameInput.View()
+	} else if v := lp.nameInput.Value(); v == "" {
+		nameField = dimStyle.Render("(unnamed)")
+	} else {
+		nameField = v
+	}
+	d.WriteString(marker(lp.focus == lpFocusName) + dialogLabel.Render("Name: ") + nameField + "\n\n")
+
+	// The layout preview.
+	width, height := previewDims(lp.rects)
+	d.WriteString(renderLayoutPreview(lp.rects, lp.order, lp.focusedSlot(), lp.assigned, width, height))
+	d.WriteString("\n")
+
+	// Context line under the preview: the focused pane's command (or the
+	// in-progress edit).
+	switch {
+	case lp.editingCmd:
+		d.WriteString("\n" + dialogLabel.Render(fmt.Sprintf("Pane %d command: ", lp.focusedSlot()+1)) + lp.cmdInput.View() + "\n")
+	case lp.focusedSlot() >= 0:
+		slot := lp.focusedSlot()
+		cmd := lp.commands[slot]
+		switch {
+		case !lp.assigned[slot]:
+			d.WriteString("\n" + dimStyle.Render(fmt.Sprintf("pane %d: unassigned — enter to set its command", slot+1)) + "\n")
+		case cmd == "":
+			d.WriteString("\n" + dimStyle.Render(fmt.Sprintf("pane %d: plain shell", slot+1)) + "\n")
+		default:
+			d.WriteString("\n" + dimStyle.Render(fmt.Sprintf("pane %d: ", slot+1)) + dialogLabel.Render(cmd) + "\n")
+		}
+	default:
+		d.WriteString("\n" + dimStyle.Render("panes run their command when a session is created") + "\n")
+	}
+
+	if lp.errMsg != "" {
+		d.WriteString(errorStyle.Render("✗ "+lp.errMsg) + "\n")
+	}
+
+	// Button row, per the issue: until every pane is assigned the right-hand
+	// side explains what is missing instead of offering [create].
+	cancel := "[ cancel ]"
+	if lp.focus == lp.focusCancel() {
+		cancel = selectedStyle.Render(cancel)
+	} else {
+		cancel = dimStyle.Render(cancel)
+	}
+	var right string
+	if !lp.confirmVisible() {
+		right = dimStyle.Render("Assign startup commands to all panels to continue")
+	} else {
+		label := "[ create ]"
+		if lp.editIdx >= 0 {
+			label = "[ save ]"
+		}
+		if lp.focus == lp.focusConfirm() {
+			right = selectedStyle.Render(label)
+		} else {
+			right = dimStyle.Render(label)
+		}
+	}
+	d.WriteString("\n" + cancel + "       " + right + "\n")
+
+	d.WriteString(dialogHint.Render(lp.editStageHint()))
+	return d.String()
+}
+
+func (lp *layoutPresetFlow) editStageHint() string {
+	if lp.editingName {
+		return "[enter] Done  [esc] Done  [ctrl+c] Cancel"
+	}
+	if lp.editingCmd {
+		return "[enter] Assign  [esc] Back  [ctrl+c] Cancel"
+	}
+	if lp.focusedSlot() >= 0 {
+		return "[enter] Set command  [j/k/h/l] Navigate  [q/esc] Cancel"
+	}
+	return "[enter] Activate  [j/k] Navigate  [q/esc] Cancel"
+}

--- a/internal/tui/layout_preset_dialog.go
+++ b/internal/tui/layout_preset_dialog.go
@@ -334,30 +334,32 @@ func (fleetPage *fleetPage) updateLayoutPresetEdit(m *model, lp *layoutPresetFlo
 		fleetPage.closeLayoutPresetFlow()
 		return nil
 
+	// Arrow / hjkl keys move spatially over the preview's regions (name above,
+	// the pane grid in the middle, the buttons below) so a multi-column layout
+	// navigates the way it looks — "down" stays in a column instead of walking
+	// to the next pane in position order. Tab keeps the flat cycle.
 	case "up", "k":
-		lp.moveFocus(-1)
+		lp.navVertical(-1)
 		return nil
 
-	case "down", "j", "tab":
-		lp.moveFocus(1)
+	case "down", "j":
+		lp.navVertical(1)
 		return nil
 
 	case "left", "h":
-		// Between the buttons, left/right move sideways; on panes they step
-		// through the slots (position order, so this walks the layout).
-		if lp.focus == lp.focusConfirm() {
-			lp.focus = lp.focusCancel()
-		} else if lp.focusedSlot() > 0 {
-			lp.focus--
-		}
+		lp.navHorizontal(-1)
 		return nil
 
 	case "right", "l":
-		if lp.focus == lp.focusCancel() {
-			lp.focus = lp.focusConfirm()
-		} else if s := lp.focusedSlot(); s >= 0 && s < lp.paneCount()-1 {
-			lp.focus++
-		}
+		lp.navHorizontal(1)
+		return nil
+
+	case "tab":
+		lp.moveFocus(1)
+		return nil
+
+	case "shift+tab":
+		lp.moveFocus(-1)
 		return nil
 
 	case "enter", " ":
@@ -387,10 +389,137 @@ func (fleetPage *fleetPage) updateLayoutPresetEdit(m *model, lp *layoutPresetFlo
 
 // moveFocus steps through the focus stops (name → panes → cancel → save),
 // wrapping. The save button is always reachable — assigning per-pane commands
-// is optional, so there is no gating.
+// is optional, so there is no gating. Bound to Tab; the arrow/hjkl keys use the
+// spatial navigation below instead.
 func (lp *layoutPresetFlow) moveFocus(delta int) {
 	maxFocus := lp.focusConfirm()
 	lp.focus = (lp.focus + delta + maxFocus + 1) % (maxFocus + 1)
+}
+
+// The preview is laid out as three stacked regions — the name row on top, the
+// pane grid in the middle, the cancel/save buttons on the bottom — so spatial
+// navigation treats them in that vertical order and moves between panes by
+// their on-screen geometry rather than their flat position-order index.
+
+// slotCenter returns the screen-space center of the pane at slot (in the
+// captured layout's cell coordinates).
+func (lp *layoutPresetFlow) slotCenter(slot int) (int, int) {
+	r := lp.rects[lp.order[slot]]
+	return r.x + r.w/2, r.y + r.h/2
+}
+
+// windowWidth is the captured layout's full width (max right edge), used to
+// decide which button a downward move from a pane lands on.
+func (lp *layoutPresetFlow) windowWidth() int {
+	w := 0
+	for _, r := range lp.rects {
+		w = max(w, r.x+r.w)
+	}
+	return w
+}
+
+// paneInDir returns the slot of the best pane in direction (dx, dy) from slot s
+// — strictly in that direction, preferring panes aligned on the cross axis — or
+// -1 when there is none. (dy>0 is down, dx>0 is right.)
+func (lp *layoutPresetFlow) paneInDir(s, dx, dy int) int {
+	cx, cy := lp.slotCenter(s)
+	best, bestScore := -1, 0
+	for slot := range lp.order {
+		if slot == s {
+			continue
+		}
+		nx, ny := lp.slotCenter(slot)
+		if dy > 0 && ny <= cy || dy < 0 && ny >= cy {
+			continue
+		}
+		if dx > 0 && nx <= cx || dx < 0 && nx >= cx {
+			continue
+		}
+		// Distance along the move axis, plus a heavy penalty for drifting on
+		// the cross axis so neighbors in the same row/column win.
+		var score int
+		if dy != 0 {
+			score = absInt(ny-cy) + 2*absInt(nx-cx)
+		} else {
+			score = absInt(nx-cx) + 2*absInt(ny-cy)
+		}
+		if best == -1 || score < bestScore {
+			best, bestScore = slot, score
+		}
+	}
+	return best
+}
+
+// bottomPaneForButton returns the bottom-most pane nearest the given button's
+// side (save → right, cancel → left), where an upward move from a button lands.
+func (lp *layoutPresetFlow) bottomPaneForButton(button int) int {
+	wantRight := button == lp.focusConfirm()
+	best := 0
+	bx, by := lp.slotCenter(0)
+	for slot := 1; slot < lp.paneCount(); slot++ {
+		cx, cy := lp.slotCenter(slot)
+		better := cy > by || (cy == by && (wantRight && cx > bx || !wantRight && cx < bx))
+		if better {
+			best, bx, by = slot, cx, cy
+		}
+	}
+	return best
+}
+
+// navVertical moves the focus up (dir<0) or down (dir>0) across the regions:
+// name → pane grid → buttons, wrapping at the ends.
+func (lp *layoutPresetFlow) navVertical(dir int) {
+	switch {
+	case lp.focus == lpFocusName:
+		if dir > 0 {
+			lp.focus = 1 // top-left pane (slot 0, position order)
+		} else {
+			lp.focus = lp.focusCancel() // wrap up to the buttons
+		}
+	case lp.focusedSlot() >= 0:
+		if next := lp.paneInDir(lp.focusedSlot(), 0, dir); next >= 0 {
+			lp.focus = 1 + next
+		} else if dir > 0 {
+			// No pane below: drop to the button under this pane's column.
+			cx, _ := lp.slotCenter(lp.focusedSlot())
+			if cx*2 >= lp.windowWidth() {
+				lp.focus = lp.focusConfirm()
+			} else {
+				lp.focus = lp.focusCancel()
+			}
+		} else {
+			lp.focus = lpFocusName
+		}
+	default: // on a button
+		if dir > 0 {
+			lp.focus = lpFocusName // wrap down to the name row
+		} else {
+			lp.focus = 1 + lp.bottomPaneForButton(lp.focus)
+		}
+	}
+}
+
+// navHorizontal moves left (dir<0) or right (dir>0): between adjacent panes in
+// the grid, or between the cancel and save buttons. The name row is a single
+// full-width field, so horizontal movement there is a no-op.
+func (lp *layoutPresetFlow) navHorizontal(dir int) {
+	switch {
+	case lp.focusedSlot() >= 0:
+		if next := lp.paneInDir(lp.focusedSlot(), dir, 0); next >= 0 {
+			lp.focus = 1 + next
+		}
+	case lp.focus == lp.focusCancel() && dir > 0:
+		lp.focus = lp.focusConfirm()
+	case lp.focus == lp.focusConfirm() && dir < 0:
+		lp.focus = lp.focusCancel()
+	}
+}
+
+func absInt(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
 }
 
 // advanceAfterCommand moves the focus to the next pane after a command is set,

--- a/internal/tui/layout_preset_dialog.go
+++ b/internal/tui/layout_preset_dialog.go
@@ -13,9 +13,10 @@ import (
 // layout_preset_dialog.go implements the layout-preset creation/edit flow
 // (issue #150), opened from the edit-fleet dialog's Layouts section. Creation
 // is two stages: pick a live session group to capture (its saved outer-tmux
-// layout is the template geometry), then assign a startup command to every
-// pane in a navigable preview and name the preset. Editing an existing preset
-// reuses stage two with the commands pre-assigned.
+// layout is the template geometry), then in a navigable preview optionally set
+// a startup command per pane (an empty one is a plain shell), name the preset,
+// and save. Editing an existing preset reuses stage two with its commands
+// pre-filled.
 
 type layoutPresetStage int
 
@@ -55,7 +56,6 @@ type layoutPresetFlow struct {
 	rects          []layoutRect // parsed leaves; rects[0] is the TUI pane
 	order          []int        // rect index per slot, position-sorted
 	commands       []string     // per-slot startup command ("" = plain shell)
-	assigned       []bool       // per-slot: the user confirmed this pane's command
 	focus          int
 	editingName    bool
 	nameBeforeEdit string // restored when a name edit is escaped
@@ -79,13 +79,15 @@ func (lp *layoutPresetFlow) focusedSlot() int {
 	return -1
 }
 
-func (lp *layoutPresetFlow) allAssigned() bool {
-	for _, a := range lp.assigned {
-		if !a {
-			return false
-		}
+// paneCommandFlags reports, per slot, whether the pane has a non-empty startup
+// command — drives the ✓ marker in the preview. A pane with no command just
+// opens a plain shell, so assigning commands is never required to save.
+func (lp *layoutPresetFlow) paneCommandFlags() []bool {
+	flags := make([]bool, len(lp.commands))
+	for i, c := range lp.commands {
+		flags[i] = c != ""
 	}
-	return true
+	return flags
 }
 
 // openLayoutPresetCreate opens the flow at the pick stage. Returns false (with
@@ -116,7 +118,7 @@ func (fleetPage *fleetPage) openLayoutPresetEdit(idx int) {
 		stage:   lpStageEdit,
 		editIdx: idx,
 	}
-	lp.initEditStage(preset.Layout, preset.PaneCount(), preset.Name, slices.Clone(preset.PaneCommands), true)
+	lp.initEditStage(preset.Layout, preset.PaneCount(), preset.Name, slices.Clone(preset.PaneCommands))
 	fleetPage.lpFlow = lp
 	fleetPage.mode = viewLayoutPreset
 }
@@ -162,7 +164,7 @@ func (fleetPage *fleetPage) collectLayoutPresetCandidates(m *model, fleetName st
 // count. When the layout fails to parse — or disagrees with the pane count —
 // the geometry falls back to the synthesized stack that applying a layout-less
 // preset would actually produce, so the preview never lies about the result.
-func (lp *layoutPresetFlow) initEditStage(layout string, paneCount int, name string, commands []string, preAssigned bool) {
+func (lp *layoutPresetFlow) initEditStage(layout string, paneCount int, name string, commands []string) {
 	if paneCount < 1 {
 		paneCount = 1
 	}
@@ -185,12 +187,6 @@ func (lp *layoutPresetFlow) initEditStage(layout string, paneCount int, name str
 		commands = resized
 	}
 	lp.commands = commands
-	lp.assigned = make([]bool, paneCount)
-	if preAssigned {
-		for i := range lp.assigned {
-			lp.assigned[i] = true
-		}
-	}
 
 	lp.nameInput = textinput.New()
 	lp.nameInput.Placeholder = "preset-name"
@@ -276,7 +272,7 @@ func (fleetPage *fleetPage) updateLayoutPresetPick(lp *layoutPresetFlow, keyMsg 
 	case "enter", " ":
 		c := lp.candidates[lp.pickCursor]
 		name := uniquePresetName(c.groupName, fleetPage.dialogLayoutPresets, -1)
-		lp.initEditStage(c.layout, c.paneCount, name, nil, false)
+		lp.initEditStage(c.layout, c.paneCount, name, nil)
 	case "esc", "q", "Q", "ctrl+c":
 		fleetPage.closeLayoutPresetFlow()
 	}
@@ -314,11 +310,10 @@ func (fleetPage *fleetPage) updateLayoutPresetEdit(m *model, lp *layoutPresetFlo
 		case "enter":
 			if slot >= 0 {
 				lp.commands[slot] = strings.TrimSpace(lp.cmdInput.Value())
-				lp.assigned[slot] = true
 			}
 			lp.editingCmd = false
 			lp.cmdInput.Blur()
-			lp.advanceToNextUnassigned()
+			lp.advanceAfterCommand()
 			return nil
 		case "esc":
 			lp.editingCmd = false
@@ -358,7 +353,7 @@ func (fleetPage *fleetPage) updateLayoutPresetEdit(m *model, lp *layoutPresetFlo
 		return nil
 
 	case "right", "l":
-		if lp.focus == lp.focusCancel() && lp.confirmVisible() {
+		if lp.focus == lp.focusCancel() {
 			lp.focus = lp.focusConfirm()
 		} else if s := lp.focusedSlot(); s >= 0 && s < lp.paneCount()-1 {
 			lp.focus++
@@ -390,29 +385,22 @@ func (fleetPage *fleetPage) updateLayoutPresetEdit(m *model, lp *layoutPresetFlo
 	return nil
 }
 
-// confirmVisible reports whether the [create]/[save] button is shown: every
-// pane must have been assigned a command first (the issue's gating text).
-func (lp *layoutPresetFlow) confirmVisible() bool { return lp.allAssigned() }
-
-// moveFocus steps through the visible focus stops (name → panes → buttons),
-// wrapping, and skipping the confirm button while it is hidden.
+// moveFocus steps through the focus stops (name → panes → cancel → save),
+// wrapping. The save button is always reachable — assigning per-pane commands
+// is optional, so there is no gating.
 func (lp *layoutPresetFlow) moveFocus(delta int) {
-	maxFocus := lp.focusCancel()
-	if lp.confirmVisible() {
-		maxFocus = lp.focusConfirm()
-	}
+	maxFocus := lp.focusConfirm()
 	lp.focus = (lp.focus + delta + maxFocus + 1) % (maxFocus + 1)
 }
 
-// advanceToNextUnassigned moves the focus to the next pane the user has not
-// yet visited; once all are assigned it lands on the confirm button, so the
-// happy path is enter → type command → enter, repeated, then enter to create.
-func (lp *layoutPresetFlow) advanceToNextUnassigned() {
-	for i := range lp.assigned {
-		if !lp.assigned[i] {
-			lp.focus = 1 + i
-			return
-		}
+// advanceAfterCommand moves the focus to the next pane after a command is set,
+// so the happy path is enter → type command → enter, repeated; on the last
+// pane it lands on the save button. Walking to save is just a convenience —
+// the user can move to it (or cancel) with the arrow keys at any time.
+func (lp *layoutPresetFlow) advanceAfterCommand() {
+	if s := lp.focusedSlot(); s >= 0 && s < lp.paneCount()-1 {
+		lp.focus = 1 + s + 1
+		return
 	}
 	lp.focus = lp.focusConfirm()
 }
@@ -443,7 +431,7 @@ func (fleetPage *fleetPage) activateLayoutPresetFocus(m *model, lp *layoutPreset
 	case lp.focus == lp.focusCancel():
 		fleetPage.closeLayoutPresetFlow()
 		return nil
-	case lp.focus == lp.focusConfirm() && lp.confirmVisible():
+	case lp.focus == lp.focusConfirm():
 		return fleetPage.commitLayoutPreset(m, lp)
 	}
 	return nil
@@ -561,25 +549,21 @@ func (lp *layoutPresetFlow) renderEditStage() string {
 	}
 	d.WriteString(marker(lp.focus == lpFocusName) + dialogLabel.Render("Name: ") + nameField + "\n\n")
 
-	// The layout preview.
+	// The layout preview. The ✓ marks panes that carry a startup command.
 	width, height := previewDims(lp.rects)
-	d.WriteString(renderLayoutPreview(lp.rects, lp.order, lp.focusedSlot(), lp.assigned, width, height))
+	d.WriteString(renderLayoutPreview(lp.rects, lp.order, lp.focusedSlot(), lp.paneCommandFlags(), width, height))
 	d.WriteString("\n")
 
 	// Context line under the preview: the focused pane's command (or the
-	// in-progress edit).
+	// in-progress edit). A pane with no command just opens a plain shell.
 	switch {
 	case lp.editingCmd:
 		d.WriteString("\n" + dialogLabel.Render(fmt.Sprintf("Pane %d command: ", lp.focusedSlot()+1)) + lp.cmdInput.View() + "\n")
 	case lp.focusedSlot() >= 0:
 		slot := lp.focusedSlot()
-		cmd := lp.commands[slot]
-		switch {
-		case !lp.assigned[slot]:
-			d.WriteString("\n" + dimStyle.Render(fmt.Sprintf("pane %d: unassigned — enter to set its command", slot+1)) + "\n")
-		case cmd == "":
-			d.WriteString("\n" + dimStyle.Render(fmt.Sprintf("pane %d: plain shell", slot+1)) + "\n")
-		default:
+		if cmd := lp.commands[slot]; cmd == "" {
+			d.WriteString("\n" + dimStyle.Render(fmt.Sprintf("pane %d: plain shell — enter to set a command", slot+1)) + "\n")
+		} else {
 			d.WriteString("\n" + dimStyle.Render(fmt.Sprintf("pane %d: ", slot+1)) + dialogLabel.Render(cmd) + "\n")
 		}
 	default:
@@ -590,29 +574,21 @@ func (lp *layoutPresetFlow) renderEditStage() string {
 		d.WriteString(errorStyle.Render("✗ "+lp.errMsg) + "\n")
 	}
 
-	// Button row, per the issue: until every pane is assigned the right-hand
-	// side explains what is missing instead of offering [create].
+	// Button row: cancel and save, both arrow-navigable. Saving is allowed at
+	// any time — per-pane commands are optional (an empty one is a plain shell).
 	cancel := "[ cancel ]"
 	if lp.focus == lp.focusCancel() {
 		cancel = selectedStyle.Render(cancel)
 	} else {
 		cancel = dimStyle.Render(cancel)
 	}
-	var right string
-	if !lp.confirmVisible() {
-		right = dimStyle.Render("Assign startup commands to all panels to continue")
+	save := "[ save ]"
+	if lp.focus == lp.focusConfirm() {
+		save = selectedStyle.Render(save)
 	} else {
-		label := "[ create ]"
-		if lp.editIdx >= 0 {
-			label = "[ save ]"
-		}
-		if lp.focus == lp.focusConfirm() {
-			right = selectedStyle.Render(label)
-		} else {
-			right = dimStyle.Render(label)
-		}
+		save = dimStyle.Render(save)
 	}
-	d.WriteString("\n" + cancel + "       " + right + "\n")
+	d.WriteString("\n" + cancel + "                       " + save + "\n")
 
 	d.WriteString(dialogHint.Render(lp.editStageHint()))
 	return d.String()
@@ -623,10 +599,10 @@ func (lp *layoutPresetFlow) editStageHint() string {
 		return "[enter] Done  [esc] Done  [ctrl+c] Cancel"
 	}
 	if lp.editingCmd {
-		return "[enter] Assign  [esc] Back  [ctrl+c] Cancel"
+		return "[enter] Set  [esc] Back  [ctrl+c] Cancel"
 	}
 	if lp.focusedSlot() >= 0 {
 		return "[enter] Set command  [j/k/h/l] Navigate  [q/esc] Cancel"
 	}
-	return "[enter] Activate  [j/k] Navigate  [q/esc] Cancel"
+	return "[enter] Select  [j/k/h/l] Navigate  [q/esc] Cancel"
 }

--- a/internal/tui/layout_preset_test.go
+++ b/internal/tui/layout_preset_test.go
@@ -99,7 +99,7 @@ func TestInitEditStageFallsBackOnPaneCountMismatch(t *testing.T) {
 	lp := &layoutPresetFlow{editIdx: -1}
 	// sampleLayout has 2 session panes; claiming 3 must drop the geometry and
 	// synthesize a 3-pane stack so the preview matches what apply would do.
-	lp.initEditStage(sampleLayout, 3, "dev", nil, false)
+	lp.initEditStage(sampleLayout, 3, "dev", nil)
 	if lp.layout != "" {
 		t.Fatalf("mismatched layout kept: %q", lp.layout)
 	}
@@ -110,7 +110,7 @@ func TestInitEditStageFallsBackOnPaneCountMismatch(t *testing.T) {
 
 func TestInitEditStageParsesMatchingLayout(t *testing.T) {
 	lp := &layoutPresetFlow{editIdx: -1}
-	lp.initEditStage(sampleLayout, 2, "dev", nil, false)
+	lp.initEditStage(sampleLayout, 2, "dev", nil)
 	if lp.layout != sampleLayout {
 		t.Fatalf("layout dropped: %q", lp.layout)
 	}
@@ -123,59 +123,56 @@ func TestInitEditStageParsesMatchingLayout(t *testing.T) {
 	if lp.focus != 1 {
 		t.Fatalf("focus = %d, want first pane", lp.focus)
 	}
-	if lp.allAssigned() {
-		t.Fatal("new capture must start unassigned")
-	}
 }
 
-func TestInitEditStagePreAssignsExistingPreset(t *testing.T) {
+func TestInitEditStageCarriesOverExistingCommands(t *testing.T) {
 	lp := &layoutPresetFlow{editIdx: 0}
-	lp.initEditStage(sampleLayout, 2, "dev", []string{"htop", ""}, true)
-	if !lp.allAssigned() {
-		t.Fatal("editing an existing preset must start fully assigned")
-	}
+	lp.initEditStage(sampleLayout, 2, "dev", []string{"htop", ""})
 	if lp.commands[0] != "htop" || lp.commands[1] != "" {
 		t.Fatalf("commands not carried over: %v", lp.commands)
 	}
+	// The ✓ marks panes carrying a command; the empty pane is a plain shell.
+	flags := lp.paneCommandFlags()
+	if !flags[0] || flags[1] {
+		t.Fatalf("paneCommandFlags = %v, want [true false]", flags)
+	}
 }
 
-func TestLayoutPresetFlowFocusSkipsHiddenConfirm(t *testing.T) {
+func TestLayoutPresetFocusCycleIncludesSaveUngated(t *testing.T) {
 	lp := &layoutPresetFlow{editIdx: -1}
-	lp.initEditStage("", 2, "dev", nil, false)
+	lp.initEditStage("", 2, "dev", nil)
 
-	// Unassigned: cycle name(0) → pane1(1) → pane2(2) → cancel(3) → name(0).
+	// Cycle name(0) → pane1(1) → pane2(2) → cancel(3) → save(4) → name(0).
+	// The save stop is always present — no gating on assigning commands.
 	lp.focus = lpFocusName
 	seen := []int{}
-	for range 4 {
+	for range 5 {
 		lp.moveFocus(1)
 		seen = append(seen, lp.focus)
 	}
-	want := []int{1, 2, 3, 0}
+	want := []int{1, 2, 3, 4, 0}
 	for i := range want {
 		if seen[i] != want[i] {
-			t.Fatalf("unassigned cycle = %v, want %v", seen, want)
+			t.Fatalf("focus cycle = %v, want %v", seen, want)
 		}
 	}
-
-	// Fully assigned: the confirm stop (4) joins the cycle.
-	lp.assigned[0], lp.assigned[1] = true, true
-	lp.focus = lp.focusCancel()
-	lp.moveFocus(1)
-	if lp.focus != lp.focusConfirm() {
-		t.Fatalf("focus = %d, want confirm %d", lp.focus, lp.focusConfirm())
+	if lp.focusConfirm() != 4 {
+		t.Fatalf("focusConfirm = %d, want 4", lp.focusConfirm())
 	}
 }
 
-func TestAdvanceToNextUnassigned(t *testing.T) {
+func TestAdvanceAfterCommand(t *testing.T) {
 	lp := &layoutPresetFlow{editIdx: -1}
-	lp.initEditStage("", 3, "dev", nil, false)
-	lp.assigned[0] = true
-	lp.advanceToNextUnassigned()
+	lp.initEditStage("", 3, "dev", nil)
+	// From pane 1 (focus=1) → pane 2 (focus=2).
+	lp.focus = 1
+	lp.advanceAfterCommand()
 	if lp.focusedSlot() != 1 {
 		t.Fatalf("slot = %d, want 1", lp.focusedSlot())
 	}
-	lp.assigned[1], lp.assigned[2] = true, true
-	lp.advanceToNextUnassigned()
+	// From the last pane → save.
+	lp.focus = lp.paneCount() // focus on last pane (slot paneCount-1)
+	lp.advanceAfterCommand()
 	if lp.focus != lp.focusConfirm() {
 		t.Fatalf("focus = %d, want confirm", lp.focus)
 	}

--- a/internal/tui/layout_preset_test.go
+++ b/internal/tui/layout_preset_test.go
@@ -161,6 +161,118 @@ func TestLayoutPresetFocusCycleIncludesSaveUngated(t *testing.T) {
 	}
 }
 
+// twoByTwoFlow builds a flow whose session panes form a 2x2 grid (plus the TUI
+// pane on the left), so spatial navigation has both rows and columns to move
+// between. Slots (position order, top-then-left): 0=TL, 1=TR, 2=BL, 3=BR.
+func twoByTwoFlow() *layoutPresetFlow {
+	lp := &layoutPresetFlow{editIdx: -1}
+	lp.rects = []layoutRect{
+		{x: 0, y: 0, w: 30, h: 20},  // TUI pane (leaf 0)
+		{x: 31, y: 0, w: 34, h: 10}, // top-left
+		{x: 66, y: 0, w: 34, h: 10}, // top-right
+		{x: 31, y: 11, w: 34, h: 9}, // bottom-left
+		{x: 66, y: 11, w: 34, h: 9}, // bottom-right
+	}
+	lp.order = orderRectsByPosition(lp.rects)
+	lp.commands = make([]string, 4)
+	return lp
+}
+
+func TestSpatialNavStaysInColumnAndRow(t *testing.T) {
+	lp := twoByTwoFlow()
+
+	// Down from top-left must reach bottom-left (same column), not top-right.
+	lp.focus = 1 // slot 0 (TL)
+	lp.navVertical(1)
+	if lp.focusedSlot() != 2 {
+		t.Fatalf("down from TL → slot %d, want 2 (BL)", lp.focusedSlot())
+	}
+
+	// Right from top-left must reach top-right (same row).
+	lp.focus = 1 // slot 0 (TL)
+	lp.navHorizontal(1)
+	if lp.focusedSlot() != 1 {
+		t.Fatalf("right from TL → slot %d, want 1 (TR)", lp.focusedSlot())
+	}
+
+	// Down from top-right → bottom-right.
+	lp.focus = 2 // slot 1 (TR)
+	lp.navVertical(1)
+	if lp.focusedSlot() != 3 {
+		t.Fatalf("down from TR → slot %d, want 3 (BR)", lp.focusedSlot())
+	}
+
+	// Up from bottom-left → top-left.
+	lp.focus = 3 // slot 2 (BL)
+	lp.navVertical(-1)
+	if lp.focusedSlot() != 0 {
+		t.Fatalf("up from BL → slot %d, want 0 (TL)", lp.focusedSlot())
+	}
+
+	// Left from bottom-right → bottom-left.
+	lp.focus = 4 // slot 3 (BR)
+	lp.navHorizontal(-1)
+	if lp.focusedSlot() != 2 {
+		t.Fatalf("left from BR → slot %d, want 2 (BL)", lp.focusedSlot())
+	}
+}
+
+func TestSpatialNavRegionTransitions(t *testing.T) {
+	lp := twoByTwoFlow()
+
+	// Name → down → top-left pane.
+	lp.focus = lpFocusName
+	lp.navVertical(1)
+	if lp.focusedSlot() != 0 {
+		t.Fatalf("name down → slot %d, want 0 (TL)", lp.focusedSlot())
+	}
+
+	// Up from a top-row pane → name.
+	lp.focus = 1 // TL
+	lp.navVertical(-1)
+	if lp.focus != lpFocusName {
+		t.Fatalf("up from TL → focus %d, want name", lp.focus)
+	}
+
+	// Down from bottom-right (no pane below) → save (right-side button).
+	lp.focus = 4 // BR
+	lp.navVertical(1)
+	if lp.focus != lp.focusConfirm() {
+		t.Fatalf("down from BR → focus %d, want save", lp.focus)
+	}
+
+	// Down from bottom-left → cancel (left-side button).
+	lp.focus = 3 // BL
+	lp.navVertical(1)
+	if lp.focus != lp.focusCancel() {
+		t.Fatalf("down from BL → focus %d, want cancel", lp.focus)
+	}
+
+	// Cancel ↔ save via horizontal.
+	lp.focus = lp.focusCancel()
+	lp.navHorizontal(1)
+	if lp.focus != lp.focusConfirm() {
+		t.Fatalf("right from cancel → focus %d, want save", lp.focus)
+	}
+	lp.navHorizontal(-1)
+	if lp.focus != lp.focusCancel() {
+		t.Fatalf("left from save → focus %d, want cancel", lp.focus)
+	}
+
+	// Up from save → bottom-right pane (nearest its side).
+	lp.focus = lp.focusConfirm()
+	lp.navVertical(-1)
+	if lp.focusedSlot() != 3 {
+		t.Fatalf("up from save → slot %d, want 3 (BR)", lp.focusedSlot())
+	}
+	// Up from cancel → bottom-left pane.
+	lp.focus = lp.focusCancel()
+	lp.navVertical(-1)
+	if lp.focusedSlot() != 2 {
+		t.Fatalf("up from cancel → slot %d, want 2 (BL)", lp.focusedSlot())
+	}
+}
+
 func TestAdvanceAfterCommand(t *testing.T) {
 	lp := &layoutPresetFlow{editIdx: -1}
 	lp.initEditStage("", 3, "dev", nil)

--- a/internal/tui/layout_preset_test.go
+++ b/internal/tui/layout_preset_test.go
@@ -18,10 +18,11 @@ func TestBuildPresetSessionScript(t *testing.T) {
 	if !strings.Contains(script, `tmux new-session -d -s 'inst~dev~a1' 2>/dev/null`) {
 		t.Fatalf("missing pane new-session: %s", script)
 	}
-	// The first pane's command is typed literally then submitted; the exact
-	// (=, colon-terminated) session target prevents tmux prefix-matching from
-	// hitting inst~dev~a1.
-	if !strings.Contains(script, `tmux send-keys -t '=inst~dev:' -l 'npm run dev'`) {
+	// The first pane's command is typed literally (-l) after a "--" flag
+	// terminator (so a leading-dash command isn't parsed as a flag) then
+	// submitted; the exact (=, colon-terminated) session target prevents tmux
+	// prefix-matching from hitting inst~dev~a1.
+	if !strings.Contains(script, `tmux send-keys -t '=inst~dev:' -l -- 'npm run dev'`) {
 		t.Fatalf("missing literal send-keys: %s", script)
 	}
 	if !strings.Contains(script, `tmux send-keys -t '=inst~dev:' Enter`) {

--- a/internal/tui/layout_preset_test.go
+++ b/internal/tui/layout_preset_test.go
@@ -1,0 +1,181 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+)
+
+func TestBuildPresetSessionScript(t *testing.T) {
+	script := buildPresetSessionScript(
+		[]string{"inst~dev", "inst~dev~a1"},
+		[]string{"npm run dev", ""},
+	)
+	if !strings.Contains(script, `tmux new-session -d -s 'inst~dev' 2>/dev/null`) {
+		t.Fatalf("missing root new-session: %s", script)
+	}
+	if !strings.Contains(script, `tmux new-session -d -s 'inst~dev~a1' 2>/dev/null`) {
+		t.Fatalf("missing pane new-session: %s", script)
+	}
+	// The first pane's command is typed literally then submitted; the exact
+	// (=, colon-terminated) session target prevents tmux prefix-matching from
+	// hitting inst~dev~a1.
+	if !strings.Contains(script, `tmux send-keys -t '=inst~dev:' -l 'npm run dev'`) {
+		t.Fatalf("missing literal send-keys: %s", script)
+	}
+	if !strings.Contains(script, `tmux send-keys -t '=inst~dev:' Enter`) {
+		t.Fatalf("missing Enter send-keys: %s", script)
+	}
+	// The empty second command must not produce a send-keys for that pane.
+	if strings.Contains(script, `'=inst~dev~a1:'`) {
+		t.Fatalf("plain-shell pane got a send-keys: %s", script)
+	}
+	// Steps are &&-chained so a name collision aborts instead of minting a
+	// partial group.
+	if !strings.Contains(script, "&&") {
+		t.Fatalf("steps not chained: %s", script)
+	}
+}
+
+func TestCyclePresetTemplateWrapsThroughNone(t *testing.T) {
+	page := newFleetPage()
+	page.dialogPresets = []fleet.LayoutPreset{
+		{Name: "a", PaneCommands: []string{""}},
+		{Name: "b", PaneCommands: []string{""}},
+	}
+	page.dialogPresetIdx = -1
+
+	want := []int{0, 1, -1, 0}
+	for i, w := range want {
+		page.cyclePresetTemplate(1)
+		if page.dialogPresetIdx != w {
+			t.Fatalf("step %d: idx = %d, want %d", i, page.dialogPresetIdx, w)
+		}
+	}
+	// And backwards from 0 → -1 → 1.
+	page.dialogPresetIdx = 0
+	page.cyclePresetTemplate(-1)
+	if page.dialogPresetIdx != -1 {
+		t.Fatalf("backward from 0: idx = %d, want -1", page.dialogPresetIdx)
+	}
+	page.cyclePresetTemplate(-1)
+	if page.dialogPresetIdx != 1 {
+		t.Fatalf("backward from -1: idx = %d, want 1", page.dialogPresetIdx)
+	}
+}
+
+func TestCyclePresetTemplateNoPresetsIsNoop(t *testing.T) {
+	page := newFleetPage()
+	page.dialogPresetIdx = -1
+	page.cyclePresetTemplate(1)
+	if page.dialogPresetIdx != -1 {
+		t.Fatalf("idx = %d, want -1", page.dialogPresetIdx)
+	}
+}
+
+func TestUniquePresetName(t *testing.T) {
+	presets := []fleet.LayoutPreset{
+		{Name: "dev"},
+		{Name: "dev-2"},
+	}
+	if got := uniquePresetName("dev", presets, -1); got != "dev-3" {
+		t.Fatalf("got %q, want dev-3", got)
+	}
+	if got := uniquePresetName("fresh", presets, -1); got != "fresh" {
+		t.Fatalf("got %q, want fresh", got)
+	}
+	// Editing preset 0 may keep its own name.
+	if got := uniquePresetName("dev", presets, 0); got != "dev" {
+		t.Fatalf("got %q, want dev (own name)", got)
+	}
+	if got := uniquePresetName("", nil, -1); got != "layout" {
+		t.Fatalf("got %q, want layout fallback", got)
+	}
+}
+
+func TestInitEditStageFallsBackOnPaneCountMismatch(t *testing.T) {
+	lp := &layoutPresetFlow{editIdx: -1}
+	// sampleLayout has 2 session panes; claiming 3 must drop the geometry and
+	// synthesize a 3-pane stack so the preview matches what apply would do.
+	lp.initEditStage(sampleLayout, 3, "dev", nil, false)
+	if lp.layout != "" {
+		t.Fatalf("mismatched layout kept: %q", lp.layout)
+	}
+	if lp.paneCount() != 3 {
+		t.Fatalf("paneCount = %d, want 3", lp.paneCount())
+	}
+}
+
+func TestInitEditStageParsesMatchingLayout(t *testing.T) {
+	lp := &layoutPresetFlow{editIdx: -1}
+	lp.initEditStage(sampleLayout, 2, "dev", nil, false)
+	if lp.layout != sampleLayout {
+		t.Fatalf("layout dropped: %q", lp.layout)
+	}
+	if lp.paneCount() != 2 {
+		t.Fatalf("paneCount = %d, want 2", lp.paneCount())
+	}
+	if len(lp.rects) != 3 {
+		t.Fatalf("rects = %d, want 3 (TUI + 2)", len(lp.rects))
+	}
+	if lp.focus != 1 {
+		t.Fatalf("focus = %d, want first pane", lp.focus)
+	}
+	if lp.allAssigned() {
+		t.Fatal("new capture must start unassigned")
+	}
+}
+
+func TestInitEditStagePreAssignsExistingPreset(t *testing.T) {
+	lp := &layoutPresetFlow{editIdx: 0}
+	lp.initEditStage(sampleLayout, 2, "dev", []string{"htop", ""}, true)
+	if !lp.allAssigned() {
+		t.Fatal("editing an existing preset must start fully assigned")
+	}
+	if lp.commands[0] != "htop" || lp.commands[1] != "" {
+		t.Fatalf("commands not carried over: %v", lp.commands)
+	}
+}
+
+func TestLayoutPresetFlowFocusSkipsHiddenConfirm(t *testing.T) {
+	lp := &layoutPresetFlow{editIdx: -1}
+	lp.initEditStage("", 2, "dev", nil, false)
+
+	// Unassigned: cycle name(0) → pane1(1) → pane2(2) → cancel(3) → name(0).
+	lp.focus = lpFocusName
+	seen := []int{}
+	for range 4 {
+		lp.moveFocus(1)
+		seen = append(seen, lp.focus)
+	}
+	want := []int{1, 2, 3, 0}
+	for i := range want {
+		if seen[i] != want[i] {
+			t.Fatalf("unassigned cycle = %v, want %v", seen, want)
+		}
+	}
+
+	// Fully assigned: the confirm stop (4) joins the cycle.
+	lp.assigned[0], lp.assigned[1] = true, true
+	lp.focus = lp.focusCancel()
+	lp.moveFocus(1)
+	if lp.focus != lp.focusConfirm() {
+		t.Fatalf("focus = %d, want confirm %d", lp.focus, lp.focusConfirm())
+	}
+}
+
+func TestAdvanceToNextUnassigned(t *testing.T) {
+	lp := &layoutPresetFlow{editIdx: -1}
+	lp.initEditStage("", 3, "dev", nil, false)
+	lp.assigned[0] = true
+	lp.advanceToNextUnassigned()
+	if lp.focusedSlot() != 1 {
+		t.Fatalf("slot = %d, want 1", lp.focusedSlot())
+	}
+	lp.assigned[1], lp.assigned[2] = true, true
+	lp.advanceToNextUnassigned()
+	if lp.focus != lp.focusConfirm() {
+		t.Fatalf("focus = %d, want confirm", lp.focus)
+	}
+}

--- a/internal/tui/layout_preview.go
+++ b/internal/tui/layout_preview.go
@@ -1,0 +1,369 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// layout_preview.go renders a miniature, navigable picture of a saved tmux
+// window layout for the layout-preset dialog (issue #150). The input is the
+// same #{window_layout} string the group save/restore mechanism persists
+// (savedGroup.Layout): leaf 0 is the pane select-layout assigns to the fleet
+// TUI itself (pane index 0), and the remaining leaves — sorted by position,
+// top then left, exactly like listPanesByPosition — are the session panes a
+// preset assigns startup commands to.
+
+// layoutRect is one leaf pane of a parsed tmux layout, in the cell coordinates
+// of the window the layout was captured from.
+type layoutRect struct {
+	x, y, w, h int
+}
+
+// parseTmuxLayout parses a tmux #{window_layout} string into its leaf panes,
+// in string order (which select-layout maps to pane-index order). The grammar:
+//
+//	layout := checksum ',' cell
+//	cell   := WxH ',' X ',' Y ( ',' paneID | '{' cell (',' cell)* '}' | '[' cell (',' cell)* ']' )
+//
+// where '{}' is a left-right split and '[]' top-bottom. Container dims are
+// discarded — only leaves are returned.
+func parseTmuxLayout(layout string) ([]layoutRect, error) {
+	s := strings.TrimSpace(layout)
+	if s == "" {
+		return nil, fmt.Errorf("empty layout")
+	}
+	// Strip the leading 4-hex-digit checksum ("b25d,...").
+	comma := strings.IndexByte(s, ',')
+	if comma < 0 {
+		return nil, fmt.Errorf("layout %q: missing checksum separator", layout)
+	}
+	p := &layoutParser{s: s, pos: comma + 1}
+	var leaves []layoutRect
+	if err := p.parseCell(&leaves); err != nil {
+		return nil, fmt.Errorf("layout %q: %w", layout, err)
+	}
+	if p.pos != len(p.s) {
+		return nil, fmt.Errorf("layout %q: trailing garbage at %d", layout, p.pos)
+	}
+	if len(leaves) == 0 {
+		return nil, fmt.Errorf("layout %q: no panes", layout)
+	}
+	return leaves, nil
+}
+
+type layoutParser struct {
+	s   string
+	pos int
+}
+
+func (p *layoutParser) parseCell(leaves *[]layoutRect) error {
+	w, err := p.parseInt()
+	if err != nil {
+		return err
+	}
+	if err := p.expect('x'); err != nil {
+		return err
+	}
+	h, err := p.parseInt()
+	if err != nil {
+		return err
+	}
+	if err := p.expect(','); err != nil {
+		return err
+	}
+	x, err := p.parseInt()
+	if err != nil {
+		return err
+	}
+	if err := p.expect(','); err != nil {
+		return err
+	}
+	y, err := p.parseInt()
+	if err != nil {
+		return err
+	}
+
+	switch p.peek() {
+	case '{', '[':
+		open := p.peek()
+		close := byte('}')
+		if open == '[' {
+			close = ']'
+		}
+		p.pos++
+		for {
+			if err := p.parseCell(leaves); err != nil {
+				return err
+			}
+			if p.peek() == ',' {
+				p.pos++
+				continue
+			}
+			break
+		}
+		if err := p.expect(close); err != nil {
+			return err
+		}
+	case ',':
+		// A leaf: ",paneID". The ID is the pane's %N number at capture time;
+		// it is meaningless after a restore, so it is parsed and dropped.
+		p.pos++
+		if _, err := p.parseInt(); err != nil {
+			return err
+		}
+		*leaves = append(*leaves, layoutRect{x: x, y: y, w: w, h: h})
+	default:
+		// A bare leaf with no pane ID (not produced by tmux, but harmless).
+		*leaves = append(*leaves, layoutRect{x: x, y: y, w: w, h: h})
+	}
+	return nil
+}
+
+func (p *layoutParser) peek() byte {
+	if p.pos >= len(p.s) {
+		return 0
+	}
+	return p.s[p.pos]
+}
+
+func (p *layoutParser) expect(c byte) error {
+	if p.peek() != c {
+		return fmt.Errorf("expected %q at %d", string(c), p.pos)
+	}
+	p.pos++
+	return nil
+}
+
+func (p *layoutParser) parseInt() (int, error) {
+	start := p.pos
+	for p.pos < len(p.s) && p.s[p.pos] >= '0' && p.s[p.pos] <= '9' {
+		p.pos++
+	}
+	if p.pos == start {
+		return 0, fmt.Errorf("expected number at %d", start)
+	}
+	return strconv.Atoi(p.s[start:p.pos])
+}
+
+// synthesizedStackRects builds the pane geometry a preset with no captured
+// layout string produces when applied: restoreGroupCmd with an empty layout
+// leaves the phase-1 placeholder splits in place — the TUI pane on the left
+// (30%) and the session panes stacked vertically on the right. Leaf 0 is the
+// TUI pane, matching parseTmuxLayout's convention.
+func synthesizedStackRects(panes int) []layoutRect {
+	if panes < 1 {
+		panes = 1
+	}
+	const w, tuiW = 100, 30
+	// Right column: panes cells of equal height with 1-cell separators.
+	paneH := 8
+	h := panes*paneH + (panes - 1)
+	rects := []layoutRect{{x: 0, y: 0, w: tuiW, h: h}}
+	for i := range panes {
+		rects = append(rects, layoutRect{x: tuiW + 1, y: i * (paneH + 1), w: w - tuiW - 1, h: paneH})
+	}
+	return rects
+}
+
+// orderRectsByPosition returns the indices of the session panes (every leaf
+// but leaf 0, the TUI pane) sorted by screen position, top then left — the
+// same ordering listPanesByPosition gives the live panes, so slot i of the
+// result is the pane that GroupLayout.Sessions[i] / LayoutPreset.PaneCommands[i]
+// maps to at restore time.
+func orderRectsByPosition(rects []layoutRect) []int {
+	order := make([]int, 0, len(rects)-1)
+	for i := 1; i < len(rects); i++ {
+		order = append(order, i)
+	}
+	sort.SliceStable(order, func(a, b int) bool {
+		ra, rb := rects[order[a]], rects[order[b]]
+		if ra.y != rb.y {
+			return ra.y < rb.y
+		}
+		return ra.x < rb.x
+	})
+	return order
+}
+
+// Box-drawing assembly: each grid cell carries a bitmask of line directions
+// and the mask resolves to the matching rune, so abutting pane borders fuse
+// into ├ ┬ ┼ etc. instead of overdrawing each other.
+const (
+	lineUp = 1 << iota
+	lineDown
+	lineLeft
+	lineRight
+)
+
+var lineRunes = map[int]rune{
+	lineLeft | lineRight:                     '─',
+	lineUp | lineDown:                        '│',
+	lineDown | lineRight:                     '┌',
+	lineDown | lineLeft:                      '┐',
+	lineUp | lineRight:                       '└',
+	lineUp | lineLeft:                        '┘',
+	lineUp | lineDown | lineRight:            '├',
+	lineUp | lineDown | lineLeft:             '┤',
+	lineDown | lineLeft | lineRight:          '┬',
+	lineUp | lineLeft | lineRight:            '┴',
+	lineUp | lineDown | lineLeft | lineRight: '┼',
+	lineUp:                                   '│',
+	lineDown:                                 '│',
+	lineLeft:                                 '─',
+	lineRight:                                '─',
+}
+
+// previewBorders maps each pane to its scaled border-line coordinates on a
+// charWidth x charHeight canvas. tmux pane cells abut across a 1-cell
+// separator (a pane at x occupies [x, x+w) with the separator at x-1 / x+w),
+// so the shared border line of two adjacent panes is the same window
+// coordinate — left edge x-1 (or 0 at the window edge) and right edge x+w —
+// which keeps neighbors' scaled borders coincident.
+type previewBox struct {
+	x0, y0, x1, y1 int // inclusive border-line coordinates on the canvas
+}
+
+func previewBorderBoxes(rects []layoutRect, charWidth, charHeight int) []previewBox {
+	// Window extent in cells: the furthest right/bottom edge.
+	winW, winH := 0, 0
+	for _, r := range rects {
+		winW = max(winW, r.x+r.w)
+		winH = max(winH, r.y+r.h)
+	}
+	scaleX := func(b int) int { return b * (charWidth - 1) / max(winW, 1) }
+	scaleY := func(b int) int { return b * (charHeight - 1) / max(winH, 1) }
+
+	boxes := make([]previewBox, 0, len(rects))
+	for _, r := range rects {
+		left, top := 0, 0
+		if r.x > 0 {
+			left = r.x - 1
+		}
+		if r.y > 0 {
+			top = r.y - 1
+		}
+		boxes = append(boxes, previewBox{
+			x0: scaleX(left),
+			y0: scaleY(top),
+			x1: scaleX(r.x + r.w),
+			y1: scaleY(r.y + r.h),
+		})
+	}
+	return boxes
+}
+
+// renderLayoutPreview draws the pane layout as a charWidth x charHeight
+// box-drawing diagram. Leaf 0 is labeled as the fleet TUI pane; session panes
+// are labeled by their 1-based slot number (position order, see
+// orderRectsByPosition) with a ✓ once their command slot has been assigned.
+// selectedSlot (an index into the slot order, -1 for none) highlights that
+// pane's interior.
+func renderLayoutPreview(rects []layoutRect, order []int, selectedSlot int, assigned []bool, charWidth, charHeight int) string {
+	if len(rects) == 0 || charWidth < 8 || charHeight < 3 {
+		return ""
+	}
+	boxes := previewBorderBoxes(rects, charWidth, charHeight)
+
+	masks := make([][]int, charHeight)
+	for i := range masks {
+		masks[i] = make([]int, charWidth)
+	}
+	for _, b := range boxes {
+		for x := b.x0; x < b.x1; x++ {
+			masks[b.y0][x] |= lineRight
+			masks[b.y1][x] |= lineRight
+			masks[b.y0][x+1] |= lineLeft
+			masks[b.y1][x+1] |= lineLeft
+		}
+		for y := b.y0; y < b.y1; y++ {
+			masks[y][b.x0] |= lineDown
+			masks[y][b.x1] |= lineDown
+			masks[y+1][b.x0] |= lineUp
+			masks[y+1][b.x1] |= lineUp
+		}
+	}
+
+	grid := make([][]rune, charHeight)
+	for y := range grid {
+		grid[y] = make([]rune, charWidth)
+		for x := range grid[y] {
+			if r, ok := lineRunes[masks[y][x]]; ok {
+				grid[y][x] = r
+			} else {
+				grid[y][x] = ' '
+			}
+		}
+	}
+
+	// Slot lookup: rect index -> slot number (0-based), -1 for the TUI pane.
+	slotOf := make(map[int]int, len(order))
+	for slot, rectIdx := range order {
+		slotOf[rectIdx] = slot
+	}
+
+	// Labels, centered in each pane's interior.
+	for i, b := range boxes {
+		label := "fleet"
+		if i > 0 {
+			slot := slotOf[i]
+			label = strconv.Itoa(slot + 1)
+			if slot < len(assigned) && assigned[slot] {
+				label += " ✓"
+			}
+		}
+		placeLabel(grid, b, label)
+	}
+
+	// Assemble lines, highlighting the selected pane's interior (borders
+	// included so the selection reads as a frame around the pane).
+	var selBox *previewBox
+	if selectedSlot >= 0 && selectedSlot < len(order) {
+		selBox = &boxes[order[selectedSlot]]
+	}
+	var lines []string
+	for y := range charHeight {
+		if selBox == nil || y < selBox.y0 || y > selBox.y1 {
+			lines = append(lines, string(grid[y]))
+			continue
+		}
+		row := grid[y]
+		var sb strings.Builder
+		sb.WriteString(string(row[:selBox.x0]))
+		sb.WriteString(selectedStyle.Render(string(row[selBox.x0 : selBox.x1+1])))
+		sb.WriteString(string(row[selBox.x1+1:]))
+		lines = append(lines, sb.String())
+	}
+	return strings.Join(lines, "\n")
+}
+
+// placeLabel writes label centered inside box b's interior, truncating to fit;
+// a pane too small for even one character keeps its blank interior.
+func placeLabel(grid [][]rune, b previewBox, label string) {
+	innerW := b.x1 - b.x0 - 1
+	innerH := b.y1 - b.y0 - 1
+	if innerW < 1 || innerH < 1 {
+		return
+	}
+	runes := []rune(label)
+	if len(runes) > innerW {
+		runes = runes[:innerW]
+	}
+	y := b.y0 + 1 + (innerH-1)/2
+	x := b.x0 + 1 + (innerW-len(runes))/2
+	copy(grid[y][x:], runes)
+}
+
+// previewDims picks the preview canvas size for a pane set: wide enough for
+// the 44-column dialog interior, and tall enough that each stacked pane keeps
+// a usable interior (3 rows per vertical level, bounded so a deep stack still
+// fits on screen).
+func previewDims(rects []layoutRect) (int, int) {
+	levels := map[int]bool{}
+	for _, r := range rects {
+		levels[r.y] = true
+	}
+	height := min(max(9, 3*len(levels)+1), 19)
+	return 42, height
+}

--- a/internal/tui/layout_preview_test.go
+++ b/internal/tui/layout_preview_test.go
@@ -1,0 +1,121 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// Captured from a real tmux server (208x58 window): TUI pane on the left,
+// right column split into two stacked panes.
+const sampleLayout = "a0c2,208x58,0,0{104x58,0,0,0,103x58,105,0[103x29,105,0,1,103x28,105,30,2]}"
+
+func TestParseTmuxLayoutNested(t *testing.T) {
+	rects, err := parseTmuxLayout(sampleLayout)
+	if err != nil {
+		t.Fatalf("parseTmuxLayout: %v", err)
+	}
+	want := []layoutRect{
+		{x: 0, y: 0, w: 104, h: 58},
+		{x: 105, y: 0, w: 103, h: 29},
+		{x: 105, y: 30, w: 103, h: 28},
+	}
+	if len(rects) != len(want) {
+		t.Fatalf("got %d leaves, want %d: %v", len(rects), len(want), rects)
+	}
+	for i, w := range want {
+		if rects[i] != w {
+			t.Fatalf("leaf %d = %+v, want %+v", i, rects[i], w)
+		}
+	}
+}
+
+func TestParseTmuxLayoutSinglePane(t *testing.T) {
+	rects, err := parseTmuxLayout("c3d4,80x24,0,0,5")
+	if err != nil {
+		t.Fatalf("parseTmuxLayout: %v", err)
+	}
+	if len(rects) != 1 || rects[0] != (layoutRect{x: 0, y: 0, w: 80, h: 24}) {
+		t.Fatalf("unexpected leaves: %v", rects)
+	}
+}
+
+func TestParseTmuxLayoutRejectsGarbage(t *testing.T) {
+	for _, layout := range []string{
+		"",
+		"nochecksum",
+		"abcd,80x24,0,0,5trailing",
+		"abcd,80x24,0,0{40x24,0,0,1,39x24,41,0,2", // unclosed brace
+		"abcd,80x,0,0,5",
+	} {
+		if _, err := parseTmuxLayout(layout); err == nil {
+			t.Fatalf("parseTmuxLayout(%q): want error", layout)
+		}
+	}
+}
+
+func TestOrderRectsByPositionTopThenLeft(t *testing.T) {
+	// Leaves in capture order: TUI, bottom-right, top-right — position order
+	// must come back top-right (y=0) before bottom-right (y=30).
+	rects := []layoutRect{
+		{x: 0, y: 0, w: 104, h: 58},    // TUI (excluded)
+		{x: 105, y: 30, w: 103, h: 28}, // bottom
+		{x: 105, y: 0, w: 103, h: 29},  // top
+	}
+	order := orderRectsByPosition(rects)
+	if len(order) != 2 || order[0] != 2 || order[1] != 1 {
+		t.Fatalf("order = %v, want [2 1]", order)
+	}
+}
+
+func TestSynthesizedStackRects(t *testing.T) {
+	rects := synthesizedStackRects(3)
+	if len(rects) != 4 {
+		t.Fatalf("got %d rects, want 4 (TUI + 3 panes)", len(rects))
+	}
+	order := orderRectsByPosition(rects)
+	// Stacked panes must come back in top-to-bottom order.
+	for i := 1; i < len(order); i++ {
+		if rects[order[i]].y <= rects[order[i-1]].y {
+			t.Fatalf("stack not top-to-bottom: %v", rects)
+		}
+	}
+}
+
+func TestRenderLayoutPreviewLabelsAndChecks(t *testing.T) {
+	rects, err := parseTmuxLayout(sampleLayout)
+	if err != nil {
+		t.Fatalf("parseTmuxLayout: %v", err)
+	}
+	order := orderRectsByPosition(rects)
+	out := renderLayoutPreview(rects, order, -1, []bool{true, false}, 42, 12)
+
+	if !strings.Contains(out, "fleet") {
+		t.Fatalf("preview missing TUI pane label:\n%s", out)
+	}
+	if !strings.Contains(out, "1 ✓") {
+		t.Fatalf("preview missing assigned slot-1 label:\n%s", out)
+	}
+	if !strings.Contains(out, "2") {
+		t.Fatalf("preview missing slot-2 label:\n%s", out)
+	}
+	lines := strings.Split(out, "\n")
+	if len(lines) != 12 {
+		t.Fatalf("preview height = %d lines, want 12", len(lines))
+	}
+}
+
+func TestRenderLayoutPreviewSharedBordersFuse(t *testing.T) {
+	rects, err := parseTmuxLayout(sampleLayout)
+	if err != nil {
+		t.Fatalf("parseTmuxLayout: %v", err)
+	}
+	out := renderLayoutPreview(rects, orderRectsByPosition(rects), -1, nil, 42, 12)
+	// The right column's two panes share a horizontal border that meets the
+	// TUI/right vertical border in a ├ junction; the outer corners must be
+	// rounded off as plain corners.
+	for _, r := range []string{"┌", "┐", "└", "┘", "├"} {
+		if !strings.Contains(out, r) {
+			t.Fatalf("preview missing %q:\n%s", r, out)
+		}
+	}
+}

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -78,6 +78,7 @@ type fleetPage struct {
 	// itself lives in lpFlow while mode == viewLayoutPreset.
 	dialogLayoutsExpanded     bool                 // ▼ Layouts expanded, revealing per-preset rows + the add row
 	dialogLayoutPresets       []fleet.LayoutPreset // working copy of the fleet's layout presets (instant-save)
+	dialogPresetRemoveFocused bool                 // horizontal sub-cursor: on the [remove] button vs the preset row (mirrors dialogCacheButtonFocused)
 	dialogPresetRemoveConfirm bool                 // inline "[remove?]" confirm armed on the focused preset row
 	lpFlow                    *layoutPresetFlow    // open preset creation/edit flow (nil unless mode == viewLayoutPreset)
 
@@ -2042,9 +2043,12 @@ func (fleetPage *fleetPage) renderLayoutPresetRow(row int, marker func(int) stri
 }
 
 // renderRemovePresetButton renders the [remove] affordance next to an existing
-// layout preset, mirroring renderRemoveMountButton's three states.
+// layout preset. Like the Caching section's [Delete cache] button it is only
+// highlighted when the horizontal sub-cursor is on it (dialogPresetRemoveFocused
+// on this row) — selecting the row alone leaves it dim, so it never looks armed
+// before the user arrows onto it.
 func (fleetPage *fleetPage) renderRemovePresetButton(row int) string {
-	focused := fleetPage.dialogRow == row
+	focused := fleetPage.dialogRow == row && fleetPage.dialogPresetRemoveFocused
 	if focused && fleetPage.dialogPresetRemoveConfirm {
 		return selectedStyle.Render("[remove?]")
 	}
@@ -2150,10 +2154,13 @@ func (fleetPage *fleetPage) editFleetHint() string {
 		if fleetPage.dialogRow == fleetPage.layoutPresetAddRow() {
 			return "[enter] New preset  [j/k] Select  [q/esc] Save & Close"
 		}
-		if fleetPage.dialogPresetRemoveConfirm {
-			return "[d] Confirm remove  [esc] Cancel"
+		if fleetPage.dialogPresetRemoveFocused {
+			if fleetPage.dialogPresetRemoveConfirm {
+				return "[enter] Confirm remove  [esc] Cancel"
+			}
+			return "[enter] Remove  [h/←] Back  [esc] Close"
 		}
-		return "[enter] Edit  [d] Remove  [j/k] Select  [q/esc] Save & Close"
+		return "[enter] Edit  [l/→] Remove button  [j/k] Select  [q/esc] Save & Close"
 	}
 	switch fleetPage.dialogRow {
 	case editFleetRowCustomMounts:

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -74,6 +74,18 @@ type fleetPage struct {
 	dialogCustomMountErr       string   // inline validation error shown under the add-mount input
 	dialogMountRemoveConfirm   bool     // inline "[remove?]" confirm armed on the focused custom-mount row (mirrors the Caching [Delete cache] flow)
 
+	// Layouts section (edit-fleet dialog) state. The preset creation/edit flow
+	// itself lives in lpFlow while mode == viewLayoutPreset.
+	dialogLayoutsExpanded     bool                 // ▼ Layouts expanded, revealing per-preset rows + the add row
+	dialogLayoutPresets       []fleet.LayoutPreset // working copy of the fleet's layout presets (instant-save)
+	dialogPresetRemoveConfirm bool                 // inline "[remove?]" confirm armed on the focused preset row
+	lpFlow                    *layoutPresetFlow    // open preset creation/edit flow (nil unless mode == viewLayoutPreset)
+
+	// New-session dialog template cycling: the fleet's presets snapshotted at
+	// dialog open, and the Tab-cycled selection (-1 = none, a plain session).
+	dialogPresets   []fleet.LayoutPreset
+	dialogPresetIdx int
+
 	dialogDetecting bool // true while a homedir auto-detect cmd is in flight
 
 	// dialogBrowserSwitching is true while the switch-browser dialog
@@ -290,6 +302,8 @@ func (fleetPage *fleetPage) Update(m *model, msg tea.Msg) tea.Cmd {
 		return fleetPage.updateArmadaSelect(m, msg)
 	case viewCreateSession:
 		return fleetPage.updateCreateSession(m, msg)
+	case viewLayoutPreset:
+		return fleetPage.updateLayoutPreset(m, msg)
 	case viewRenameSession:
 		return fleetPage.updateRenameSession(m, msg)
 	case viewCloneInstance:
@@ -708,13 +722,7 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 					m.message = "Instance must be running to create sessions"
 					break
 				}
-				fleetPage.mode = viewCreateSession
-				fleetPage.dialogFleet = r.fleetName
-				fleetPage.dialogInst = instance.Name
-				fleetPage.textInput.SetValue("")
-				fleetPage.textInput.Placeholder = "session-name (or empty for auto)"
-				fleetPage.textInput.CharLimit = 64
-				return fleetPage.activateTextInput()
+				return fleetPage.openCreateSessionDialog(m, r.fleetName, instance)
 			}
 			fleetName := fleetPage.currentFleetName()
 			if fleetName == "" {
@@ -938,14 +946,7 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 		fleetPage.buildRows(m)
 
 	case rowNewSession:
-		instance := r.instance
-		fleetPage.mode = viewCreateSession
-		fleetPage.dialogFleet = r.fleetName
-		fleetPage.dialogInst = instance.Name
-		fleetPage.textInput.SetValue("")
-		fleetPage.textInput.Placeholder = "session-name (or empty for auto)"
-		fleetPage.textInput.CharLimit = 64
-		return fleetPage.activateTextInput()
+		return fleetPage.openCreateSessionDialog(m, r.fleetName, r.instance)
 
 	case rowSession:
 		instance := r.instance
@@ -1651,6 +1652,11 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 		b.WriteString(dialogBox.Render(fleetPage.renderEditFleet(m)))
 		b.WriteString("\n")
 
+	case viewLayoutPreset:
+		b.WriteString("\n")
+		b.WriteString(dialogBox.Render(fleetPage.renderLayoutPresetDialog()))
+		b.WriteString("\n")
+
 	case viewTagInstance:
 		b.WriteString("\n")
 		dialog := fmt.Sprintf(
@@ -1745,15 +1751,28 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 
 	case viewCreateSession:
 		b.WriteString("\n")
-		dialog := fmt.Sprintf(
-			"%s\n\n%s %s\n%s %s\n\n%s",
+		hint := fleetPage.textDialogHint("Create (empty for auto-name)")
+		body := fmt.Sprintf(
+			"%s\n\n%s %s\n%s %s",
 			dialogTitle.Render("New session"),
 			dialogLabel.Render("Instance:"),
 			fleetExpandedStyle.Render(fleetPage.dialogFleet+"/"+fleetPage.dialogInst),
 			dialogLabel.Render("Name:    "),
 			fleetPage.textInput.View(),
-			dialogHint.Render(fleetPage.textDialogHint("Create (empty for auto-name)")),
 		)
+		// Template line, only when the fleet has layout presets to cycle.
+		if len(fleetPage.dialogPresets) > 0 {
+			var tmpl string
+			if idx := fleetPage.dialogPresetIdx; idx >= 0 && idx < len(fleetPage.dialogPresets) {
+				p := fleetPage.dialogPresets[idx]
+				tmpl = selectedStyle.Render(fmt.Sprintf("%s (%s)", p.Name, paneCountLabel(p.PaneCount())))
+			} else {
+				tmpl = dimStyle.Render("(none)")
+			}
+			body += fmt.Sprintf("\n%s %s", dialogLabel.Render("Template:"), tmpl)
+			hint = "[tab] Cycle template  " + hint
+		}
+		dialog := fmt.Sprintf("%s\n\n%s", body, dialogHint.Render(hint))
 		b.WriteString(dialogBox.Render(dialog))
 		b.WriteString("\n")
 
@@ -1950,6 +1969,12 @@ func (fleetPage *fleetPage) renderEditFleet(m *model) string {
 			d.WriteString(marker(row) + dialogLabel.Render("Home dir: ") + " " + field)
 		case editFleetRowPreferFleetLaunch:
 			d.WriteString(marker(row) + checkbox(fleetPage.dialogPreferFleetLaunch) + " " + dialogLabel.Render("Prefer Fleet Launch"))
+		case editFleetRowLayouts:
+			arrow := "▶ "
+			if fleetPage.dialogLayoutsExpanded {
+				arrow = "▼ "
+			}
+			d.WriteString(marker(row) + dialogLabel.Render(fmt.Sprintf("%sLayouts (%d)", arrow, len(fleetPage.dialogLayoutPresets))))
 		case editFleetRowCustomMounts:
 			arrow := "▶ "
 			if fleetPage.dialogCustomMountsExpanded {
@@ -1969,9 +1994,13 @@ func (fleetPage *fleetPage) renderEditFleet(m *model) string {
 		case editFleetRowImageCache:
 			d.WriteString(marker(row) + fleetPage.renderCacheRow(m, cacheImage, "Docker image cache"))
 		default:
-			// Dynamic custom-mount child rows (existing mounts + the add row),
-			// indented one level under the Custom mounts header.
-			d.WriteString(fleetPage.renderCustomMountRow(row, marker))
+			// Dynamic child rows, indented one level under their section
+			// header: layout presets or custom mounts.
+			if isLayoutPresetChildRow(row) {
+				d.WriteString(fleetPage.renderLayoutPresetRow(row, marker))
+			} else {
+				d.WriteString(fleetPage.renderCustomMountRow(row, marker))
+			}
 		}
 		d.WriteString("\n")
 	}
@@ -1997,6 +2026,32 @@ func (fleetPage *fleetPage) renderCustomMountRow(row int, marker func(int) strin
 		return marker(row) + "  " + dialogLabel.Render("+ Add mount")
 	}
 	return marker(row) + "  " + fleetPage.dialogCustomMounts[idx] + "   " + fleetPage.renderRemoveMountButton(row)
+}
+
+// renderLayoutPresetRow renders one dynamic layout-preset child row: an
+// existing preset (name + pane count, with a [remove] affordance) or the
+// "+ Layout Preset" row that starts the capture flow.
+func (fleetPage *fleetPage) renderLayoutPresetRow(row int, marker func(int) string) string {
+	idx := row - editFleetRowLayoutPresetBase
+	if idx == len(fleetPage.dialogLayoutPresets) {
+		return marker(row) + "  " + dialogLabel.Render("+ Layout Preset")
+	}
+	p := fleetPage.dialogLayoutPresets[idx]
+	label := fmt.Sprintf("%s (%s)", p.Name, paneCountLabel(p.PaneCount()))
+	return marker(row) + "  " + label + "   " + fleetPage.renderRemovePresetButton(row)
+}
+
+// renderRemovePresetButton renders the [remove] affordance next to an existing
+// layout preset, mirroring renderRemoveMountButton's three states.
+func (fleetPage *fleetPage) renderRemovePresetButton(row int) string {
+	focused := fleetPage.dialogRow == row
+	if focused && fleetPage.dialogPresetRemoveConfirm {
+		return selectedStyle.Render("[remove?]")
+	}
+	if focused {
+		return selectedStyle.Render("[remove]")
+	}
+	return dimStyle.Render("[remove]")
 }
 
 // renderRemoveMountButton renders the [remove] affordance next to an existing
@@ -2091,9 +2146,23 @@ func (fleetPage *fleetPage) editFleetHint() string {
 		}
 		return "[enter/d] Remove  [j/k] Select  [q/esc] Save & Close"
 	}
+	if isLayoutPresetChildRow(fleetPage.dialogRow) {
+		if fleetPage.dialogRow == fleetPage.layoutPresetAddRow() {
+			return "[enter] New preset  [j/k] Select  [q/esc] Save & Close"
+		}
+		if fleetPage.dialogPresetRemoveConfirm {
+			return "[d] Confirm remove  [esc] Cancel"
+		}
+		return "[enter] Edit  [d] Remove  [j/k] Select  [q/esc] Save & Close"
+	}
 	switch fleetPage.dialogRow {
 	case editFleetRowCustomMounts:
 		if fleetPage.dialogCustomMountsExpanded {
+			return "[h/←] Collapse  [j/k] Select  [q/esc] Save & Close"
+		}
+		return "[l/→/space] Expand  [j/k] Select  [q/esc] Save & Close"
+	case editFleetRowLayouts:
+		if fleetPage.dialogLayoutsExpanded {
 			return "[h/←] Collapse  [j/k] Select  [q/esc] Save & Close"
 		}
 		return "[l/→/space] Expand  [j/k] Select  [q/esc] Save & Close"

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -1761,14 +1761,15 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			dialogLabel.Render("Name:    "),
 			fleetPage.textInput.View(),
 		)
-		// Template line, only when the fleet has layout presets to cycle.
+		// Template line, only when the fleet has layout presets to cycle. Shown
+		// as a bracketed cycle option ([ none ] / [ name ]) like the backend
+		// selector, with the chosen template highlighted.
 		if len(fleetPage.dialogPresets) > 0 {
 			var tmpl string
 			if idx := fleetPage.dialogPresetIdx; idx >= 0 && idx < len(fleetPage.dialogPresets) {
-				p := fleetPage.dialogPresets[idx]
-				tmpl = selectedStyle.Render(fmt.Sprintf("%s (%s)", p.Name, paneCountLabel(p.PaneCount())))
+				tmpl = selectedStyle.Render(fmt.Sprintf("[ %s ]", fleetPage.dialogPresets[idx].Name))
 			} else {
-				tmpl = dimStyle.Render("(none)")
+				tmpl = dimStyle.Render("[ none ]")
 			}
 			body += fmt.Sprintf("\n%s %s", dialogLabel.Render("Template:"), tmpl)
 			hint = "[tab] Cycle template  " + hint

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -1051,6 +1051,47 @@ func TestEditFleetPresetRowEnterEdits(t *testing.T) {
 	}
 }
 
+// TestCreateSessionBlankNameWithTemplateUsesTemplateName verifies that creating
+// a session from a selected template with no name typed defaults the session
+// name to the template's name (not the generic "session-N").
+func TestCreateSessionBlankNameWithTemplateUsesTemplateName(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	f := &fleet.Fleet{Name: "alpha", Instances: []*fleet.Instance{{Name: "i1"}}}
+	fp := newFleetPage()
+	fp.dialogFleet = "alpha"
+	fp.dialogInst = "i1"
+	fp.dialogPresets = []fleet.LayoutPreset{{Name: "app-run", PaneCommands: []string{"htop", "top"}}}
+	fp.dialogPresetIdx = 0
+	fp.textInput.SetValue("") // no name entered
+	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}}, fleetPage: fp, sessionStore: NewSessionStore()}
+
+	cmd := fp.saveCreateSession(m)
+	if cmd == nil {
+		t.Fatal("expected a create command")
+	}
+	if !strings.Contains(m.message, "app-run") || strings.Contains(m.message, "session-") {
+		t.Fatalf("blank name with a template should default to the template name; message=%q", m.message)
+	}
+}
+
+// TestCreateSessionBlankNameNoTemplateAutoNames verifies the existing behavior
+// is unchanged when no template is selected: a blank name auto-generates one.
+func TestCreateSessionBlankNameNoTemplateAutoNames(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	f := &fleet.Fleet{Name: "alpha", Instances: []*fleet.Instance{{Name: "i1"}}}
+	fp := newFleetPage()
+	fp.dialogFleet = "alpha"
+	fp.dialogInst = "i1"
+	fp.dialogPresetIdx = -1 // no template selected
+	fp.textInput.SetValue("")
+	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}}, fleetPage: fp, sessionStore: NewSessionStore()}
+
+	fp.saveCreateSession(m)
+	if !strings.Contains(m.message, "session-") {
+		t.Fatalf("blank name without a template should auto-name; message=%q", m.message)
+	}
+}
+
 // TestEditFleetDeleteCacheError surfaces the failure path: a failed wipe clears
 // the in-flight flag and reports the error to the user.
 func TestEditFleetDeleteCacheError(t *testing.T) {

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -958,6 +958,99 @@ func TestEditFleetDeleteCacheButtonFlow(t *testing.T) {
 	}
 }
 
+// navigateToFirstPresetRow opens the Layouts section and lands the cursor on
+// the first existing preset row.
+func navigateToFirstPresetRow(t *testing.T, fp *fleetPage, m *model) {
+	t.Helper()
+	guard := 0
+	for fp.dialogRow != editFleetRowLayouts {
+		fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyDown})
+		if guard++; guard > 20 {
+			t.Fatal("never reached Layouts header")
+		}
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}}) // expand
+	if !fp.dialogLayoutsExpanded {
+		t.Fatal("Layouts section should expand on l")
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyDown}) // into the first preset row
+	if fp.dialogRow != editFleetRowLayoutPresetBase {
+		t.Fatalf("dialogRow = %d, want first preset row", fp.dialogRow)
+	}
+}
+
+// TestEditFleetPresetRemoveButtonFlow verifies the [remove] button on a preset
+// row behaves like the Caching [Delete cache] button: dim until the →/l
+// sub-cursor lands on it, Enter there arms a confirm, and a second Enter
+// removes — so selecting the row alone never looks armed.
+func TestEditFleetPresetRemoveButtonFlow(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
+
+	f := &fleet.Fleet{Name: "alpha", Settings: fleet.FleetSettings{
+		LayoutPresets: []fleet.LayoutPreset{{Name: "app-run", PaneCommands: []string{"htop"}}},
+	}}
+	fp := newFleetPage()
+	fp.rows = []row{{kind: rowFleetHeader, fleetName: "alpha"}}
+	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}}, fleetPage: fp}
+
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	navigateToFirstPresetRow(t, fp, m)
+
+	// Selecting the row must NOT focus (or arm) the remove button.
+	if fp.dialogPresetRemoveFocused {
+		t.Fatal("remove button should not be focused just by selecting the row")
+	}
+
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}}) // → focus the button
+	if !fp.dialogPresetRemoveFocused {
+		t.Fatal("l should focus the remove button")
+	}
+
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter}) // first enter: arm
+	if !fp.dialogPresetRemoveConfirm {
+		t.Fatal("first enter on the remove button should arm the confirm")
+	}
+	if len(fp.dialogLayoutPresets) != 1 {
+		t.Fatalf("preset removed before confirm: %d", len(fp.dialogLayoutPresets))
+	}
+
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter}) // second enter: remove
+	if len(fp.dialogLayoutPresets) != 0 {
+		t.Fatalf("preset not removed after confirm: %d", len(fp.dialogLayoutPresets))
+	}
+}
+
+// TestEditFleetPresetRowEnterEdits verifies Enter on a preset row (sub-cursor
+// not on [remove]) opens the editor, and ←/h clears the remove sub-cursor.
+func TestEditFleetPresetRowEnterEdits(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
+
+	f := &fleet.Fleet{Name: "alpha", Settings: fleet.FleetSettings{
+		LayoutPresets: []fleet.LayoutPreset{{Name: "app-run", PaneCommands: []string{"htop"}}},
+	}}
+	fp := newFleetPage()
+	fp.rows = []row{{kind: rowFleetHeader, fleetName: "alpha"}}
+	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}}, fleetPage: fp}
+
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	navigateToFirstPresetRow(t, fp, m)
+
+	// → then ← clears the sub-cursor back to the row.
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	if fp.dialogPresetRemoveFocused {
+		t.Fatal("h should clear the remove sub-cursor")
+	}
+
+	// Enter on the row (not the button) opens the editor.
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if fp.mode != viewLayoutPreset || fp.lpFlow == nil {
+		t.Fatalf("enter on the preset row should open the editor; mode=%v lpFlow=%v", fp.mode, fp.lpFlow)
+	}
+}
+
 // TestEditFleetDeleteCacheError surfaces the failure path: a failed wipe clears
 // the in-flight flag and reports the error to the user.
 func TestEditFleetDeleteCacheError(t *testing.T) {

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -161,6 +162,57 @@ func createSessionCmd(ref InstanceRef, sessionName string) tea.Cmd {
 			return sessionCreatedMsg{ref: ref, err: err}
 		}
 		return sessionCreatedMsg{ref: ref}
+	}
+}
+
+// presetSessionsCreatedMsg is sent after creating a session group from a
+// layout preset (issue #150). On success the handler records the group's
+// saved layout so opening the group restores the preset's pane geometry.
+type presetSessionsCreatedMsg struct {
+	ref      InstanceRef
+	groupID  string
+	sessions []string // position-ordered session names (slot i = pane i)
+	layout   string   // the preset's tmux layout string ("" = default stacking)
+	err      error
+}
+
+// buildPresetSessionScript builds the in-container one-liner that mints a
+// preset's tmux sessions and types each pane's startup command into its
+// session. Steps are chained with && so a failure (e.g. a name collision on
+// the first new-session) stops the script instead of minting a partial group
+// silently. send-keys targets use "=<name>:" — exact session match (the
+// group's pane names extend the root name, so prefix matching would be
+// ambiguous) and the trailing ":" makes it a session target; a bare "=<name>"
+// fails target-pane parsing ("can't find pane") on tmux 3.x. -l sends the
+// command literally so key names inside it (e.g. "Enter") are not interpreted.
+func buildPresetSessionScript(sessions []string, commands []string) string {
+	var b strings.Builder
+	b.WriteString(tmuxEnsureInstalled)
+	for i, name := range sessions {
+		if i > 0 {
+			b.WriteString(" && ")
+		}
+		fmt.Fprintf(&b, `tmux new-session -d -s %s 2>/dev/null`, shQuote(name))
+		if i < len(commands) && commands[i] != "" {
+			target := shQuote("=" + name + ":")
+			fmt.Fprintf(&b, ` && tmux send-keys -t %s -l %s && tmux send-keys -t %s Enter`,
+				target, shQuote(commands[i]), target)
+		}
+	}
+	return b.String()
+}
+
+// createSessionGroupFromPresetCmd creates every session of a preset-backed
+// group inside the container (running each pane's startup command) and reports
+// the outcome; the handler persists the group layout on success.
+func createSessionGroupFromPresetCmd(ref InstanceRef, groupID string, sessions []string, preset fleet.LayoutPreset) tea.Cmd {
+	script := buildPresetSessionScript(sessions, preset.PaneCommands)
+	layout := preset.Layout
+	return func() tea.Msg {
+		if _, err := runSessionScript(ref, script); err != nil {
+			return presetSessionsCreatedMsg{ref: ref, groupID: groupID, err: err}
+		}
+		return presetSessionsCreatedMsg{ref: ref, groupID: groupID, sessions: sessions, layout: layout}
 	}
 }
 

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -184,7 +184,10 @@ type presetSessionsCreatedMsg struct {
 // group's pane names extend the root name, so prefix matching would be
 // ambiguous) and the trailing ":" makes it a session target; a bare "=<name>"
 // fails target-pane parsing ("can't find pane") on tmux 3.x. -l sends the
-// command literally so key names inside it (e.g. "Enter") are not interpreted.
+// command literally so key names inside it (e.g. "Enter") are not interpreted,
+// and the "--" terminates send-keys' own flag parsing so a command beginning
+// with "-" (e.g. "-rf ...") is not mistaken for a flag (which would fail the
+// step and abort the whole && chain).
 func buildPresetSessionScript(sessions []string, commands []string) string {
 	var b strings.Builder
 	b.WriteString(tmuxEnsureInstalled)
@@ -195,7 +198,7 @@ func buildPresetSessionScript(sessions []string, commands []string) string {
 		fmt.Fprintf(&b, `tmux new-session -d -s %s 2>/dev/null`, shQuote(name))
 		if i < len(commands) && commands[i] != "" {
 			target := shQuote("=" + name + ":")
-			fmt.Fprintf(&b, ` && tmux send-keys -t %s -l %s && tmux send-keys -t %s Enter`,
+			fmt.Fprintf(&b, ` && tmux send-keys -t %s -l -- %s && tmux send-keys -t %s Enter`,
 				target, shQuote(commands[i]), target)
 		}
 	}

--- a/internal/tui/view_mode.go
+++ b/internal/tui/view_mode.go
@@ -25,6 +25,7 @@ const (
 	viewCodespacesLimit
 	viewCodespacesMachine
 	viewCreateSession
+	viewLayoutPreset
 	viewRenameSession
 	viewConfirmDeleteSession
 	viewConfirmBrowserSwitch


### PR DESCRIPTION
## Summary

Implements **layout presets** (issue #150): per-fleet templates that pair a captured tmux pane layout with a startup command per pane, so a user can spin up a fresh session pre-split and pre-loaded with the right programs.

**Setup** — the edit-fleet dialog gains a collapsible **Layouts** section (above Custom mounts, under Home dir). `+ Layout Preset` starts an inline flow: pick a live session group across any of the fleet's instances (shown as `<instance> / <session>`), preview its pane layout in a navigable box-drawing diagram, optionally set a bash startup command per pane (an empty one is a plain shell), name it, and `[ save ]`. Navigation in the preview is spatial — arrows/`hjkl` move between panes by their on-screen geometry, plus the name row and the cancel/save buttons. Existing presets reopen the same preview to edit, and each row's `[ remove ]` button works like the Caching section's `[ Delete cache ]` (→ to focus it, Enter to arm a `[remove?]` confirm, Enter again to remove).

**Usage** — the new-session dialog `Tab`-cycles the fleet's presets as a bracketed selector (`[ none ]` → `[ name ]`, like the backend selector). Creating with a template selected mints the whole session group — one session per pane — auto-runs each saved command, and records the group layout so opening the session restores the captured geometry. A blank name defaults to the template's name.

**Data model** — `FleetSettings` grows `repeated LayoutPreset {name, layout, pane_commands}`, validated server-side in `SetFleetSettings` (`NormalizeLayoutPresets`: non-empty unique names, 1–32 panes) and round-tripped through all four proto⇄legacy converters + `state.json`. The captured `layout` is the same `window_layout` string the existing group save/restore already persists; `pane_commands` is position-ordered (top then left) like `GroupLayout.sessions`.

## Notes

- Persistence rounds entirely through fleetd (`SetFleetSettings` RPC → `state.Update` → `state.json`); an integration test (`291`) creates a preset, kills the daemon, and confirms it reloads on restart.
- Pane startup commands are sent with `tmux send-keys -l --` so a command beginning with `-` is typed literally rather than parsed as a flag.
