### PR TITLE
feat/rebuild-instance — rebuild an instance's container in place (#161)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ fleet launch
 # View logs
 fleet logs agent-1
 
+# Rebuild an instance's container in place (e.g. after editing devcontainer.json)
+fleet rebuild agent-1
+
 # Remove an instance
 fleet down agent-1
 
@@ -116,6 +119,7 @@ fleet up my-project/agent-3
 | `n` | New fleet |
 | `d` | Delete instance/fleet |
 | `c` | Open VS Code |
+| `R` | Rebuild instance (preserves workspace) |
 | `l` | View logs |
 | `A` | Switch armada (remote fleet) |
 | `r` | Refresh |
@@ -174,9 +178,9 @@ An MCP client config (`mcp.json`) can then reference them directly:
 
 Tools mirror the non-interactive CLI: `fleet_list`, `fleet_status`,
 `fleet_version`, `fleet_logs`, `fleet_up`, `fleet_start`, `fleet_stop`,
-`fleet_down`, `fleet_destroy_fleet`, `fleet_clone`, `fleet_exec`, and the tmux
-session tools `fleet_session_spawn` / `fleet_session_exec` / `fleet_session_read` /
-`fleet_session_list`.
+`fleet_down`, `fleet_destroy_fleet`, `fleet_clone`, `fleet_rebuild`, `fleet_exec`,
+and the tmux session tools `fleet_session_spawn` / `fleet_session_exec` /
+`fleet_session_read` / `fleet_session_list`.
 Interactive, open-ended commands (`fleet shell`, log following) are intentionally
 not exposed.
 

