### PR TITLE
feat/settings-copy-url-token — copy MCP/GRPC URLs and bearer token from Settings

### DIFF
--- a/internal/fleetclient/endpoint.go
+++ b/internal/fleetclient/endpoint.go
@@ -103,3 +103,12 @@ func gatewayToken() string {
 	}
 	return ""
 }
+
+// BearerToken resolves the bearer token used to authenticate to a fleet daemon:
+// FLEET_TOKEN if set, else the on-disk MCP token (~/.fleet/mcp.token). It is the
+// same secret the MCP HTTP server and the remote-fleet gRPC surface accept, so
+// callers (e.g. the Settings page) can hand it out for copy-paste setup of
+// remote clients. Returns "" when neither source yields a token.
+func BearerToken() string {
+	return gatewayToken()
+}

--- a/internal/fleetclient/grpc_gateway_test.go
+++ b/internal/fleetclient/grpc_gateway_test.go
@@ -1,6 +1,8 @@
 package fleetclient
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -105,5 +107,35 @@ func TestGatewayTokenFromEnv(t *testing.T) {
 	t.Setenv("FLEET_TOKEN", "  env-token  ")
 	if got := gatewayToken(); got != "env-token" {
 		t.Fatalf("gatewayToken() = %q, want trimmed env-token", got)
+	}
+}
+
+// TestBearerToken confirms the exported token resolver's precedence: FLEET_TOKEN
+// wins, otherwise the on-disk ~/.fleet/mcp.token (trimmed), otherwise empty.
+func TestBearerToken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Neither source present → empty.
+	t.Setenv("FLEET_TOKEN", "")
+	if got := BearerToken(); got != "" {
+		t.Fatalf("no sources: want empty, got %q", got)
+	}
+
+	// On-disk token is read and trimmed.
+	if err := os.MkdirAll(filepath.Join(home, ".fleet"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".fleet", "mcp.token"), []byte("  file-token  \n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := BearerToken(); got != "file-token" {
+		t.Fatalf("on-disk: want %q, got %q", "file-token", got)
+	}
+
+	// FLEET_TOKEN overrides the file.
+	t.Setenv("FLEET_TOKEN", " env-token ")
+	if got := BearerToken(); got != "env-token" {
+		t.Fatalf("env override: want %q, got %q", "env-token", got)
 	}
 }

