### PR TITLE
refactor/dev-fleetd-always-relaunch — add a manual "Restart daemon" settings action

### DIFF
--- a/internal/fleetclient/dial.go
+++ b/internal/fleetclient/dial.go
@@ -50,6 +50,24 @@ func DialLocal(ctx context.Context) (*Conn, error) {
 	return dialEndpoint(ctx, localEndpoint{socket: fleetpaths.SocketPath()})
 }
 
+// RestartLocalServer stops the running local fleet daemon and relaunches it from
+// the current binary — the same drain-and-respawn mechanic the version handshake
+// uses, exposed for a manual "restart daemon" action in the TUI. It always
+// targets the local unix socket regardless of FLEET_GATEWAY/FLEET_SERVER (a
+// remote daemon can't be relaunched from here); if no daemon is running it simply
+// starts a fresh one. Safe under racing clients: the relaunch is serialized by
+// the spawn lock.
+func RestartLocalServer(ctx context.Context) error {
+	ep := localEndpoint{socket: fleetpaths.SocketPath()}
+	conn, err := grpc.NewClient(ep.Target(), ep.DialOptions()...)
+	if err != nil {
+		return fmt.Errorf("create client for %s: %w", ep, err)
+	}
+	defer conn.Close()
+	svc := fleetgrpc.NewFleetServiceClient(conn)
+	return restartServer(ctx, ep, svc, "user requested restart from the TUI")
+}
+
 func dialEndpoint(ctx context.Context, ep Endpoint) (*Conn, error) {
 	conn, err := grpc.NewClient(ep.Target(), ep.DialOptions()...)
 	if err != nil {

--- a/internal/fleetclient/version_check.go
+++ b/internal/fleetclient/version_check.go
@@ -3,6 +3,7 @@ package fleetclient
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -18,10 +19,12 @@ import (
 func reconcileServer(ctx context.Context, ep Endpoint, svc fleetgrpc.FleetServiceClient, reply *fleetgrpc.HelloReply, spawned bool) (restarted bool, err error) {
 	cv := version.Version
 	sv := reply.GetServerVersion()
+	// Binary-mtime staleness only matters for a dev client; skip the stat otherwise.
+	stale := cv == "" && serverIsStale(reply)
 
-	switch action, decErr := decideReconcile(cv, sv, ep.IsLocal(), spawned); action {
+	switch action, decErr := decideReconcile(cv, sv, ep.IsLocal(), spawned, stale); action {
 	case actionRestart:
-		if err := restartServer(ctx, ep, svc); err != nil {
+		if err := restartServer(ctx, ep, svc, restartReason()); err != nil {
 			return false, err
 		}
 		return true, nil
@@ -45,20 +48,19 @@ const (
 // so every case is unit-testable without spawning a process. cv is this client's
 // compiled-in version ("" = a dev build); sv is the server's reported version
 // ("" = a dev build); isLocal = the server runs on this host; spawned = WE just
-// started it.
+// started it; stale = (dev client only) this binary postdates the server's start.
 //
-//   - DEV client: ignore versions entirely — always relaunch a local,
-//     pre-existing server so it picks up freshly-built code. Restarting is cheap,
-//     so we do it unconditionally rather than guess at staleness, guaranteeing
-//     the local server never runs stale code. This holds even against a VERSIONED
-//     server, since one machine both tests dev builds and runs the release.
+//   - DEV client: ignore versions entirely — restart a local, pre-existing
+//     server only when this freshly-built binary postdates it. This holds even
+//     against a VERSIONED server, since one machine both tests dev builds and
+//     runs the release, so build-time is the only reliable signal.
 //   - VERSIONED client: a server reporting NO version is a dev build — replace it
 //     locally, error on a remote one. The same numeric core is fine (a
 //     pre-release counts as its release; see versionCore). A strictly-older local
 //     server is replaced; a newer one (or any remote version mismatch) errors.
-func decideReconcile(cv, sv string, isLocal, spawned bool) (reconcileAction, error) {
+func decideReconcile(cv, sv string, isLocal, spawned, stale bool) (reconcileAction, error) {
 	if cv == "" { // dev client
-		if spawned || !isLocal {
+		if spawned || !isLocal || !stale {
 			return actionNone, nil
 		}
 		return actionRestart, nil
@@ -83,11 +85,34 @@ func decideReconcile(cv, sv string, isLocal, spawned bool) (reconcileAction, err
 	return actionError, fmt.Errorf("fleet server is newer (%s) than this client (%s) — upgrade your client", sv, cv)
 }
 
+// serverIsStale reports whether the running server predates this client binary —
+// i.e. the binary was (re)built after the server started, so the server is
+// running old code. Used only for dev builds. On any uncertainty it returns
+// false (leave the server alone) rather than risk thrashing, EXCEPT when the
+// server reports no start time, which we treat as stale.
+func serverIsStale(reply *fleetgrpc.HelloReply) bool {
+	started := reply.GetStartedAt()
+	if started == nil {
+		return true
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	fi, err := os.Stat(self)
+	if err != nil {
+		return false
+	}
+	return fi.ModTime().After(started.AsTime())
+}
+
 // restartServer drains the running server and relaunches it from the current
 // binary, under the single-winner spawn lock so racing clients cause exactly one
 // restart at a time. It is a pure mechanic — the decision to restart belongs to
-// reconcileServer.
-func restartServer(ctx context.Context, ep Endpoint, svc fleetgrpc.FleetServiceClient) error {
+// reconcileServer (the version handshake) or to an explicit caller like
+// RestartLocalServer (the manual "restart daemon" action). reason is logged by
+// the server in its shutdown event.
+func restartServer(ctx context.Context, ep Endpoint, svc fleetgrpc.FleetServiceClient, reason string) error {
 	lockFD, err := acquireSpawnLock(ctx)
 	if err != nil {
 		return err
@@ -100,7 +125,7 @@ func restartServer(ctx context.Context, ep Endpoint, svc fleetgrpc.FleetServiceC
 	sctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	_, _ = svc.Shutdown(sctx, &fleetgrpc.ShutdownRequest{
 		Drain:  true,
-		Reason: strptr(restartReason()),
+		Reason: strptr(reason),
 	})
 	cancel()
 
@@ -119,7 +144,7 @@ func restartServer(ctx context.Context, ep Endpoint, svc fleetgrpc.FleetServiceC
 
 func restartReason() string {
 	if version.Version == "" {
-		return "dev client: relaunching local server from freshly-built binary"
+		return "dev client: replacing stale server with freshly-built binary"
 	}
 	return fmt.Sprintf("client %s newer than server", version.Version)
 }

--- a/internal/fleetclient/version_check.go
+++ b/internal/fleetclient/version_check.go
@@ -3,7 +3,6 @@ package fleetclient
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -19,10 +18,8 @@ import (
 func reconcileServer(ctx context.Context, ep Endpoint, svc fleetgrpc.FleetServiceClient, reply *fleetgrpc.HelloReply, spawned bool) (restarted bool, err error) {
 	cv := version.Version
 	sv := reply.GetServerVersion()
-	// Binary-mtime staleness only matters for a dev client; skip the stat otherwise.
-	stale := cv == "" && serverIsStale(reply)
 
-	switch action, decErr := decideReconcile(cv, sv, ep.IsLocal(), spawned, stale); action {
+	switch action, decErr := decideReconcile(cv, sv, ep.IsLocal(), spawned); action {
 	case actionRestart:
 		if err := restartServer(ctx, ep, svc); err != nil {
 			return false, err
@@ -48,19 +45,20 @@ const (
 // so every case is unit-testable without spawning a process. cv is this client's
 // compiled-in version ("" = a dev build); sv is the server's reported version
 // ("" = a dev build); isLocal = the server runs on this host; spawned = WE just
-// started it; stale = (dev client only) this binary postdates the server's start.
+// started it.
 //
-//   - DEV client: ignore versions entirely — restart a local, pre-existing
-//     server only when this freshly-built binary postdates it. This holds even
-//     against a VERSIONED server, since one machine both tests dev builds and
-//     runs the release, so build-time is the only reliable signal.
+//   - DEV client: ignore versions entirely — always relaunch a local,
+//     pre-existing server so it picks up freshly-built code. Restarting is cheap,
+//     so we do it unconditionally rather than guess at staleness, guaranteeing
+//     the local server never runs stale code. This holds even against a VERSIONED
+//     server, since one machine both tests dev builds and runs the release.
 //   - VERSIONED client: a server reporting NO version is a dev build — replace it
 //     locally, error on a remote one. The same numeric core is fine (a
 //     pre-release counts as its release; see versionCore). A strictly-older local
 //     server is replaced; a newer one (or any remote version mismatch) errors.
-func decideReconcile(cv, sv string, isLocal, spawned, stale bool) (reconcileAction, error) {
+func decideReconcile(cv, sv string, isLocal, spawned bool) (reconcileAction, error) {
 	if cv == "" { // dev client
-		if spawned || !isLocal || !stale {
+		if spawned || !isLocal {
 			return actionNone, nil
 		}
 		return actionRestart, nil
@@ -83,27 +81,6 @@ func decideReconcile(cv, sv string, isLocal, spawned, stale bool) (reconcileActi
 		return actionRestart, nil
 	}
 	return actionError, fmt.Errorf("fleet server is newer (%s) than this client (%s) — upgrade your client", sv, cv)
-}
-
-// serverIsStale reports whether the running server predates this client binary —
-// i.e. the binary was (re)built after the server started, so the server is
-// running old code. Used only for dev builds. On any uncertainty it returns
-// false (leave the server alone) rather than risk thrashing, EXCEPT when the
-// server reports no start time, which we treat as stale.
-func serverIsStale(reply *fleetgrpc.HelloReply) bool {
-	started := reply.GetStartedAt()
-	if started == nil {
-		return true
-	}
-	self, err := os.Executable()
-	if err != nil {
-		return false
-	}
-	fi, err := os.Stat(self)
-	if err != nil {
-		return false
-	}
-	return fi.ModTime().After(started.AsTime())
 }
 
 // restartServer drains the running server and relaunches it from the current
@@ -142,7 +119,7 @@ func restartServer(ctx context.Context, ep Endpoint, svc fleetgrpc.FleetServiceC
 
 func restartReason() string {
 	if version.Version == "" {
-		return "dev client: replacing stale server with freshly-built binary"
+		return "dev client: relaunching local server from freshly-built binary"
 	}
 	return fmt.Sprintf("client %s newer than server", version.Version)
 }

--- a/internal/fleetclient/version_check_test.go
+++ b/internal/fleetclient/version_check_test.go
@@ -3,7 +3,7 @@ package fleetclient
 import "testing"
 
 // TestDecideReconcile encodes the full version/freshness policy table. Each row
-// is (client version, server version, isLocal, spawned) -> action.
+// is (client version, server version, isLocal, spawned, stale) -> action.
 func TestDecideReconcile(t *testing.T) {
 	const (
 		dev  = "" // a dev build reports no version
@@ -12,43 +12,45 @@ func TestDecideReconcile(t *testing.T) {
 		v101 = "v1.0.1"
 	)
 	cases := []struct {
-		name             string
-		cv, sv           string
-		isLocal, spawned bool
-		want             reconcileAction
+		name                   string
+		cv, sv                 string
+		isLocal, spawned, stale bool
+		want                   reconcileAction
 	}{
-		// --- DEV client: versions ignored; always relaunch a pre-existing local server ---
-		{"dev: just spawned", dev, dev, true, true, actionNone},
-		{"dev: remote", dev, dev, false, false, actionNone},
-		{"dev: local, pre-existing", dev, dev, true, false, actionRestart},
-		// A dev client relaunches even a VERSIONED local server (one machine both
-		// tests dev builds and runs the release).
-		{"dev: local, versioned server", dev, v100, true, false, actionRestart},
+		// --- DEV client: versions ignored, decided by binary freshness ---
+		{"dev: just spawned", dev, dev, true, true, true, actionNone},
+		{"dev: remote", dev, dev, false, false, true, actionNone},
+		{"dev: local, not stale", dev, dev, true, false, false, actionNone},
+		{"dev: local, stale", dev, dev, true, false, true, actionRestart},
+		// A dev client restarts even a VERSIONED server when its binary is newer
+		// (one machine both tests dev builds and runs the release).
+		{"dev: local, stale, versioned server", dev, v100, true, false, true, actionRestart},
+		{"dev: local, not stale, versioned server", dev, v100, true, false, false, actionNone},
 
 		// --- VERSIONED client ---
 		// The fix: a release reclaims a leftover LOCAL dev (no-version) server.
-		{"versioned: dev server, local -> restart", v100, dev, true, false, actionRestart},
+		{"versioned: dev server, local -> restart", v100, dev, true, false, false, actionRestart},
 		// A remote dev server can't be relaunched -> error.
-		{"versioned: dev server, remote -> error", v100, dev, false, false, actionError},
+		{"versioned: dev server, remote -> error", v100, dev, false, false, false, actionError},
 		// Same numeric core (pre-release counts as its release) -> leave it.
-		{"versioned: same core (stable vs beta) -> none", v100, beta, true, false, actionNone},
-		{"versioned: identical -> none", v100, v100, true, false, actionNone},
-		{"versioned: beta client vs beta server -> none", beta, beta, true, false, actionNone},
+		{"versioned: same core (stable vs beta) -> none", v100, beta, true, false, false, actionNone},
+		{"versioned: identical -> none", v100, v100, true, false, false, actionNone},
+		{"versioned: beta client vs beta server -> none", beta, beta, true, false, false, actionNone},
 		// Older local server -> replace.
-		{"versioned: older server, local -> restart", v101, v100, true, false, actionRestart},
-		{"versioned: older server core via beta -> restart", v101, beta, true, false, actionRestart},
+		{"versioned: older server, local -> restart", v101, v100, true, false, false, actionRestart},
+		{"versioned: older server core via beta -> restart", v101, beta, true, false, false, actionRestart},
 		// Newer server -> client must upgrade (error), never restart.
-		{"versioned: newer server -> error", v100, v101, true, false, actionError},
+		{"versioned: newer server -> error", v100, v101, true, false, false, actionError},
 		// Any version mismatch on a remote server -> error.
-		{"versioned: older server but remote -> error", v101, v100, false, false, actionError},
+		{"versioned: older server but remote -> error", v101, v100, false, false, false, actionError},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := decideReconcile(tc.cv, tc.sv, tc.isLocal, tc.spawned)
+			got, err := decideReconcile(tc.cv, tc.sv, tc.isLocal, tc.spawned, tc.stale)
 			if got != tc.want {
-				t.Fatalf("decideReconcile(%q,%q,local=%v,spawned=%v) action = %v, want %v",
-					tc.cv, tc.sv, tc.isLocal, tc.spawned, got, tc.want)
+				t.Fatalf("decideReconcile(%q,%q,local=%v,spawned=%v,stale=%v) action = %v, want %v",
+					tc.cv, tc.sv, tc.isLocal, tc.spawned, tc.stale, got, tc.want)
 			}
 			if (err != nil) != (tc.want == actionError) {
 				t.Fatalf("error presence = %v (err=%v), want error==%v", err != nil, err, tc.want == actionError)

--- a/internal/fleetclient/version_check_test.go
+++ b/internal/fleetclient/version_check_test.go
@@ -3,7 +3,7 @@ package fleetclient
 import "testing"
 
 // TestDecideReconcile encodes the full version/freshness policy table. Each row
-// is (client version, server version, isLocal, spawned, stale) -> action.
+// is (client version, server version, isLocal, spawned) -> action.
 func TestDecideReconcile(t *testing.T) {
 	const (
 		dev  = "" // a dev build reports no version
@@ -12,45 +12,43 @@ func TestDecideReconcile(t *testing.T) {
 		v101 = "v1.0.1"
 	)
 	cases := []struct {
-		name                   string
-		cv, sv                 string
-		isLocal, spawned, stale bool
-		want                   reconcileAction
+		name             string
+		cv, sv           string
+		isLocal, spawned bool
+		want             reconcileAction
 	}{
-		// --- DEV client: versions ignored, decided by binary freshness ---
-		{"dev: just spawned", dev, dev, true, true, true, actionNone},
-		{"dev: remote", dev, dev, false, false, true, actionNone},
-		{"dev: local, not stale", dev, dev, true, false, false, actionNone},
-		{"dev: local, stale", dev, dev, true, false, true, actionRestart},
-		// A dev client restarts even a VERSIONED server when its binary is newer
-		// (one machine both tests dev builds and runs the release).
-		{"dev: local, stale, versioned server", dev, v100, true, false, true, actionRestart},
-		{"dev: local, not stale, versioned server", dev, v100, true, false, false, actionNone},
+		// --- DEV client: versions ignored; always relaunch a pre-existing local server ---
+		{"dev: just spawned", dev, dev, true, true, actionNone},
+		{"dev: remote", dev, dev, false, false, actionNone},
+		{"dev: local, pre-existing", dev, dev, true, false, actionRestart},
+		// A dev client relaunches even a VERSIONED local server (one machine both
+		// tests dev builds and runs the release).
+		{"dev: local, versioned server", dev, v100, true, false, actionRestart},
 
 		// --- VERSIONED client ---
 		// The fix: a release reclaims a leftover LOCAL dev (no-version) server.
-		{"versioned: dev server, local -> restart", v100, dev, true, false, false, actionRestart},
+		{"versioned: dev server, local -> restart", v100, dev, true, false, actionRestart},
 		// A remote dev server can't be relaunched -> error.
-		{"versioned: dev server, remote -> error", v100, dev, false, false, false, actionError},
+		{"versioned: dev server, remote -> error", v100, dev, false, false, actionError},
 		// Same numeric core (pre-release counts as its release) -> leave it.
-		{"versioned: same core (stable vs beta) -> none", v100, beta, true, false, false, actionNone},
-		{"versioned: identical -> none", v100, v100, true, false, false, actionNone},
-		{"versioned: beta client vs beta server -> none", beta, beta, true, false, false, actionNone},
+		{"versioned: same core (stable vs beta) -> none", v100, beta, true, false, actionNone},
+		{"versioned: identical -> none", v100, v100, true, false, actionNone},
+		{"versioned: beta client vs beta server -> none", beta, beta, true, false, actionNone},
 		// Older local server -> replace.
-		{"versioned: older server, local -> restart", v101, v100, true, false, false, actionRestart},
-		{"versioned: older server core via beta -> restart", v101, beta, true, false, false, actionRestart},
+		{"versioned: older server, local -> restart", v101, v100, true, false, actionRestart},
+		{"versioned: older server core via beta -> restart", v101, beta, true, false, actionRestart},
 		// Newer server -> client must upgrade (error), never restart.
-		{"versioned: newer server -> error", v100, v101, true, false, false, actionError},
+		{"versioned: newer server -> error", v100, v101, true, false, actionError},
 		// Any version mismatch on a remote server -> error.
-		{"versioned: older server but remote -> error", v101, v100, false, false, false, actionError},
+		{"versioned: older server but remote -> error", v101, v100, false, false, actionError},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := decideReconcile(tc.cv, tc.sv, tc.isLocal, tc.spawned, tc.stale)
+			got, err := decideReconcile(tc.cv, tc.sv, tc.isLocal, tc.spawned)
 			if got != tc.want {
-				t.Fatalf("decideReconcile(%q,%q,local=%v,spawned=%v,stale=%v) action = %v, want %v",
-					tc.cv, tc.sv, tc.isLocal, tc.spawned, tc.stale, got, tc.want)
+				t.Fatalf("decideReconcile(%q,%q,local=%v,spawned=%v) action = %v, want %v",
+					tc.cv, tc.sv, tc.isLocal, tc.spawned, got, tc.want)
 			}
 			if (err != nil) != (tc.want == actionError) {
 				t.Fatalf("error presence = %v (err=%v), want error==%v", err != nil, err, tc.want == actionError)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -92,6 +92,8 @@ type model struct {
 	coderPresets        []string // available preset names (in-memory, from API)
 	coderFetchingParams bool     // true while fetching template parameters
 
+	daemonRestarting bool // true while the settings "Restart daemon" action is in flight
+
 	codespaceMachines         []codespaceMachine // available machine types (from GitHub API)
 	codespaceFetchingMachines bool               // true while fetching machine types
 
@@ -843,6 +845,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.pendingExecArgs = msg.args
 		m.quitting = true
 		return m, tea.Quit
+
+	case daemonRestartedMsg:
+		m.daemonRestarting = false
+		if msg.err != nil {
+			m.message = fmt.Sprintf("Failed to restart daemon: %v", msg.err)
+		} else {
+			m.message = "Fleet daemon restarted"
+		}
+		return m, spinCmd
 
 	case coderParamsFetchedMsg:
 		m.coderFetchingParams = false

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetclient"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetpaths"
 	"github.com/BenjaminBenetti/fleet-man/internal/portforward"
 
@@ -138,6 +140,21 @@ func deleteFleetCmd(fleetName string, instances []*fleet.Instance, pf *portforwa
 			return operationDoneMsg{fleetName, "", "", err}
 		}
 		return operationDoneMsg{fleetName, "", fmt.Sprintf("Removed fleet %s", fleetName), nil}
+	}
+}
+
+// daemonRestartedMsg is sent when the settings "Restart daemon" action finishes.
+type daemonRestartedMsg struct{ err error }
+
+// restartDaemonCmd stops the local fleet daemon and relaunches it from the TUI's
+// current binary (the same mechanic the version handshake uses). It runs on its
+// own background context so the restart isn't cancelled mid-flight, and is
+// bounded by the drain/spawn timeouts inside RestartLocalServer.
+func restartDaemonCmd() tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		return daemonRestartedMsg{err: fleetclient.RestartLocalServer(ctx)}
 	}
 }
 

--- a/internal/tui/page_settings.go
+++ b/internal/tui/page_settings.go
@@ -58,6 +58,8 @@ const (
 	settingsItemArmadaAdd  = 800
 	settingsItemArmadaBase = 100000
 
+	settingsItemDaemonRestart = 900 // "Restart daemon" action row (below the tool-status band)
+
 	settingsItemToolStatusBase = 1000 // tool status rows start here
 	settingsItemDoctor         = 2000 // doctor action row
 	settingsItemKeybindings    = 2001 // keybindings dialog row
@@ -227,9 +229,10 @@ func (settingsPage *settingsPage) View(m *model) string {
 // settingsSection defines a titled group of settings rows that can be
 // conditionally shown based on tool availability.
 type settingsSection struct {
-	Title string               // section header text
-	Tool  string               // required tool binary; "" = always visible
-	Items func(m *model) []int // returns navigable item IDs for this section
+	Title   string               // section header text
+	Tool    string               // required tool binary; "" = always visible
+	Visible func(m *model) bool  // extra visibility gate; nil = always (subject to Tool)
+	Items   func(m *model) []int // returns navigable item IDs for this section
 }
 
 // settingsSections lists all settings sections in display order.
@@ -318,6 +321,16 @@ var settingsSections = []settingsSection{
 		},
 	},
 	{
+		// Only meaningful for a local TUI: the restart relaunches the LOCAL
+		// daemon from the current binary. A remote TUI (FLEET_GATEWAY/
+		// FLEET_SERVER) can't relaunch the daemon it talks to, so hide it.
+		Title:   "Fleet Daemon",
+		Visible: func(_ *model) bool { return !fleetclient.IsRemote() },
+		Items: func(_ *model) []int {
+			return []int{settingsItemDaemonRestart}
+		},
+	},
+	{
 		Title: "Help",
 		Items: func(_ *model) []int {
 			return []int{settingsItemDoctor, settingsItemKeybindings}
@@ -331,6 +344,9 @@ var settingsSections = []settingsSection{
 
 // sectionVisible reports whether a settings section should be shown.
 func (settingsPage *settingsPage) sectionVisible(m *model, section settingsSection) bool {
+	if section.Visible != nil && !section.Visible(m) {
+		return false
+	}
 	if section.Tool == "" {
 		return true
 	}
@@ -901,6 +917,14 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 			if item == settingsItemKeybindings {
 				settingsPage.showKeybindings = true
 				return nil
+			}
+			if item == settingsItemDaemonRestart {
+				if m.daemonRestarting {
+					return nil // already in flight; ignore repeat presses
+				}
+				m.daemonRestarting = true
+				m.message = "Restarting fleet daemon…"
+				return restartDaemonCmd()
 			}
 			if item == settingsItemDotfilesSetup {
 				cmd, err := agent.CommandWithPrompt(dotfilesSetupPrompt)
@@ -1477,6 +1501,19 @@ func (settingsPage *settingsPage) viewSettings(m *model) string {
 				itemID := settingsItemToolStatusBase + i
 				recordRow(itemID, settingsPage.renderSettingsRow(m, currentItem == itemID, tool.Name, value))
 			}
+
+		case "Fleet Daemon":
+			var daemonValue string
+			if m.daemonRestarting {
+				daemonValue = m.spinner.View() + " restarting…"
+			} else {
+				ver := m.serverVersion
+				if ver == "" {
+					ver = "dev build"
+				}
+				daemonValue = statusRunningStyle.Render(ver) + "  " + dimStyle.Render("press enter to relaunch fleetd from this TUI's binary")
+			}
+			recordRow(settingsItemDaemonRestart, settingsPage.renderSettingsRow(m, currentItem == settingsItemDaemonRestart, "Restart daemon", daemonValue))
 
 		case "Help":
 			agentName, _, agentErr := doctor.FindAgent()

--- a/internal/tui/page_settings_test.go
+++ b/internal/tui/page_settings_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -52,6 +53,70 @@ func TestSettingsSectionIncludesRemoteMcp(t *testing.T) {
 	}
 	if !strings.Contains(out, "Public MCP URL") {
 		t.Fatal("settings view missing the computed Public MCP URL row when enabled")
+	}
+}
+
+// TestDaemonSectionLocalOnly confirms the "Fleet Daemon" / restart action shows
+// for a local TUI but is hidden when the TUI is pointed at a remote daemon (it
+// can't relaunch a remote process).
+func TestDaemonSectionLocalOnly(t *testing.T) {
+	sp := newSettingsPage()
+	m := &model{
+		config:     state.DefaultConfig(),
+		toolStatus: allToolsFound(),
+		spinner:    spinner.New(),
+	}
+
+	// Local (no FLEET_GATEWAY/FLEET_SERVER): the restart row is navigable and rendered.
+	if !slices.Contains(sp.visibleItems(m), settingsItemDaemonRestart) {
+		t.Fatal("local TUI: Restart daemon row missing from settings nav")
+	}
+	out := sp.viewSettings(m)
+	if !strings.Contains(out, "Fleet Daemon") || !strings.Contains(out, "Restart daemon") {
+		t.Fatal("local TUI: settings view missing the Fleet Daemon section / restart row")
+	}
+
+	// Remote: the section is hidden.
+	t.Setenv("FLEET_GATEWAY", "https://gw.example/abc")
+	if slices.Contains(sp.visibleItems(m), settingsItemDaemonRestart) {
+		t.Fatal("remote TUI: Restart daemon row must be hidden")
+	}
+	if strings.Contains(sp.viewSettings(m), "Fleet Daemon") {
+		t.Fatal("remote TUI: Fleet Daemon section header must be hidden")
+	}
+}
+
+// TestDaemonRestartActionInFlight confirms pressing enter on the restart row arms
+// the in-flight flag (so the view shows a spinner) and returns a command, and
+// that a repeat press while in flight is ignored.
+func TestDaemonRestartActionInFlight(t *testing.T) {
+	sp := newSettingsPage()
+	m := &model{
+		config:      state.DefaultConfig(),
+		toolStatus:  allToolsFound(),
+		currentPage: sp,
+		fleetPage:   newFleetPage(),
+		spinner:     spinner.New(),
+	}
+	sp.cursor = settingsPositionOf(sp, m, settingsItemDaemonRestart)
+	if sp.cursor < 0 {
+		t.Fatal("Restart daemon row not found")
+	}
+
+	cmd := sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if !m.daemonRestarting {
+		t.Fatal("enter on Restart daemon should set daemonRestarting")
+	}
+	if cmd == nil {
+		t.Fatal("enter on Restart daemon should return a restart command")
+	}
+	if !strings.Contains(sp.viewSettings(m), "restarting") {
+		t.Fatal("in-flight restart should render a 'restarting' spinner row")
+	}
+
+	// A second press while the restart is in flight must be a no-op (no new cmd).
+	if cmd := sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter}); cmd != nil {
+		t.Fatal("repeat enter while restarting should be ignored")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a **Fleet Daemon** section to the TUI settings page with a **Restart daemon** action that stops the running local `fleetd` and relaunches it from the TUI's current binary — the same drain-and-respawn mechanic the version handshake already uses.

This solves the real gap: in some situations the automatic version/freshness reconcile leaves an old daemon running (e.g. a dev rebuild whose binary mtime didn't advance past the daemon's start time), and there was no easy way to force a fresh one. Now it's one keypress.

### Changes
- **fleetclient**: expose `RestartLocalServer(ctx)`; parameterize `restartServer` with a `reason` string (the handshake passes `restartReason()`, the manual action passes its own). The automatic reconcile policy (`decideReconcile` / `serverIsStale`) is **unchanged from main**.
- **tui**: new local-only settings section (hidden for a remote TUI, which can't relaunch the daemon it talks to), an in-flight spinner, a completion message, and the running daemon version shown next to the button. Tests cover the local/remote visibility gating and the in-flight / no-double-press behavior.

### History note
This branch first explored making the dev-build reconcile *always* relaunch the local daemon. CI caught that doing it on every `Dial` thrashes an attached TUI (every CLI command / Watch reconnect restarts the daemon, dropping the subscriber-gated control socket — integration test `530` — and ping-ponging between two TUIs). The staleness check is load-bearing for convergence, so that approach was reverted in favor of this explicit manual action. The branch name is historical.