--- a/fleetgrpc/domain.pb.go
+++ b/fleetgrpc/domain.pb.go
@@ -43,11 +43,11 @@ const (
 // reconciliation" rather than accidentally meaning "creating".
 //
 // CONTRACT: transitional statuses (CREATING, CLONING, DELETING, STOPPING,
-// STARTING) are set ONLY by the SERVER when a job begins; clients MUST NOT
-// write status (no SetInstanceStatus RPC exists, by design). The TUI renders
-// optimistic transitions from JobStarted/JobProgress, never by writing status
-// itself — this prevents a stray client-side status write from re-introducing
-// the issue #63 class of state-file race.
+// STARTING, REBUILDING) are set ONLY by the SERVER when a job begins; clients
+// MUST NOT write status (no SetInstanceStatus RPC exists, by design). The TUI
+// renders optimistic transitions from JobStarted/JobProgress, never by writing
+// status itself — this prevents a stray client-side status write from
+// re-introducing the issue #63 class of state-file race.
 type InstanceStatus int32
 
 const (
@@ -60,6 +60,7 @@ const (
 	InstanceStatus_INSTANCE_STATUS_STOPPING    InstanceStatus = 6
 	InstanceStatus_INSTANCE_STATUS_STARTING    InstanceStatus = 7
 	InstanceStatus_INSTANCE_STATUS_DELETING    InstanceStatus = 8
+	InstanceStatus_INSTANCE_STATUS_REBUILDING  InstanceStatus = 9
 )
 
 // Enum value maps for InstanceStatus.
@@ -74,6 +75,7 @@ var (
 		6: "INSTANCE_STATUS_STOPPING",
 		7: "INSTANCE_STATUS_STARTING",
 		8: "INSTANCE_STATUS_DELETING",
+		9: "INSTANCE_STATUS_REBUILDING",
 	}
 	InstanceStatus_value = map[string]int32{
 		"INSTANCE_STATUS_UNSPECIFIED": 0,
@@ -85,6 +87,7 @@ var (
 		"INSTANCE_STATUS_STOPPING":    6,
 		"INSTANCE_STATUS_STARTING":    7,
 		"INSTANCE_STATUS_DELETING":    8,
+		"INSTANCE_STATUS_REBUILDING":  9,
 	}
 )
 
@@ -868,7 +871,7 @@ const file_domain_proto_rawDesc = "" +
 	"\x11GroupLayoutsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12,\n" +
 	"\x05value\x18\x02 \x01(\v2\x16.fleetgrpc.GroupLayoutR\x05value:\x028\x01B\x14\n" +
-	"\x12_last_seen_versionJ\x04\b\x04\x10\x10*\x9c\x02\n" +
+	"\x12_last_seen_versionJ\x04\b\x04\x10\x10*\xbc\x02\n" +
 	"\x0eInstanceStatus\x12\x1f\n" +
 	"\x1bINSTANCE_STATUS_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18INSTANCE_STATUS_CREATING\x10\x01\x12\x1b\n" +
@@ -878,7 +881,8 @@ const file_domain_proto_rawDesc = "" +
 	"\x16INSTANCE_STATUS_FAILED\x10\x05\x12\x1c\n" +
 	"\x18INSTANCE_STATUS_STOPPING\x10\x06\x12\x1c\n" +
 	"\x18INSTANCE_STATUS_STARTING\x10\a\x12\x1c\n" +
-	"\x18INSTANCE_STATUS_DELETING\x10\b*\x7f\n" +
+	"\x18INSTANCE_STATUS_DELETING\x10\b\x12\x1e\n" +
+	"\x1aINSTANCE_STATUS_REBUILDING\x10\t*\x7f\n" +
 	"\vBackendType\x12\x1c\n" +
 	"\x18BACKEND_TYPE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19BACKEND_TYPE_DEVCONTAINER\x10\x01\x12\x16\n" +

--- a/fleetgrpc/domain.proto
+++ b/fleetgrpc/domain.proto
@@ -30,11 +30,11 @@ option go_package = "github.com/BenjaminBenetti/fleet-man/fleetgrpc;fleetgrpc";
 // reconciliation" rather than accidentally meaning "creating".
 //
 // CONTRACT: transitional statuses (CREATING, CLONING, DELETING, STOPPING,
-// STARTING) are set ONLY by the SERVER when a job begins; clients MUST NOT
-// write status (no SetInstanceStatus RPC exists, by design). The TUI renders
-// optimistic transitions from JobStarted/JobProgress, never by writing status
-// itself — this prevents a stray client-side status write from re-introducing
-// the issue #63 class of state-file race.
+// STARTING, REBUILDING) are set ONLY by the SERVER when a job begins; clients
+// MUST NOT write status (no SetInstanceStatus RPC exists, by design). The TUI
+// renders optimistic transitions from JobStarted/JobProgress, never by writing
+// status itself — this prevents a stray client-side status write from
+// re-introducing the issue #63 class of state-file race.
 enum InstanceStatus {
   INSTANCE_STATUS_UNSPECIFIED = 0;
   INSTANCE_STATUS_CREATING = 1;
@@ -45,6 +45,7 @@ enum InstanceStatus {
   INSTANCE_STATUS_STOPPING = 6;
   INSTANCE_STATUS_STARTING = 7;
   INSTANCE_STATUS_DELETING = 8;
+  INSTANCE_STATUS_REBUILDING = 9;
 }
 
 // BackendType mirrors internal/fleet.BackendType. Zero value UNSPECIFIED is

--- a/fleetgrpc/domain_methods.go
+++ b/fleetgrpc/domain_methods.go
@@ -30,6 +30,8 @@ func (s InstanceStatus) Display() string {
 		return "starting"
 	case InstanceStatus_INSTANCE_STATUS_DELETING:
 		return "deleting"
+	case InstanceStatus_INSTANCE_STATUS_REBUILDING:
+		return "rebuilding"
 	default:
 		return "unknown"
 	}

--- a/fleetgrpc/domain_methods_test.go
+++ b/fleetgrpc/domain_methods_test.go
@@ -13,6 +13,7 @@ func TestInstanceStatusDisplay(t *testing.T) {
 		InstanceStatus_INSTANCE_STATUS_STOPPING:    "stopping",
 		InstanceStatus_INSTANCE_STATUS_STARTING:    "starting",
 		InstanceStatus_INSTANCE_STATUS_DELETING:    "deleting",
+		InstanceStatus_INSTANCE_STATUS_REBUILDING:  "rebuilding",
 	}
 	for status, want := range cases {
 		if got := status.Display(); got != want {

--- a/fleetgrpc/jobs.pb.go
+++ b/fleetgrpc/jobs.pb.go
@@ -33,6 +33,7 @@ const (
 	JobKind_JOB_KIND_START_INSTANCE   JobKind = 3
 	JobKind_JOB_KIND_STOP_INSTANCE    JobKind = 4
 	JobKind_JOB_KIND_CLONE_INSTANCE   JobKind = 5
+	JobKind_JOB_KIND_REBUILD_INSTANCE JobKind = 6
 )
 
 // Enum value maps for JobKind.
@@ -44,6 +45,7 @@ var (
 		3: "JOB_KIND_START_INSTANCE",
 		4: "JOB_KIND_STOP_INSTANCE",
 		5: "JOB_KIND_CLONE_INSTANCE",
+		6: "JOB_KIND_REBUILD_INSTANCE",
 	}
 	JobKind_value = map[string]int32{
 		"JOB_KIND_UNSPECIFIED":      0,
@@ -52,6 +54,7 @@ var (
 		"JOB_KIND_START_INSTANCE":   3,
 		"JOB_KIND_STOP_INSTANCE":    4,
 		"JOB_KIND_CLONE_INSTANCE":   5,
+		"JOB_KIND_REBUILD_INSTANCE": 6,
 	}
 )
 
@@ -968,6 +971,67 @@ func (x *StartInstanceRequest) GetInstance() string {
 	return ""
 }
 
+// RebuildInstanceRequest recreates one instance's container in place. The
+// backend tears down and reprovisions the container (devcontainer: `devcontainer
+// up --remove-existing-container`; codespaces: `gh codespace rebuild`) while
+// PRESERVING the workspace — the git checkout, uncommitted edits, and mounted
+// state survive. Fleet then re-runs the post-Up provisioning (fleet-launch
+// staging, dotfiles, startup scripts, Claude hooks) so the fresh container is
+// equivalent to a freshly created one. Backends whose runtime has no rebuild
+// primitive (coder) reject the job. Unlike destroy, the record is kept and
+// flips back to RUNNING (or FAILED) on completion.
+type RebuildInstanceRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Fleet         string                 `protobuf:"bytes,1,opt,name=fleet,proto3" json:"fleet,omitempty"`
+	Instance      string                 `protobuf:"bytes,2,opt,name=instance,proto3" json:"instance,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RebuildInstanceRequest) Reset() {
+	*x = RebuildInstanceRequest{}
+	mi := &file_jobs_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RebuildInstanceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RebuildInstanceRequest) ProtoMessage() {}
+
+func (x *RebuildInstanceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_jobs_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RebuildInstanceRequest.ProtoReflect.Descriptor instead.
+func (*RebuildInstanceRequest) Descriptor() ([]byte, []int) {
+	return file_jobs_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *RebuildInstanceRequest) GetFleet() string {
+	if x != nil {
+		return x.Fleet
+	}
+	return ""
+}
+
+func (x *RebuildInstanceRequest) GetInstance() string {
+	if x != nil {
+		return x.Instance
+	}
+	return ""
+}
+
 type StopInstanceRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Fleet         string                 `protobuf:"bytes,1,opt,name=fleet,proto3" json:"fleet,omitempty"`
@@ -978,7 +1042,7 @@ type StopInstanceRequest struct {
 
 func (x *StopInstanceRequest) Reset() {
 	*x = StopInstanceRequest{}
-	mi := &file_jobs_proto_msgTypes[9]
+	mi := &file_jobs_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -990,7 +1054,7 @@ func (x *StopInstanceRequest) String() string {
 func (*StopInstanceRequest) ProtoMessage() {}
 
 func (x *StopInstanceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_jobs_proto_msgTypes[9]
+	mi := &file_jobs_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1003,7 +1067,7 @@ func (x *StopInstanceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopInstanceRequest.ProtoReflect.Descriptor instead.
 func (*StopInstanceRequest) Descriptor() ([]byte, []int) {
-	return file_jobs_proto_rawDescGZIP(), []int{9}
+	return file_jobs_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *StopInstanceRequest) GetFleet() string {
@@ -1043,7 +1107,7 @@ type CloneInstanceRequest struct {
 
 func (x *CloneInstanceRequest) Reset() {
 	*x = CloneInstanceRequest{}
-	mi := &file_jobs_proto_msgTypes[10]
+	mi := &file_jobs_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1055,7 +1119,7 @@ func (x *CloneInstanceRequest) String() string {
 func (*CloneInstanceRequest) ProtoMessage() {}
 
 func (x *CloneInstanceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_jobs_proto_msgTypes[10]
+	mi := &file_jobs_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1068,7 +1132,7 @@ func (x *CloneInstanceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloneInstanceRequest.ProtoReflect.Descriptor instead.
 func (*CloneInstanceRequest) Descriptor() ([]byte, []int) {
-	return file_jobs_proto_rawDescGZIP(), []int{10}
+	return file_jobs_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *CloneInstanceRequest) GetFleet() string {
@@ -1184,6 +1248,9 @@ const file_jobs_proto_rawDesc = "" +
 	"\t_instance\"H\n" +
 	"\x14StartInstanceRequest\x12\x14\n" +
 	"\x05fleet\x18\x01 \x01(\tR\x05fleet\x12\x1a\n" +
+	"\binstance\x18\x02 \x01(\tR\binstance\"J\n" +
+	"\x16RebuildInstanceRequest\x12\x14\n" +
+	"\x05fleet\x18\x01 \x01(\tR\x05fleet\x12\x1a\n" +
 	"\binstance\x18\x02 \x01(\tR\binstance\"G\n" +
 	"\x13StopInstanceRequest\x12\x14\n" +
 	"\x05fleet\x18\x01 \x01(\tR\x05fleet\x12\x1a\n" +
@@ -1199,14 +1266,15 @@ const file_jobs_proto_rawDesc = "" +
 	"\x11_new_display_nameB\x0f\n" +
 	"\r_tag_overrideB\x11\n" +
 	"\x0f_color_overrideB\x12\n" +
-	"\x10_branch_override*\xb6\x01\n" +
+	"\x10_branch_override*\xd5\x01\n" +
 	"\aJobKind\x12\x18\n" +
 	"\x14JOB_KIND_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18JOB_KIND_CREATE_INSTANCE\x10\x01\x12\x1d\n" +
 	"\x19JOB_KIND_DESTROY_INSTANCE\x10\x02\x12\x1b\n" +
 	"\x17JOB_KIND_START_INSTANCE\x10\x03\x12\x1a\n" +
 	"\x16JOB_KIND_STOP_INSTANCE\x10\x04\x12\x1b\n" +
-	"\x17JOB_KIND_CLONE_INSTANCE\x10\x05*\xca\x04\n" +
+	"\x17JOB_KIND_CLONE_INSTANCE\x10\x05\x12\x1d\n" +
+	"\x19JOB_KIND_REBUILD_INSTANCE\x10\x06*\xca\x04\n" +
 	"\aJobStep\x12\x18\n" +
 	"\x14JOB_STEP_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19JOB_STEP_VALIDATE_BACKEND\x10\x01\x12\x1a\n" +
@@ -1248,7 +1316,7 @@ func file_jobs_proto_rawDescGZIP() []byte {
 }
 
 var file_jobs_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_jobs_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_jobs_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_jobs_proto_goTypes = []any{
 	(JobKind)(0),                   // 0: fleetgrpc.JobKind
 	(JobStep)(0),                   // 1: fleetgrpc.JobStep
@@ -1262,27 +1330,28 @@ var file_jobs_proto_goTypes = []any{
 	(*CreateInstanceRequest)(nil),  // 9: fleetgrpc.CreateInstanceRequest
 	(*DestroyInstanceRequest)(nil), // 10: fleetgrpc.DestroyInstanceRequest
 	(*StartInstanceRequest)(nil),   // 11: fleetgrpc.StartInstanceRequest
-	(*StopInstanceRequest)(nil),    // 12: fleetgrpc.StopInstanceRequest
-	(*CloneInstanceRequest)(nil),   // 13: fleetgrpc.CloneInstanceRequest
-	(*timestamppb.Timestamp)(nil),  // 14: google.protobuf.Timestamp
-	(*Instance)(nil),               // 15: fleetgrpc.Instance
-	(BackendType)(0),               // 16: fleetgrpc.BackendType
+	(*RebuildInstanceRequest)(nil), // 12: fleetgrpc.RebuildInstanceRequest
+	(*StopInstanceRequest)(nil),    // 13: fleetgrpc.StopInstanceRequest
+	(*CloneInstanceRequest)(nil),   // 14: fleetgrpc.CloneInstanceRequest
+	(*timestamppb.Timestamp)(nil),  // 15: google.protobuf.Timestamp
+	(*Instance)(nil),               // 16: fleetgrpc.Instance
+	(BackendType)(0),               // 17: fleetgrpc.BackendType
 }
 var file_jobs_proto_depIdxs = []int32{
 	0,  // 0: fleetgrpc.JobSummary.kind:type_name -> fleetgrpc.JobKind
 	1,  // 1: fleetgrpc.JobSummary.current_step:type_name -> fleetgrpc.JobStep
-	14, // 2: fleetgrpc.JobSummary.started_at:type_name -> google.protobuf.Timestamp
+	15, // 2: fleetgrpc.JobSummary.started_at:type_name -> google.protobuf.Timestamp
 	5,  // 3: fleetgrpc.JobEvent.started:type_name -> fleetgrpc.JobStarted
 	6,  // 4: fleetgrpc.JobEvent.progress:type_name -> fleetgrpc.JobProgress
 	7,  // 5: fleetgrpc.JobEvent.log:type_name -> fleetgrpc.JobLog
 	8,  // 6: fleetgrpc.JobEvent.done:type_name -> fleetgrpc.JobDone
 	0,  // 7: fleetgrpc.JobStarted.kind:type_name -> fleetgrpc.JobKind
-	14, // 8: fleetgrpc.JobStarted.started_at:type_name -> google.protobuf.Timestamp
+	15, // 8: fleetgrpc.JobStarted.started_at:type_name -> google.protobuf.Timestamp
 	1,  // 9: fleetgrpc.JobProgress.step:type_name -> fleetgrpc.JobStep
 	2,  // 10: fleetgrpc.JobLog.level:type_name -> fleetgrpc.LogLevel
-	14, // 11: fleetgrpc.JobLog.at:type_name -> google.protobuf.Timestamp
-	15, // 12: fleetgrpc.JobDone.instance:type_name -> fleetgrpc.Instance
-	16, // 13: fleetgrpc.CreateInstanceRequest.backend:type_name -> fleetgrpc.BackendType
+	15, // 11: fleetgrpc.JobLog.at:type_name -> google.protobuf.Timestamp
+	16, // 12: fleetgrpc.JobDone.instance:type_name -> fleetgrpc.Instance
+	17, // 13: fleetgrpc.CreateInstanceRequest.backend:type_name -> fleetgrpc.BackendType
 	14, // [14:14] is the sub-list for method output_type
 	14, // [14:14] is the sub-list for method input_type
 	14, // [14:14] is the sub-list for extension type_name
@@ -1306,14 +1375,14 @@ func file_jobs_proto_init() {
 	file_jobs_proto_msgTypes[5].OneofWrappers = []any{}
 	file_jobs_proto_msgTypes[6].OneofWrappers = []any{}
 	file_jobs_proto_msgTypes[7].OneofWrappers = []any{}
-	file_jobs_proto_msgTypes[10].OneofWrappers = []any{}
+	file_jobs_proto_msgTypes[11].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_jobs_proto_rawDesc), len(file_jobs_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   11,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/fleetgrpc/jobs.proto
+++ b/fleetgrpc/jobs.proto
@@ -20,6 +20,7 @@ enum JobKind {
   JOB_KIND_START_INSTANCE = 3;
   JOB_KIND_STOP_INSTANCE = 4;
   JOB_KIND_CLONE_INSTANCE = 5;
+  JOB_KIND_REBUILD_INSTANCE = 6;
 }
 
 // JobStep enumerates the discrete provisioning/lifecycle steps (create.Run /
@@ -173,6 +174,20 @@ message DestroyInstanceRequest {
 }
 
 message StartInstanceRequest {
+  string fleet = 1;
+  string instance = 2;
+}
+
+// RebuildInstanceRequest recreates one instance's container in place. The
+// backend tears down and reprovisions the container (devcontainer: `devcontainer
+// up --remove-existing-container`; codespaces: `gh codespace rebuild`) while
+// PRESERVING the workspace — the git checkout, uncommitted edits, and mounted
+// state survive. Fleet then re-runs the post-Up provisioning (fleet-launch
+// staging, dotfiles, startup scripts, Claude hooks) so the fresh container is
+// equivalent to a freshly created one. Backends whose runtime has no rebuild
+// primitive (coder) reject the job. Unlike destroy, the record is kept and
+// flips back to RUNNING (or FAILED) on completion.
+message RebuildInstanceRequest {
   string fleet = 1;
   string instance = 2;
 }

--- a/fleetgrpc/service.pb.go
+++ b/fleetgrpc/service.pb.go
@@ -26,7 +26,7 @@ const file_service_proto_rawDesc = "" +
 	"\n" +
 	"\rservice.proto\x12\tfleetgrpc\x1a\farmada.proto\x1a\rcontrol.proto\x1a\vwatch.proto\x1a\n" +
 	"jobs.proto\x1a\fconfig.proto\x1a\n" +
-	"exec.proto\x1a\rinspect.proto2\xbb\x14\n" +
+	"exec.proto\x1a\rinspect.proto2\x88\x15\n" +
 	"\fFleetService\x127\n" +
 	"\x05Hello\x12\x17.fleetgrpc.HelloRequest\x1a\x15.fleetgrpc.HelloReply\x12@\n" +
 	"\bShutdown\x12\x1a.fleetgrpc.ShutdownRequest\x1a\x18.fleetgrpc.ShutdownReply\x12[\n" +
@@ -37,7 +37,8 @@ const file_service_proto_rawDesc = "" +
 	"\x0fDestroyInstance\x12!.fleetgrpc.DestroyInstanceRequest\x1a\x13.fleetgrpc.JobEvent0\x01\x12G\n" +
 	"\rStartInstance\x12\x1f.fleetgrpc.StartInstanceRequest\x1a\x13.fleetgrpc.JobEvent0\x01\x12E\n" +
 	"\fStopInstance\x12\x1e.fleetgrpc.StopInstanceRequest\x1a\x13.fleetgrpc.JobEvent0\x01\x12G\n" +
-	"\rCloneInstance\x12\x1f.fleetgrpc.CloneInstanceRequest\x1a\x13.fleetgrpc.JobEvent0\x01\x12F\n" +
+	"\rCloneInstance\x12\x1f.fleetgrpc.CloneInstanceRequest\x1a\x13.fleetgrpc.JobEvent0\x01\x12K\n" +
+	"\x0fRebuildInstance\x12!.fleetgrpc.RebuildInstanceRequest\x1a\x13.fleetgrpc.JobEvent0\x01\x12F\n" +
 	"\vCreateFleet\x12\x1d.fleetgrpc.CreateFleetRequest\x1a\x18.fleetgrpc.MutationReply\x12H\n" +
 	"\fDestroyFleet\x12\x1e.fleetgrpc.DestroyFleetRequest\x1a\x18.fleetgrpc.MutationReply\x12P\n" +
 	"\x10SetFleetSettings\x12\".fleetgrpc.SetFleetSettingsRequest\x1a\x18.fleetgrpc.MutationReply\x12a\n" +
@@ -74,53 +75,54 @@ var file_service_proto_goTypes = []any{
 	(*StartInstanceRequest)(nil),          // 7: fleetgrpc.StartInstanceRequest
 	(*StopInstanceRequest)(nil),           // 8: fleetgrpc.StopInstanceRequest
 	(*CloneInstanceRequest)(nil),          // 9: fleetgrpc.CloneInstanceRequest
-	(*CreateFleetRequest)(nil),            // 10: fleetgrpc.CreateFleetRequest
-	(*DestroyFleetRequest)(nil),           // 11: fleetgrpc.DestroyFleetRequest
-	(*SetFleetSettingsRequest)(nil),       // 12: fleetgrpc.SetFleetSettingsRequest
-	(*DeleteBuildkitCacheRequest)(nil),    // 13: fleetgrpc.DeleteBuildkitCacheRequest
-	(*DeleteDebCacheRequest)(nil),         // 14: fleetgrpc.DeleteDebCacheRequest
-	(*DeleteImageCacheRequest)(nil),       // 15: fleetgrpc.DeleteImageCacheRequest
-	(*SetInstanceMetadataRequest)(nil),    // 16: fleetgrpc.SetInstanceMetadataRequest
-	(*SetGroupLayoutRequest)(nil),         // 17: fleetgrpc.SetGroupLayoutRequest
-	(*DeleteGroupLayoutRequest)(nil),      // 18: fleetgrpc.DeleteGroupLayoutRequest
-	(*SetLastSeenVersionRequest)(nil),     // 19: fleetgrpc.SetLastSeenVersionRequest
-	(*GetConfigRequest)(nil),              // 20: fleetgrpc.GetConfigRequest
-	(*SetConfigRequest)(nil),              // 21: fleetgrpc.SetConfigRequest
-	(*GetArmadaRequest)(nil),              // 22: fleetgrpc.GetArmadaRequest
-	(*SetArmadaRequest)(nil),              // 23: fleetgrpc.SetArmadaRequest
-	(*ExecIn)(nil),                        // 24: fleetgrpc.ExecIn
-	(*ResolveExecCommandRequest)(nil),     // 25: fleetgrpc.ResolveExecCommandRequest
-	(*ResolveLogsCommandRequest)(nil),     // 26: fleetgrpc.ResolveLogsCommandRequest
-	(*LogsRequest)(nil),                   // 27: fleetgrpc.LogsRequest
-	(*ForwardChunk)(nil),                  // 28: fleetgrpc.ForwardChunk
-	(*CopyFileRequest)(nil),               // 29: fleetgrpc.CopyFileRequest
-	(*InspectRepoRequest)(nil),            // 30: fleetgrpc.InspectRepoRequest
-	(*GetCoderTemplateParamsRequest)(nil), // 31: fleetgrpc.GetCoderTemplateParamsRequest
-	(*GetBrowserConfigRequest)(nil),       // 32: fleetgrpc.GetBrowserConfigRequest
-	(*PrepareBrowserRequest)(nil),         // 33: fleetgrpc.PrepareBrowserRequest
-	(*HelloReply)(nil),                    // 34: fleetgrpc.HelloReply
-	(*ShutdownReply)(nil),                 // 35: fleetgrpc.ShutdownReply
-	(*FleetTUIConnectedReply)(nil),        // 36: fleetgrpc.FleetTUIConnectedReply
-	(*GetStateReply)(nil),                 // 37: fleetgrpc.GetStateReply
-	(*Event)(nil),                         // 38: fleetgrpc.Event
-	(*JobEvent)(nil),                      // 39: fleetgrpc.JobEvent
-	(*MutationReply)(nil),                 // 40: fleetgrpc.MutationReply
-	(*DeleteBuildkitCacheReply)(nil),      // 41: fleetgrpc.DeleteBuildkitCacheReply
-	(*DeleteDebCacheReply)(nil),           // 42: fleetgrpc.DeleteDebCacheReply
-	(*DeleteImageCacheReply)(nil),         // 43: fleetgrpc.DeleteImageCacheReply
-	(*GetConfigReply)(nil),                // 44: fleetgrpc.GetConfigReply
-	(*SetConfigReply)(nil),                // 45: fleetgrpc.SetConfigReply
-	(*GetArmadaReply)(nil),                // 46: fleetgrpc.GetArmadaReply
-	(*SetArmadaReply)(nil),                // 47: fleetgrpc.SetArmadaReply
-	(*ExecOut)(nil),                       // 48: fleetgrpc.ExecOut
-	(*ResolveExecCommandReply)(nil),       // 49: fleetgrpc.ResolveExecCommandReply
-	(*ResolveLogsCommandReply)(nil),       // 50: fleetgrpc.ResolveLogsCommandReply
-	(*LogLine)(nil),                       // 51: fleetgrpc.LogLine
-	(*CopyFileChunk)(nil),                 // 52: fleetgrpc.CopyFileChunk
-	(*InspectRepoReply)(nil),              // 53: fleetgrpc.InspectRepoReply
-	(*GetCoderTemplateParamsReply)(nil),   // 54: fleetgrpc.GetCoderTemplateParamsReply
-	(*GetBrowserConfigReply)(nil),         // 55: fleetgrpc.GetBrowserConfigReply
-	(*PrepareBrowserReply)(nil),           // 56: fleetgrpc.PrepareBrowserReply
+	(*RebuildInstanceRequest)(nil),        // 10: fleetgrpc.RebuildInstanceRequest
+	(*CreateFleetRequest)(nil),            // 11: fleetgrpc.CreateFleetRequest
+	(*DestroyFleetRequest)(nil),           // 12: fleetgrpc.DestroyFleetRequest
+	(*SetFleetSettingsRequest)(nil),       // 13: fleetgrpc.SetFleetSettingsRequest
+	(*DeleteBuildkitCacheRequest)(nil),    // 14: fleetgrpc.DeleteBuildkitCacheRequest
+	(*DeleteDebCacheRequest)(nil),         // 15: fleetgrpc.DeleteDebCacheRequest
+	(*DeleteImageCacheRequest)(nil),       // 16: fleetgrpc.DeleteImageCacheRequest
+	(*SetInstanceMetadataRequest)(nil),    // 17: fleetgrpc.SetInstanceMetadataRequest
+	(*SetGroupLayoutRequest)(nil),         // 18: fleetgrpc.SetGroupLayoutRequest
+	(*DeleteGroupLayoutRequest)(nil),      // 19: fleetgrpc.DeleteGroupLayoutRequest
+	(*SetLastSeenVersionRequest)(nil),     // 20: fleetgrpc.SetLastSeenVersionRequest
+	(*GetConfigRequest)(nil),              // 21: fleetgrpc.GetConfigRequest
+	(*SetConfigRequest)(nil),              // 22: fleetgrpc.SetConfigRequest
+	(*GetArmadaRequest)(nil),              // 23: fleetgrpc.GetArmadaRequest
+	(*SetArmadaRequest)(nil),              // 24: fleetgrpc.SetArmadaRequest
+	(*ExecIn)(nil),                        // 25: fleetgrpc.ExecIn
+	(*ResolveExecCommandRequest)(nil),     // 26: fleetgrpc.ResolveExecCommandRequest
+	(*ResolveLogsCommandRequest)(nil),     // 27: fleetgrpc.ResolveLogsCommandRequest
+	(*LogsRequest)(nil),                   // 28: fleetgrpc.LogsRequest
+	(*ForwardChunk)(nil),                  // 29: fleetgrpc.ForwardChunk
+	(*CopyFileRequest)(nil),               // 30: fleetgrpc.CopyFileRequest
+	(*InspectRepoRequest)(nil),            // 31: fleetgrpc.InspectRepoRequest
+	(*GetCoderTemplateParamsRequest)(nil), // 32: fleetgrpc.GetCoderTemplateParamsRequest
+	(*GetBrowserConfigRequest)(nil),       // 33: fleetgrpc.GetBrowserConfigRequest
+	(*PrepareBrowserRequest)(nil),         // 34: fleetgrpc.PrepareBrowserRequest
+	(*HelloReply)(nil),                    // 35: fleetgrpc.HelloReply
+	(*ShutdownReply)(nil),                 // 36: fleetgrpc.ShutdownReply
+	(*FleetTUIConnectedReply)(nil),        // 37: fleetgrpc.FleetTUIConnectedReply
+	(*GetStateReply)(nil),                 // 38: fleetgrpc.GetStateReply
+	(*Event)(nil),                         // 39: fleetgrpc.Event
+	(*JobEvent)(nil),                      // 40: fleetgrpc.JobEvent
+	(*MutationReply)(nil),                 // 41: fleetgrpc.MutationReply
+	(*DeleteBuildkitCacheReply)(nil),      // 42: fleetgrpc.DeleteBuildkitCacheReply
+	(*DeleteDebCacheReply)(nil),           // 43: fleetgrpc.DeleteDebCacheReply
+	(*DeleteImageCacheReply)(nil),         // 44: fleetgrpc.DeleteImageCacheReply
+	(*GetConfigReply)(nil),                // 45: fleetgrpc.GetConfigReply
+	(*SetConfigReply)(nil),                // 46: fleetgrpc.SetConfigReply
+	(*GetArmadaReply)(nil),                // 47: fleetgrpc.GetArmadaReply
+	(*SetArmadaReply)(nil),                // 48: fleetgrpc.SetArmadaReply
+	(*ExecOut)(nil),                       // 49: fleetgrpc.ExecOut
+	(*ResolveExecCommandReply)(nil),       // 50: fleetgrpc.ResolveExecCommandReply
+	(*ResolveLogsCommandReply)(nil),       // 51: fleetgrpc.ResolveLogsCommandReply
+	(*LogLine)(nil),                       // 52: fleetgrpc.LogLine
+	(*CopyFileChunk)(nil),                 // 53: fleetgrpc.CopyFileChunk
+	(*InspectRepoReply)(nil),              // 54: fleetgrpc.InspectRepoReply
+	(*GetCoderTemplateParamsReply)(nil),   // 55: fleetgrpc.GetCoderTemplateParamsReply
+	(*GetBrowserConfigReply)(nil),         // 56: fleetgrpc.GetBrowserConfigReply
+	(*PrepareBrowserReply)(nil),           // 57: fleetgrpc.PrepareBrowserReply
 }
 var file_service_proto_depIdxs = []int32{
 	0,  // 0: fleetgrpc.FleetService.Hello:input_type -> fleetgrpc.HelloRequest
@@ -133,66 +135,68 @@ var file_service_proto_depIdxs = []int32{
 	7,  // 7: fleetgrpc.FleetService.StartInstance:input_type -> fleetgrpc.StartInstanceRequest
 	8,  // 8: fleetgrpc.FleetService.StopInstance:input_type -> fleetgrpc.StopInstanceRequest
 	9,  // 9: fleetgrpc.FleetService.CloneInstance:input_type -> fleetgrpc.CloneInstanceRequest
-	10, // 10: fleetgrpc.FleetService.CreateFleet:input_type -> fleetgrpc.CreateFleetRequest
-	11, // 11: fleetgrpc.FleetService.DestroyFleet:input_type -> fleetgrpc.DestroyFleetRequest
-	12, // 12: fleetgrpc.FleetService.SetFleetSettings:input_type -> fleetgrpc.SetFleetSettingsRequest
-	13, // 13: fleetgrpc.FleetService.DeleteBuildkitCache:input_type -> fleetgrpc.DeleteBuildkitCacheRequest
-	14, // 14: fleetgrpc.FleetService.DeleteDebCache:input_type -> fleetgrpc.DeleteDebCacheRequest
-	15, // 15: fleetgrpc.FleetService.DeleteImageCache:input_type -> fleetgrpc.DeleteImageCacheRequest
-	16, // 16: fleetgrpc.FleetService.SetInstanceMetadata:input_type -> fleetgrpc.SetInstanceMetadataRequest
-	17, // 17: fleetgrpc.FleetService.SetGroupLayout:input_type -> fleetgrpc.SetGroupLayoutRequest
-	18, // 18: fleetgrpc.FleetService.DeleteGroupLayout:input_type -> fleetgrpc.DeleteGroupLayoutRequest
-	19, // 19: fleetgrpc.FleetService.SetLastSeenVersion:input_type -> fleetgrpc.SetLastSeenVersionRequest
-	20, // 20: fleetgrpc.FleetService.GetConfig:input_type -> fleetgrpc.GetConfigRequest
-	21, // 21: fleetgrpc.FleetService.SetConfig:input_type -> fleetgrpc.SetConfigRequest
-	22, // 22: fleetgrpc.FleetService.GetArmada:input_type -> fleetgrpc.GetArmadaRequest
-	23, // 23: fleetgrpc.FleetService.SetArmada:input_type -> fleetgrpc.SetArmadaRequest
-	24, // 24: fleetgrpc.FleetService.Exec:input_type -> fleetgrpc.ExecIn
-	25, // 25: fleetgrpc.FleetService.ResolveExecCommand:input_type -> fleetgrpc.ResolveExecCommandRequest
-	26, // 26: fleetgrpc.FleetService.ResolveLogsCommand:input_type -> fleetgrpc.ResolveLogsCommandRequest
-	27, // 27: fleetgrpc.FleetService.Logs:input_type -> fleetgrpc.LogsRequest
-	28, // 28: fleetgrpc.FleetService.Forward:input_type -> fleetgrpc.ForwardChunk
-	29, // 29: fleetgrpc.FleetService.CopyFile:input_type -> fleetgrpc.CopyFileRequest
-	30, // 30: fleetgrpc.FleetService.InspectRepo:input_type -> fleetgrpc.InspectRepoRequest
-	31, // 31: fleetgrpc.FleetService.GetCoderTemplateParams:input_type -> fleetgrpc.GetCoderTemplateParamsRequest
-	32, // 32: fleetgrpc.FleetService.GetBrowserConfig:input_type -> fleetgrpc.GetBrowserConfigRequest
-	33, // 33: fleetgrpc.FleetService.PrepareBrowser:input_type -> fleetgrpc.PrepareBrowserRequest
-	34, // 34: fleetgrpc.FleetService.Hello:output_type -> fleetgrpc.HelloReply
-	35, // 35: fleetgrpc.FleetService.Shutdown:output_type -> fleetgrpc.ShutdownReply
-	36, // 36: fleetgrpc.FleetService.FleetTUIConnected:output_type -> fleetgrpc.FleetTUIConnectedReply
-	37, // 37: fleetgrpc.FleetService.GetState:output_type -> fleetgrpc.GetStateReply
-	38, // 38: fleetgrpc.FleetService.Watch:output_type -> fleetgrpc.Event
-	39, // 39: fleetgrpc.FleetService.CreateInstance:output_type -> fleetgrpc.JobEvent
-	39, // 40: fleetgrpc.FleetService.DestroyInstance:output_type -> fleetgrpc.JobEvent
-	39, // 41: fleetgrpc.FleetService.StartInstance:output_type -> fleetgrpc.JobEvent
-	39, // 42: fleetgrpc.FleetService.StopInstance:output_type -> fleetgrpc.JobEvent
-	39, // 43: fleetgrpc.FleetService.CloneInstance:output_type -> fleetgrpc.JobEvent
-	40, // 44: fleetgrpc.FleetService.CreateFleet:output_type -> fleetgrpc.MutationReply
-	40, // 45: fleetgrpc.FleetService.DestroyFleet:output_type -> fleetgrpc.MutationReply
-	40, // 46: fleetgrpc.FleetService.SetFleetSettings:output_type -> fleetgrpc.MutationReply
-	41, // 47: fleetgrpc.FleetService.DeleteBuildkitCache:output_type -> fleetgrpc.DeleteBuildkitCacheReply
-	42, // 48: fleetgrpc.FleetService.DeleteDebCache:output_type -> fleetgrpc.DeleteDebCacheReply
-	43, // 49: fleetgrpc.FleetService.DeleteImageCache:output_type -> fleetgrpc.DeleteImageCacheReply
-	40, // 50: fleetgrpc.FleetService.SetInstanceMetadata:output_type -> fleetgrpc.MutationReply
-	40, // 51: fleetgrpc.FleetService.SetGroupLayout:output_type -> fleetgrpc.MutationReply
-	40, // 52: fleetgrpc.FleetService.DeleteGroupLayout:output_type -> fleetgrpc.MutationReply
-	40, // 53: fleetgrpc.FleetService.SetLastSeenVersion:output_type -> fleetgrpc.MutationReply
-	44, // 54: fleetgrpc.FleetService.GetConfig:output_type -> fleetgrpc.GetConfigReply
-	45, // 55: fleetgrpc.FleetService.SetConfig:output_type -> fleetgrpc.SetConfigReply
-	46, // 56: fleetgrpc.FleetService.GetArmada:output_type -> fleetgrpc.GetArmadaReply
-	47, // 57: fleetgrpc.FleetService.SetArmada:output_type -> fleetgrpc.SetArmadaReply
-	48, // 58: fleetgrpc.FleetService.Exec:output_type -> fleetgrpc.ExecOut
-	49, // 59: fleetgrpc.FleetService.ResolveExecCommand:output_type -> fleetgrpc.ResolveExecCommandReply
-	50, // 60: fleetgrpc.FleetService.ResolveLogsCommand:output_type -> fleetgrpc.ResolveLogsCommandReply
-	51, // 61: fleetgrpc.FleetService.Logs:output_type -> fleetgrpc.LogLine
-	28, // 62: fleetgrpc.FleetService.Forward:output_type -> fleetgrpc.ForwardChunk
-	52, // 63: fleetgrpc.FleetService.CopyFile:output_type -> fleetgrpc.CopyFileChunk
-	53, // 64: fleetgrpc.FleetService.InspectRepo:output_type -> fleetgrpc.InspectRepoReply
-	54, // 65: fleetgrpc.FleetService.GetCoderTemplateParams:output_type -> fleetgrpc.GetCoderTemplateParamsReply
-	55, // 66: fleetgrpc.FleetService.GetBrowserConfig:output_type -> fleetgrpc.GetBrowserConfigReply
-	56, // 67: fleetgrpc.FleetService.PrepareBrowser:output_type -> fleetgrpc.PrepareBrowserReply
-	34, // [34:68] is the sub-list for method output_type
-	0,  // [0:34] is the sub-list for method input_type
+	10, // 10: fleetgrpc.FleetService.RebuildInstance:input_type -> fleetgrpc.RebuildInstanceRequest
+	11, // 11: fleetgrpc.FleetService.CreateFleet:input_type -> fleetgrpc.CreateFleetRequest
+	12, // 12: fleetgrpc.FleetService.DestroyFleet:input_type -> fleetgrpc.DestroyFleetRequest
+	13, // 13: fleetgrpc.FleetService.SetFleetSettings:input_type -> fleetgrpc.SetFleetSettingsRequest
+	14, // 14: fleetgrpc.FleetService.DeleteBuildkitCache:input_type -> fleetgrpc.DeleteBuildkitCacheRequest
+	15, // 15: fleetgrpc.FleetService.DeleteDebCache:input_type -> fleetgrpc.DeleteDebCacheRequest
+	16, // 16: fleetgrpc.FleetService.DeleteImageCache:input_type -> fleetgrpc.DeleteImageCacheRequest
+	17, // 17: fleetgrpc.FleetService.SetInstanceMetadata:input_type -> fleetgrpc.SetInstanceMetadataRequest
+	18, // 18: fleetgrpc.FleetService.SetGroupLayout:input_type -> fleetgrpc.SetGroupLayoutRequest
+	19, // 19: fleetgrpc.FleetService.DeleteGroupLayout:input_type -> fleetgrpc.DeleteGroupLayoutRequest
+	20, // 20: fleetgrpc.FleetService.SetLastSeenVersion:input_type -> fleetgrpc.SetLastSeenVersionRequest
+	21, // 21: fleetgrpc.FleetService.GetConfig:input_type -> fleetgrpc.GetConfigRequest
+	22, // 22: fleetgrpc.FleetService.SetConfig:input_type -> fleetgrpc.SetConfigRequest
+	23, // 23: fleetgrpc.FleetService.GetArmada:input_type -> fleetgrpc.GetArmadaRequest
+	24, // 24: fleetgrpc.FleetService.SetArmada:input_type -> fleetgrpc.SetArmadaRequest
+	25, // 25: fleetgrpc.FleetService.Exec:input_type -> fleetgrpc.ExecIn
+	26, // 26: fleetgrpc.FleetService.ResolveExecCommand:input_type -> fleetgrpc.ResolveExecCommandRequest
+	27, // 27: fleetgrpc.FleetService.ResolveLogsCommand:input_type -> fleetgrpc.ResolveLogsCommandRequest
+	28, // 28: fleetgrpc.FleetService.Logs:input_type -> fleetgrpc.LogsRequest
+	29, // 29: fleetgrpc.FleetService.Forward:input_type -> fleetgrpc.ForwardChunk
+	30, // 30: fleetgrpc.FleetService.CopyFile:input_type -> fleetgrpc.CopyFileRequest
+	31, // 31: fleetgrpc.FleetService.InspectRepo:input_type -> fleetgrpc.InspectRepoRequest
+	32, // 32: fleetgrpc.FleetService.GetCoderTemplateParams:input_type -> fleetgrpc.GetCoderTemplateParamsRequest
+	33, // 33: fleetgrpc.FleetService.GetBrowserConfig:input_type -> fleetgrpc.GetBrowserConfigRequest
+	34, // 34: fleetgrpc.FleetService.PrepareBrowser:input_type -> fleetgrpc.PrepareBrowserRequest
+	35, // 35: fleetgrpc.FleetService.Hello:output_type -> fleetgrpc.HelloReply
+	36, // 36: fleetgrpc.FleetService.Shutdown:output_type -> fleetgrpc.ShutdownReply
+	37, // 37: fleetgrpc.FleetService.FleetTUIConnected:output_type -> fleetgrpc.FleetTUIConnectedReply
+	38, // 38: fleetgrpc.FleetService.GetState:output_type -> fleetgrpc.GetStateReply
+	39, // 39: fleetgrpc.FleetService.Watch:output_type -> fleetgrpc.Event
+	40, // 40: fleetgrpc.FleetService.CreateInstance:output_type -> fleetgrpc.JobEvent
+	40, // 41: fleetgrpc.FleetService.DestroyInstance:output_type -> fleetgrpc.JobEvent
+	40, // 42: fleetgrpc.FleetService.StartInstance:output_type -> fleetgrpc.JobEvent
+	40, // 43: fleetgrpc.FleetService.StopInstance:output_type -> fleetgrpc.JobEvent
+	40, // 44: fleetgrpc.FleetService.CloneInstance:output_type -> fleetgrpc.JobEvent
+	40, // 45: fleetgrpc.FleetService.RebuildInstance:output_type -> fleetgrpc.JobEvent
+	41, // 46: fleetgrpc.FleetService.CreateFleet:output_type -> fleetgrpc.MutationReply
+	41, // 47: fleetgrpc.FleetService.DestroyFleet:output_type -> fleetgrpc.MutationReply
+	41, // 48: fleetgrpc.FleetService.SetFleetSettings:output_type -> fleetgrpc.MutationReply
+	42, // 49: fleetgrpc.FleetService.DeleteBuildkitCache:output_type -> fleetgrpc.DeleteBuildkitCacheReply
+	43, // 50: fleetgrpc.FleetService.DeleteDebCache:output_type -> fleetgrpc.DeleteDebCacheReply
+	44, // 51: fleetgrpc.FleetService.DeleteImageCache:output_type -> fleetgrpc.DeleteImageCacheReply
+	41, // 52: fleetgrpc.FleetService.SetInstanceMetadata:output_type -> fleetgrpc.MutationReply
+	41, // 53: fleetgrpc.FleetService.SetGroupLayout:output_type -> fleetgrpc.MutationReply
+	41, // 54: fleetgrpc.FleetService.DeleteGroupLayout:output_type -> fleetgrpc.MutationReply
+	41, // 55: fleetgrpc.FleetService.SetLastSeenVersion:output_type -> fleetgrpc.MutationReply
+	45, // 56: fleetgrpc.FleetService.GetConfig:output_type -> fleetgrpc.GetConfigReply
+	46, // 57: fleetgrpc.FleetService.SetConfig:output_type -> fleetgrpc.SetConfigReply
+	47, // 58: fleetgrpc.FleetService.GetArmada:output_type -> fleetgrpc.GetArmadaReply
+	48, // 59: fleetgrpc.FleetService.SetArmada:output_type -> fleetgrpc.SetArmadaReply
+	49, // 60: fleetgrpc.FleetService.Exec:output_type -> fleetgrpc.ExecOut
+	50, // 61: fleetgrpc.FleetService.ResolveExecCommand:output_type -> fleetgrpc.ResolveExecCommandReply
+	51, // 62: fleetgrpc.FleetService.ResolveLogsCommand:output_type -> fleetgrpc.ResolveLogsCommandReply
+	52, // 63: fleetgrpc.FleetService.Logs:output_type -> fleetgrpc.LogLine
+	29, // 64: fleetgrpc.FleetService.Forward:output_type -> fleetgrpc.ForwardChunk
+	53, // 65: fleetgrpc.FleetService.CopyFile:output_type -> fleetgrpc.CopyFileChunk
+	54, // 66: fleetgrpc.FleetService.InspectRepo:output_type -> fleetgrpc.InspectRepoReply
+	55, // 67: fleetgrpc.FleetService.GetCoderTemplateParams:output_type -> fleetgrpc.GetCoderTemplateParamsReply
+	56, // 68: fleetgrpc.FleetService.GetBrowserConfig:output_type -> fleetgrpc.GetBrowserConfigReply
+	57, // 69: fleetgrpc.FleetService.PrepareBrowser:output_type -> fleetgrpc.PrepareBrowserReply
+	35, // [35:70] is the sub-list for method output_type
+	0,  // [0:35] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/fleetgrpc/service.proto
+++ b/fleetgrpc/service.proto
@@ -47,6 +47,7 @@ service FleetService {
   rpc StartInstance(StartInstanceRequest) returns (stream JobEvent);
   rpc StopInstance(StopInstanceRequest) returns (stream JobEvent);
   rpc CloneInstance(CloneInstanceRequest) returns (stream JobEvent);
+  rpc RebuildInstance(RebuildInstanceRequest) returns (stream JobEvent);
 
   // ---- Synchronous (non-job) state mutations ----
   rpc CreateFleet(CreateFleetRequest) returns (MutationReply);

--- a/fleetgrpc/service_grpc.pb.go
+++ b/fleetgrpc/service_grpc.pb.go
@@ -29,6 +29,7 @@ const (
 	FleetService_StartInstance_FullMethodName          = "/fleetgrpc.FleetService/StartInstance"
 	FleetService_StopInstance_FullMethodName           = "/fleetgrpc.FleetService/StopInstance"
 	FleetService_CloneInstance_FullMethodName          = "/fleetgrpc.FleetService/CloneInstance"
+	FleetService_RebuildInstance_FullMethodName        = "/fleetgrpc.FleetService/RebuildInstance"
 	FleetService_CreateFleet_FullMethodName            = "/fleetgrpc.FleetService/CreateFleet"
 	FleetService_DestroyFleet_FullMethodName           = "/fleetgrpc.FleetService/DestroyFleet"
 	FleetService_SetFleetSettings_FullMethodName       = "/fleetgrpc.FleetService/SetFleetSettings"
@@ -86,6 +87,7 @@ type FleetServiceClient interface {
 	StartInstance(ctx context.Context, in *StartInstanceRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[JobEvent], error)
 	StopInstance(ctx context.Context, in *StopInstanceRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[JobEvent], error)
 	CloneInstance(ctx context.Context, in *CloneInstanceRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[JobEvent], error)
+	RebuildInstance(ctx context.Context, in *RebuildInstanceRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[JobEvent], error)
 	// ---- Synchronous (non-job) state mutations ----
 	CreateFleet(ctx context.Context, in *CreateFleetRequest, opts ...grpc.CallOption) (*MutationReply, error)
 	DestroyFleet(ctx context.Context, in *DestroyFleetRequest, opts ...grpc.CallOption) (*MutationReply, error)
@@ -300,6 +302,25 @@ func (c *fleetServiceClient) CloneInstance(ctx context.Context, in *CloneInstanc
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type FleetService_CloneInstanceClient = grpc.ServerStreamingClient[JobEvent]
 
+func (c *fleetServiceClient) RebuildInstance(ctx context.Context, in *RebuildInstanceRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[JobEvent], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &FleetService_ServiceDesc.Streams[6], FleetService_RebuildInstance_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[RebuildInstanceRequest, JobEvent]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type FleetService_RebuildInstanceClient = grpc.ServerStreamingClient[JobEvent]
+
 func (c *fleetServiceClient) CreateFleet(ctx context.Context, in *CreateFleetRequest, opts ...grpc.CallOption) (*MutationReply, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(MutationReply)
@@ -442,7 +463,7 @@ func (c *fleetServiceClient) SetArmada(ctx context.Context, in *SetArmadaRequest
 
 func (c *fleetServiceClient) Exec(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[ExecIn, ExecOut], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &FleetService_ServiceDesc.Streams[6], FleetService_Exec_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &FleetService_ServiceDesc.Streams[7], FleetService_Exec_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -475,7 +496,7 @@ func (c *fleetServiceClient) ResolveLogsCommand(ctx context.Context, in *Resolve
 
 func (c *fleetServiceClient) Logs(ctx context.Context, in *LogsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[LogLine], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &FleetService_ServiceDesc.Streams[7], FleetService_Logs_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &FleetService_ServiceDesc.Streams[8], FleetService_Logs_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -494,7 +515,7 @@ type FleetService_LogsClient = grpc.ServerStreamingClient[LogLine]
 
 func (c *fleetServiceClient) Forward(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[ForwardChunk, ForwardChunk], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &FleetService_ServiceDesc.Streams[8], FleetService_Forward_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &FleetService_ServiceDesc.Streams[9], FleetService_Forward_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -507,7 +528,7 @@ type FleetService_ForwardClient = grpc.BidiStreamingClient[ForwardChunk, Forward
 
 func (c *fleetServiceClient) CopyFile(ctx context.Context, in *CopyFileRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CopyFileChunk], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &FleetService_ServiceDesc.Streams[9], FleetService_CopyFile_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &FleetService_ServiceDesc.Streams[10], FleetService_CopyFile_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -595,6 +616,7 @@ type FleetServiceServer interface {
 	StartInstance(*StartInstanceRequest, grpc.ServerStreamingServer[JobEvent]) error
 	StopInstance(*StopInstanceRequest, grpc.ServerStreamingServer[JobEvent]) error
 	CloneInstance(*CloneInstanceRequest, grpc.ServerStreamingServer[JobEvent]) error
+	RebuildInstance(*RebuildInstanceRequest, grpc.ServerStreamingServer[JobEvent]) error
 	// ---- Synchronous (non-job) state mutations ----
 	CreateFleet(context.Context, *CreateFleetRequest) (*MutationReply, error)
 	DestroyFleet(context.Context, *DestroyFleetRequest) (*MutationReply, error)
@@ -684,6 +706,9 @@ func (UnimplementedFleetServiceServer) StopInstance(*StopInstanceRequest, grpc.S
 }
 func (UnimplementedFleetServiceServer) CloneInstance(*CloneInstanceRequest, grpc.ServerStreamingServer[JobEvent]) error {
 	return status.Errorf(codes.Unimplemented, "method CloneInstance not implemented")
+}
+func (UnimplementedFleetServiceServer) RebuildInstance(*RebuildInstanceRequest, grpc.ServerStreamingServer[JobEvent]) error {
+	return status.Errorf(codes.Unimplemented, "method RebuildInstance not implemented")
 }
 func (UnimplementedFleetServiceServer) CreateFleet(context.Context, *CreateFleetRequest) (*MutationReply, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateFleet not implemented")
@@ -915,6 +940,17 @@ func _FleetService_CloneInstance_Handler(srv interface{}, stream grpc.ServerStre
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type FleetService_CloneInstanceServer = grpc.ServerStreamingServer[JobEvent]
+
+func _FleetService_RebuildInstance_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(RebuildInstanceRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(FleetServiceServer).RebuildInstance(m, &grpc.GenericServerStream[RebuildInstanceRequest, JobEvent]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type FleetService_RebuildInstanceServer = grpc.ServerStreamingServer[JobEvent]
 
 func _FleetService_CreateFleet_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(CreateFleetRequest)
@@ -1445,6 +1481,11 @@ var FleetService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "CloneInstance",
 			Handler:       _FleetService_CloneInstance_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "RebuildInstance",
+			Handler:       _FleetService_RebuildInstance_Handler,
 			ServerStreams: true,
 		},
 		{

--- a/integration/tests/057_rebuild.sh
+++ b/integration/tests/057_rebuild.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Description: `fleet rebuild` recreates the container (new id) while preserving the workspace, and the instance stays usable.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test
+fleet_up alpha
+
+old_container=$(grep -oE '"container_id":\s*"[^"]+"' "${HOME}/.fleet/state.json" | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
+[ -n "${old_container}" ] || fail "could not read container_id from state"
+info "first container: ${old_container}"
+
+# Drop a marker into the workspace (a host bind mount), so we can prove the
+# rebuild preserves the checkout rather than wiping it like a destroy would.
+ws_dir="${HOME}/.fleet/workspaces/${FIXTURE_REPO_NAME}/alpha/${FIXTURE_REPO_NAME}"
+echo "preserved-through-rebuild" > "${ws_dir}/REBUILD_MARKER.txt"
+
+# --- rebuild ---
+info "fleet rebuild alpha"
+rebuild_out=$("${FLEET_BIN}" rebuild "${FIXTURE_REPO_NAME}/alpha")
+printf '%s\n' "${rebuild_out}"
+assert_contains "${rebuild_out}" "rebuilt" "rebuild output should mention rebuilt"
+
+# The container is torn down and recreated, so its id changes...
+new_container=$(grep -oE '"container_id":\s*"[^"]+"' "${HOME}/.fleet/state.json" | head -1 | sed -E 's/.*"([^"]+)"$/\1/')
+[ -n "${new_container}" ] || fail "could not read new container_id from state"
+info "new container: ${new_container}"
+if [ "${old_container}" = "${new_container}" ]; then
+  fail "container id should change after rebuild (container was not recreated)"
+fi
+
+# ...and the old container is gone.
+if docker inspect "${old_container}" >/dev/null 2>&1; then
+  fail "old container ${old_container} should have been removed by rebuild"
+fi
+
+# The fresh container is running.
+docker_state=$(docker inspect -f '{{.State.Status}}' "${new_container}")
+assert_equals "running" "${docker_state}" "rebuilt container should be running"
+
+# State reports running again (rebuilding -> running).
+ls_after=$("${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}")
+assert_contains "${ls_after}" "running" "ls should report running after rebuild"
+
+# The workspace survived: the marker is readable from inside the new container.
+marker_out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- cat "/workspaces/${FIXTURE_REPO_NAME}/REBUILD_MARKER.txt")
+assert_equals "preserved-through-rebuild" "${marker_out}" "workspace should be preserved through rebuild"
+
+# exec works against the rebuilt container.
+echo_out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- sh -c "echo back-online")
+assert_equals "back-online" "${echo_out}" "exec after rebuild"
+
+pass "rebuild recreates container, preserves workspace"

--- a/internal/admiralskill/SKILL.md
+++ b/internal/admiralskill/SKILL.md
@@ -61,9 +61,9 @@ the daemon's version and liveness. `fleet_logs` returns an instance's container
 logs (use `tail` to cap to the last N lines).
 
 **Manage instance lifecycle.** The slow, job-shaped tools — `fleet_up`,
-`fleet_clone`, `fleet_down`, `fleet_destroy_fleet` — are async-first: they
-return within seconds with `{job_id, done: false, instance}` while the job
-keeps running server-side. Kick off as many as you need (e.g. bulk-provision
+`fleet_clone`, `fleet_rebuild`, `fleet_down`, `fleet_destroy_fleet` — are
+async-first: they return within seconds with `{job_id, done: false, instance}`
+while the job keeps running server-side. Kick off as many as you need (e.g. bulk-provision
 several instances), keep working, then poll `fleet_job_status {job_id}` until
 `state` leaves `running` — it reports `succeeded` (with `warnings` and the
 final `result` record) or `failed` (with `error`). The instance's `status` in
@@ -92,6 +92,10 @@ surfaces as a tool error.
 - `fleet_clone {fleet, source, destination, ..., wait?}` duplicates an
   instance, keeping its installed state (optional `display_name`, `tag`,
   `color`, `branch` overrides).
+- `fleet_rebuild {fleet, instance, wait?}` recreates an instance's container in
+  place (e.g. after its devcontainer config changed), **preserving the
+  workspace** — the git checkout and uncommitted edits survive. Only the
+  `devcontainer` and `codespaces` backends support it; `coder` does not.
 - `fleet_job_status {job_id}` reports a lifecycle job:
   `{state: running|succeeded|failed, error?, warnings?, result?}`. A failed job
   is data here (`state: "failed"`), not a tool error. An unknown `job_id`
@@ -163,6 +167,7 @@ INSPECT
 LIFECYCLE  (async-first: returns {job_id, done:false} in seconds; wait:true blocks)
   fleet_up {fleet, instance, remote?, branch?, backend?, wait?}
   fleet_clone {fleet, source, destination, display_name?, tag?, color?, branch?, wait?}
+  fleet_rebuild {fleet, instance, wait?}            # recreate container, keep workspace (devcontainer/codespaces)
   fleet_down {fleet, instance, wait?}               # remove one instance      (irreversible)
   fleet_destroy_fleet {fleet, wait?}                # remove fleet + instances (irreversible)
   fleet_job_status {job_id}                         # poll: running | succeeded | failed

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -39,6 +39,30 @@ type Backend interface {
 	// primitives live outside fleet-man's control.
 	SupportsClone() bool
 
+	// Rebuild tears down the instance's existing container and provisions a
+	// fresh one in place, PRESERVING the workspace: the host-side bind mount
+	// (devcontainer) or the codespace's persisted code survives, so uncommitted
+	// edits are not lost. It is the way to pick up an edited devcontainer.json /
+	// Dockerfile without recreating the instance from scratch.
+	//
+	// containerID identifies the existing container/workspace (the codespace
+	// name for the codespaces backend; unused by devcontainer, which matches by
+	// workspace-folder label). mounts carry the same caller-supplied bind mounts
+	// as Up and must be re-applied so the rebuilt container keeps its control
+	// socket / shared-cache / agent-state mounts; backends returning false from
+	// SupportsCustomMounts ignore them.
+	//
+	// Returns the same UpResult shape as Up so callers can persist the new
+	// ContainerID (it CHANGES for devcontainer; it is stable for codespaces).
+	// Backends that cannot rebuild return false from SupportsRebuild and an
+	// error from Rebuild.
+	Rebuild(containerID, workspaceDir string, mounts []Mount) (*UpResult, error)
+
+	// SupportsRebuild reports whether this backend implements Rebuild. Callers
+	// should check this before offering a rebuild action; managed backends whose
+	// runtime exposes no rebuild primitive (coder) report false.
+	SupportsRebuild() bool
+
 	// Down stops and removes a container permanently.
 	Down(containerID string) error
 

--- a/internal/backend/coder/coder_backend.go
+++ b/internal/backend/coder/coder_backend.go
@@ -284,6 +284,17 @@ func (coderBackend *CoderBackend) Clone(sourceContainerID, destWorkspaceDir stri
 	return nil, fmt.Errorf("coder backend does not support cloning")
 }
 
+// SupportsRebuild reports false: Coder workspaces are managed by a remote
+// control plane that exposes no in-place container rebuild primitive.
+func (coderBackend *CoderBackend) SupportsRebuild() bool {
+	return false
+}
+
+// Rebuild is unsupported for Coder workspaces.
+func (coderBackend *CoderBackend) Rebuild(containerID, workspaceDir string, mounts []backend.Mount) (*backend.UpResult, error) {
+	return nil, fmt.Errorf("coder backend does not support rebuild")
+}
+
 // Status reports the live state of a Coder workspace by reading
 // `coder list`'s LatestBuild.Status. Lifecycle: running/started →
 // running; stopped/canceled → stopped; transitional builds (starting,

--- a/internal/backend/coder/rebuild_test.go
+++ b/internal/backend/coder/rebuild_test.go
@@ -1,0 +1,20 @@
+package coder
+
+import (
+	"strings"
+	"testing"
+)
+
+// Coder workspaces have no rebuild primitive, so the backend must advertise the
+// capability as unsupported and reject Rebuild with a clear error — the signal
+// the CLI/TUI/MCP layers gate on.
+func TestCoderRebuildUnsupported(t *testing.T) {
+	b := New()
+	if b.SupportsRebuild() {
+		t.Fatal("coder backend should not support rebuild")
+	}
+	_, err := b.Rebuild("ws", "/tmp/ws", nil)
+	if err == nil || !strings.Contains(err.Error(), "does not support rebuild") {
+		t.Fatalf("Rebuild error = %v, want a 'does not support rebuild' error", err)
+	}
+}

--- a/internal/backend/codespaces/codespaces_backend.go
+++ b/internal/backend/codespaces/codespaces_backend.go
@@ -321,6 +321,49 @@ func (codespacesBackend *CodespacesBackend) Clone(sourceContainerID, destWorkspa
 	return nil, fmt.Errorf("codespaces backend does not support cloning")
 }
 
+// SupportsRebuild reports true: `gh codespace rebuild` recreates the dev
+// container inside an existing codespace.
+func (codespacesBackend *CodespacesBackend) SupportsRebuild() bool {
+	return true
+}
+
+// Rebuild recreates the dev container inside the codespace via
+// `gh codespace rebuild`. The codespace VM and its name are unchanged and the
+// user's code is preserved by GitHub — only the container is rebuilt — so the
+// returned UpResult carries the same containerID. mounts are ignored (the gh
+// CLI cannot inject host bind mounts). After triggering the rebuild we wait for
+// the codespace to report Available again and regenerate the SSH config (the
+// fresh container may present new connection details), mirroring Up. A future
+// "full" rebuild could pass --full to also drop cached Docker images.
+func (codespacesBackend *CodespacesBackend) Rebuild(containerID, workspaceDir string, _ []backend.Mount) (*backend.UpResult, error) {
+	if containerID == "" {
+		return nil, fmt.Errorf("codespaces rebuild requires a codespace name")
+	}
+
+	cmd := exec.Command("gh", "codespace", "rebuild", "-c", containerID)
+	var stderrBuf strings.Builder
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("gh codespace rebuild failed: %w\nstderr: %s", err, strings.TrimSpace(stderrBuf.String()))
+	}
+
+	// Wait for the rebuild to settle back to Available before reporting success,
+	// then refresh cached connection info. generateSSHConfig is best-effort
+	// (methods fall back to `gh codespace ssh` if it fails), as in Up.
+	if err := codespacesBackend.waitForState(containerID, "Available", 5*time.Minute); err != nil {
+		return nil, err
+	}
+	codespacesBackend.nameCache[workspaceDir] = containerID
+	_, _ = codespacesBackend.generateSSHConfig(containerID, workspaceDir)
+
+	return &backend.UpResult{
+		Outcome:               "success",
+		ContainerID:           containerID,
+		RemoteUser:            "codespace",
+		RemoteWorkspaceFolder: "/workspaces",
+	}, nil
+}
+
 // Status reports the live state of a GitHub Codespace via
 // `gh codespace view`. GitHub's lifecycle: Available → running;
 // Shutdown/Archived → stopped (the most common drift the live probe

--- a/internal/backend/codespaces/rebuild_test.go
+++ b/internal/backend/codespaces/rebuild_test.go
@@ -1,0 +1,23 @@
+package codespaces
+
+import (
+	"strings"
+	"testing"
+)
+
+// `gh codespace rebuild` recreates the dev container, so the codespaces backend
+// advertises rebuild support.
+func TestCodespacesSupportsRebuild(t *testing.T) {
+	if !New().SupportsRebuild() {
+		t.Fatal("codespaces backend should support rebuild")
+	}
+}
+
+// Rebuild needs the codespace name (the container id) to target `gh codespace
+// rebuild -c`; an empty id is rejected before shelling out.
+func TestCodespacesRebuildRequiresName(t *testing.T) {
+	_, err := New().Rebuild("", "/tmp/ws", nil)
+	if err == nil || !strings.Contains(err.Error(), "codespace name") {
+		t.Fatalf("Rebuild(\"\") error = %v, want a missing-name error", err)
+	}
+}

--- a/internal/backend/devcontainer/devcontainer_backend.go
+++ b/internal/backend/devcontainer/devcontainer_backend.go
@@ -67,20 +67,46 @@ func (devcontainerBackend *DevcontainerBackend) containerUser(containerID string
 	return user
 }
 
-// Up runs `devcontainer up` for the given workspace folder. Any mounts
+// Up provisions a devcontainer for the given workspace folder.
+func (devcontainerBackend *DevcontainerBackend) Up(workspaceDir string, mounts []backend.Mount) (*backend.UpResult, error) {
+	return devcontainerBackend.up(workspaceDir, mounts, nil)
+}
+
+// Rebuild recreates the workspace's container in place by re-running
+// `devcontainer up --remove-existing-container`: the existing container is
+// removed and a fresh one is provisioned from the (possibly edited)
+// devcontainer.json / Dockerfile. The host-side workspace bind mount is
+// preserved, so uncommitted work in the checkout survives; the new container
+// gets a new ID, returned in UpResult. containerID is unused — the devcontainer
+// CLI matches the container by workspace-folder label (and up's
+// pruneStaleContainers already drops it), so --remove-existing-container is the
+// belt-and-braces signal of rebuild intent. A future "full" rebuild could add
+// --build-no-cache to force a from-scratch image build.
+func (devcontainerBackend *DevcontainerBackend) Rebuild(_, workspaceDir string, mounts []backend.Mount) (*backend.UpResult, error) {
+	return devcontainerBackend.up(workspaceDir, mounts, []string{"--remove-existing-container"})
+}
+
+// SupportsRebuild reports true: the devcontainer backend can recreate a
+// container in place from its workspace folder.
+func (devcontainerBackend *DevcontainerBackend) SupportsRebuild() bool {
+	return true
+}
+
+// up runs `devcontainer up` for the given workspace folder. Any mounts
 // in the slice are translated into `--mount type=bind,source=L,target=C`
 // flags so they appear inside the container alongside the SSH agent
-// socket and the workspace itself.
+// socket and the workspace itself. extraArgs are passed through verbatim to
+// the `up` subcommand (Rebuild uses it for --remove-existing-container).
 //
 // When the workspace's devcontainer.json declares its own mount at the
 // same container path as one of the fleet-supplied mounts, the user's
 // entry is temporarily stripped from the file before launching the
-// devcontainer CLI and restored once Up returns. Without this, docker
+// devcontainer CLI and restored once up returns. Without this, docker
 // rejects the resulting `docker run` invocation with "Duplicate mount
 // point" and the instance enters StatusFailed. Fleet's mount wins by
 // design — the user's per-fleet agent state should override whatever
 // the repo's devcontainer.json was pointing at.
-func (devcontainerBackend *DevcontainerBackend) Up(workspaceDir string, mounts []backend.Mount) (*backend.UpResult, error) {
+func (devcontainerBackend *DevcontainerBackend) up(workspaceDir string, mounts []backend.Mount, extraArgs []string) (*backend.UpResult, error) {
 	// Drop any docker container still labelled with this workspace
 	// folder before provisioning. The devcontainer CLI matches existing
 	// containers by `devcontainer.local_folder=<wsDir>` and silently
@@ -114,6 +140,7 @@ func (devcontainerBackend *DevcontainerBackend) Up(workspaceDir string, mounts [
 	defer os.RemoveAll(runnerTmp)
 
 	args := []string{"up", "--workspace-folder", workspaceDir}
+	args = append(args, extraArgs...)
 	args, err = devcontainerUpArgs(args)
 	if err != nil {
 		return nil, err

--- a/internal/backend/devcontainer/rebuild_test.go
+++ b/internal/backend/devcontainer/rebuild_test.go
@@ -1,0 +1,11 @@
+package devcontainer
+
+import "testing"
+
+// The devcontainer backend recreates a container in place, so it advertises
+// rebuild support (the capability the CLI/TUI/MCP layers gate on).
+func TestDevcontainerSupportsRebuild(t *testing.T) {
+	if !New().SupportsRebuild() {
+		t.Fatal("devcontainer backend should support rebuild")
+	}
+}

--- a/internal/cli/rebuild.go
+++ b/internal/cli/rebuild.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+func newRebuildCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "rebuild <name>",
+		Aliases: []string{"rb"},
+		Short:   "Rebuild an instance's container in place (preserves the workspace)",
+		Long: "Tear down and reprovision an instance's container without recreating the instance — " +
+			"handy after editing devcontainer.json. The workspace (git checkout and uncommitted edits) " +
+			"is preserved. Only backends with a rebuild primitive are supported (devcontainer, codespaces).",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target, err := fleet.Resolve(args[0], "")
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Rebuilding %s/%s...\n", target.Fleet, target.Instance)
+			// The server validates the target, refuses an unsupported backend, and
+			// reprovisions the container in place (it errors NotFound / FailedPrecondition
+			// for a missing or non-rebuildable target).
+			if err := runInstanceJob(cmd.Context(), func(ctx context.Context, svc fleetgrpc.FleetServiceClient) (grpc.ServerStreamingClient[fleetgrpc.JobEvent], error) {
+				return svc.RebuildInstance(ctx, &fleetgrpc.RebuildInstanceRequest{Fleet: target.Fleet, Instance: target.Instance})
+			}); err != nil {
+				return err
+			}
+			fmt.Printf("Instance %s/%s rebuilt.\n", target.Fleet, target.Instance)
+			return nil
+		},
+	}
+}

--- a/internal/cli/rebuild_test.go
+++ b/internal/cli/rebuild_test.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"google.golang.org/grpc"
+)
+
+// TestRebuildCmdRunsJob verifies `fleet rebuild <name>` resolves its target and
+// drives the lifecycle job runner (the gRPC RebuildInstance path is exercised by
+// the server tests).
+func TestRebuildCmdRunsJob(t *testing.T) {
+	orig := runInstanceJob
+	defer func() { runInstanceJob = orig }()
+
+	called := false
+	runInstanceJob = func(ctx context.Context, open func(context.Context, fleetgrpc.FleetServiceClient) (grpc.ServerStreamingClient[fleetgrpc.JobEvent], error)) error {
+		called = true
+		return nil
+	}
+
+	cmd := newRebuildCmd()
+	cmd.SetArgs([]string{"alpha/i1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("rebuild execute: %v", err)
+	}
+	if !called {
+		t.Fatal("runInstanceJob was not invoked")
+	}
+}
+
+// TestRebuildCmdAlias locks in the short `rb` alias.
+func TestRebuildCmdAlias(t *testing.T) {
+	got := newRebuildCmd().Aliases
+	if len(got) != 1 || got[0] != "rb" {
+		t.Fatalf("aliases = %v, want [rb]", got)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -39,6 +39,7 @@ func NewRootCmd() *cobra.Command {
 		newStartCmd(),
 		newDownCmd(),
 		newDestroyCmd(),
+		newRebuildCmd(),
 		newListCmd(),
 		newExecCmd(),
 		newCodeCmd(),

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -7,15 +7,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
-	"github.com/BenjaminBenetti/fleet-man/internal/agentdetect"
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
-	"github.com/BenjaminBenetti/fleet-man/internal/dotfiles"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
-	"github.com/BenjaminBenetti/fleet-man/internal/fleetlaunch"
 	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 )
@@ -83,37 +79,10 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backen
 		}
 	}
 
-	resolvedMounts, err := resolveCustomMounts(instanceBackend, fleetName)
+	resolvedMounts, err := resolveProvisionMounts(instanceBackend, fleetName, instanceName)
 	if err != nil {
 		setFailed(fleetName, instanceName, err)
 		return err
-	}
-
-	// Bind-mount the per-instance control directory so the host fleet TUI
-	// can create a unix socket the in-instance `fleet launch` connects to.
-	// Only devcontainer-style backends honor custom mounts; cloud-managed
-	// backends ignore them, so we skip the host-side prep for those. A
-	// failure to create the host directory is non-fatal — the instance is
-	// still usable, it just won't have in-instance control until recreated —
-	// so we surface it as a warning and continue, matching the surrounding
-	// best-effort pattern.
-	if instanceBackend.SupportsCustomMounts() {
-		mount, err := controlMount(fleetName, instanceName)
-		if err != nil {
-			state.WriteWarn(fleetName, instanceName, fmt.Sprintf("control mount: %v", err))
-		} else {
-			resolvedMounts.Mounts = append(resolvedMounts.Mounts, mount)
-		}
-	}
-
-	// When the fleet enables a shared buildkit server, ensure its container is
-	// running and bind its socket directory into the instance so docker buildx
-	// can use the fleet-wide build cache. Non-fatal: a failure to start the
-	// server just means this instance builds without the shared cache.
-	if mount, ok, err := prepareBuildkitMount(instanceBackend, fleetName); err != nil {
-		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("buildkit server: %v", err))
-	} else if ok {
-		resolvedMounts.Mounts = append(resolvedMounts.Mounts, mount)
 	}
 
 	result, err := instanceBackend.Up(wsDir, resolvedMounts.Mounts)
@@ -122,86 +91,11 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backen
 		return err
 	}
 
-	// Stage the fleet-launch binary into the container so its
-	// in-container subcommands (landing-page server, etc.) are ready
-	// without waiting for the first browser open. Non-fatal: the
-	// browser-open path stages on demand too, so a failure here just
-	// defers the work, it doesn't break the instance.
-	if _, err := fleetlaunch.EnsureFresh(instanceBackend, wsDir, nil); err != nil {
-		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("stage fleet-launch: %v", err))
-	}
-
-	// Stage fleet.rc into the container user's home so interactive
-	// shells can source fleet-aware aliases. Respects the fleet's
-	// HomeDir setting; empty falls back to fleetlaunch.DefaultHomeDir.
-	// Non-fatal for the same reason as the binary stage.
-	if err := fleetlaunch.EnsureFleetRC(instanceBackend, wsDir, homeDirForFleet(fleetName), instanceName); err != nil {
-		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("stage fleet.rc: %v", err))
-	}
-
-	// Materialise the post-Up symlinks for any single-file mounts.
-	// Failure is non-fatal — the instance is still usable; the agent
-	// will just have to log in fresh — so we surface the error as a
-	// warning and keep going.
-	if err := applyMountSymlinks(instanceBackend, wsDir, resolvedMounts.Symlinks); err != nil {
-		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("setting up agentic mount symlinks: %v", err))
-	}
-
-	// Point the instance's docker buildx at the fleet's shared buildkit server
-	// (when enabled). A silent no-op for images without docker/buildx, and
-	// non-fatal otherwise — the instance is usable regardless of buildx wiring.
-	if err := configureBuildkit(instanceBackend, fleetName, wsDir); err != nil {
-		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("configure buildkit buildx: %v", err))
-	}
-
-	// Wire the instance into the fleet's shared deb/image caches (when enabled):
-	// ensure each cache server, join the instance to the fleet's shared docker
-	// network, and write the in-instance apt/docker config. Network-based (no
-	// bind mount, so it runs here with result.ContainerID in scope), best-effort,
-	// and a silent no-op for instances lacking apt / a local dockerd.
-	if err := setupDebCache(instanceBackend, fleetName, result.ContainerID, wsDir); err != nil {
-		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("deb cache: %v", err))
-	}
-	if err := setupImageCache(instanceBackend, fleetName, instanceName, result.ContainerID, wsDir); err != nil {
-		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("image cache: %v", err))
-	}
-
-	// Auto-install dotfiles. A failure here is non-fatal — the instance
-	// is still usable, so we mark it running and surface the error as a
-	// warning rather than blocking the whole creation.
-	config, _ := state.LoadConfig()
-	if config != nil && config.DotfilesSettings.AutoInstall {
-		if script := dotfiles.SetupScript(config); script != "" {
-			cmd := instanceBackend.ExecCommand(wsDir, []string{"sh", "-c", script})
-			out, err := cmd.CombinedOutput()
-			if err != nil {
-				detail := strings.TrimSpace(string(out))
-				// Write warning to a file the TUI can pick up.
-				state.WriteWarn(fleetName, instanceName, fmt.Sprintf("dotfiles install failed: %v\n%s", err, detail))
-			}
-		}
-	}
-
-	// Run any agent install scripts associated with the fleet's
-	// settings (Claude Code, Codex). Each script self-redirects its
-	// output to ~/.fleet/startup/<name>.log inside the container, and
-	// failures are non-fatal — the instance is still usable, so we
-	// surface them as a warning rather than aborting creation.
-	runStartupScripts(instanceBackend, wsDir, fleetName, instanceName)
-
-	// Install Claude Code state-detection hooks. Runs after the
-	// startup scripts so any per-fleet Claude Code install above
-	// has had a chance to land before we drop our hooks alongside
-	// it. Like dotfiles, this is non-fatal: if hook installation
-	// fails the user can still use the instance — fleet-man's
-	// per-instance Detector falls back to a safe default for
-	// Claude state. We always install (regardless of which agent
-	// the user actually runs) because we don't know the choice at
-	// creation time, and the cost of unused hooks is negligible.
-	executor := agentdetect.NewBackendExecutor(instanceBackend, wsDir)
-	if err := agentdetect.NewClaudeProvisioner(executor).Provision(); err != nil {
-		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("claude hook install failed: %v", err))
-	}
+	// Run the post-Up provisioning (fleet-launch staging, dotfiles, startup
+	// scripts, Claude hooks, shared caches). Shared with RunRebuild so a
+	// rebuilt container ends up equivalently provisioned. Every step is
+	// best-effort — the instance is marked running even if one fails.
+	finishProvision(instanceBackend, fleetName, instanceName, wsDir, result.ContainerID, resolvedMounts.Symlinks)
 
 	// Success: update state (instance is running even if dotfiles failed)
 	if err := markInstanceRunning(fleetName, instanceName, result.ContainerID); err != nil {

--- a/internal/create/provision.go
+++ b/internal/create/provision.go
@@ -12,10 +12,13 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 )
 
-// provision.go holds the provisioning steps shared by Run (create), RunClone,
-// and RunRebuild so the three paths stay in lock-step: resolveProvisionMounts
+// provision.go holds the provisioning steps shared by Run (create) and
+// RunRebuild so those two paths stay in lock-step: resolveProvisionMounts
 // assembles the mounts handed to the backend's Up/Rebuild, and finishProvision
-// runs everything that has to happen once the container exists.
+// runs everything that has to happen once the container exists. RunClone does
+// NOT use finishProvision — a clone inherits its source's dotfiles/startup
+// effects via the committed image and deliberately must not re-run them — though
+// it mirrors the same mount + re-stage steps inline (see clone.go).
 
 // resolveProvisionMounts assembles the bind mounts for a provisioning run: the
 // fleet's custom mounts, the per-instance control directory (so the host TUI

--- a/internal/create/provision.go
+++ b/internal/create/provision.go
@@ -1,0 +1,140 @@
+package create
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/agentdetect"
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+	"github.com/BenjaminBenetti/fleet-man/internal/dotfiles"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetlaunch"
+	mountresolver "github.com/BenjaminBenetti/fleet-man/internal/mounts/resolver"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// provision.go holds the provisioning steps shared by Run (create), RunClone,
+// and RunRebuild so the three paths stay in lock-step: resolveProvisionMounts
+// assembles the mounts handed to the backend's Up/Rebuild, and finishProvision
+// runs everything that has to happen once the container exists.
+
+// resolveProvisionMounts assembles the bind mounts for a provisioning run: the
+// fleet's custom mounts, the per-instance control directory (so the host TUI
+// can drive the in-instance `fleet launch` over a unix socket), and the shared
+// buildkit socket (when the fleet enables it). The custom-mount resolution can
+// hard-fail (returned error); the control + buildkit mounts are best-effort —
+// a failure becomes a warning and the run continues, matching the surrounding
+// pattern. Only devcontainer-style backends honor mounts; cloud-managed
+// backends ignore them, so the host-side prep is skipped for those.
+func resolveProvisionMounts(instanceBackend backend.Backend, fleetName, instanceName string) (mountresolver.Resolved, error) {
+	resolvedMounts, err := resolveCustomMounts(instanceBackend, fleetName)
+	if err != nil {
+		return resolvedMounts, err
+	}
+
+	// Bind-mount the per-instance control directory so the host fleet TUI
+	// can create a unix socket the in-instance `fleet launch` connects to.
+	// A failure to create the host directory is non-fatal — the instance is
+	// still usable, it just won't have in-instance control until recreated.
+	if instanceBackend.SupportsCustomMounts() {
+		mount, err := controlMount(fleetName, instanceName)
+		if err != nil {
+			state.WriteWarn(fleetName, instanceName, fmt.Sprintf("control mount: %v", err))
+		} else {
+			resolvedMounts.Mounts = append(resolvedMounts.Mounts, mount)
+		}
+	}
+
+	// When the fleet enables a shared buildkit server, ensure its container is
+	// running and bind its socket directory into the instance so docker buildx
+	// can use the fleet-wide build cache. Non-fatal: a failure to start the
+	// server just means this instance builds without the shared cache.
+	if mount, ok, err := prepareBuildkitMount(instanceBackend, fleetName); err != nil {
+		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("buildkit server: %v", err))
+	} else if ok {
+		resolvedMounts.Mounts = append(resolvedMounts.Mounts, mount)
+	}
+
+	return resolvedMounts, nil
+}
+
+// finishProvision runs the post-Up provisioning steps shared by Run and
+// RunRebuild: stage the fleet-launch binary + fleet.rc, materialise mount
+// symlinks, point docker buildx at the shared buildkit server, wire the
+// instance into the fleet's shared deb/image caches, install dotfiles, run the
+// per-fleet agent startup scripts, and install the Claude state-detection
+// hooks. Every step is best-effort — a failure is surfaced as a warning and
+// the instance is still marked running — so the order matters but no single
+// step aborts the run. symlinks comes from the resolved mounts (the single-file
+// agent-state links). containerID is the freshly-provisioned container's id,
+// needed by the network-based cache wiring.
+func finishProvision(instanceBackend backend.Backend, fleetName, instanceName, wsDir, containerID string, symlinks []mountresolver.Symlink) {
+	// Stage the fleet-launch binary into the container so its in-container
+	// subcommands (landing-page server, etc.) are ready without waiting for the
+	// first browser open. Non-fatal: the browser-open path stages on demand too.
+	if _, err := fleetlaunch.EnsureFresh(instanceBackend, wsDir, nil); err != nil {
+		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("stage fleet-launch: %v", err))
+	}
+
+	// Stage fleet.rc into the container user's home so interactive shells can
+	// source fleet-aware aliases. Respects the fleet's HomeDir setting; empty
+	// falls back to fleetlaunch.DefaultHomeDir. Non-fatal.
+	if err := fleetlaunch.EnsureFleetRC(instanceBackend, wsDir, homeDirForFleet(fleetName), instanceName); err != nil {
+		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("stage fleet.rc: %v", err))
+	}
+
+	// Materialise the post-Up symlinks for any single-file mounts. Failure is
+	// non-fatal — the instance is still usable; the agent will just have to log
+	// in fresh.
+	if err := applyMountSymlinks(instanceBackend, wsDir, symlinks); err != nil {
+		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("setting up agentic mount symlinks: %v", err))
+	}
+
+	// Point the instance's docker buildx at the fleet's shared buildkit server
+	// (when enabled). A silent no-op for images without docker/buildx, and
+	// non-fatal otherwise — the instance is usable regardless of buildx wiring.
+	if err := configureBuildkit(instanceBackend, fleetName, wsDir); err != nil {
+		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("configure buildkit buildx: %v", err))
+	}
+
+	// Wire the instance into the fleet's shared deb/image caches (when enabled):
+	// ensure each cache server, join the instance to the fleet's shared docker
+	// network, and write the in-instance apt/docker config. Network-based (no
+	// bind mount, so it runs here with containerID in scope), best-effort, and a
+	// silent no-op for instances lacking apt / a local dockerd.
+	if err := setupDebCache(instanceBackend, fleetName, containerID, wsDir); err != nil {
+		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("deb cache: %v", err))
+	}
+	if err := setupImageCache(instanceBackend, fleetName, instanceName, containerID, wsDir); err != nil {
+		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("image cache: %v", err))
+	}
+
+	// Auto-install dotfiles. A failure here is non-fatal — the instance is still
+	// usable, so we surface the error as a warning rather than blocking.
+	config, _ := state.LoadConfig()
+	if config != nil && config.DotfilesSettings.AutoInstall {
+		if script := dotfiles.SetupScript(config); script != "" {
+			cmd := instanceBackend.ExecCommand(wsDir, []string{"sh", "-c", script})
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				detail := strings.TrimSpace(string(out))
+				state.WriteWarn(fleetName, instanceName, fmt.Sprintf("dotfiles install failed: %v\n%s", err, detail))
+			}
+		}
+	}
+
+	// Run any agent install scripts associated with the fleet's settings (Claude
+	// Code, Codex). Each script self-redirects its output to
+	// ~/.fleet/startup/<name>.log inside the container, and failures are
+	// non-fatal — the instance is still usable.
+	runStartupScripts(instanceBackend, wsDir, fleetName, instanceName)
+
+	// Install Claude Code state-detection hooks. Runs after the startup scripts
+	// so any per-fleet Claude Code install above has had a chance to land before
+	// we drop our hooks alongside it. Non-fatal: the per-instance Detector falls
+	// back to a safe default. We always install (regardless of which agent the
+	// user actually runs) because the cost of unused hooks is negligible.
+	executor := agentdetect.NewBackendExecutor(instanceBackend, wsDir)
+	if err := agentdetect.NewClaudeProvisioner(executor).Provision(); err != nil {
+		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("claude hook install failed: %v", err))
+	}
+}

--- a/internal/create/rebuild.go
+++ b/internal/create/rebuild.go
@@ -1,0 +1,88 @@
+package create
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// RunRebuild recreates an existing instance's container in place. The instance
+// record must already exist (the server pre-flips it to StatusRebuilding so the
+// teardown is visible in the UI while the backend works).
+//
+// The flow:
+//
+//  1. Look up the instance from state and build its backend.
+//  2. Refuse early if the backend does not support rebuild so the caller
+//     surfaces a clear error instead of partial work.
+//  3. Resolve the same mounts a fresh Up would (control socket, shared
+//     buildkit, agent-state mounts) — they must be re-applied to the new
+//     container.
+//  4. Hand off to backend.Rebuild, which tears down the old container and
+//     provisions a fresh one from the (possibly edited) devcontainer config,
+//     PRESERVING the workspace (the git checkout and uncommitted edits survive).
+//  5. Re-run the full post-Up provisioning so the rebuilt container is
+//     equivalent to a freshly created one — unlike a clone, the fresh container
+//     carries none of the prior fleet-launch / dotfiles / hook state.
+//  6. Persist the new ContainerID (it changes for devcontainer) and flip back
+//     to StatusRunning.
+func RunRebuild(fleetName, instanceName string, verbose bool) (err error) {
+	start := time.Now()
+	flog.Info("instance rebuild started", "fleet", fleetName, "instance", instanceName)
+	// Failure outcome (with elapsed time) is logged from one place; setFailed
+	// only annotates state. Success is logged inline at the end.
+	defer func() {
+		if err != nil {
+			flog.Error("instance rebuild failed", "fleet", fleetName, "instance", instanceName, "ms", flog.MillisSince(start), "err", err)
+		}
+	}()
+
+	st, err := state.Load()
+	if err != nil {
+		setFailed(fleetName, instanceName, err)
+		return err
+	}
+	f, ok := st.Fleets[fleetName]
+	if !ok {
+		err := fmt.Errorf("fleet %q not found", fleetName)
+		setFailed(fleetName, instanceName, err)
+		return err
+	}
+	inst, err := f.GetInstance(instanceName)
+	if err != nil {
+		setFailed(fleetName, instanceName, err)
+		return err
+	}
+
+	instanceBackend := backendutil.NewForInstance(inst, verbose)
+	if !instanceBackend.SupportsRebuild() {
+		err := fmt.Errorf("backend %q does not support rebuild", inst.Backend)
+		setFailed(fleetName, instanceName, err)
+		return err
+	}
+
+	resolvedMounts, err := resolveProvisionMounts(instanceBackend, fleetName, instanceName)
+	if err != nil {
+		setFailed(fleetName, instanceName, err)
+		return err
+	}
+
+	result, err := instanceBackend.Rebuild(inst.ContainerID, inst.WorkspaceDir, resolvedMounts.Mounts)
+	if err != nil {
+		setFailed(fleetName, instanceName, err)
+		return err
+	}
+
+	// Re-run the post-Up provisioning so the fresh container ends up equivalent
+	// to a newly created one. All best-effort (warnings, never fatal).
+	finishProvision(instanceBackend, fleetName, instanceName, inst.WorkspaceDir, result.ContainerID, resolvedMounts.Symlinks)
+
+	if err := markInstanceRunning(fleetName, instanceName, result.ContainerID); err != nil {
+		return err
+	}
+	flog.Info("instance rebuilt", "fleet", fleetName, "instance", instanceName, "container", result.ContainerID, "ms", flog.MillisSince(start))
+	return nil
+}

--- a/internal/fleet/instance_status.go
+++ b/internal/fleet/instance_status.go
@@ -12,4 +12,9 @@ const (
 	StatusStopping InstanceStatus = "stopping"
 	StatusStarting InstanceStatus = "starting"
 	StatusDeleting InstanceStatus = "deleting"
+
+	// StatusRebuilding marks an instance whose container is being torn down and
+	// reprovisioned in place (the workspace is preserved). Transitional: the
+	// rebuild job flips it back to StatusRunning (or StatusFailed) on completion.
+	StatusRebuilding InstanceStatus = "rebuilding"
 )

--- a/internal/server/convert.go
+++ b/internal/server/convert.go
@@ -145,6 +145,8 @@ func statusToProto(s fleet.InstanceStatus) fleetgrpc.InstanceStatus {
 		return fleetgrpc.InstanceStatus_INSTANCE_STATUS_STARTING
 	case fleet.StatusDeleting:
 		return fleetgrpc.InstanceStatus_INSTANCE_STATUS_DELETING
+	case fleet.StatusRebuilding:
+		return fleetgrpc.InstanceStatus_INSTANCE_STATUS_REBUILDING
 	default:
 		return fleetgrpc.InstanceStatus_INSTANCE_STATUS_UNSPECIFIED
 	}

--- a/internal/server/jobs.go
+++ b/internal/server/jobs.go
@@ -63,6 +63,10 @@ var jobRunStop = func(fleetName, instanceName string) error {
 	return err
 }
 
+var jobRunRebuild = func(fleetName, instanceName string) error {
+	return create.RunRebuild(fleetName, instanceName, false)
+}
+
 // stopBuildkitServer is the buildkit teardown seam (a package var so the destroy
 // paths can be exercised in tests without docker).
 var stopBuildkitServer = buildkit.StopSharedServer
@@ -615,6 +619,81 @@ func (s *service) StopInstance(req *fleetgrpc.StopInstanceRequest, stream fleetg
 		return err
 	}
 	return relay(j, stream)
+}
+
+// startRebuildInstanceJob validates the target, refuses fast when the backend
+// has no rebuild primitive or the instance is mid-transition, marks it
+// StatusRebuilding, and starts the in-place reprovision job. The record is kept
+// (unlike destroy) and flips back to running/failed on completion.
+func (s *service) startRebuildInstanceJob(req *fleetgrpc.RebuildInstanceRequest) (*job, error) {
+	fleetName, instanceName := req.GetFleet(), req.GetInstance()
+	if fleetName == "" || instanceName == "" {
+		return nil, status.Error(codes.InvalidArgument, "fleet and instance are required")
+	}
+
+	// Validate the target AND mark it StatusRebuilding in a single state.Update
+	// so the check and the transitional-status pre-write are atomic: a second
+	// concurrent rebuild (or a stop/destroy) can't slip past the guard in the
+	// window between a separate read and write. This mirrors how
+	// startCreateInstanceJob / startCloneInstanceJob validate-then-mark under one
+	// lock. A typo / unsupported backend / mid-flight instance fails fast with a
+	// clear gRPC error (state.Update propagates the closure's error) rather than
+	// a failed job. The pre-write is the in-place sibling of the StatusCreating
+	// pre-write, so pollers — fleet_list, async MCP callers, the TUI — see the
+	// rebuild in flight instead of a stale running status.
+	err := state.Update(func(st *state.State) error {
+		f, ok := st.Fleets[fleetName]
+		if !ok {
+			return status.Errorf(codes.NotFound, "fleet %q not found", fleetName)
+		}
+		inst, err := f.GetInstance(instanceName)
+		if err != nil {
+			return status.Errorf(codes.NotFound, "instance %q not found in fleet %q", instanceName, fleetName)
+		}
+		if isTransitionalStatus(inst.Status) {
+			return status.Errorf(codes.FailedPrecondition, "instance %s/%s is %s; wait for it to settle before rebuilding", fleetName, instanceName, inst.Status)
+		}
+		// SupportsRebuild is a pure capability check, so construct by type
+		// (no RegisterName / SSH-config file I/O under the state lock).
+		if !backendutil.New(inst.Backend, false).SupportsRebuild() {
+			return status.Errorf(codes.FailedPrecondition, "backend %q does not support rebuild", inst.Backend)
+		}
+		inst.Status = fleet.StatusRebuilding
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	s.pushState()
+
+	j := s.jobs.start(fleetgrpc.JobKind_JOB_KIND_REBUILD_INSTANCE, fleetName, instanceName, time.Now())
+	go s.runJob(j, func() (*fleetgrpc.Instance, []string, error) {
+		err := jobRunRebuild(fleetName, instanceName)
+		return loadInstanceSnapshot(fleetName, instanceName), nil, err
+	})
+	return j, nil
+}
+
+// RebuildInstance starts the in-place rebuild job and relays its events.
+func (s *service) RebuildInstance(req *fleetgrpc.RebuildInstanceRequest, stream fleetgrpc.FleetService_RebuildInstanceServer) error {
+	j, err := s.startRebuildInstanceJob(req)
+	if err != nil {
+		return err
+	}
+	return relay(j, stream)
+}
+
+// isTransitionalStatus reports whether a status reflects an in-flight lifecycle
+// job, so a second mutating job (e.g. rebuild) can refuse to pile on. Mirrors
+// the TUI's isTransitional check, kept server-side so CLI/MCP get the same
+// guard.
+func isTransitionalStatus(s fleet.InstanceStatus) bool {
+	switch s {
+	case fleet.StatusCreating, fleet.StatusCloning, fleet.StatusStopping,
+		fleet.StatusStarting, fleet.StatusDeleting, fleet.StatusRebuilding:
+		return true
+	}
+	return false
 }
 
 // startDestroyInstanceJob validates the target, marks it deleting, and starts

--- a/internal/server/jobs_test.go
+++ b/internal/server/jobs_test.go
@@ -242,6 +242,106 @@ func TestStartStopJobs(t *testing.T) {
 	}
 }
 
+func TestRebuildInstanceJob(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Instances: []*fleet.Instance{{Name: "i1", Status: fleet.StatusRunning, ContainerID: "c1"}}},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	orig := jobRunRebuild
+	// Simulate create.RunRebuild's success path: a new container id, running.
+	jobRunRebuild = func(f, i string) error {
+		return state.Update(func(st *state.State) error {
+			inst, _ := st.Fleets[f].GetInstance(i)
+			inst.ContainerID = "c2"
+			inst.Status = fleet.StatusRunning
+			return nil
+		})
+	}
+	defer func() { jobRunRebuild = orig }()
+
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+
+	stream, err := client.RebuildInstance(context.Background(), &fleetgrpc.RebuildInstanceRequest{Fleet: "alpha", Instance: "i1"})
+	if err != nil {
+		t.Fatalf("RebuildInstance: %v", err)
+	}
+	evs := drainJob(t, stream)
+	if k := evs[0].GetStarted().GetKind(); k != fleetgrpc.JobKind_JOB_KIND_REBUILD_INSTANCE {
+		t.Fatalf("first event kind = %v, want REBUILD_INSTANCE", k)
+	}
+	if d := evs[len(evs)-1].GetDone(); d == nil || !d.GetSuccess() {
+		t.Fatalf("rebuild not done-success: %v", evs)
+	}
+	st, _ := state.Load()
+	inst, _ := st.Fleets["alpha"].GetInstance("i1")
+	if inst.Status != fleet.StatusRunning || inst.ContainerID != "c2" {
+		t.Fatalf("instance not running with new container after rebuild: %+v", inst)
+	}
+}
+
+func TestRebuildInstanceRejectsUnsupportedBackend(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Instances: []*fleet.Instance{
+			{Name: "i1", Status: fleet.StatusRunning, ContainerID: "c1", Backend: fleet.BackendCoder},
+		}},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+
+	stream, err := client.RebuildInstance(context.Background(), &fleetgrpc.RebuildInstanceRequest{Fleet: "alpha", Instance: "i1"})
+	if err != nil {
+		t.Fatalf("RebuildInstance call: %v", err)
+	}
+	if _, err = stream.Recv(); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("want FailedPrecondition for coder backend, got %v", err)
+	}
+}
+
+func TestRebuildInstanceRejectsTransitional(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Instances: []*fleet.Instance{{Name: "i1", Status: fleet.StatusCreating}}},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+
+	stream, err := client.RebuildInstance(context.Background(), &fleetgrpc.RebuildInstanceRequest{Fleet: "alpha", Instance: "i1"})
+	if err != nil {
+		t.Fatalf("RebuildInstance call: %v", err)
+	}
+	if _, err = stream.Recv(); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("want FailedPrecondition for mid-transition instance, got %v", err)
+	}
+}
+
+func TestRebuildInstanceRejectsMissing(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha"},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+
+	stream, err := client.RebuildInstance(context.Background(), &fleetgrpc.RebuildInstanceRequest{Fleet: "alpha", Instance: "nope"})
+	if err != nil {
+		t.Fatalf("RebuildInstance call: %v", err)
+	}
+	if _, err = stream.Recv(); status.Code(err) != codes.NotFound {
+		t.Fatalf("want NotFound for missing instance, got %v", err)
+	}
+}
+
 func TestDestroyInstanceJobRemovesRecord(t *testing.T) {
 	isolateFleetDir(t)
 	wsDir := t.TempDir()

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -114,7 +114,7 @@ func TestNewMCPServerRegistersAllTools(t *testing.T) {
 	want := []string{
 		"fleet_list", "fleet_status", "fleet_version", "fleet_logs",
 		"fleet_up", "fleet_start", "fleet_stop", "fleet_down",
-		"fleet_destroy_fleet", "fleet_clone", "fleet_job_status",
+		"fleet_destroy_fleet", "fleet_clone", "fleet_rebuild", "fleet_job_status",
 		"fleet_exec", "fleet_session_spawn", "fleet_session_exec", "fleet_session_read",
 		"fleet_session_list",
 	}

--- a/internal/server/mcp_tools.go
+++ b/internal/server/mcp_tools.go
@@ -85,6 +85,10 @@ func registerMCPTools(srv *mcp.Server, s *service) {
 		Description: "Clone an existing instance into a new one within the same fleet, preserving its container state. Returns immediately with a job_id to poll via fleet_job_status; pass wait:true to block until done.",
 	}, s.mcpClone)
 	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "fleet_rebuild",
+		Description: "Rebuild an instance's container in place (e.g. after editing its devcontainer config), preserving the workspace — the git checkout and uncommitted edits survive. Only devcontainer and codespaces backends support rebuild; coder does not. Returns immediately with a job_id to poll via fleet_job_status; pass wait:true to block until done.",
+	}, s.mcpRebuild)
+	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "fleet_job_status",
 		Description: "Report the state of a lifecycle job (running, succeeded, or failed) with its error and warnings. Poll this to await a job started by fleet_up, fleet_clone, fleet_down, or fleet_destroy_fleet.",
 	}, s.mcpJobStatus)