--- a/internal/tui/page_settings.go
+++ b/internal/tui/page_settings.go
@@ -48,6 +48,9 @@ const (
 	settingsItemRemoteMcpCopyLocal  = 702 // copy local mcp.json snippet to clipboard
 	settingsItemRemoteMcpCopyRemote = 703 // copy gateway mcp.json snippet to clipboard
 	settingsItemRemoteFleetEnabled  = 704 // expose the gRPC control surface through the gateway
+	settingsItemRemoteMcpPublicURL  = 705 // copy the gateway-assigned public MCP URL
+	settingsItemRemoteGrpcPublicURL = 706 // copy the gateway-assigned public gRPC URL
+	settingsItemRemoteMcpToken      = 707 // copy the bearer token (~/.fleet/mcp.token)
 
 	// Fleet armada: the "+ Remote Fleet" button has a fixed id; registered
 	// remotes get base+i. The base is placed FAR above every other block (and
@@ -68,6 +71,18 @@ const (
 // isArmadaRemoteItem reports whether an item ID is one of the registered-remote
 // rows (base+i). Open-ended: nothing else lives at or above the armada base.
 func isArmadaRemoteItem(item int) bool { return item >= settingsItemArmadaBase }
+
+// isCopyRow reports whether an item ID is a Fleet MCP copy action — a row whose
+// enter copies to the clipboard rather than editing or cycling a value. Used to
+// show the right footer hint and nothing else.
+func isCopyRow(item int) bool {
+	switch item {
+	case settingsItemRemoteMcpCopyLocal, settingsItemRemoteMcpCopyRemote,
+		settingsItemRemoteMcpPublicURL, settingsItemRemoteGrpcPublicURL, settingsItemRemoteMcpToken:
+		return true
+	}
+	return false
+}
 
 // toolStatusCount is the number of rows rendered in the Tool Status
 // section. Must match the length of deps.CheckTools().
@@ -285,14 +300,25 @@ var settingsSections = []settingsSection{
 		Title: "Fleet MCP",
 		Items: func(m *model) []int {
 			// Copy actions come first. The remote-copy action only appears
-			// once the gateway tunnel is enabled. The computed Public MCP URL /
-			// Public GRPC URL are rendered inline as read-only status lines
-			// (not navigable).
+			// once the gateway tunnel is enabled. The Public MCP URL / Public
+			// GRPC URL rows are navigable so enter/click copies the
+			// gateway-assigned address; each appears only once its feature is
+			// enabled. The Bearer Token copy row joins them whenever either
+			// remote surface is on — it's the secret those URLs pair with.
 			items := []int{settingsItemRemoteMcpCopyLocal}
 			if m.config != nil && m.config.RemoteMcpSettings.Enabled {
 				items = append(items, settingsItemRemoteMcpCopyRemote)
 			}
 			items = append(items, settingsItemRemoteMcpEnabled, settingsItemRemoteFleetEnabled, settingsItemRemoteMcpGatewayURL)
+			if m.config != nil && m.config.RemoteMcpSettings.Enabled {
+				items = append(items, settingsItemRemoteMcpPublicURL)
+			}
+			if m.config != nil && m.config.RemoteMcpSettings.FleetEnabled {
+				items = append(items, settingsItemRemoteGrpcPublicURL)
+			}
+			if m.config != nil && (m.config.RemoteMcpSettings.Enabled || m.config.RemoteMcpSettings.FleetEnabled) {
+				items = append(items, settingsItemRemoteMcpToken)
+			}
 			return items
 		},
 	},
@@ -530,8 +556,11 @@ func (settingsPage *settingsPage) toggleRemoteMcpEnabled(m *model) {
 // toggleRemoteFleetEnabled flips the "Enable Remote Fleet" preference — exposing
 // this daemon's gRPC control surface through the gateway so a remote `fleet`
 // binary can drive it — and saves. Reverts on a save failure, mirroring the
-// other toggles. Unlike the MCP toggle it inserts no navigable rows, so the
-// cursor needs no re-pin.
+// other toggles. Toggling this shows/hides the Public GRPC URL and Bearer Token
+// rows, but both sit BELOW this toggle in the Fleet MCP section, so this row's
+// index is preserved and no cursor re-pin is needed — unlike the MCP toggle,
+// whose Copy-remote row sits ABOVE it. Re-pin (cursorToItem) if that ordering
+// ever changes.
 func (settingsPage *settingsPage) toggleRemoteFleetEnabled(m *model) {
 	if m.config == nil {
 		m.config = configutil.DefaultConfig()
@@ -635,7 +664,7 @@ func (settingsPage *settingsPage) codespacesMachineLabel(m *model) string {
 	return name
 }
 
-// remoteMcpStatusValue renders the read-only Public MCP URL / connection-state
+// remoteMcpStatusValue renders the Public MCP URL / connection-state
 // line from the latest status the server pushed over Watch. The tunnel itself
 // lands in a later PR, so today this resolves to "not connected" once enabled;
 // the CONNECTING/CONNECTED/ERROR rendering is wired and ready for it.
@@ -672,7 +701,16 @@ func remoteMcpPublicURL(m *model) string {
 	return m.remoteMcpStatus.GetPublicUrl()
 }
 
-// remoteGrpcStatusValue renders the read-only Public GRPC URL line from the same
+// remoteGrpcPublicURL returns the live gateway-assigned Public GRPC URL, or ""
+// when the tunnel is not (yet) connected or the gateway withheld it.
+func remoteGrpcPublicURL(m *model) string {
+	if m.remoteMcpStatus == nil {
+		return ""
+	}
+	return m.remoteMcpStatus.GetPublicGrpcUrl()
+}
+
+// remoteGrpcStatusValue renders the Public GRPC URL line from the same
 // pushed tunnel status as remoteMcpStatusValue (one tunnel carries both traffic
 // kinds, so they share connection state). A connected tunnel with no gRPC URL
 // means the gateway withheld it — it is old, runs without --public-grpc-url, or
@@ -895,6 +933,33 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 				}
 				m.message = "Remote MCP config copied to clipboard"
 				return copyToClipboardCmd(remoteMcpConfigJSON(url))
+			}
+			if item == settingsItemRemoteMcpPublicURL {
+				url := remoteMcpPublicURL(m)
+				if url == "" {
+					m.message = "No public MCP URL yet — connect to the gateway first"
+					return nil
+				}
+				m.message = "Public MCP URL copied to clipboard"
+				return copyToClipboardCmd(url)
+			}
+			if item == settingsItemRemoteGrpcPublicURL {
+				url := remoteGrpcPublicURL(m)
+				if url == "" {
+					m.message = "No public GRPC URL yet — connect to the gateway first"
+					return nil
+				}
+				m.message = "Public GRPC URL copied to clipboard"
+				return copyToClipboardCmd(url)
+			}
+			if item == settingsItemRemoteMcpToken {
+				token := fleetclient.BearerToken()
+				if token == "" {
+					m.message = "No bearer token found (set FLEET_TOKEN or ~/.fleet/mcp.token)"
+					return nil
+				}
+				m.message = "Bearer token copied to clipboard"
+				return copyToClipboardCmd(token)
 			}
 			if item == settingsItemCoderPreset {
 				settingsPage.cycleCoderPreset(m, 1)
@@ -1445,19 +1510,34 @@ func (settingsPage *settingsPage) viewSettings(m *model) string {
 			}
 			recordRow(settingsItemRemoteMcpGatewayURL, settingsPage.renderSettingsRow(m, currentItem == settingsItemRemoteMcpGatewayURL, "Gateway URL", gatewayValue))
 
-			// The computed Public MCP URL / Public GRPC URL are read-only (not
-			// navigable): they are the gateway-assigned addresses, delivered over
-			// Watch, that external tools / a remote `fleet` use to reach this
-			// fleet. Each is only shown once its feature is enabled.
+			// The Public MCP URL / Public GRPC URL rows show the live tunnel
+			// status (state + gateway-assigned address) and are navigable so
+			// enter/click copies the raw URL — see updateSettingsNav. Each appears
+			// only once its feature is enabled. The Bearer Token row below copies
+			// the shared secret (~/.fleet/mcp.token) those URLs authenticate with.
+			// Each URL row advertises its copy action inline (matching the copy
+			// rows above) only when there's actually a URL to copy; otherwise the
+			// status value already explains why (e.g. "(not connected)").
 			if config.RemoteMcpSettings.Enabled {
 				listContent.WriteString("\n")
-				row := settingsPage.renderSettingsRow(m, false, "Public MCP URL", remoteMcpStatusValue(m))
-				listContent.WriteString(lipgloss.NewStyle().Width(contentWidth).Render(row))
+				mcpValue := remoteMcpStatusValue(m)
+				if remoteMcpPublicURL(m) != "" {
+					mcpValue += "  " + dimStyle.Render("press enter to copy")
+				}
+				recordRow(settingsItemRemoteMcpPublicURL, settingsPage.renderSettingsRow(m, currentItem == settingsItemRemoteMcpPublicURL, "Public MCP URL", mcpValue))
 			}
 			if config.RemoteMcpSettings.FleetEnabled {
 				listContent.WriteString("\n")
-				row := settingsPage.renderSettingsRow(m, false, "Public GRPC URL", remoteGrpcStatusValue(m))
-				listContent.WriteString(lipgloss.NewStyle().Width(contentWidth).Render(row))
+				grpcValue := remoteGrpcStatusValue(m)
+				if remoteGrpcPublicURL(m) != "" {
+					grpcValue += "  " + dimStyle.Render("press enter to copy")
+				}
+				recordRow(settingsItemRemoteGrpcPublicURL, settingsPage.renderSettingsRow(m, currentItem == settingsItemRemoteGrpcPublicURL, "Public GRPC URL", grpcValue))
+			}
+			if config.RemoteMcpSettings.Enabled || config.RemoteMcpSettings.FleetEnabled {
+				listContent.WriteString("\n")
+				tokenValue := "[ Copy Bearer Token ]  " + dimStyle.Render("press enter to copy the daemon bearer token")
+				recordRow(settingsItemRemoteMcpToken, settingsPage.renderSettingsRow(m, currentItem == settingsItemRemoteMcpToken, "Bearer Token", tokenValue))
 			}
 
 		case "Fleet Armada":
@@ -1551,6 +1631,12 @@ func (settingsPage *settingsPage) viewSettings(m *model) string {
 	}
 	if isArmadaRemoteItem(currentItem) && settingsPage.armadaAddStage == armadaAddNone {
 		tail.WriteString(dimStyle.Render("  enter: ping now  right/l: focus [ delete ]  enter twice on [ delete ]: remove"))
+		tail.WriteString("\n")
+	}
+	// Copy rows act on enter (not edit/cycle), so spell that out — the generic
+	// footer's "enter: edit / left/right: cycle" doesn't apply to them.
+	if isCopyRow(currentItem) {
+		tail.WriteString(dimStyle.Render("  enter: copy to clipboard"))
 		tail.WriteString("\n")
 	}
 	if m.message != "" {

--- a/internal/tui/page_settings_test.go
+++ b/internal/tui/page_settings_test.go
@@ -1,6 +1,10 @@
 package tui
 
 import (
+	"encoding/base64"
+	"io"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -12,9 +16,44 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+// capturedClipboard runs a copyToClipboardCmd-style command, capturing the OSC
+// 52 sequence it writes to os.Stderr, and returns the decoded clipboard payload.
+// It is how the copy tests assert WHAT was copied (not just that a copy fired).
+func capturedClipboard(t *testing.T, cmd tea.Cmd) string {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("nil command: nothing was copied")
+	}
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	cmd() // writes ESC ] 52 ; c ; <base64> BEL
+	_ = w.Close()
+	os.Stderr = orig
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := string(out)
+	i := strings.LastIndex(raw, ";")
+	if i < 0 {
+		t.Fatalf("not an OSC 52 sequence: %q", raw)
+	}
+	payload := strings.TrimRight(raw[i+1:], "\x07")
+	decoded, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		t.Fatalf("decode OSC 52 payload %q: %v", payload, err)
+	}
+	return string(decoded)
+}
+
 // TestSettingsSectionIncludesRemoteMcp confirms the "Fleet MCP" section is
-// navigable (copy actions + editable items appear) and that the read-only
-// Public MCP URL line renders once the feature is enabled.
+// navigable (copy actions + editable items appear) and that the navigable
+// Public MCP URL copy row renders once the feature is enabled.
 func TestSettingsSectionIncludesRemoteMcp(t *testing.T) {
 	sp := newSettingsPage()
 	cfg := state.DefaultConfig()
@@ -121,8 +160,8 @@ func TestDaemonRestartActionInFlight(t *testing.T) {
 }
 
 // TestSettingsSectionIncludesRemoteFleet confirms the "Enable Remote Fleet"
-// toggle is navigable right under "Enable Remote MCP", and that the read-only
-// Public GRPC URL line renders once the feature is enabled.
+// toggle is navigable right under "Enable Remote MCP", and that the navigable
+// Public GRPC URL copy row renders once the feature is enabled.
 func TestSettingsSectionIncludesRemoteFleet(t *testing.T) {
 	sp := newSettingsPage()
 	cfg := state.DefaultConfig()
@@ -160,6 +199,197 @@ func TestSettingsSectionIncludesRemoteFleet(t *testing.T) {
 	// MCP stays off here, so its computed URL row must NOT render.
 	if strings.Contains(out, "Public MCP URL") {
 		t.Fatal("Public MCP URL row rendered while remote MCP is disabled")
+	}
+}
+
+// TestSettingsCopyRowsAppearWithRemoteSurfaces confirms the navigable copy rows
+// — Public MCP URL, Public GRPC URL, Bearer Token — appear exactly when their
+// backing surface is enabled. Each URL is gated on its own feature; the bearer
+// token rides along whenever EITHER surface is on (it pairs with both URLs).
+func TestSettingsCopyRowsAppearWithRemoteSurfaces(t *testing.T) {
+	has := func(items []int, want int) bool { return slices.Contains(items, want) }
+
+	// Nothing enabled: no copy rows at all. A wide width keeps the row value on
+	// one line (so the [ Copy Bearer Token ] affordance isn't word-wrapped); no
+	// height means the whole list renders without a scrolling viewport.
+	sp := newSettingsPage()
+	m := &model{config: state.DefaultConfig(), toolStatus: allToolsFound(), spinner: spinner.New(), width: 120}
+	items := sp.visibleItems(m)
+	if has(items, settingsItemRemoteMcpPublicURL) || has(items, settingsItemRemoteGrpcPublicURL) || has(items, settingsItemRemoteMcpToken) {
+		t.Fatal("copy rows must be hidden while both remote surfaces are off")
+	}
+
+	// MCP only: Public MCP URL + Bearer Token, but not Public GRPC URL.
+	m.config.RemoteMcpSettings.Enabled = true
+	items = sp.visibleItems(m)
+	if !has(items, settingsItemRemoteMcpPublicURL) || !has(items, settingsItemRemoteMcpToken) {
+		t.Fatal("MCP enabled: Public MCP URL + Bearer Token rows should be navigable")
+	}
+	if has(items, settingsItemRemoteGrpcPublicURL) {
+		t.Fatal("MCP enabled (fleet off): Public GRPC URL row must stay hidden")
+	}
+
+	// Fleet only: Public GRPC URL + Bearer Token, but not Public MCP URL.
+	m.config.RemoteMcpSettings.Enabled = false
+	m.config.RemoteMcpSettings.FleetEnabled = true
+	items = sp.visibleItems(m)
+	if !has(items, settingsItemRemoteGrpcPublicURL) || !has(items, settingsItemRemoteMcpToken) {
+		t.Fatal("Fleet enabled: Public GRPC URL + Bearer Token rows should be navigable")
+	}
+	if has(items, settingsItemRemoteMcpPublicURL) {
+		t.Fatal("Fleet enabled (MCP off): Public MCP URL row must stay hidden")
+	}
+
+	// The Bearer Token row renders its [ Copy Bearer Token ] affordance.
+	if out := sp.viewSettings(m); !strings.Contains(out, "[ Copy Bearer Token ]") || !strings.Contains(out, "Bearer Token") {
+		t.Fatal("view missing the Bearer Token copy row")
+	}
+}
+
+// TestCopyPublicURLCommands confirms enter on a Public URL copy row copies the
+// RAW gateway URL (the MCP row copies PublicUrl, the GRPC row copies
+// PublicGrpcUrl — not each other's URL, not the JSON config snippet), and that
+// with no URL assigned it no-ops with a guidance message instead.
+func TestCopyPublicURLCommands(t *testing.T) {
+	sp := newSettingsPage()
+	cfg := state.DefaultConfig()
+	cfg.RemoteMcpSettings.Enabled = true
+	cfg.RemoteMcpSettings.FleetEnabled = true
+	m := &model{config: cfg, toolStatus: allToolsFound(), currentPage: sp, fleetPage: newFleetPage(), spinner: spinner.New()}
+
+	// No status yet: enter on either URL row copies nothing and explains why.
+	sp.cursor = settingsPositionOf(sp, m, settingsItemRemoteMcpPublicURL)
+	if cmd := sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter}); cmd != nil {
+		t.Fatal("enter on Public MCP URL with no URL should not copy")
+	}
+	if !strings.Contains(m.message, "No public MCP URL") {
+		t.Fatalf("missing MCP guidance message, got %q", m.message)
+	}
+	sp.cursor = settingsPositionOf(sp, m, settingsItemRemoteGrpcPublicURL)
+	if cmd := sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter}); cmd != nil {
+		t.Fatal("enter on Public GRPC URL with no URL should not copy")
+	}
+	if !strings.Contains(m.message, "No public GRPC URL") {
+		t.Fatalf("missing GRPC guidance message, got %q", m.message)
+	}
+
+	// Connected with distinct assigned URLs: each row copies its own raw URL.
+	const mcpURL = "https://gw.example.com/mcp/abc123"
+	const grpcURL = "https://gw.example.com:50051/grpc/abc123"
+	m.remoteMcpStatus = &fleetgrpc.RemoteMcpStatus{
+		State:         fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
+		PublicUrl:     mcpURL,
+		PublicGrpcUrl: grpcURL,
+	}
+
+	sp.cursor = settingsPositionOf(sp, m, settingsItemRemoteMcpPublicURL)
+	if got := capturedClipboard(t, sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter})); got != mcpURL {
+		t.Fatalf("Public MCP URL copied %q, want the raw URL %q", got, mcpURL)
+	}
+	if !strings.Contains(m.message, "Public MCP URL copied") {
+		t.Fatalf("missing MCP copy confirmation, got %q", m.message)
+	}
+
+	sp.cursor = settingsPositionOf(sp, m, settingsItemRemoteGrpcPublicURL)
+	if got := capturedClipboard(t, sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter})); got != grpcURL {
+		t.Fatalf("Public GRPC URL copied %q, want the raw gRPC URL %q", got, grpcURL)
+	}
+	if !strings.Contains(m.message, "Public GRPC URL copied") {
+		t.Fatalf("missing GRPC copy confirmation, got %q", m.message)
+	}
+}
+
+// TestCopyBearerToken confirms the Bearer Token row copies the daemon's MCP
+// token VALUE (trimmed) when one exists and reports its absence otherwise.
+func TestCopyBearerToken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("FLEET_TOKEN", "") // force the on-disk path
+
+	sp := newSettingsPage()
+	cfg := state.DefaultConfig()
+	cfg.RemoteMcpSettings.Enabled = true
+	m := &model{config: cfg, toolStatus: allToolsFound(), currentPage: sp, fleetPage: newFleetPage(), spinner: spinner.New()}
+
+	// No token file: enter reports the missing token and returns no command.
+	sp.cursor = settingsPositionOf(sp, m, settingsItemRemoteMcpToken)
+	if cmd := sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter}); cmd != nil {
+		t.Fatal("enter on Bearer Token without a token should not copy")
+	}
+	if !strings.Contains(m.message, "No bearer token") {
+		t.Fatalf("missing absent-token message, got %q", m.message)
+	}
+
+	// Write the token (with surrounding whitespace): enter copies the trimmed value.
+	if err := os.MkdirAll(filepath.Join(home, ".fleet"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".fleet", "mcp.token"), []byte("s3cr3t-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sp.cursor = settingsPositionOf(sp, m, settingsItemRemoteMcpToken)
+	if got := capturedClipboard(t, sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter})); got != "s3cr3t-token" {
+		t.Fatalf("Bearer token copied %q, want trimmed %q", got, "s3cr3t-token")
+	}
+	if !strings.Contains(m.message, "Bearer token copied") {
+		t.Fatalf("missing copy confirmation, got %q", m.message)
+	}
+}
+
+// TestCopyRowsClickable drives a real left-click through model.Update at each
+// copy row's recorded Y and asserts it fires the copy — covering the ticket's
+// "copy on click" requirement and the recordRow hit-testing the URL rows now
+// depend on (they were read-only, non-clickable status lines before).
+func TestCopyRowsClickable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("FLEET_TOKEN", "")
+	if err := os.MkdirAll(filepath.Join(home, ".fleet"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".fleet", "mcp.token"), []byte("tok\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	sp := newSettingsPage()
+	cfg := state.DefaultConfig()
+	cfg.RemoteMcpSettings.Enabled = true
+	cfg.RemoteMcpSettings.FleetEnabled = true
+	m := model{
+		config:      cfg,
+		toolStatus:  allToolsFound(),
+		currentPage: sp,
+		fleetPage:   newFleetPage(),
+		spinner:     spinner.New(),
+		width:       120, // wide enough that rows don't wrap; no height => full render
+		remoteMcpStatus: &fleetgrpc.RemoteMcpStatus{
+			State:         fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
+			PublicUrl:     "https://gw.example.com/mcp/abc123",
+			PublicGrpcUrl: "https://gw.example.com:50051/grpc/abc123",
+		},
+	}
+
+	// Render once so itemRowYs is populated for mouse hit-testing.
+	sp.viewSettings(&m)
+
+	cases := []struct {
+		id   int
+		want string
+	}{
+		{settingsItemRemoteMcpPublicURL, "Public MCP URL copied"},
+		{settingsItemRemoteGrpcPublicURL, "Public GRPC URL copied"},
+		{settingsItemRemoteMcpToken, "Bearer token copied"},
+	}
+	for _, tc := range cases {
+		y, ok := sp.itemRowYs[tc.id]
+		if !ok {
+			t.Fatalf("row %d not recorded for mouse hit-testing", tc.id)
+		}
+		click := tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: 4, Y: y}
+		next, _ := m.Update(click)
+		if got := next.(model).message; !strings.Contains(got, tc.want) {
+			t.Fatalf("click on row %d: message %q, want substring %q", tc.id, got, tc.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #153. Copying the MCP/gRPC connection details out of the Fleet TUI's **Settings → Fleet MCP** section was clunky. This makes them one-keypress (or one-click) copies:

- **Public MCP URL** and **Public GRPC URL** rows are now navigable — pressing enter (or clicking) copies the raw gateway-assigned URL. They still show the live tunnel status, and advertise `press enter to copy` only when a URL is actually assigned; with none yet, enter no-ops with a guidance message instead of copying nothing.
- New **Bearer Token** row with a `[ Copy Bearer Token ]` action that copies the daemon's bearer token. It appears whenever remote MCP or remote Fleet is enabled (the surfaces those URLs reach). The token is copied to the clipboard, never rendered on screen.
- The footer shows `enter: copy to clipboard` on copy rows, since the generic `enter: edit / left/right: cycle` hint doesn't apply.

Implementation notes:
- Adds `fleetclient.BearerToken()` — an exported wrapper over the existing token resolution (`FLEET_TOKEN`, else `~/.fleet/mcp.token`), so the TUI copies the same secret the MCP HTTP server and remote-fleet gRPC surface accept (correct for both local and armada-switched/remote TUIs).
- The URL rows were read-only status lines before; they now go through `recordRow`, which is what makes them clickable and scroll-tracked.

Tests cover row visibility gating, the copied content (raw URL / trimmed token via the OSC 52 payload, not the JSON snippet), the empty-URL guidance paths, the mouse-click copy path, and the `BearerToken()` precedence.