@@ -468,6 +472,29 @@ func (s *service) mcpClone(ctx context.Context, _ *mcp.CallToolRequest, in Fleet
 		req.BranchOverride = &in.Branch
 	}
 	j, err := s.startCloneInstanceJob(req)
+	if err != nil {
+		return nil, FleetJobOutput{}, mcpErr(err)
+	}
+	if !in.Wait {
+		return asyncJobResult(in.Fleet, j)
+	}
+	jctx, cancel := mergeCtx(s.bgCtx, ctx)
+	defer cancel()
+	final, warnings, err := awaitJob(jctx, j)
+	return jobResult(in.Fleet, j.summary.GetJobId(), final, warnings, err)
+}
+
+type FleetRebuildInput struct {
+	Fleet    string `json:"fleet" jsonschema:"fleet name"`
+	Instance string `json:"instance" jsonschema:"instance name"`
+	Wait     bool   `json:"wait,omitempty" jsonschema:"block until the rebuild completes instead of returning a job handle immediately; rebuilding can take minutes"`
+}
+
+func (s *service) mcpRebuild(ctx context.Context, _ *mcp.CallToolRequest, in FleetRebuildInput) (*mcp.CallToolResult, FleetJobOutput, error) {
+	if in.Fleet == "" || in.Instance == "" {
+		return nil, FleetJobOutput{}, errors.New("fleet and instance are required")
+	}
+	j, err := s.startRebuildInstanceJob(&fleetgrpc.RebuildInstanceRequest{Fleet: in.Fleet, Instance: in.Instance})
 	if err != nil {
 		return nil, FleetJobOutput{}, mcpErr(err)
 	}

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -181,6 +181,16 @@ var stopInstanceRemote = func(fleetName, instanceName string) error {
 	return err
 }
 
+// rebuildInstanceRemote recreates an instance's container in place, to
+// completion. Slower than start/stop (it reprovisions), so it shares the same
+// long-lived job stream as create/clone.
+var rebuildInstanceRemote = func(fleetName, instanceName string) error {
+	_, err := awaitJobDone(func(ctx context.Context, svc fleetgrpc.FleetServiceClient) (jobStream, error) {
+		return svc.RebuildInstance(ctx, &fleetgrpc.RebuildInstanceRequest{Fleet: fleetName, Instance: instanceName})
+	})
+	return err
+}
+
 // destroyInstanceRemote tears down one instance (destroyFleet=false) or the
 // whole fleet (destroyFleet=true), to completion.
 var destroyInstanceRemote = func(fleetName, instanceName string, destroyFleet bool) error {
@@ -662,6 +672,8 @@ func statusProtoToLegacy(s fleetgrpc.InstanceStatus) fleet.InstanceStatus {
 		return fleet.StatusStarting
 	case fleetgrpc.InstanceStatus_INSTANCE_STATUS_DELETING:
 		return fleet.StatusDeleting
+	case fleetgrpc.InstanceStatus_INSTANCE_STATUS_REBUILDING:
+		return fleet.StatusRebuilding
 	default:
 		return ""
 	}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -112,6 +112,19 @@ func stopInstanceCmd(fleetName, instanceName string) tea.Cmd {
 	}
 }
 
+// rebuildInstanceCmd recreates an instance's container in place via a server
+// job and reports completion. Like start/stop, the TUI flips an optimistic
+// in-memory Rebuilding status at the call site for the spinner and reload()s the
+// authoritative result on completion.
+func rebuildInstanceCmd(fleetName, instanceName string) tea.Cmd {
+	return func() tea.Msg {
+		if err := rebuildInstanceRemote(fleetName, instanceName); err != nil {
+			return operationDoneMsg{fleetName, instanceName, "", err}
+		}
+		return operationDoneMsg{fleetName, instanceName, fmt.Sprintf("Rebuilt %s/%s", fleetName, instanceName), nil}
+	}
+}
+
 // deleteInstanceCmd tears down an instance via a server job. Port forwards are
 // the TUI's own (the server doesn't manage them), so they're removed here first.
 func deleteInstanceCmd(fleetName, instanceName string, pf *portforward.Manager) tea.Cmd {

--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -67,6 +67,39 @@ func (fleetPage *fleetPage) updateConfirmDelete(m *model, msg tea.Msg) tea.Cmd {
 	return nil
 }
 
+// updateConfirmRebuild handles the instance rebuild confirmation dialog.
+// Rebuild recreates the container in place (preserving the workspace), so it is
+// a single-step confirm — no double warning like fleet delete.
+func (fleetPage *fleetPage) updateConfirmRebuild(m *model, msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "y", "Y", "enter":
+			// Rebuild runs as a server job. Flip an optimistic in-memory
+			// Rebuilding status for the spinner (NOT persisted — the server owns
+			// the reprovision and the persisted status); operationDoneMsg reload()s
+			// the authoritative result.
+			f, ok := m.st.Fleets[fleetPage.dialogFleet]
+			if ok {
+				instance, err := f.GetInstance(fleetPage.dialogInst)
+				if err == nil {
+					instance.Status = fleet.StatusRebuilding
+					fleetPage.buildRows(m)
+					fleetPage.mode = viewNormal
+					return rebuildInstanceCmd(fleetPage.dialogFleet, fleetPage.dialogInst)
+				}
+			}
+			fleetPage.mode = viewNormal
+
+		case "n", "N", "esc", "q", "Q", "ctrl+c":
+			fleetPage.mode = viewNormal
+			fleetPage.blurDialogFields()
+			m.message = "Cancelled"
+		}
+	}
+	return nil
+}
+
 // updateConfirmDeleteFleetWarn handles the double-confirm dialog for
 // fleets with running instances.
 func (fleetPage *fleetPage) updateConfirmDeleteFleetWarn(m *model, msg tea.Msg) tea.Cmd {

--- a/internal/tui/keybindings.go
+++ b/internal/tui/keybindings.go
@@ -42,6 +42,7 @@ func keybindingsData() []keybindingGroup {
 				{"p", "Port forward"},
 				{"c", "Open VS Code"},
 				{"C", "Clone instance"},
+				{"R", "Rebuild instance"},
 				{"o", "Open external terminal"},
 				{"l", "View logs"},
 				{"A", "Switch armada (remote fleet)"},

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -276,6 +276,8 @@ func (fleetPage *fleetPage) Update(m *model, msg tea.Msg) tea.Cmd {
 	switch fleetPage.mode {
 	case viewConfirmDelete:
 		return fleetPage.updateConfirmDelete(m, msg)
+	case viewConfirmRebuild:
+		return fleetPage.updateConfirmRebuild(m, msg)
 	case viewConfirmDeleteFleetWarn:
 		return fleetPage.updateConfirmDeleteFleetWarn(m, msg)
 	case viewAddInstance:
@@ -944,6 +946,30 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			fleetPage.textInput.CharLimit = 64
 			return fleetPage.activateTextInput()
 
+		case "R":
+			_, instance := fleetPage.selectedInstance(m)
+			if instance == nil {
+				m.message = "Select an instance"
+				break
+			}
+			// Coder workspaces have no rebuild primitive; devcontainer ("" defaults
+			// to devcontainer) and codespaces do. Pure check — no backend construction.
+			if instance.Backend == fleet.BackendCoder {
+				m.message = fmt.Sprintf("Rebuild not supported by %s backend", instance.Backend)
+				break
+			}
+			if isTransitional(instance.Status) {
+				m.message = fmt.Sprintf("Instance %s/%s is %s", fleetPage.currentFleetName(), instance.Name, instance.Status)
+				break
+			}
+			if instance.ContainerID == "" {
+				m.message = "Instance has not finished provisioning; nothing to rebuild yet"
+				break
+			}
+			fleetPage.mode = viewConfirmRebuild
+			fleetPage.dialogFleet = fleetPage.currentFleetName()
+			fleetPage.dialogInst = instance.Name
+
 		case "b":
 			_, instance := fleetPage.selectedInstance(m)
 			if instance == nil {
@@ -1240,13 +1266,13 @@ func (fleetPage *fleetPage) contextualHelpKeysBase(m *model) []string {
 				keys = append(keys,
 					"space: show sessions", "enter: open shell", "e: edit",
 					"s: stop", "a: new session", "d: delete", "t: tag",
-					"p: port-forward", "b: browser", "c: code", "C: clone", "o: terminal", "l: logs",
+					"p: port-forward", "b: browser", "c: code", "C: clone", "R: rebuild", "o: terminal", "l: logs",
 					"r: refresh", "q: quit",
 				)
 			case r.instance.Status == fleet.StatusStopped:
 				keys = append(keys,
 					"enter: open shell", "e: edit", "s: start",
-					"a: new session", "d: delete", "t: tag", "r: refresh", "q: quit",
+					"a: new session", "d: delete", "t: tag", "R: rebuild", "r: refresh", "q: quit",
 				)
 			case r.instance.Status == fleet.StatusFailed:
 				keys = append(keys, "d: delete", "r: refresh", "q: quit")
@@ -1630,6 +1656,18 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 		dialog := fmt.Sprintf(
 			"%s\n\n%s\n\n%s",
 			dialogTitle.Render(title),
+			dialogLabel.Render(body),
+			dialogHint.Render("[y] Yes  [n/q/esc] No"),
+		)
+		b.WriteString(dialogBox.Render(dialog))
+		b.WriteString("\n")
+
+	case viewConfirmRebuild:
+		b.WriteString("\n")
+		body := fmt.Sprintf("Rebuild %s/%s? This recreates the container from its devcontainer config. Your workspace — the git checkout and any uncommitted changes — is preserved.", fleetPage.dialogFleet, fleetPage.dialogInst)
+		dialog := fmt.Sprintf(
+			"%s\n\n%s\n\n%s",
+			dialogTitle.Render("Rebuild instance"),
 			dialogLabel.Render(body),
 			dialogHint.Render("[y] Yes  [n/q/esc] No"),
 		)

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -120,6 +120,8 @@ func renderStatus(s fleet.InstanceStatus) string {
 		return statusCreatingStyle.Render("starting")
 	case fleet.StatusDeleting:
 		return statusCreatingStyle.Render("deleting")
+	case fleet.StatusRebuilding:
+		return statusCreatingStyle.Render("rebuilding")
 	case fleet.StatusFailed:
 		return errorStyle.Render("failed")
 	default:
@@ -131,7 +133,7 @@ func renderStatus(s fleet.InstanceStatus) string {
 // background operation (shown with a spinner on the instance row).
 func isTransitional(s fleet.InstanceStatus) bool {
 	switch s {
-	case fleet.StatusCreating, fleet.StatusCloning, fleet.StatusStopping, fleet.StatusStarting, fleet.StatusDeleting:
+	case fleet.StatusCreating, fleet.StatusCloning, fleet.StatusStopping, fleet.StatusStarting, fleet.StatusDeleting, fleet.StatusRebuilding:
 		return true
 	}
 	return false

--- a/internal/tui/view_mode.go
+++ b/internal/tui/view_mode.go
@@ -12,6 +12,7 @@ type viewMode int
 const (
 	viewNormal viewMode = iota
 	viewConfirmDelete
+	viewConfirmRebuild
 	viewConfirmDeleteFleetWarn
 	viewAddInstance
 	viewCloneInstance


### PR DESCRIPTION
## Summary

Adds a **Rebuild instance** operation across the CLI, TUI, and MCP, backed by a new `RebuildInstance` gRPC job and a `StatusRebuilding` transitional state. Closes #161.

Rebuild recreates an instance's container from its (possibly edited) devcontainer config while **preserving the workspace** — the git checkout and uncommitted edits survive — then re-runs the full post-`Up` provisioning so the fresh container ends up equivalent to a newly created one (fleet-launch binary, `fleet.rc`, dotfiles, startup scripts, Claude hooks, shared caches).

### Backend-specific (gated on a new `SupportsRebuild()` capability)
- **devcontainer** → re-runs `devcontainer up --remove-existing-container` (the workspace bind mount is preserved; the container id changes).
- **codespaces** → runs `gh codespace rebuild -c <name>`, waits for `Available`, refreshes SSH config (same codespace, same id).
- **coder** → unsupported; returns a clear error and `SupportsRebuild() == false`.

### Surfaces
- **CLI**: `fleet rebuild <name>` (alias `rb`).
- **TUI**: `R` on an instance row → confirm dialog → optimistic `rebuilding` spinner. (`R` is conflict-free with existing keys.)
- **MCP**: `fleet_rebuild {fleet, instance, wait?}` — async-first like the other lifecycle tools, pollable via `fleet_job_status`.

### Notable internals
- The shared post-`Up` provisioning is extracted into `create/provision.go` (`resolveProvisionMounts` + `finishProvision`) so `create.Run` and the new `create.RunRebuild` stay in lock-step — no behavioral change to create.
- The server validates the target **and** marks `StatusRebuilding` atomically under one `state.Update`, rejecting unsupported backends and mid-transition instances with `FailedPrecondition` (mirrors `startCreate/CloneInstanceJob`, avoids a TOCTOU on the transitional guard).
- `StatusRebuilding` / `INSTANCE_STATUS_REBUILDING` threaded through the proto enum, `convert.go`, `Display()`, `statusProtoToLegacy`, and the TUI render/`isTransitional`.

### Tests
- Server: rebuild job happy-path + rejection of unsupported backend / mid-transition / missing instance.
- Backend: capability assertions for all three backends (coder unsupported error, codespaces empty-name guard).
- CLI: command wiring + alias.
- Integration: `057_rebuild.sh` — `fleet rebuild` recreates the container (new id, old gone), preserves a workspace marker, and the instance stays usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)