### PR TITLE
feat/fleet-copy-bidirectional — generic scp-style copy in both directions and between instances (#164)

### DIFF
--- a/fleetgrpc/exec.pb.go
+++ b/fleetgrpc/exec.pb.go
@@ -1014,6 +1014,245 @@ func (x *CopyFileMeta) GetSize() int64 {
 	return 0
 }
 
+// CopyInto streams one file INTO an instance — the reverse of CopyFile, the
+// other half of scp-style `fleet copy`. It is CLIENT-streaming: the FIRST chunk
+// MUST carry `open` (which instance, the destination, and the file's
+// name/mode/size); every following chunk carries `data`. The server resolves the
+// destination inside the container (an existing directory keeps the source
+// basename; otherwise `dest` is the target path) and writes the bytes through
+// the backend with a single `tar -xf -` exec — the mirror of CopyFile's
+// `tar -chf -` read — preserving the file mode. Works unchanged over the remote
+// gateway: pushing a local file into a fully remote deployment.
+type CopyIntoChunk struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Msg:
+	//
+	//	*CopyIntoChunk_Open
+	//	*CopyIntoChunk_Data
+	Msg           isCopyIntoChunk_Msg `protobuf_oneof:"msg"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CopyIntoChunk) Reset() {
+	*x = CopyIntoChunk{}
+	mi := &file_exec_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CopyIntoChunk) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CopyIntoChunk) ProtoMessage() {}
+
+func (x *CopyIntoChunk) ProtoReflect() protoreflect.Message {
+	mi := &file_exec_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CopyIntoChunk.ProtoReflect.Descriptor instead.
+func (*CopyIntoChunk) Descriptor() ([]byte, []int) {
+	return file_exec_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *CopyIntoChunk) GetMsg() isCopyIntoChunk_Msg {
+	if x != nil {
+		return x.Msg
+	}
+	return nil
+}
+
+func (x *CopyIntoChunk) GetOpen() *CopyIntoOpen {
+	if x != nil {
+		if x, ok := x.Msg.(*CopyIntoChunk_Open); ok {
+			return x.Open
+		}
+	}
+	return nil
+}
+
+func (x *CopyIntoChunk) GetData() []byte {
+	if x != nil {
+		if x, ok := x.Msg.(*CopyIntoChunk_Data); ok {
+			return x.Data
+		}
+	}
+	return nil
+}
+
+type isCopyIntoChunk_Msg interface {
+	isCopyIntoChunk_Msg()
+}
+
+type CopyIntoChunk_Open struct {
+	Open *CopyIntoOpen `protobuf:"bytes,1,opt,name=open,proto3,oneof"`
+}
+
+type CopyIntoChunk_Data struct {
+	Data []byte `protobuf:"bytes,2,opt,name=data,proto3,oneof"`
+}
+
+func (*CopyIntoChunk_Open) isCopyIntoChunk_Msg() {}
+
+func (*CopyIntoChunk_Data) isCopyIntoChunk_Msg() {}
+
+type CopyIntoOpen struct {
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	Fleet    string                 `protobuf:"bytes,1,opt,name=fleet,proto3" json:"fleet,omitempty"`
+	Instance string                 `protobuf:"bytes,2,opt,name=instance,proto3" json:"instance,omitempty"`
+	// dest is the destination path inside the instance. A relative path resolves
+	// against the workspace folder (the backend exec working directory). When it
+	// names (or is) an existing directory the file keeps `name`; otherwise dest is
+	// the full target path. Empty means the workspace folder.
+	Dest string `protobuf:"bytes,3,opt,name=dest,proto3" json:"dest,omitempty"`
+	// name is the source file's basename — used when dest resolves to a directory.
+	Name string `protobuf:"bytes,4,opt,name=name,proto3" json:"name,omitempty"`
+	// mode is the file's permission bits to set on the written file (the perm bits
+	// are honoured; a 0 mode defaults to 0644). setuid/setgid/sticky are stripped.
+	Mode uint32 `protobuf:"varint,5,opt,name=mode,proto3" json:"mode,omitempty"`
+	// size is the source file's byte count — needed up front for the tar header,
+	// and enforced as a hard cap so a truncated or oversized stream fails cleanly
+	// rather than leaving a partial file.
+	Size          int64 `protobuf:"varint,6,opt,name=size,proto3" json:"size,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CopyIntoOpen) Reset() {
+	*x = CopyIntoOpen{}
+	mi := &file_exec_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CopyIntoOpen) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CopyIntoOpen) ProtoMessage() {}
+
+func (x *CopyIntoOpen) ProtoReflect() protoreflect.Message {
+	mi := &file_exec_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CopyIntoOpen.ProtoReflect.Descriptor instead.
+func (*CopyIntoOpen) Descriptor() ([]byte, []int) {
+	return file_exec_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *CopyIntoOpen) GetFleet() string {
+	if x != nil {
+		return x.Fleet
+	}
+	return ""
+}
+
+func (x *CopyIntoOpen) GetInstance() string {
+	if x != nil {
+		return x.Instance
+	}
+	return ""
+}
+
+func (x *CopyIntoOpen) GetDest() string {
+	if x != nil {
+		return x.Dest
+	}
+	return ""
+}
+
+func (x *CopyIntoOpen) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *CopyIntoOpen) GetMode() uint32 {
+	if x != nil {
+		return x.Mode
+	}
+	return 0
+}
+
+func (x *CopyIntoOpen) GetSize() int64 {
+	if x != nil {
+		return x.Size
+	}
+	return 0
+}
+
+type CopyIntoReply struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// path is the final absolute path written inside the instance.
+	Path string `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	// written is the number of file bytes received and written.
+	Written       int64 `protobuf:"varint,2,opt,name=written,proto3" json:"written,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CopyIntoReply) Reset() {
+	*x = CopyIntoReply{}
+	mi := &file_exec_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CopyIntoReply) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CopyIntoReply) ProtoMessage() {}
+
+func (x *CopyIntoReply) ProtoReflect() protoreflect.Message {
+	mi := &file_exec_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CopyIntoReply.ProtoReflect.Descriptor instead.
+func (*CopyIntoReply) Descriptor() ([]byte, []int) {
+	return file_exec_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *CopyIntoReply) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *CopyIntoReply) GetWritten() int64 {
+	if x != nil {
+		return x.Written
+	}
+	return 0
+}
+
 // ResolveLogsCommand returns the host-side command argv the server would run to
 // show an instance's container runtime logs. The client embeds it in its own
 // pager script (cat the creation log, then the runtime logs) and runs it
@@ -1028,7 +1267,7 @@ type ResolveLogsCommandRequest struct {
 
 func (x *ResolveLogsCommandRequest) Reset() {
 	*x = ResolveLogsCommandRequest{}
-	mi := &file_exec_proto_msgTypes[14]
+	mi := &file_exec_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1040,7 +1279,7 @@ func (x *ResolveLogsCommandRequest) String() string {
 func (*ResolveLogsCommandRequest) ProtoMessage() {}
 
 func (x *ResolveLogsCommandRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_exec_proto_msgTypes[14]
+	mi := &file_exec_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1053,7 +1292,7 @@ func (x *ResolveLogsCommandRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveLogsCommandRequest.ProtoReflect.Descriptor instead.
 func (*ResolveLogsCommandRequest) Descriptor() ([]byte, []int) {
-	return file_exec_proto_rawDescGZIP(), []int{14}
+	return file_exec_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ResolveLogsCommandRequest) GetFleet() string {
@@ -1079,7 +1318,7 @@ type ResolveLogsCommandReply struct {
 
 func (x *ResolveLogsCommandReply) Reset() {
 	*x = ResolveLogsCommandReply{}
-	mi := &file_exec_proto_msgTypes[15]
+	mi := &file_exec_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1091,7 +1330,7 @@ func (x *ResolveLogsCommandReply) String() string {
 func (*ResolveLogsCommandReply) ProtoMessage() {}
 
 func (x *ResolveLogsCommandReply) ProtoReflect() protoreflect.Message {
-	mi := &file_exec_proto_msgTypes[15]
+	mi := &file_exec_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1104,7 +1343,7 @@ func (x *ResolveLogsCommandReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveLogsCommandReply.ProtoReflect.Descriptor instead.
 func (*ResolveLogsCommandReply) Descriptor() ([]byte, []int) {
-	return file_exec_proto_rawDescGZIP(), []int{15}
+	return file_exec_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ResolveLogsCommandReply) GetArgv() []string {
@@ -1126,7 +1365,7 @@ type GetCoderTemplateParamsRequest struct {
 
 func (x *GetCoderTemplateParamsRequest) Reset() {
 	*x = GetCoderTemplateParamsRequest{}
-	mi := &file_exec_proto_msgTypes[16]
+	mi := &file_exec_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1138,7 +1377,7 @@ func (x *GetCoderTemplateParamsRequest) String() string {
 func (*GetCoderTemplateParamsRequest) ProtoMessage() {}
 
 func (x *GetCoderTemplateParamsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_exec_proto_msgTypes[16]
+	mi := &file_exec_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1151,7 +1390,7 @@ func (x *GetCoderTemplateParamsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoderTemplateParamsRequest.ProtoReflect.Descriptor instead.
 func (*GetCoderTemplateParamsRequest) Descriptor() ([]byte, []int) {
-	return file_exec_proto_rawDescGZIP(), []int{16}
+	return file_exec_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *GetCoderTemplateParamsRequest) GetTemplate() string {
@@ -1177,7 +1416,7 @@ type CoderRichParameter struct {
 
 func (x *CoderRichParameter) Reset() {
 	*x = CoderRichParameter{}
-	mi := &file_exec_proto_msgTypes[17]
+	mi := &file_exec_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1189,7 +1428,7 @@ func (x *CoderRichParameter) String() string {
 func (*CoderRichParameter) ProtoMessage() {}
 
 func (x *CoderRichParameter) ProtoReflect() protoreflect.Message {
-	mi := &file_exec_proto_msgTypes[17]
+	mi := &file_exec_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1202,7 +1441,7 @@ func (x *CoderRichParameter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CoderRichParameter.ProtoReflect.Descriptor instead.
 func (*CoderRichParameter) Descriptor() ([]byte, []int) {
-	return file_exec_proto_rawDescGZIP(), []int{17}
+	return file_exec_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *CoderRichParameter) GetName() string {
@@ -1250,7 +1489,7 @@ type GetCoderTemplateParamsReply struct {
 
 func (x *GetCoderTemplateParamsReply) Reset() {
 	*x = GetCoderTemplateParamsReply{}
-	mi := &file_exec_proto_msgTypes[18]
+	mi := &file_exec_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1262,7 +1501,7 @@ func (x *GetCoderTemplateParamsReply) String() string {
 func (*GetCoderTemplateParamsReply) ProtoMessage() {}
 
 func (x *GetCoderTemplateParamsReply) ProtoReflect() protoreflect.Message {
-	mi := &file_exec_proto_msgTypes[18]
+	mi := &file_exec_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1275,7 +1514,7 @@ func (x *GetCoderTemplateParamsReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoderTemplateParamsReply.ProtoReflect.Descriptor instead.
 func (*GetCoderTemplateParamsReply) Descriptor() ([]byte, []int) {
-	return file_exec_proto_rawDescGZIP(), []int{18}
+	return file_exec_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *GetCoderTemplateParamsReply) GetParameters() []*CoderRichParameter {
@@ -1305,7 +1544,7 @@ type GetBrowserConfigRequest struct {
 
 func (x *GetBrowserConfigRequest) Reset() {
 	*x = GetBrowserConfigRequest{}
-	mi := &file_exec_proto_msgTypes[19]
+	mi := &file_exec_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1317,7 +1556,7 @@ func (x *GetBrowserConfigRequest) String() string {
 func (*GetBrowserConfigRequest) ProtoMessage() {}
 
 func (x *GetBrowserConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_exec_proto_msgTypes[19]
+	mi := &file_exec_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1330,7 +1569,7 @@ func (x *GetBrowserConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBrowserConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetBrowserConfigRequest) Descriptor() ([]byte, []int) {
-	return file_exec_proto_rawDescGZIP(), []int{19}
+	return file_exec_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *GetBrowserConfigRequest) GetFleet() string {
@@ -1359,7 +1598,7 @@ type GetBrowserConfigReply struct {
 
 func (x *GetBrowserConfigReply) Reset() {
 	*x = GetBrowserConfigReply{}
-	mi := &file_exec_proto_msgTypes[20]
+	mi := &file_exec_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1371,7 +1610,7 @@ func (x *GetBrowserConfigReply) String() string {
 func (*GetBrowserConfigReply) ProtoMessage() {}
 
 func (x *GetBrowserConfigReply) ProtoReflect() protoreflect.Message {
-	mi := &file_exec_proto_msgTypes[20]
+	mi := &file_exec_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1384,7 +1623,7 @@ func (x *GetBrowserConfigReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBrowserConfigReply.ProtoReflect.Descriptor instead.
 func (*GetBrowserConfigReply) Descriptor() ([]byte, []int) {
-	return file_exec_proto_rawDescGZIP(), []int{20}
+	return file_exec_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *GetBrowserConfigReply) GetInitialUrl() string {
@@ -1422,7 +1661,7 @@ type PrepareBrowserRequest struct {
 
 func (x *PrepareBrowserRequest) Reset() {
 	*x = PrepareBrowserRequest{}
-	mi := &file_exec_proto_msgTypes[21]
+	mi := &file_exec_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1434,7 +1673,7 @@ func (x *PrepareBrowserRequest) String() string {
 func (*PrepareBrowserRequest) ProtoMessage() {}
 
 func (x *PrepareBrowserRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_exec_proto_msgTypes[21]
+	mi := &file_exec_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1447,7 +1686,7 @@ func (x *PrepareBrowserRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareBrowserRequest.ProtoReflect.Descriptor instead.
 func (*PrepareBrowserRequest) Descriptor() ([]byte, []int) {
-	return file_exec_proto_rawDescGZIP(), []int{21}
+	return file_exec_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *PrepareBrowserRequest) GetFleet() string {
@@ -1487,7 +1726,7 @@ type PrepareBrowserReply struct {
 
 func (x *PrepareBrowserReply) Reset() {
 	*x = PrepareBrowserReply{}
-	mi := &file_exec_proto_msgTypes[22]
+	mi := &file_exec_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1499,7 +1738,7 @@ func (x *PrepareBrowserReply) String() string {
 func (*PrepareBrowserReply) ProtoMessage() {}
 
 func (x *PrepareBrowserReply) ProtoReflect() protoreflect.Message {
-	mi := &file_exec_proto_msgTypes[22]
+	mi := &file_exec_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1512,7 +1751,7 @@ func (x *PrepareBrowserReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareBrowserReply.ProtoReflect.Descriptor instead.
 func (*PrepareBrowserReply) Descriptor() ([]byte, []int) {
-	return file_exec_proto_rawDescGZIP(), []int{22}
+	return file_exec_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *PrepareBrowserReply) GetInitialUrl() string {
@@ -1594,7 +1833,21 @@ const file_exec_proto_rawDesc = "" +
 	"\fCopyFileMeta\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04mode\x18\x02 \x01(\rR\x04mode\x12\x12\n" +
-	"\x04size\x18\x03 \x01(\x03R\x04size\"M\n" +
+	"\x04size\x18\x03 \x01(\x03R\x04size\"[\n" +
+	"\rCopyIntoChunk\x12-\n" +
+	"\x04open\x18\x01 \x01(\v2\x17.fleetgrpc.CopyIntoOpenH\x00R\x04open\x12\x14\n" +
+	"\x04data\x18\x02 \x01(\fH\x00R\x04dataB\x05\n" +
+	"\x03msg\"\x90\x01\n" +
+	"\fCopyIntoOpen\x12\x14\n" +
+	"\x05fleet\x18\x01 \x01(\tR\x05fleet\x12\x1a\n" +
+	"\binstance\x18\x02 \x01(\tR\binstance\x12\x12\n" +
+	"\x04dest\x18\x03 \x01(\tR\x04dest\x12\x12\n" +
+	"\x04name\x18\x04 \x01(\tR\x04name\x12\x12\n" +
+	"\x04mode\x18\x05 \x01(\rR\x04mode\x12\x12\n" +
+	"\x04size\x18\x06 \x01(\x03R\x04size\"=\n" +
+	"\rCopyIntoReply\x12\x12\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\x12\x18\n" +
+	"\awritten\x18\x02 \x01(\x03R\awritten\"M\n" +
 	"\x19ResolveLogsCommandRequest\x12\x14\n" +
 	"\x05fleet\x18\x01 \x01(\tR\x05fleet\x12\x1a\n" +
 	"\binstance\x18\x02 \x01(\tR\binstance\"-\n" +
@@ -1644,7 +1897,7 @@ func file_exec_proto_rawDescGZIP() []byte {
 	return file_exec_proto_rawDescData
 }
 
-var file_exec_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
+var file_exec_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
 var file_exec_proto_goTypes = []any{
 	(*ExecIn)(nil),                        // 0: fleetgrpc.ExecIn
 	(*ExecStart)(nil),                     // 1: fleetgrpc.ExecStart
@@ -1660,34 +1913,38 @@ var file_exec_proto_goTypes = []any{
 	(*CopyFileRequest)(nil),               // 11: fleetgrpc.CopyFileRequest
 	(*CopyFileChunk)(nil),                 // 12: fleetgrpc.CopyFileChunk
 	(*CopyFileMeta)(nil),                  // 13: fleetgrpc.CopyFileMeta
-	(*ResolveLogsCommandRequest)(nil),     // 14: fleetgrpc.ResolveLogsCommandRequest
-	(*ResolveLogsCommandReply)(nil),       // 15: fleetgrpc.ResolveLogsCommandReply
-	(*GetCoderTemplateParamsRequest)(nil), // 16: fleetgrpc.GetCoderTemplateParamsRequest
-	(*CoderRichParameter)(nil),            // 17: fleetgrpc.CoderRichParameter
-	(*GetCoderTemplateParamsReply)(nil),   // 18: fleetgrpc.GetCoderTemplateParamsReply
-	(*GetBrowserConfigRequest)(nil),       // 19: fleetgrpc.GetBrowserConfigRequest
-	(*GetBrowserConfigReply)(nil),         // 20: fleetgrpc.GetBrowserConfigReply
-	(*PrepareBrowserRequest)(nil),         // 21: fleetgrpc.PrepareBrowserRequest
-	(*PrepareBrowserReply)(nil),           // 22: fleetgrpc.PrepareBrowserReply
-	nil,                                   // 23: fleetgrpc.ExecStart.EnvEntry
-	nil,                                   // 24: fleetgrpc.ResolveExecCommandReply.EnvEntry
-	(*timestamppb.Timestamp)(nil),         // 25: google.protobuf.Timestamp
+	(*CopyIntoChunk)(nil),                 // 14: fleetgrpc.CopyIntoChunk
+	(*CopyIntoOpen)(nil),                  // 15: fleetgrpc.CopyIntoOpen
+	(*CopyIntoReply)(nil),                 // 16: fleetgrpc.CopyIntoReply
+	(*ResolveLogsCommandRequest)(nil),     // 17: fleetgrpc.ResolveLogsCommandRequest
+	(*ResolveLogsCommandReply)(nil),       // 18: fleetgrpc.ResolveLogsCommandReply
+	(*GetCoderTemplateParamsRequest)(nil), // 19: fleetgrpc.GetCoderTemplateParamsRequest
+	(*CoderRichParameter)(nil),            // 20: fleetgrpc.CoderRichParameter
+	(*GetCoderTemplateParamsReply)(nil),   // 21: fleetgrpc.GetCoderTemplateParamsReply
+	(*GetBrowserConfigRequest)(nil),       // 22: fleetgrpc.GetBrowserConfigRequest
+	(*GetBrowserConfigReply)(nil),         // 23: fleetgrpc.GetBrowserConfigReply
+	(*PrepareBrowserRequest)(nil),         // 24: fleetgrpc.PrepareBrowserRequest
+	(*PrepareBrowserReply)(nil),           // 25: fleetgrpc.PrepareBrowserReply
+	nil,                                   // 26: fleetgrpc.ExecStart.EnvEntry
+	nil,                                   // 27: fleetgrpc.ResolveExecCommandReply.EnvEntry
+	(*timestamppb.Timestamp)(nil),         // 28: google.protobuf.Timestamp
 }
 var file_exec_proto_depIdxs = []int32{
 	1,  // 0: fleetgrpc.ExecIn.start:type_name -> fleetgrpc.ExecStart
 	2,  // 1: fleetgrpc.ExecIn.resize:type_name -> fleetgrpc.ExecResize
-	23, // 2: fleetgrpc.ExecStart.env:type_name -> fleetgrpc.ExecStart.EnvEntry
+	26, // 2: fleetgrpc.ExecStart.env:type_name -> fleetgrpc.ExecStart.EnvEntry
 	4,  // 3: fleetgrpc.ExecOut.exit:type_name -> fleetgrpc.ExecExit
-	24, // 4: fleetgrpc.ResolveExecCommandReply.env:type_name -> fleetgrpc.ResolveExecCommandReply.EnvEntry
-	25, // 5: fleetgrpc.LogLine.at:type_name -> google.protobuf.Timestamp
+	27, // 4: fleetgrpc.ResolveExecCommandReply.env:type_name -> fleetgrpc.ResolveExecCommandReply.EnvEntry
+	28, // 5: fleetgrpc.LogLine.at:type_name -> google.protobuf.Timestamp
 	10, // 6: fleetgrpc.ForwardChunk.open:type_name -> fleetgrpc.ForwardOpen
 	13, // 7: fleetgrpc.CopyFileChunk.meta:type_name -> fleetgrpc.CopyFileMeta
-	17, // 8: fleetgrpc.GetCoderTemplateParamsReply.parameters:type_name -> fleetgrpc.CoderRichParameter
-	9,  // [9:9] is the sub-list for method output_type
-	9,  // [9:9] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	15, // 8: fleetgrpc.CopyIntoChunk.open:type_name -> fleetgrpc.CopyIntoOpen
+	20, // 9: fleetgrpc.GetCoderTemplateParamsReply.parameters:type_name -> fleetgrpc.CoderRichParameter
+	10, // [10:10] is the sub-list for method output_type
+	10, // [10:10] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_exec_proto_init() }
@@ -1715,14 +1972,18 @@ func file_exec_proto_init() {
 		(*CopyFileChunk_Meta)(nil),
 		(*CopyFileChunk_Data)(nil),
 	}
-	file_exec_proto_msgTypes[21].OneofWrappers = []any{}
+	file_exec_proto_msgTypes[14].OneofWrappers = []any{
+		(*CopyIntoChunk_Open)(nil),
+		(*CopyIntoChunk_Data)(nil),
+	}
+	file_exec_proto_msgTypes[24].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_exec_proto_rawDesc), len(file_exec_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   25,
+			NumMessages:   28,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/fleetgrpc/exec.proto
+++ b/fleetgrpc/exec.proto
@@ -144,6 +144,48 @@ message CopyFileMeta {
   int64 size = 3;
 }
 
+// CopyInto streams one file INTO an instance — the reverse of CopyFile, the
+// other half of scp-style `fleet copy`. It is CLIENT-streaming: the FIRST chunk
+// MUST carry `open` (which instance, the destination, and the file's
+// name/mode/size); every following chunk carries `data`. The server resolves the
+// destination inside the container (an existing directory keeps the source
+// basename; otherwise `dest` is the target path) and writes the bytes through
+// the backend with a single `tar -xf -` exec — the mirror of CopyFile's
+// `tar -chf -` read — preserving the file mode. Works unchanged over the remote
+// gateway: pushing a local file into a fully remote deployment.
+message CopyIntoChunk {
+  oneof msg {
+    CopyIntoOpen open = 1;
+    bytes data = 2;
+  }
+}
+
+message CopyIntoOpen {
+  string fleet = 1;
+  string instance = 2;
+  // dest is the destination path inside the instance. A relative path resolves
+  // against the workspace folder (the backend exec working directory). When it
+  // names (or is) an existing directory the file keeps `name`; otherwise dest is
+  // the full target path. Empty means the workspace folder.
+  string dest = 3;
+  // name is the source file's basename — used when dest resolves to a directory.
+  string name = 4;
+  // mode is the file's permission bits to set on the written file (the perm bits
+  // are honoured; a 0 mode defaults to 0644). setuid/setgid/sticky are stripped.
+  uint32 mode = 5;
+  // size is the source file's byte count — needed up front for the tar header,
+  // and enforced as a hard cap so a truncated or oversized stream fails cleanly
+  // rather than leaving a partial file.
+  int64 size = 6;
+}
+
+message CopyIntoReply {
+  // path is the final absolute path written inside the instance.
+  string path = 1;
+  // written is the number of file bytes received and written.
+  int64 written = 2;
+}
+
 // ResolveLogsCommand returns the host-side command argv the server would run to
 // show an instance's container runtime logs. The client embeds it in its own
 // pager script (cat the creation log, then the runtime logs) and runs it

--- a/fleetgrpc/service.pb.go
+++ b/fleetgrpc/service.pb.go
@@ -26,7 +26,7 @@ const file_service_proto_rawDesc = "" +
 	"\n" +
 	"\rservice.proto\x12\tfleetgrpc\x1a\farmada.proto\x1a\rcontrol.proto\x1a\vwatch.proto\x1a\n" +
 	"jobs.proto\x1a\fconfig.proto\x1a\n" +
-	"exec.proto\x1a\rinspect.proto2\x88\x15\n" +
+	"exec.proto\x1a\rinspect.proto2\xca\x15\n" +
 	"\fFleetService\x127\n" +
 	"\x05Hello\x12\x17.fleetgrpc.HelloRequest\x1a\x15.fleetgrpc.HelloReply\x12@\n" +
 	"\bShutdown\x12\x1a.fleetgrpc.ShutdownRequest\x1a\x18.fleetgrpc.ShutdownReply\x12[\n" +
@@ -58,7 +58,8 @@ const file_service_proto_rawDesc = "" +
 	"\x12ResolveLogsCommand\x12$.fleetgrpc.ResolveLogsCommandRequest\x1a\".fleetgrpc.ResolveLogsCommandReply\x124\n" +
 	"\x04Logs\x12\x16.fleetgrpc.LogsRequest\x1a\x12.fleetgrpc.LogLine0\x01\x12?\n" +
 	"\aForward\x12\x17.fleetgrpc.ForwardChunk\x1a\x17.fleetgrpc.ForwardChunk(\x010\x01\x12B\n" +
-	"\bCopyFile\x12\x1a.fleetgrpc.CopyFileRequest\x1a\x18.fleetgrpc.CopyFileChunk0\x01\x12I\n" +
+	"\bCopyFile\x12\x1a.fleetgrpc.CopyFileRequest\x1a\x18.fleetgrpc.CopyFileChunk0\x01\x12@\n" +
+	"\bCopyInto\x12\x18.fleetgrpc.CopyIntoChunk\x1a\x18.fleetgrpc.CopyIntoReply(\x01\x12I\n" +
 	"\vInspectRepo\x12\x1d.fleetgrpc.InspectRepoRequest\x1a\x1b.fleetgrpc.InspectRepoReply\x12j\n" +
 	"\x16GetCoderTemplateParams\x12(.fleetgrpc.GetCoderTemplateParamsRequest\x1a&.fleetgrpc.GetCoderTemplateParamsReply\x12X\n" +
 	"\x10GetBrowserConfig\x12\".fleetgrpc.GetBrowserConfigRequest\x1a .fleetgrpc.GetBrowserConfigReply\x12R\n" +
@@ -96,33 +97,35 @@ var file_service_proto_goTypes = []any{
 	(*LogsRequest)(nil),                   // 28: fleetgrpc.LogsRequest
 	(*ForwardChunk)(nil),                  // 29: fleetgrpc.ForwardChunk
 	(*CopyFileRequest)(nil),               // 30: fleetgrpc.CopyFileRequest
-	(*InspectRepoRequest)(nil),            // 31: fleetgrpc.InspectRepoRequest
-	(*GetCoderTemplateParamsRequest)(nil), // 32: fleetgrpc.GetCoderTemplateParamsRequest
-	(*GetBrowserConfigRequest)(nil),       // 33: fleetgrpc.GetBrowserConfigRequest
-	(*PrepareBrowserRequest)(nil),         // 34: fleetgrpc.PrepareBrowserRequest
-	(*HelloReply)(nil),                    // 35: fleetgrpc.HelloReply
-	(*ShutdownReply)(nil),                 // 36: fleetgrpc.ShutdownReply
-	(*FleetTUIConnectedReply)(nil),        // 37: fleetgrpc.FleetTUIConnectedReply
-	(*GetStateReply)(nil),                 // 38: fleetgrpc.GetStateReply
-	(*Event)(nil),                         // 39: fleetgrpc.Event
-	(*JobEvent)(nil),                      // 40: fleetgrpc.JobEvent
-	(*MutationReply)(nil),                 // 41: fleetgrpc.MutationReply
-	(*DeleteBuildkitCacheReply)(nil),      // 42: fleetgrpc.DeleteBuildkitCacheReply
-	(*DeleteDebCacheReply)(nil),           // 43: fleetgrpc.DeleteDebCacheReply
-	(*DeleteImageCacheReply)(nil),         // 44: fleetgrpc.DeleteImageCacheReply
-	(*GetConfigReply)(nil),                // 45: fleetgrpc.GetConfigReply
-	(*SetConfigReply)(nil),                // 46: fleetgrpc.SetConfigReply
-	(*GetArmadaReply)(nil),                // 47: fleetgrpc.GetArmadaReply
-	(*SetArmadaReply)(nil),                // 48: fleetgrpc.SetArmadaReply
-	(*ExecOut)(nil),                       // 49: fleetgrpc.ExecOut
-	(*ResolveExecCommandReply)(nil),       // 50: fleetgrpc.ResolveExecCommandReply
-	(*ResolveLogsCommandReply)(nil),       // 51: fleetgrpc.ResolveLogsCommandReply
-	(*LogLine)(nil),                       // 52: fleetgrpc.LogLine
-	(*CopyFileChunk)(nil),                 // 53: fleetgrpc.CopyFileChunk
-	(*InspectRepoReply)(nil),              // 54: fleetgrpc.InspectRepoReply
-	(*GetCoderTemplateParamsReply)(nil),   // 55: fleetgrpc.GetCoderTemplateParamsReply
-	(*GetBrowserConfigReply)(nil),         // 56: fleetgrpc.GetBrowserConfigReply
-	(*PrepareBrowserReply)(nil),           // 57: fleetgrpc.PrepareBrowserReply
+	(*CopyIntoChunk)(nil),                 // 31: fleetgrpc.CopyIntoChunk
+	(*InspectRepoRequest)(nil),            // 32: fleetgrpc.InspectRepoRequest
+	(*GetCoderTemplateParamsRequest)(nil), // 33: fleetgrpc.GetCoderTemplateParamsRequest
+	(*GetBrowserConfigRequest)(nil),       // 34: fleetgrpc.GetBrowserConfigRequest
+	(*PrepareBrowserRequest)(nil),         // 35: fleetgrpc.PrepareBrowserRequest
+	(*HelloReply)(nil),                    // 36: fleetgrpc.HelloReply
+	(*ShutdownReply)(nil),                 // 37: fleetgrpc.ShutdownReply
+	(*FleetTUIConnectedReply)(nil),        // 38: fleetgrpc.FleetTUIConnectedReply
+	(*GetStateReply)(nil),                 // 39: fleetgrpc.GetStateReply
+	(*Event)(nil),                         // 40: fleetgrpc.Event
+	(*JobEvent)(nil),                      // 41: fleetgrpc.JobEvent
+	(*MutationReply)(nil),                 // 42: fleetgrpc.MutationReply
+	(*DeleteBuildkitCacheReply)(nil),      // 43: fleetgrpc.DeleteBuildkitCacheReply
+	(*DeleteDebCacheReply)(nil),           // 44: fleetgrpc.DeleteDebCacheReply
+	(*DeleteImageCacheReply)(nil),         // 45: fleetgrpc.DeleteImageCacheReply
+	(*GetConfigReply)(nil),                // 46: fleetgrpc.GetConfigReply
+	(*SetConfigReply)(nil),                // 47: fleetgrpc.SetConfigReply
+	(*GetArmadaReply)(nil),                // 48: fleetgrpc.GetArmadaReply
+	(*SetArmadaReply)(nil),                // 49: fleetgrpc.SetArmadaReply
+	(*ExecOut)(nil),                       // 50: fleetgrpc.ExecOut
+	(*ResolveExecCommandReply)(nil),       // 51: fleetgrpc.ResolveExecCommandReply
+	(*ResolveLogsCommandReply)(nil),       // 52: fleetgrpc.ResolveLogsCommandReply
+	(*LogLine)(nil),                       // 53: fleetgrpc.LogLine
+	(*CopyFileChunk)(nil),                 // 54: fleetgrpc.CopyFileChunk
+	(*CopyIntoReply)(nil),                 // 55: fleetgrpc.CopyIntoReply
+	(*InspectRepoReply)(nil),              // 56: fleetgrpc.InspectRepoReply
+	(*GetCoderTemplateParamsReply)(nil),   // 57: fleetgrpc.GetCoderTemplateParamsReply
+	(*GetBrowserConfigReply)(nil),         // 58: fleetgrpc.GetBrowserConfigReply
+	(*PrepareBrowserReply)(nil),           // 59: fleetgrpc.PrepareBrowserReply
 }
 var file_service_proto_depIdxs = []int32{
 	0,  // 0: fleetgrpc.FleetService.Hello:input_type -> fleetgrpc.HelloRequest
@@ -156,47 +159,49 @@ var file_service_proto_depIdxs = []int32{
 	28, // 28: fleetgrpc.FleetService.Logs:input_type -> fleetgrpc.LogsRequest
 	29, // 29: fleetgrpc.FleetService.Forward:input_type -> fleetgrpc.ForwardChunk
 	30, // 30: fleetgrpc.FleetService.CopyFile:input_type -> fleetgrpc.CopyFileRequest
-	31, // 31: fleetgrpc.FleetService.InspectRepo:input_type -> fleetgrpc.InspectRepoRequest
-	32, // 32: fleetgrpc.FleetService.GetCoderTemplateParams:input_type -> fleetgrpc.GetCoderTemplateParamsRequest
-	33, // 33: fleetgrpc.FleetService.GetBrowserConfig:input_type -> fleetgrpc.GetBrowserConfigRequest
-	34, // 34: fleetgrpc.FleetService.PrepareBrowser:input_type -> fleetgrpc.PrepareBrowserRequest
-	35, // 35: fleetgrpc.FleetService.Hello:output_type -> fleetgrpc.HelloReply
-	36, // 36: fleetgrpc.FleetService.Shutdown:output_type -> fleetgrpc.ShutdownReply
-	37, // 37: fleetgrpc.FleetService.FleetTUIConnected:output_type -> fleetgrpc.FleetTUIConnectedReply
-	38, // 38: fleetgrpc.FleetService.GetState:output_type -> fleetgrpc.GetStateReply
-	39, // 39: fleetgrpc.FleetService.Watch:output_type -> fleetgrpc.Event
-	40, // 40: fleetgrpc.FleetService.CreateInstance:output_type -> fleetgrpc.JobEvent
-	40, // 41: fleetgrpc.FleetService.DestroyInstance:output_type -> fleetgrpc.JobEvent
-	40, // 42: fleetgrpc.FleetService.StartInstance:output_type -> fleetgrpc.JobEvent
-	40, // 43: fleetgrpc.FleetService.StopInstance:output_type -> fleetgrpc.JobEvent
-	40, // 44: fleetgrpc.FleetService.CloneInstance:output_type -> fleetgrpc.JobEvent
-	40, // 45: fleetgrpc.FleetService.RebuildInstance:output_type -> fleetgrpc.JobEvent
-	41, // 46: fleetgrpc.FleetService.CreateFleet:output_type -> fleetgrpc.MutationReply
-	41, // 47: fleetgrpc.FleetService.DestroyFleet:output_type -> fleetgrpc.MutationReply
-	41, // 48: fleetgrpc.FleetService.SetFleetSettings:output_type -> fleetgrpc.MutationReply
-	42, // 49: fleetgrpc.FleetService.DeleteBuildkitCache:output_type -> fleetgrpc.DeleteBuildkitCacheReply
-	43, // 50: fleetgrpc.FleetService.DeleteDebCache:output_type -> fleetgrpc.DeleteDebCacheReply
-	44, // 51: fleetgrpc.FleetService.DeleteImageCache:output_type -> fleetgrpc.DeleteImageCacheReply
-	41, // 52: fleetgrpc.FleetService.SetInstanceMetadata:output_type -> fleetgrpc.MutationReply
-	41, // 53: fleetgrpc.FleetService.SetGroupLayout:output_type -> fleetgrpc.MutationReply
-	41, // 54: fleetgrpc.FleetService.DeleteGroupLayout:output_type -> fleetgrpc.MutationReply
-	41, // 55: fleetgrpc.FleetService.SetLastSeenVersion:output_type -> fleetgrpc.MutationReply
-	45, // 56: fleetgrpc.FleetService.GetConfig:output_type -> fleetgrpc.GetConfigReply
-	46, // 57: fleetgrpc.FleetService.SetConfig:output_type -> fleetgrpc.SetConfigReply
-	47, // 58: fleetgrpc.FleetService.GetArmada:output_type -> fleetgrpc.GetArmadaReply
-	48, // 59: fleetgrpc.FleetService.SetArmada:output_type -> fleetgrpc.SetArmadaReply
-	49, // 60: fleetgrpc.FleetService.Exec:output_type -> fleetgrpc.ExecOut
-	50, // 61: fleetgrpc.FleetService.ResolveExecCommand:output_type -> fleetgrpc.ResolveExecCommandReply
-	51, // 62: fleetgrpc.FleetService.ResolveLogsCommand:output_type -> fleetgrpc.ResolveLogsCommandReply
-	52, // 63: fleetgrpc.FleetService.Logs:output_type -> fleetgrpc.LogLine
-	29, // 64: fleetgrpc.FleetService.Forward:output_type -> fleetgrpc.ForwardChunk
-	53, // 65: fleetgrpc.FleetService.CopyFile:output_type -> fleetgrpc.CopyFileChunk
-	54, // 66: fleetgrpc.FleetService.InspectRepo:output_type -> fleetgrpc.InspectRepoReply
-	55, // 67: fleetgrpc.FleetService.GetCoderTemplateParams:output_type -> fleetgrpc.GetCoderTemplateParamsReply
-	56, // 68: fleetgrpc.FleetService.GetBrowserConfig:output_type -> fleetgrpc.GetBrowserConfigReply
-	57, // 69: fleetgrpc.FleetService.PrepareBrowser:output_type -> fleetgrpc.PrepareBrowserReply
-	35, // [35:70] is the sub-list for method output_type
-	0,  // [0:35] is the sub-list for method input_type
+	31, // 31: fleetgrpc.FleetService.CopyInto:input_type -> fleetgrpc.CopyIntoChunk
+	32, // 32: fleetgrpc.FleetService.InspectRepo:input_type -> fleetgrpc.InspectRepoRequest
+	33, // 33: fleetgrpc.FleetService.GetCoderTemplateParams:input_type -> fleetgrpc.GetCoderTemplateParamsRequest
+	34, // 34: fleetgrpc.FleetService.GetBrowserConfig:input_type -> fleetgrpc.GetBrowserConfigRequest
+	35, // 35: fleetgrpc.FleetService.PrepareBrowser:input_type -> fleetgrpc.PrepareBrowserRequest
+	36, // 36: fleetgrpc.FleetService.Hello:output_type -> fleetgrpc.HelloReply
+	37, // 37: fleetgrpc.FleetService.Shutdown:output_type -> fleetgrpc.ShutdownReply
+	38, // 38: fleetgrpc.FleetService.FleetTUIConnected:output_type -> fleetgrpc.FleetTUIConnectedReply
+	39, // 39: fleetgrpc.FleetService.GetState:output_type -> fleetgrpc.GetStateReply
+	40, // 40: fleetgrpc.FleetService.Watch:output_type -> fleetgrpc.Event
+	41, // 41: fleetgrpc.FleetService.CreateInstance:output_type -> fleetgrpc.JobEvent
+	41, // 42: fleetgrpc.FleetService.DestroyInstance:output_type -> fleetgrpc.JobEvent
+	41, // 43: fleetgrpc.FleetService.StartInstance:output_type -> fleetgrpc.JobEvent
+	41, // 44: fleetgrpc.FleetService.StopInstance:output_type -> fleetgrpc.JobEvent
+	41, // 45: fleetgrpc.FleetService.CloneInstance:output_type -> fleetgrpc.JobEvent
+	41, // 46: fleetgrpc.FleetService.RebuildInstance:output_type -> fleetgrpc.JobEvent
+	42, // 47: fleetgrpc.FleetService.CreateFleet:output_type -> fleetgrpc.MutationReply
+	42, // 48: fleetgrpc.FleetService.DestroyFleet:output_type -> fleetgrpc.MutationReply
+	42, // 49: fleetgrpc.FleetService.SetFleetSettings:output_type -> fleetgrpc.MutationReply
+	43, // 50: fleetgrpc.FleetService.DeleteBuildkitCache:output_type -> fleetgrpc.DeleteBuildkitCacheReply
+	44, // 51: fleetgrpc.FleetService.DeleteDebCache:output_type -> fleetgrpc.DeleteDebCacheReply
+	45, // 52: fleetgrpc.FleetService.DeleteImageCache:output_type -> fleetgrpc.DeleteImageCacheReply
+	42, // 53: fleetgrpc.FleetService.SetInstanceMetadata:output_type -> fleetgrpc.MutationReply
+	42, // 54: fleetgrpc.FleetService.SetGroupLayout:output_type -> fleetgrpc.MutationReply
+	42, // 55: fleetgrpc.FleetService.DeleteGroupLayout:output_type -> fleetgrpc.MutationReply
+	42, // 56: fleetgrpc.FleetService.SetLastSeenVersion:output_type -> fleetgrpc.MutationReply
+	46, // 57: fleetgrpc.FleetService.GetConfig:output_type -> fleetgrpc.GetConfigReply
+	47, // 58: fleetgrpc.FleetService.SetConfig:output_type -> fleetgrpc.SetConfigReply
+	48, // 59: fleetgrpc.FleetService.GetArmada:output_type -> fleetgrpc.GetArmadaReply
+	49, // 60: fleetgrpc.FleetService.SetArmada:output_type -> fleetgrpc.SetArmadaReply
+	50, // 61: fleetgrpc.FleetService.Exec:output_type -> fleetgrpc.ExecOut
+	51, // 62: fleetgrpc.FleetService.ResolveExecCommand:output_type -> fleetgrpc.ResolveExecCommandReply
+	52, // 63: fleetgrpc.FleetService.ResolveLogsCommand:output_type -> fleetgrpc.ResolveLogsCommandReply
+	53, // 64: fleetgrpc.FleetService.Logs:output_type -> fleetgrpc.LogLine
+	29, // 65: fleetgrpc.FleetService.Forward:output_type -> fleetgrpc.ForwardChunk
+	54, // 66: fleetgrpc.FleetService.CopyFile:output_type -> fleetgrpc.CopyFileChunk
+	55, // 67: fleetgrpc.FleetService.CopyInto:output_type -> fleetgrpc.CopyIntoReply
+	56, // 68: fleetgrpc.FleetService.InspectRepo:output_type -> fleetgrpc.InspectRepoReply
+	57, // 69: fleetgrpc.FleetService.GetCoderTemplateParams:output_type -> fleetgrpc.GetCoderTemplateParamsReply
+	58, // 70: fleetgrpc.FleetService.GetBrowserConfig:output_type -> fleetgrpc.GetBrowserConfigReply
+	59, // 71: fleetgrpc.FleetService.PrepareBrowser:output_type -> fleetgrpc.PrepareBrowserReply
+	36, // [36:72] is the sub-list for method output_type
+	0,  // [0:36] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/fleetgrpc/service.proto
+++ b/fleetgrpc/service.proto
@@ -93,6 +93,10 @@ service FleetService {
   // CopyFile streams a single file out of an instance: first chunk is metadata,
   // the rest are data. Backs `fleet copy` and the in-instance `fc` shorthand.
   rpc CopyFile(CopyFileRequest) returns (stream CopyFileChunk);
+  // CopyInto streams a single file INTO an instance — the reverse of CopyFile.
+  // Client-streaming: first chunk is the open header, the rest are data. Backs
+  // the scp-style upload (and instance→instance relay) direction of `fleet copy`.
+  rpc CopyInto(stream CopyIntoChunk) returns (CopyIntoReply);
 
   // ---- Repo inspection (server-side clone + checks) ----
   // InspectRepo shallow-clones remote_url on the DAEMON's host and reports

--- a/fleetgrpc/service_grpc.pb.go
+++ b/fleetgrpc/service_grpc.pb.go
@@ -50,6 +50,7 @@ const (
 	FleetService_Logs_FullMethodName                   = "/fleetgrpc.FleetService/Logs"
 	FleetService_Forward_FullMethodName                = "/fleetgrpc.FleetService/Forward"
 	FleetService_CopyFile_FullMethodName               = "/fleetgrpc.FleetService/CopyFile"
+	FleetService_CopyInto_FullMethodName               = "/fleetgrpc.FleetService/CopyInto"
 	FleetService_InspectRepo_FullMethodName            = "/fleetgrpc.FleetService/InspectRepo"
 	FleetService_GetCoderTemplateParams_FullMethodName = "/fleetgrpc.FleetService/GetCoderTemplateParams"
 	FleetService_GetBrowserConfig_FullMethodName       = "/fleetgrpc.FleetService/GetBrowserConfig"
@@ -127,6 +128,10 @@ type FleetServiceClient interface {
 	// CopyFile streams a single file out of an instance: first chunk is metadata,
 	// the rest are data. Backs `fleet copy` and the in-instance `fc` shorthand.
 	CopyFile(ctx context.Context, in *CopyFileRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CopyFileChunk], error)
+	// CopyInto streams a single file INTO an instance — the reverse of CopyFile.
+	// Client-streaming: first chunk is the open header, the rest are data. Backs
+	// the scp-style upload (and instance→instance relay) direction of `fleet copy`.
+	CopyInto(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[CopyIntoChunk, CopyIntoReply], error)
 	// ---- Repo inspection (server-side clone + checks) ----
 	// InspectRepo shallow-clones remote_url on the DAEMON's host and reports
 	// devcontainer presence (and optionally the detected container home dir).
@@ -545,6 +550,19 @@ func (c *fleetServiceClient) CopyFile(ctx context.Context, in *CopyFileRequest, 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type FleetService_CopyFileClient = grpc.ServerStreamingClient[CopyFileChunk]
 
+func (c *fleetServiceClient) CopyInto(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[CopyIntoChunk, CopyIntoReply], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &FleetService_ServiceDesc.Streams[11], FleetService_CopyInto_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[CopyIntoChunk, CopyIntoReply]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type FleetService_CopyIntoClient = grpc.ClientStreamingClient[CopyIntoChunk, CopyIntoReply]
+
 func (c *fleetServiceClient) InspectRepo(ctx context.Context, in *InspectRepoRequest, opts ...grpc.CallOption) (*InspectRepoReply, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(InspectRepoReply)
@@ -656,6 +674,10 @@ type FleetServiceServer interface {
 	// CopyFile streams a single file out of an instance: first chunk is metadata,
 	// the rest are data. Backs `fleet copy` and the in-instance `fc` shorthand.
 	CopyFile(*CopyFileRequest, grpc.ServerStreamingServer[CopyFileChunk]) error
+	// CopyInto streams a single file INTO an instance — the reverse of CopyFile.
+	// Client-streaming: first chunk is the open header, the rest are data. Backs
+	// the scp-style upload (and instance→instance relay) direction of `fleet copy`.
+	CopyInto(grpc.ClientStreamingServer[CopyIntoChunk, CopyIntoReply]) error
 	// ---- Repo inspection (server-side clone + checks) ----
 	// InspectRepo shallow-clones remote_url on the DAEMON's host and reports
 	// devcontainer presence (and optionally the detected container home dir).
@@ -769,6 +791,9 @@ func (UnimplementedFleetServiceServer) Forward(grpc.BidiStreamingServer[ForwardC
 }
 func (UnimplementedFleetServiceServer) CopyFile(*CopyFileRequest, grpc.ServerStreamingServer[CopyFileChunk]) error {
 	return status.Errorf(codes.Unimplemented, "method CopyFile not implemented")
+}
+func (UnimplementedFleetServiceServer) CopyInto(grpc.ClientStreamingServer[CopyIntoChunk, CopyIntoReply]) error {
+	return status.Errorf(codes.Unimplemented, "method CopyInto not implemented")
 }
 func (UnimplementedFleetServiceServer) InspectRepo(context.Context, *InspectRepoRequest) (*InspectRepoReply, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method InspectRepo not implemented")
@@ -1276,6 +1301,13 @@ func _FleetService_CopyFile_Handler(srv interface{}, stream grpc.ServerStream) e
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type FleetService_CopyFileServer = grpc.ServerStreamingServer[CopyFileChunk]
 
+func _FleetService_CopyInto_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(FleetServiceServer).CopyInto(&grpc.GenericServerStream[CopyIntoChunk, CopyIntoReply]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type FleetService_CopyIntoServer = grpc.ClientStreamingServer[CopyIntoChunk, CopyIntoReply]
+
 func _FleetService_InspectRepo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(InspectRepoRequest)
 	if err := dec(in); err != nil {
@@ -1509,6 +1541,11 @@ var FleetService_ServiceDesc = grpc.ServiceDesc{
 			StreamName:    "CopyFile",
 			Handler:       _FleetService_CopyFile_Handler,
 			ServerStreams: true,
+		},
+		{
+			StreamName:    "CopyInto",
+			Handler:       _FleetService_CopyInto_Handler,
+			ClientStreams: true,
 		},
 	},
 	Metadata: "service.proto",

--- a/fleetgrpc/watch.pb.go
+++ b/fleetgrpc/watch.pb.go
@@ -624,25 +624,31 @@ func (x *BrowserOpen) GetInstance() string {
 	return ""
 }
 
-// FileCopy asks the receiving client to pull a file out of an instance to its
-// local disk. Pushed when the server's per-instance control listener receives a
-// file.copy envelope from an in-container `fleet copy` (fc); the CLIENT then
-// fetches the bytes itself via the CopyFile RPC and writes them to its downloads
-// folder — the same control-socket → Watch → client-action split as BrowserOpen,
-// which is what makes fc work for fully remote deployments.
+// FileCopy asks the receiving client (the connected TUI) to PERFORM a scp-style
+// copy on the in-container sender's behalf. Pushed when the server's per-instance
+// control listener receives a file.copy envelope from an in-container `fleet
+// copy` (fc): the in-instance process cannot reach the host fleetd over gRPC
+// (only the control socket is bind-mounted), so it delegates the whole copy to
+// the TUI, which runs the generic copy engine against the host fleet with its
+// own disk as the "local" side. Same control-socket → Watch → client-action
+// split as BrowserOpen, which is what makes fc work for fully remote deployments.
+//
+// src and dst are the two scp endpoints AS TYPED inside the instance, verbatim.
+// Each is either `[fleet/]instance:path` (an instance), a plain path (a file on
+// the TUI machine — the human's disk), or `:path` (the CURRENT instance: the TUI
+// substitutes the originating fleet/instance below). Direction is inferred from
+// which side is local vs an instance.
 type FileCopy struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// fleet/instance label which workspace requested the copy.
+	// fleet/instance label of the instance that requested the copy. Also the value
+	// the TUI substitutes for a `:path` (self) endpoint in src/dst.
 	Fleet    string `protobuf:"bytes,1,opt,name=fleet,proto3" json:"fleet,omitempty"`
 	Instance string `protobuf:"bytes,2,opt,name=instance,proto3" json:"instance,omitempty"`
-	// path is the absolute in-instance path of the file to copy (resolved by the
-	// in-instance sender, so the server-side exec needs no cwd context).
-	Path string `protobuf:"bytes,3,opt,name=path,proto3" json:"path,omitempty"`
-	// dest is the optional destination on the receiving client's machine; ""
-	// means the client's downloads folder. The client interprets it scp-style:
-	// absolute is used as-is, ~/ and relative paths resolve against the client
-	// user's home, and a directory keeps the source basename.
-	Dest          string `protobuf:"bytes,4,opt,name=dest,proto3" json:"dest,omitempty"`
+	// src is the source endpoint as typed inside the instance.
+	Src string `protobuf:"bytes,3,opt,name=src,proto3" json:"src,omitempty"`
+	// dst is the destination endpoint as typed inside the instance. Empty is the
+	// 1-arg download shorthand: the TUI delivers to its downloads folder.
+	Dst           string `protobuf:"bytes,4,opt,name=dst,proto3" json:"dst,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -691,16 +697,16 @@ func (x *FileCopy) GetInstance() string {
 	return ""
 }
 
-func (x *FileCopy) GetPath() string {
+func (x *FileCopy) GetSrc() string {
 	if x != nil {
-		return x.Path
+		return x.Src
 	}
 	return ""
 }
 
-func (x *FileCopy) GetDest() string {
+func (x *FileCopy) GetDst() string {
 	if x != nil {
-		return x.Dest
+		return x.Dst
 	}
 	return ""
 }
@@ -743,12 +749,12 @@ const file_watch_proto_rawDesc = "" +
 	"\bdata_dir\x18\x02 \x01(\tH\x00R\adataDir\x88\x01\x01\x12\x14\n" +
 	"\x05fleet\x18\x03 \x01(\tR\x05fleet\x12\x1a\n" +
 	"\binstance\x18\x04 \x01(\tR\binstanceB\v\n" +
-	"\t_data_dir\"d\n" +
+	"\t_data_dir\"`\n" +
 	"\bFileCopy\x12\x14\n" +
 	"\x05fleet\x18\x01 \x01(\tR\x05fleet\x12\x1a\n" +
-	"\binstance\x18\x02 \x01(\tR\binstance\x12\x12\n" +
-	"\x04path\x18\x03 \x01(\tR\x04path\x12\x12\n" +
-	"\x04dest\x18\x04 \x01(\tR\x04dest*\x8a\x01\n" +
+	"\binstance\x18\x02 \x01(\tR\binstance\x12\x10\n" +
+	"\x03src\x18\x03 \x01(\tR\x03src\x12\x10\n" +
+	"\x03dst\x18\x04 \x01(\tR\x03dst*\x8a\x01\n" +
 	"\rRemoteMcpConn\x12\x1f\n" +
 	"\x1bREMOTE_MCP_CONN_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aREMOTE_MCP_CONN_CONNECTING\x10\x01\x12\x1d\n" +

--- a/fleetgrpc/watch.proto
+++ b/fleetgrpc/watch.proto
@@ -129,22 +129,28 @@ message BrowserOpen {
   string instance = 4;
 }
 
-// FileCopy asks the receiving client to pull a file out of an instance to its
-// local disk. Pushed when the server's per-instance control listener receives a
-// file.copy envelope from an in-container `fleet copy` (fc); the CLIENT then
-// fetches the bytes itself via the CopyFile RPC and writes them to its downloads
-// folder — the same control-socket → Watch → client-action split as BrowserOpen,
-// which is what makes fc work for fully remote deployments.
+// FileCopy asks the receiving client (the connected TUI) to PERFORM a scp-style
+// copy on the in-container sender's behalf. Pushed when the server's per-instance
+// control listener receives a file.copy envelope from an in-container `fleet
+// copy` (fc): the in-instance process cannot reach the host fleetd over gRPC
+// (only the control socket is bind-mounted), so it delegates the whole copy to
+// the TUI, which runs the generic copy engine against the host fleet with its
+// own disk as the "local" side. Same control-socket → Watch → client-action
+// split as BrowserOpen, which is what makes fc work for fully remote deployments.
+//
+// src and dst are the two scp endpoints AS TYPED inside the instance, verbatim.
+// Each is either `[fleet/]instance:path` (an instance), a plain path (a file on
+// the TUI machine — the human's disk), or `:path` (the CURRENT instance: the TUI
+// substitutes the originating fleet/instance below). Direction is inferred from
+// which side is local vs an instance.
 message FileCopy {
-  // fleet/instance label which workspace requested the copy.
+  // fleet/instance label of the instance that requested the copy. Also the value
+  // the TUI substitutes for a `:path` (self) endpoint in src/dst.
   string fleet = 1;
   string instance = 2;
-  // path is the absolute in-instance path of the file to copy (resolved by the
-  // in-instance sender, so the server-side exec needs no cwd context).
-  string path = 3;
-  // dest is the optional destination on the receiving client's machine; ""
-  // means the client's downloads folder. The client interprets it scp-style:
-  // absolute is used as-is, ~/ and relative paths resolve against the client
-  // user's home, and a directory keeps the source basename.
-  string dest = 4;
+  // src is the source endpoint as typed inside the instance.
+  string src = 3;
+  // dst is the destination endpoint as typed inside the instance. Empty is the
+  // 1-arg download shorthand: the TUI delivers to its downloads folder.
+  string dst = 4;
 }

--- a/integration/tests/025_copy.sh
+++ b/integration/tests/025_copy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Description: `fleet copy instance:path` pulls a file out of the container, preserving content and mode.
+# Description: `fleet copy` is bidirectional scp-style — out of, into, and between instances, preserving content and mode.
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
@@ -49,5 +49,43 @@ set -e
 if [ "${rc}" -eq 0 ]; then
   fail "expected non-zero exit copying a directory, got 0"
 fi
+
+# ---- the reverse direction: copy a local file INTO an instance ----
+
+info "fleet copy <local> alpha:/tmp/up.bin uploads into the instance, keeping mode"
+printf 'uploaded-bytes' > "${workdir}/up.bin"
+chmod 755 "${workdir}/up.bin"
+"${FLEET_BIN}" copy "${workdir}/up.bin" "${FIXTURE_REPO_NAME}/alpha:/tmp/up.bin"
+assert_equals "uploaded-bytes" "$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- cat /tmp/up.bin)" "uploaded file content"
+assert_equals "755" "$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- stat -c '%a' /tmp/up.bin)" "uploaded file keeps its mode"
+
+info "fleet copy into an instance directory keeps the source basename"
+"${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- mkdir -p /tmp/updir
+"${FLEET_BIN}" copy "${workdir}/up.bin" "${FIXTURE_REPO_NAME}/alpha:/tmp/updir/"
+assert_equals "uploaded-bytes" "$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- cat /tmp/updir/up.bin)" "directory upload basename"
+
+info "fleet copy into a non-existent instance directory fails"
+set +e
+"${FLEET_BIN}" copy "${workdir}/up.bin" "${FIXTURE_REPO_NAME}/alpha:/tmp/no-such-dir/" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "${rc}" -eq 0 ]; then
+  fail "expected non-zero exit uploading into a missing directory, got 0"
+fi
+
+info "fleet copy of a missing local file fails"
+set +e
+"${FLEET_BIN}" copy "${workdir}/ghost-local" "${FIXTURE_REPO_NAME}/alpha:/tmp/ghost" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "${rc}" -eq 0 ]; then
+  fail "expected non-zero exit uploading a missing local file, got 0"
+fi
+
+# ---- instance → instance (the relay path) ----
+
+info "fleet copy alpha:path alpha:path2 relays between two instance paths"
+"${FLEET_BIN}" copy "${FIXTURE_REPO_NAME}/alpha:/tmp/up.bin" "${FIXTURE_REPO_NAME}/alpha:/tmp/relayed.bin"
+assert_equals "uploaded-bytes" "$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- cat /tmp/relayed.bin)" "relayed file content"
 
 pass "copy"

--- a/internal/cli/copy.go
+++ b/internal/cli/copy.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"slices"
-	"strings"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetclient"
@@ -14,38 +12,41 @@ import (
 )
 
 // newCopyCmd creates the `fleet copy` command (aliased `cp`; inside an instance
-// the staged fleet.rc also provides `fc`). It copies a single file out of an
-// instance, scp-style, in one of two forms picked per argument:
+// the staged fleet.rc also provides `fc`). It is a generic, scp-style copy: each
+// of the two arguments is an endpoint — `[fleet/]instance:path` (a file inside an
+// instance), a plain path (a file on the orchestrating machine), or `:path` (the
+// current instance) — and the direction is inferred from which side is which. The
+// same command copies out of, into, and between instances.
 //
-//   - `fleet copy [fleet/]instance:path [dest]` pulls the file from any
-//     reachable fleet server (including a remote one) and writes it locally.
-//   - `fleet copy <path> [dest]` — the in-instance form: like `fleet launch`,
-//     it messages the host over the control socket; the connected fleet TUI
-//     pulls the file to the user's machine — downloads folder by default, dest
-//     there when given.
-//
-// Both forms work from anywhere (a dev instance may run its own nested fleet,
-// so the instance:path form must keep working inside one), but the HELP text is
-// built for where the command runs: telling a user who is already inside an
-// instance to name a fleet/instance makes no sense, and vice versa.
+// Where the copy is performed depends only on where the command runs, not on the
+// direction: a host invocation drives the fleet server directly; an in-instance
+// invocation delegates to the connected fleet TUI (the container can't reach the
+// host fleetd over gRPC), which runs the very same copy against the host fleet.
+// The HELP text is tailored to where the command runs.
 func newCopyCmd() *cobra.Command {
-	use := "copy <[fleet/]instance:path> [dest]"
-	short := "Copy a file out of an instance"
-	long := "Copy a single file out of a fleet instance, scp-style: pull\n" +
-		"`[fleet/]instance:path` through the fleet server (including a remote one) and\n" +
-		"write it to dest — default: same name in the current directory; a directory\n" +
-		"dest keeps the file's name. A relative source path resolves against the\n" +
-		"instance's workspace folder.\n\n" +
-		"Inside an instance the same command (shorthand: `fc`) takes plain paths and\n" +
-		"delivers to your machine via the connected fleet TUI."
+	use := "copy <src> <dst>"
+	short := "Copy a file to, from, or between fleet instances, scp-style"
+	long := "Copy a single file between your machine and a fleet instance — or between\n" +
+		"two instances — scp-style. Each path is either `[fleet/]instance:path` (a file\n" +
+		"inside an instance, reachable even on a remote fleet) or a plain local path;\n" +
+		"the direction follows which side is which:\n\n" +
+		"  fleet copy alpha:bin/tool ./tool         # download out of an instance\n" +
+		"  fleet copy ./tool alpha:/usr/local/bin/  # upload into an instance\n" +
+		"  fleet copy alpha:a beta:b                # copy between two instances\n\n" +
+		"A relative instance path resolves against the workspace folder; a directory\n" +
+		"destination keeps the source's name. Given a single instance source the file\n" +
+		"downloads to the current directory."
 	if fleetcopy.InInstance() {
-		use = "copy <path> [dest]"
-		short = "Copy a file from this instance to your machine (shorthand: fc)"
-		long = "Copy a single file out of this instance to the machine your fleet TUI runs\n" +
-			"on — even when this instance lives on a remote server.\n\n" +
-			"With no destination the file lands in your downloads folder. With one, it\n" +
-			"lands there instead: an absolute path is used as-is, `~/` and relative paths\n" +
-			"resolve against your home directory, and a directory keeps the file's name.\n" +
+		short = "Copy a file to or from an instance via your fleet TUI (shorthand: fc)"
+		long = "Copy a single file between your machine and an instance — or between two\n" +
+			"instances — scp-style. The copy is performed by the fleet TUI on your\n" +
+			"machine, so it works even when this instance lives on a remote server.\n\n" +
+			"A plain path is a file on your machine (where the TUI runs); `:path` is a\n" +
+			"file in THIS instance; `[fleet/]instance:path` is any instance in your fleet:\n\n" +
+			"  fc :bin/tool ~/Downloads/   # copy this instance's file to your machine\n" +
+			"  fc report.csv :/tmp/        # copy a file from your machine into this instance\n" +
+			"  fc :out.bin other:/tmp/     # copy this instance's file into another instance\n\n" +
+			"Given a single `:`/instance source the file lands in your downloads folder.\n" +
 			"Needs the fleet TUI connected on the other end."
 	}
 
@@ -56,49 +57,39 @@ func newCopyCmd() *cobra.Command {
 		Long:    long,
 		Args:    cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			dest := ""
+			dst := ""
 			if len(args) == 2 {
-				dest = args[1]
+				dst = args[1]
 			}
-			if target, srcPath, ok := splitCopySource(args[0]); ok {
-				return copyFromInstance(cmd.Context(), cmd.OutOrStdout(), target, srcPath, dest)
-			}
-			// The in-instance form: like `fleet launch`, message the host over
-			// the control socket; the connected TUI pulls the file — to dest on
-			// the user's machine when given, their downloads folder otherwise.
-			return fleetcopy.Request(fleetcopy.Config{}, cmd.OutOrStdout(), args[0], dest)
+			return runCopy(cmd.Context(), cmd.OutOrStdout(), args[0], dst)
 		},
 	}
 }
 
-// splitCopySource splits a "[fleet/]instance:path" source argument; ok is false
-// when the argument is a plain local path (the in-instance form). Mirrors scp's
-// disambiguation rule: anything starting with /, . or ~ is always a path, so a
-// local filename containing a colon can be spelled unambiguously.
-func splitCopySource(arg string) (target, path string, ok bool) {
-	i := strings.Index(arg, ":")
-	if i <= 0 {
-		return "", "", false
+// runCopy validates the arguments and routes the copy: in-instance invocations
+// delegate to the connected host TUI; host invocations drive the fleet server
+// directly. The single-argument form is a download shorthand, so a lone source
+// must name an instance — a lone local path has no destination.
+func runCopy(ctx context.Context, out io.Writer, src, dst string) error {
+	if dst == "" && fleetclient.ParseCopyEndpoint(src).Kind == fleetclient.CopyLocal {
+		return fmt.Errorf("a destination is required: %q is a local file, so name where it should go (e.g. `fleet copy %s instance:/path`)", src, src)
 	}
-	if strings.HasPrefix(arg, "/") || strings.HasPrefix(arg, ".") || strings.HasPrefix(arg, "~") {
-		return "", "", false
+	if fleetcopy.InInstance() {
+		// The container can't reach the host fleetd over gRPC; ask the connected
+		// TUI to perform the copy against the host fleet (its disk is "local").
+		return fleetcopy.Request(fleetcopy.Config{}, out, src, dst)
 	}
-	// The instance reference is "instance" or "fleet/instance" — nothing more.
-	prefix := arg[:i]
-	parts := strings.Split(prefix, "/")
-	if len(parts) > 2 || slices.Contains(parts, "") {
-		return "", "", false
-	}
-	if arg[i+1:] == "" {
-		return "", "", false
-	}
-	return prefix, arg[i+1:], true
+	return hostCopy(ctx, out, src, dst)
 }
 
-// copyFromInstance is the host-side form: pull fleet/instance:srcPath through
-// the server's CopyFile stream and write it to dest locally.
-func copyFromInstance(ctx context.Context, out io.Writer, targetName, srcPath, dest string) error {
-	target, err := fleet.Resolve(targetName, "")
+// hostCopy resolves both endpoints against the host fleet and runs the generic
+// copy engine over the dialled fleet server, with the CLI's own disk as local.
+func hostCopy(ctx context.Context, out io.Writer, src, dst string) error {
+	srcEnd, err := resolveHostEndpoint(src)
+	if err != nil {
+		return err
+	}
+	dstEnd, err := resolveHostEndpoint(dst)
 	if err != nil {
 		return err
 	}
@@ -107,10 +98,33 @@ func copyFromInstance(ctx context.Context, out io.Writer, targetName, srcPath, d
 		return err
 	}
 	defer conn.Close()
-	destPath, written, err := fleetclient.CopyFileTo(ctx, conn.Service(), target.Fleet, target.Instance, srcPath, dest)
+	res, err := fleetclient.Copy(ctx, conn.Service(), srcEnd, dstEnd, fleetclient.HostLocalPolicy{})
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "Copied %s/%s:%s -> %s (%d bytes)\n", target.Fleet, target.Instance, srcPath, destPath, written)
+	fmt.Fprintf(out, "Copied %s -> %s (%d bytes)\n", src, res.DestPath, res.Written)
 	return nil
+}
+
+// resolveHostEndpoint turns a typed argument into a ResolvedEndpoint for the host
+// form: a local path stays local, an instance reference resolves its fleet (a
+// bare instance infers it from the cwd, like the rest of the CLI), and `:path`
+// (self) is rejected — there is no current instance when run on a host.
+func resolveHostEndpoint(arg string) (fleetclient.ResolvedEndpoint, error) {
+	ep := fleetclient.ParseCopyEndpoint(arg)
+	switch ep.Kind {
+	case fleetclient.CopyLocal:
+		return fleetclient.ResolvedEndpoint{Local: true, Path: ep.Path}, nil
+	case fleetclient.CopySelf:
+		return fleetclient.ResolvedEndpoint{}, fmt.Errorf("`:path` means the current instance and only works inside one — name the fleet/instance instead (got %q)", arg)
+	default:
+		if ep.Fleet != "" {
+			return fleetclient.ResolvedEndpoint{Fleet: ep.Fleet, Instance: ep.Instance, Path: ep.Path}, nil
+		}
+		target, err := fleet.Resolve(ep.Instance, "")
+		if err != nil {
+			return fleetclient.ResolvedEndpoint{}, err
+		}
+		return fleetclient.ResolvedEndpoint{Fleet: target.Fleet, Instance: target.Instance, Path: ep.Path}, nil
+	}
 }

--- a/internal/cli/copy_test.go
+++ b/internal/cli/copy_test.go
@@ -1,39 +1,46 @@
 package cli
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetclient"
 )
 
-func TestSplitCopySource(t *testing.T) {
+// TestResolveHostEndpoint covers the host-form endpoint resolution: a plain path
+// stays local, an explicit fleet/instance passes through, and `:path` (self) is
+// rejected because a host invocation has no current instance. A bare instance
+// (which infers the fleet from the cwd git remote) is exercised by integration
+// tests, not here.
+func TestResolveHostEndpoint(t *testing.T) {
 	cases := []struct {
-		arg        string
-		wantTarget string
-		wantPath   string
-		wantOK     bool
+		arg  string
+		want fleetclient.ResolvedEndpoint
 	}{
-		{"alpha:bin/tool", "alpha", "bin/tool", true},
-		{"myfleet/alpha:/abs/path", "myfleet/alpha", "/abs/path", true},
-		{"alpha:/path/with:colon", "alpha", "/path/with:colon", true},
-		// Plain paths — the in-instance form.
-		{"bin/tool", "", "", false},
-		{"/abs/path", "", "", false},
-		{"./weird:name", "", "", false},
-		{"../up:name", "", "", false},
-		{"~/home:file", "", "", false},
-		// Malformed instance references.
-		{":path", "", "", false},
-		{"alpha:", "", "", false},
-		{"a/b/c:path", "", "", false},
-		{"/alpha:path", "", "", false},
-		{"alpha/:path", "", "", false},
+		{"./tool", fleetclient.ResolvedEndpoint{Local: true, Path: "./tool"}},
+		{"/abs/tool", fleetclient.ResolvedEndpoint{Local: true, Path: "/abs/tool"}},
+		{"tool.txt", fleetclient.ResolvedEndpoint{Local: true, Path: "tool.txt"}},
+		{"", fleetclient.ResolvedEndpoint{Local: true, Path: ""}},
+		{"myfleet/alpha:/bin/tool", fleetclient.ResolvedEndpoint{Fleet: "myfleet", Instance: "alpha", Path: "/bin/tool"}},
+		{"myfleet/alpha:rel/path", fleetclient.ResolvedEndpoint{Fleet: "myfleet", Instance: "alpha", Path: "rel/path"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.arg, func(t *testing.T) {
-			target, path, ok := splitCopySource(tc.arg)
-			if target != tc.wantTarget || path != tc.wantPath || ok != tc.wantOK {
-				t.Errorf("splitCopySource(%q) = (%q,%q,%v), want (%q,%q,%v)",
-					tc.arg, target, path, ok, tc.wantTarget, tc.wantPath, tc.wantOK)
+			got, err := resolveHostEndpoint(tc.arg)
+			if err != nil {
+				t.Fatalf("resolveHostEndpoint(%q): %v", tc.arg, err)
+			}
+			if got != tc.want {
+				t.Errorf("resolveHostEndpoint(%q) = %+v, want %+v", tc.arg, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestResolveHostEndpointRejectsSelf confirms `:path` errors on a host, where
+// there is no current instance to mean.
+func TestResolveHostEndpointRejectsSelf(t *testing.T) {
+	if _, err := resolveHostEndpoint(":build/tool"); err == nil || !strings.Contains(err.Error(), "inside") {
+		t.Fatalf("self on host: want error mentioning inside-an-instance, got %v", err)
 	}
 }

--- a/internal/control/client.go
+++ b/internal/control/client.go
@@ -78,11 +78,11 @@ func (c *Client) OpenBrowser(url string) error {
 	return c.Send(TypeOpenBrowser, OpenBrowserPayload{URL: url})
 }
 
-// CopyFile is a typed convenience over Send for TypeCopyFile: it asks the host
-// to copy the file at the absolute in-instance path out to the user's machine —
-// to dest there when given, the user's downloads folder otherwise.
-func (c *Client) CopyFile(path, dest string) error {
-	return c.Send(TypeCopyFile, CopyFilePayload{Path: path, Dest: dest})
+// CopyFile is a typed convenience over Send for TypeCopyFile: it asks the
+// connected host TUI to perform a scp-style copy between src and dst (endpoints
+// as typed inside the instance). An empty dst is the download shorthand.
+func (c *Client) CopyFile(src, dst string) error {
+	return c.Send(TypeCopyFile, CopyFilePayload{Src: src, Dst: dst})
 }
 
 // Close closes the underlying connection. It is safe to call once; further

--- a/internal/control/control.go
+++ b/internal/control/control.go
@@ -44,7 +44,8 @@ const (
 	// TypeOpenBrowser asks the host to open (or navigate) its browser to a
 	// URL. Its payload is OpenBrowserPayload.
 	TypeOpenBrowser = "browser.open"
-	// TypeCopyFile asks the host to copy a file out of this instance to the
-	// host user's machine. Its payload is CopyFilePayload.
+	// TypeCopyFile asks the connected host TUI to perform a scp-style copy
+	// between two endpoints (out of, into, or between instances) on this
+	// instance's behalf. Its payload is CopyFilePayload.
 	TypeCopyFile = "file.copy"
 )

--- a/internal/control/copy_file_payload.go
+++ b/internal/control/copy_file_payload.go
@@ -1,15 +1,15 @@
 package control
 
-// CopyFilePayload is the body of a TypeCopyFile Envelope: the in-instance file
-// the host should copy out to the user's machine. The receiving client pulls
-// the bytes itself (over the CopyFile RPC) — this message only names the file.
+// CopyFilePayload is the body of a TypeCopyFile Envelope: a scp-style copy the
+// in-instance `fc` is asking the connected host TUI to perform on its behalf
+// (the container can't reach the host fleetd over gRPC, only this socket). Src
+// and Dst are the two endpoints AS TYPED inside the instance — each either
+// `[fleet/]instance:path`, a plain path on the host TUI's machine, or `:path`
+// (the current instance). The TUI runs the generic copy engine over them.
 type CopyFilePayload struct {
-	// Path is the absolute in-instance path of the file to copy. The sender
-	// resolves it against its own working directory before sending, so the
-	// host-side read needs no cwd context.
-	Path string `json:"path"`
-	// Dest is the optional destination on the user's machine; empty means the
-	// user's downloads folder. It is passed through verbatim — only the
-	// receiving client can interpret a path on its own filesystem.
-	Dest string `json:"dest,omitempty"`
+	// Src is the source endpoint as typed inside the instance.
+	Src string `json:"src"`
+	// Dst is the destination endpoint as typed inside the instance. Empty is the
+	// 1-arg download shorthand (deliver to the TUI's downloads folder).
+	Dst string `json:"dst,omitempty"`
 }

--- a/internal/fleetclient/copyendpoint.go
+++ b/internal/fleetclient/copyendpoint.go
@@ -1,0 +1,64 @@
+package fleetclient
+
+import (
+	"slices"
+	"strings"
+)
+
+// copyendpoint.go classifies the two arguments of a scp-style `fleet copy`. An
+// endpoint is one of three kinds; direction is inferred from which side is local
+// vs an instance. The parser is shared by the CLI (host form) and is mirrored by
+// the in-instance form, so a path means the same thing everywhere.
+
+// CopyEndpointKind classifies one side of a copy.
+type CopyEndpointKind int
+
+const (
+	// CopyLocal is a plain path on the orchestrating client's own disk.
+	CopyLocal CopyEndpointKind = iota
+	// CopyInstance is `[fleet/]instance:path` — a path inside a named instance.
+	CopyInstance
+	// CopySelf is `:path` — a path inside the CURRENT instance. Only meaningful
+	// in the in-instance form, where the originating instance is known; the host
+	// form rejects it (there is no "current" instance).
+	CopySelf
+)
+
+// CopyEndpoint is one parsed side of a copy.
+type CopyEndpoint struct {
+	Kind     CopyEndpointKind
+	Fleet    string // set for CopyInstance when a fleet was named ("fleet/instance")
+	Instance string // set for CopyInstance
+	Path     string // the path component (the whole arg for CopyLocal)
+}
+
+// ParseCopyEndpoint classifies a `fleet copy` argument, scp-style:
+//
+//   - a leading '/', '.' or '~' always forces a LOCAL path (so a local filename
+//     containing a colon is still reachable, spelled "./name:with:colon"),
+//   - ":path" (empty prefix, non-empty path) is the CURRENT instance (SELF),
+//   - "[fleet/]instance:path" is a named INSTANCE,
+//   - anything else — including a malformed instance ref or an empty path after
+//     the colon — is treated as LOCAL, so the caller's existence check yields a
+//     plain "no such file" rather than a confusing parse error.
+func ParseCopyEndpoint(arg string) CopyEndpoint {
+	i := strings.Index(arg, ":")
+	if i < 0 || strings.HasPrefix(arg, "/") || strings.HasPrefix(arg, ".") || strings.HasPrefix(arg, "~") {
+		return CopyEndpoint{Kind: CopyLocal, Path: arg}
+	}
+	path := arg[i+1:]
+	if path == "" {
+		return CopyEndpoint{Kind: CopyLocal, Path: arg}
+	}
+	if i == 0 {
+		return CopyEndpoint{Kind: CopySelf, Path: path}
+	}
+	parts := strings.Split(arg[:i], "/")
+	if len(parts) > 2 || slices.Contains(parts, "") {
+		return CopyEndpoint{Kind: CopyLocal, Path: arg}
+	}
+	if len(parts) == 2 {
+		return CopyEndpoint{Kind: CopyInstance, Fleet: parts[0], Instance: parts[1], Path: path}
+	}
+	return CopyEndpoint{Kind: CopyInstance, Instance: parts[0], Path: path}
+}

--- a/internal/fleetclient/copyendpoint.go
+++ b/internal/fleetclient/copyendpoint.go
@@ -1,6 +1,7 @@
 package fleetclient
 
 import (
+	"path/filepath"
 	"slices"
 	"strings"
 )
@@ -34,8 +35,10 @@ type CopyEndpoint struct {
 
 // ParseCopyEndpoint classifies a `fleet copy` argument, scp-style:
 //
-//   - a leading '/', '.' or '~' always forces a LOCAL path (so a local filename
-//     containing a colon is still reachable, spelled "./name:with:colon"),
+//   - a leading '/', '.' or '~', or a platform-absolute path (so a Windows
+//     "C:\file" is local, not an instance named "C"), always forces a LOCAL path
+//     (a local filename containing a colon is still reachable, spelled
+//     "./name:with:colon"),
 //   - ":path" (empty prefix, non-empty path) is the CURRENT instance (SELF),
 //   - "[fleet/]instance:path" is a named INSTANCE,
 //   - anything else — including a malformed instance ref or an empty path after
@@ -43,7 +46,7 @@ type CopyEndpoint struct {
 //     plain "no such file" rather than a confusing parse error.
 func ParseCopyEndpoint(arg string) CopyEndpoint {
 	i := strings.Index(arg, ":")
-	if i < 0 || strings.HasPrefix(arg, "/") || strings.HasPrefix(arg, ".") || strings.HasPrefix(arg, "~") {
+	if i < 0 || strings.HasPrefix(arg, "/") || strings.HasPrefix(arg, ".") || strings.HasPrefix(arg, "~") || filepath.IsAbs(arg) {
 		return CopyEndpoint{Kind: CopyLocal, Path: arg}
 	}
 	path := arg[i+1:]

--- a/internal/fleetclient/copyendpoint_test.go
+++ b/internal/fleetclient/copyendpoint_test.go
@@ -1,0 +1,40 @@
+package fleetclient
+
+import "testing"
+
+func TestParseCopyEndpoint(t *testing.T) {
+	cases := []struct {
+		arg  string
+		want CopyEndpoint
+	}{
+		// Instance references.
+		{"alpha:bin/tool", CopyEndpoint{Kind: CopyInstance, Instance: "alpha", Path: "bin/tool"}},
+		{"myfleet/alpha:/abs/path", CopyEndpoint{Kind: CopyInstance, Fleet: "myfleet", Instance: "alpha", Path: "/abs/path"}},
+		{"alpha:/path/with:colon", CopyEndpoint{Kind: CopyInstance, Instance: "alpha", Path: "/path/with:colon"}},
+		// Self references (the current instance).
+		{":path", CopyEndpoint{Kind: CopySelf, Path: "path"}},
+		{":bin/tool", CopyEndpoint{Kind: CopySelf, Path: "bin/tool"}},
+		// Plain local paths — a leading /, . or ~ always forces local.
+		{"bin/tool", CopyEndpoint{Kind: CopyLocal, Path: "bin/tool"}},
+		{"/abs/path", CopyEndpoint{Kind: CopyLocal, Path: "/abs/path"}},
+		{"./weird:name", CopyEndpoint{Kind: CopyLocal, Path: "./weird:name"}},
+		{"../up:name", CopyEndpoint{Kind: CopyLocal, Path: "../up:name"}},
+		{"~/home:file", CopyEndpoint{Kind: CopyLocal, Path: "~/home:file"}},
+		{"", CopyEndpoint{Kind: CopyLocal, Path: ""}},
+		// Malformed instance references fall back to local (the caller's
+		// existence check then yields a plain "no such file").
+		{"alpha:", CopyEndpoint{Kind: CopyLocal, Path: "alpha:"}},
+		{":", CopyEndpoint{Kind: CopyLocal, Path: ":"}},
+		{"a/b/c:path", CopyEndpoint{Kind: CopyLocal, Path: "a/b/c:path"}},
+		{"/alpha:path", CopyEndpoint{Kind: CopyLocal, Path: "/alpha:path"}},
+		{"alpha/:path", CopyEndpoint{Kind: CopyLocal, Path: "alpha/:path"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.arg, func(t *testing.T) {
+			got := ParseCopyEndpoint(tc.arg)
+			if got != tc.want {
+				t.Errorf("ParseCopyEndpoint(%q) = %+v, want %+v", tc.arg, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/fleetclient/copyengine.go
+++ b/internal/fleetclient/copyengine.go
@@ -144,7 +144,14 @@ func downloadInstanceToLocal(ctx context.Context, svc fleetgrpc.FleetServiceClie
 		return CopyResult{}, fmt.Errorf("copy %s/%s:%s: server sent no file metadata", src.Fleet, src.Instance, src.Path)
 	}
 
-	destPath, err := policy.ResolveDest(dstTyped, meta.GetName())
+	// The default local filename comes from the server; reduce it to a bare
+	// basename so a malicious/compromised server cannot steer a directory dest
+	// into an arbitrary path on this machine (e.g. name "../../.ssh/authorized_keys").
+	name := filepath.Base(meta.GetName())
+	if name == "." || name == ".." || name == string(filepath.Separator) {
+		return CopyResult{}, fmt.Errorf("copy %s/%s:%s: server sent an invalid file name %q", src.Fleet, src.Instance, src.Path, meta.GetName())
+	}
+	destPath, err := policy.ResolveDest(dstTyped, name)
 	if err != nil {
 		return CopyResult{}, err
 	}
@@ -249,9 +256,15 @@ func relayInstanceToInstance(ctx context.Context, svc fleetgrpc.FleetServiceClie
 }
 
 // copyLocalToLocal copies one local file to another on the orchestrator's disk —
-// the degenerate case where neither endpoint is an instance.
+// the degenerate case where neither endpoint is an instance. The bytes are
+// streamed (not slurped) so a large file does not balloon memory.
 func copyLocalToLocal(srcPath, dstTyped string, policy CopyLocalPolicy) (CopyResult, error) {
-	fi, err := os.Stat(srcPath)
+	in, err := os.Open(srcPath)
+	if err != nil {
+		return CopyResult{}, err
+	}
+	defer in.Close()
+	fi, err := in.Stat()
 	if err != nil {
 		return CopyResult{}, err
 	}
@@ -262,14 +275,22 @@ func copyLocalToLocal(srcPath, dstTyped string, policy CopyLocalPolicy) (CopyRes
 	if err != nil {
 		return CopyResult{}, err
 	}
-	data, err := os.ReadFile(srcPath)
+	out, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fi.Mode().Perm())
 	if err != nil {
 		return CopyResult{}, err
 	}
-	if err := os.WriteFile(destPath, data, fi.Mode().Perm()); err != nil {
-		return CopyResult{}, err
+	written, copyErr := io.Copy(out, in)
+	if copyErr == nil {
+		// Set the mode explicitly so it is preserved even when overwriting.
+		copyErr = out.Chmod(fi.Mode().Perm())
 	}
-	return CopyResult{DestPath: destPath, Written: int64(len(data))}, nil
+	if closeErr := out.Close(); copyErr == nil {
+		copyErr = closeErr
+	}
+	if copyErr != nil {
+		return CopyResult{}, copyErr
+	}
+	return CopyResult{DestPath: destPath, Written: written}, nil
 }
 
 // requireRegularFile rejects a local source that is a directory or special file —

--- a/internal/fleetclient/copyengine.go
+++ b/internal/fleetclient/copyengine.go
@@ -93,30 +93,33 @@ func uploadLocalToInstance(ctx context.Context, svc fleetgrpc.FleetServiceClient
 	if err != nil {
 		return CopyResult{}, err
 	}
-	if err := stream.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Open{Open: &fleetgrpc.CopyIntoOpen{
+
+	// A Send error (notably io.EOF) only means the server closed the stream — it
+	// is NOT the real failure. Stop sending and let CloseAndRecv surface the
+	// server's actual status (e.g. "destination directory does not exist").
+	sendErr := stream.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Open{Open: &fleetgrpc.CopyIntoOpen{
 		Fleet:    dst.Fleet,
 		Instance: dst.Instance,
 		Dest:     dst.Path,
 		Name:     filepath.Base(srcPath),
 		Mode:     uint32(fi.Mode().Perm()),
 		Size:     fi.Size(),
-	}}}); err != nil {
-		return CopyResult{}, err
-	}
-
-	buf := make([]byte, copyChunkSize)
-	for {
-		n, readErr := f.Read(buf)
-		if n > 0 {
-			if err := stream.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Data{Data: buf[:n]}}); err != nil {
-				return CopyResult{}, err
+	}}})
+	if sendErr == nil {
+		buf := make([]byte, copyChunkSize)
+		for {
+			n, readErr := f.Read(buf)
+			if n > 0 {
+				if sendErr = stream.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Data{Data: buf[:n]}}); sendErr != nil {
+					break
+				}
 			}
-		}
-		if readErr == io.EOF {
-			break
-		}
-		if readErr != nil {
-			return CopyResult{}, readErr
+			if readErr == io.EOF {
+				break
+			}
+			if readErr != nil {
+				return CopyResult{}, readErr
+			}
 		}
 	}
 	reply, err := stream.CloseAndRecv()
@@ -222,30 +225,26 @@ func relayInstanceToInstance(ctx context.Context, svc fleetgrpc.FleetServiceClie
 	if err != nil {
 		return CopyResult{}, err
 	}
-	if err := in.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Open{Open: &fleetgrpc.CopyIntoOpen{
+	// As in uploadLocalToInstance, a Send error (incl. io.EOF) just means the
+	// destination stream closed; CloseAndRecv carries the real status.
+	sendErr := in.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Open{Open: &fleetgrpc.CopyIntoOpen{
 		Fleet:    dst.Fleet,
 		Instance: dst.Instance,
 		Dest:     dst.Path,
 		Name:     meta.GetName(),
 		Mode:     meta.GetMode(),
 		Size:     meta.GetSize(),
-	}}}); err != nil {
-		return CopyResult{}, err
-	}
-	for {
-		chunk, err := out.Recv()
-		if err == io.EOF {
+	}}})
+	for sendErr == nil {
+		chunk, recvErr := out.Recv()
+		if recvErr == io.EOF {
 			break
 		}
-		if err != nil {
-			return CopyResult{}, err
+		if recvErr != nil {
+			return CopyResult{}, recvErr
 		}
-		data := chunk.GetData()
-		if len(data) == 0 {
-			continue
-		}
-		if err := in.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Data{Data: data}}); err != nil {
-			return CopyResult{}, err
+		if data := chunk.GetData(); len(data) > 0 {
+			sendErr = in.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Data{Data: data}})
 		}
 	}
 	reply, err := in.CloseAndRecv()

--- a/internal/fleetclient/copyengine.go
+++ b/internal/fleetclient/copyengine.go
@@ -1,0 +1,285 @@
+package fleetclient
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+)
+
+// copyengine.go is the generic, single-orchestrator copy engine behind scp-style
+// `fleet copy`. It moves one file between two RESOLVED endpoints (a front-end has
+// already turned `[fleet/]instance:path`, a plain path, or `:path` into a concrete
+// local-path or fleet/instance/path), dispatching on which sides are local vs
+// instances. The same engine runs in two front-ends: the host `fleet` CLI (with
+// its own disk as "local") and the host TUI (running a delegated in-instance copy,
+// with the human's disk as "local"). Instance endpoints are reached only over the
+// CopyFile/CopyInto RPCs, so the engine works unchanged against a remote fleetd.
+
+// copyChunkSize bounds one CopyInto data frame — matches the server's read size
+// and is comfortably under gRPC's 4 MB message ceiling.
+const copyChunkSize = 64 * 1024
+
+// ResolvedEndpoint is one side of a copy after a front-end has resolved any
+// fleet/self reference: either a local path (Local true) or a path inside a
+// concrete instance.
+type ResolvedEndpoint struct {
+	Local    bool
+	Fleet    string
+	Instance string
+	Path     string
+}
+
+// CopyLocalPolicy maps typed local paths onto the orchestrating client's
+// filesystem. The host CLI resolves relative to the process cwd; the host TUI
+// (running a delegated in-instance copy) resolves relative to the human's home
+// and downloads folder. Keeping it injectable is what lets one engine serve both.
+type CopyLocalPolicy interface {
+	// ResolveSrc maps a typed local SOURCE path to the absolute path to read.
+	ResolveSrc(path string) string
+	// ResolveDest maps a typed local DEST to the absolute path to write, given
+	// the source basename — an empty dest, or a dest that is (or is spelled like)
+	// a directory, keeps that name.
+	ResolveDest(dest, srcName string) (string, error)
+}
+
+// CopyResult reports where a copy landed and how many file bytes moved.
+type CopyResult struct {
+	DestPath string // the final path written (local abs path, or in-instance abs path)
+	Written  int64
+}
+
+// Copy performs one scp-style copy between two resolved endpoints, dispatching on
+// which sides are local vs instances:
+//
+//   - local → instance: upload via the CopyInto RPC,
+//   - instance → local: download via the CopyFile RPC,
+//   - instance → instance: relay one CopyFile stream into one CopyInto stream,
+//   - local → local: a plain file copy on the orchestrator's disk.
+func Copy(ctx context.Context, svc fleetgrpc.FleetServiceClient, src, dst ResolvedEndpoint, policy CopyLocalPolicy) (CopyResult, error) {
+	switch {
+	case src.Local && !dst.Local:
+		return uploadLocalToInstance(ctx, svc, policy.ResolveSrc(src.Path), dst)
+	case !src.Local && dst.Local:
+		return downloadInstanceToLocal(ctx, svc, src, dst.Path, policy)
+	case !src.Local && !dst.Local:
+		return relayInstanceToInstance(ctx, svc, src, dst)
+	default:
+		return copyLocalToLocal(policy.ResolveSrc(src.Path), dst.Path, policy)
+	}
+}
+
+// uploadLocalToInstance streams srcPath into dst over the CopyInto RPC. The local
+// file is stat'd up front so its size rides the open header (the server needs it
+// for the tar archive and enforces it as a hard cap).
+func uploadLocalToInstance(ctx context.Context, svc fleetgrpc.FleetServiceClient, srcPath string, dst ResolvedEndpoint) (CopyResult, error) {
+	fi, err := os.Stat(srcPath)
+	if err != nil {
+		return CopyResult{}, err
+	}
+	if err := requireRegularFile(srcPath, fi); err != nil {
+		return CopyResult{}, err
+	}
+	f, err := os.Open(srcPath)
+	if err != nil {
+		return CopyResult{}, err
+	}
+	defer f.Close()
+
+	stream, err := svc.CopyInto(ctx)
+	if err != nil {
+		return CopyResult{}, err
+	}
+	if err := stream.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Open{Open: &fleetgrpc.CopyIntoOpen{
+		Fleet:    dst.Fleet,
+		Instance: dst.Instance,
+		Dest:     dst.Path,
+		Name:     filepath.Base(srcPath),
+		Mode:     uint32(fi.Mode().Perm()),
+		Size:     fi.Size(),
+	}}}); err != nil {
+		return CopyResult{}, err
+	}
+
+	buf := make([]byte, copyChunkSize)
+	for {
+		n, readErr := f.Read(buf)
+		if n > 0 {
+			if err := stream.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Data{Data: buf[:n]}}); err != nil {
+				return CopyResult{}, err
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return CopyResult{}, readErr
+		}
+	}
+	reply, err := stream.CloseAndRecv()
+	if err != nil {
+		return CopyResult{}, err
+	}
+	return CopyResult{DestPath: reply.GetPath(), Written: reply.GetWritten()}, nil
+}
+
+// downloadInstanceToLocal pulls src over the CopyFile RPC and writes it to the
+// path the policy resolves for the source basename. The bytes go to a temp file
+// in the destination directory first and are renamed into place on success, so a
+// half-finished copy never replaces a previous good one (scp semantics).
+func downloadInstanceToLocal(ctx context.Context, svc fleetgrpc.FleetServiceClient, src ResolvedEndpoint, dstTyped string, policy CopyLocalPolicy) (CopyResult, error) {
+	stream, err := svc.CopyFile(ctx, &fleetgrpc.CopyFileRequest{Fleet: src.Fleet, Instance: src.Instance, Path: src.Path})
+	if err != nil {
+		return CopyResult{}, err
+	}
+	first, err := stream.Recv()
+	if err != nil {
+		return CopyResult{}, err
+	}
+	meta := first.GetMeta()
+	if meta == nil {
+		return CopyResult{}, fmt.Errorf("copy %s/%s:%s: server sent no file metadata", src.Fleet, src.Instance, src.Path)
+	}
+
+	destPath, err := policy.ResolveDest(dstTyped, meta.GetName())
+	if err != nil {
+		return CopyResult{}, err
+	}
+	mode := os.FileMode(meta.GetMode()).Perm()
+	if mode == 0 {
+		mode = 0o644
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(destPath), "."+filepath.Base(destPath)+".fleetcopy-*")
+	if err != nil {
+		return CopyResult{}, err
+	}
+	defer func() {
+		// Best-effort cleanup on every early-error path; a clean rename leaves
+		// nothing for these to do.
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+	}()
+	if err := tmp.Chmod(mode); err != nil {
+		return CopyResult{}, err
+	}
+
+	var written int64
+	for {
+		chunk, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return CopyResult{}, err
+		}
+		data := chunk.GetData()
+		if len(data) == 0 {
+			continue
+		}
+		n, err := tmp.Write(data)
+		written += int64(n)
+		if err != nil {
+			return CopyResult{}, err
+		}
+	}
+	if err := tmp.Close(); err != nil {
+		return CopyResult{}, err
+	}
+	if err := os.Rename(tmp.Name(), destPath); err != nil {
+		return CopyResult{}, err
+	}
+	return CopyResult{DestPath: destPath, Written: written}, nil
+}
+
+// relayInstanceToInstance copies between two instances without touching local
+// disk: the source's CopyFile stream is pumped straight into the destination's
+// CopyInto stream, with the source meta (name/mode/size) seeding the open header.
+func relayInstanceToInstance(ctx context.Context, svc fleetgrpc.FleetServiceClient, src, dst ResolvedEndpoint) (CopyResult, error) {
+	out, err := svc.CopyFile(ctx, &fleetgrpc.CopyFileRequest{Fleet: src.Fleet, Instance: src.Instance, Path: src.Path})
+	if err != nil {
+		return CopyResult{}, err
+	}
+	first, err := out.Recv()
+	if err != nil {
+		return CopyResult{}, err
+	}
+	meta := first.GetMeta()
+	if meta == nil {
+		return CopyResult{}, fmt.Errorf("copy %s/%s:%s: server sent no file metadata", src.Fleet, src.Instance, src.Path)
+	}
+
+	in, err := svc.CopyInto(ctx)
+	if err != nil {
+		return CopyResult{}, err
+	}
+	if err := in.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Open{Open: &fleetgrpc.CopyIntoOpen{
+		Fleet:    dst.Fleet,
+		Instance: dst.Instance,
+		Dest:     dst.Path,
+		Name:     meta.GetName(),
+		Mode:     meta.GetMode(),
+		Size:     meta.GetSize(),
+	}}}); err != nil {
+		return CopyResult{}, err
+	}
+	for {
+		chunk, err := out.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return CopyResult{}, err
+		}
+		data := chunk.GetData()
+		if len(data) == 0 {
+			continue
+		}
+		if err := in.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Data{Data: data}}); err != nil {
+			return CopyResult{}, err
+		}
+	}
+	reply, err := in.CloseAndRecv()
+	if err != nil {
+		return CopyResult{}, err
+	}
+	return CopyResult{DestPath: reply.GetPath(), Written: reply.GetWritten()}, nil
+}
+
+// copyLocalToLocal copies one local file to another on the orchestrator's disk —
+// the degenerate case where neither endpoint is an instance.
+func copyLocalToLocal(srcPath, dstTyped string, policy CopyLocalPolicy) (CopyResult, error) {
+	fi, err := os.Stat(srcPath)
+	if err != nil {
+		return CopyResult{}, err
+	}
+	if err := requireRegularFile(srcPath, fi); err != nil {
+		return CopyResult{}, err
+	}
+	destPath, err := policy.ResolveDest(dstTyped, filepath.Base(srcPath))
+	if err != nil {
+		return CopyResult{}, err
+	}
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return CopyResult{}, err
+	}
+	if err := os.WriteFile(destPath, data, fi.Mode().Perm()); err != nil {
+		return CopyResult{}, err
+	}
+	return CopyResult{DestPath: destPath, Written: int64(len(data))}, nil
+}
+
+// requireRegularFile rejects a local source that is a directory or special file —
+// only single regular files can be copied, matching the instance side.
+func requireRegularFile(path string, fi os.FileInfo) error {
+	if fi.IsDir() {
+		return fmt.Errorf("%s is a directory — only single files can be copied", path)
+	}
+	if !fi.Mode().IsRegular() {
+		return fmt.Errorf("%s is not a regular file", path)
+	}
+	return nil
+}

--- a/internal/fleetclient/copyengine.go
+++ b/internal/fleetclient/copyengine.go
@@ -255,8 +255,10 @@ func relayInstanceToInstance(ctx context.Context, svc fleetgrpc.FleetServiceClie
 }
 
 // copyLocalToLocal copies one local file to another on the orchestrator's disk —
-// the degenerate case where neither endpoint is an instance. The bytes are
-// streamed (not slurped) so a large file does not balloon memory.
+// the degenerate case where neither endpoint is an instance. Bytes are streamed
+// (not slurped) so a large file doesn't balloon memory, and written through a
+// temp file renamed into place on success, so a failed copy never leaves a
+// partial — matching the atomicity of the instance directions.
 func copyLocalToLocal(srcPath, dstTyped string, policy CopyLocalPolicy) (CopyResult, error) {
 	in, err := os.Open(srcPath)
 	if err != nil {
@@ -274,20 +276,27 @@ func copyLocalToLocal(srcPath, dstTyped string, policy CopyLocalPolicy) (CopyRes
 	if err != nil {
 		return CopyResult{}, err
 	}
-	out, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fi.Mode().Perm())
+
+	tmp, err := os.CreateTemp(filepath.Dir(destPath), "."+filepath.Base(destPath)+".fleetcopy-*")
 	if err != nil {
 		return CopyResult{}, err
 	}
-	written, copyErr := io.Copy(out, in)
-	if copyErr == nil {
-		// Set the mode explicitly so it is preserved even when overwriting.
-		copyErr = out.Chmod(fi.Mode().Perm())
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+	}()
+	if err := tmp.Chmod(fi.Mode().Perm()); err != nil {
+		return CopyResult{}, err
 	}
-	if closeErr := out.Close(); copyErr == nil {
-		copyErr = closeErr
+	written, err := io.Copy(tmp, in)
+	if err != nil {
+		return CopyResult{}, err
 	}
-	if copyErr != nil {
-		return CopyResult{}, copyErr
+	if err := tmp.Close(); err != nil {
+		return CopyResult{}, err
+	}
+	if err := os.Rename(tmp.Name(), destPath); err != nil {
+		return CopyResult{}, err
 	}
 	return CopyResult{DestPath: destPath, Written: written}, nil
 }

--- a/internal/fleetclient/copyengine_test.go
+++ b/internal/fleetclient/copyengine_test.go
@@ -1,0 +1,250 @@
+package fleetclient
+
+import (
+	"context"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// fakeCopyServer is an in-memory FleetService exposing just CopyFile + CopyInto,
+// so the generic engine can be driven through every direction over the REAL
+// generated streaming code without a backend/container. Files are keyed
+// "fleet/instance:path"; a CopyInto stores the bytes back as a readable file so
+// instance→instance relays round-trip.
+type fakeCopyServer struct {
+	fleetgrpc.UnimplementedFleetServiceServer
+	mu    sync.Mutex
+	files map[string]fakeFile
+	intos []capturedInto
+}
+
+type fakeFile struct {
+	name string
+	mode uint32
+	data []byte
+}
+
+type capturedInto struct {
+	fleet, instance, dest, name string
+	mode                        uint32
+	size                        int64
+	data                        []byte
+}
+
+func newFakeCopyServer() *fakeCopyServer { return &fakeCopyServer{files: map[string]fakeFile{}} }
+
+func fileKey(fleet, instance, path string) string { return fleet + "/" + instance + ":" + path }
+
+func (f *fakeCopyServer) CopyFile(req *fleetgrpc.CopyFileRequest, stream grpc.ServerStreamingServer[fleetgrpc.CopyFileChunk]) error {
+	f.mu.Lock()
+	file, ok := f.files[fileKey(req.GetFleet(), req.GetInstance(), req.GetPath())]
+	f.mu.Unlock()
+	if !ok {
+		return status.Errorf(codes.NotFound, "no file %s", req.GetPath())
+	}
+	if err := stream.Send(&fleetgrpc.CopyFileChunk{Msg: &fleetgrpc.CopyFileChunk_Meta{Meta: &fleetgrpc.CopyFileMeta{
+		Name: file.name, Mode: file.mode, Size: int64(len(file.data)),
+	}}}); err != nil {
+		return err
+	}
+	return stream.Send(&fleetgrpc.CopyFileChunk{Msg: &fleetgrpc.CopyFileChunk_Data{Data: file.data}})
+}
+
+func (f *fakeCopyServer) CopyInto(stream grpc.ClientStreamingServer[fleetgrpc.CopyIntoChunk, fleetgrpc.CopyIntoReply]) error {
+	first, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	open := first.GetOpen()
+	if open == nil {
+		return status.Error(codes.InvalidArgument, "first chunk must be open")
+	}
+	var data []byte
+	for {
+		chunk, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		data = append(data, chunk.GetData()...)
+	}
+	// Resolve a final path the way the real server would for the common cases:
+	// a trailing-slash dest (or empty) keeps the source name; else dest is it.
+	dest := open.GetDest()
+	finalPath := dest
+	if dest == "" || strings.HasSuffix(dest, "/") {
+		finalPath = strings.TrimRight(dest, "/") + "/" + open.GetName()
+	}
+	f.mu.Lock()
+	f.intos = append(f.intos, capturedInto{
+		fleet: open.GetFleet(), instance: open.GetInstance(), dest: dest,
+		name: open.GetName(), mode: open.GetMode(), size: open.GetSize(), data: data,
+	})
+	f.files[fileKey(open.GetFleet(), open.GetInstance(), finalPath)] = fakeFile{
+		name: open.GetName(), mode: open.GetMode(), data: data,
+	}
+	f.mu.Unlock()
+	return stream.SendAndClose(&fleetgrpc.CopyIntoReply{Path: finalPath, Written: int64(len(data))})
+}
+
+// dialFake stands the fake server up over bufconn and returns a client.
+func dialFake(t *testing.T, srv *fakeCopyServer) fleetgrpc.FleetServiceClient {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	gs := grpc.NewServer()
+	fleetgrpc.RegisterFleetServiceServer(gs, srv)
+	go func() { _ = gs.Serve(lis) }()
+	t.Cleanup(gs.Stop)
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) { return lis.DialContext(ctx) }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return fleetgrpc.NewFleetServiceClient(conn)
+}
+
+// passthroughPolicy treats local paths as absolute as-is, keeping the source
+// name for an empty/trailing-slash dest — enough to exercise the engine.
+type passthroughPolicy struct{}
+
+func (passthroughPolicy) ResolveSrc(path string) string { return path }
+func (passthroughPolicy) ResolveDest(dest, name string) (string, error) {
+	if dest == "" {
+		return name, nil
+	}
+	if strings.HasSuffix(dest, "/") {
+		return filepath.Join(dest, name), nil
+	}
+	return dest, nil
+}
+
+func TestCopyUploadLocalToInstance(t *testing.T) {
+	srv := newFakeCopyServer()
+	client := dialFake(t, srv)
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "tool")
+	if err := os.WriteFile(src, []byte("hello world"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Copy(context.Background(), client,
+		ResolvedEndpoint{Local: true, Path: src},
+		ResolvedEndpoint{Fleet: "f", Instance: "i", Path: "/dst/"},
+		passthroughPolicy{})
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if len(srv.intos) != 1 {
+		t.Fatalf("want 1 CopyInto, got %d", len(srv.intos))
+	}
+	got := srv.intos[0]
+	if got.name != "tool" || string(got.data) != "hello world" || got.size != 11 || got.dest != "/dst/" {
+		t.Fatalf("CopyInto open = %+v, want name=tool data=hello world size=11 dest=/dst/", got)
+	}
+	if got.mode&0o777 != 0o755 {
+		t.Fatalf("mode = %o, want 0755", got.mode)
+	}
+	if res.DestPath != "/dst/tool" || res.Written != 11 {
+		t.Fatalf("result = %+v, want /dst/tool 11", res)
+	}
+}
+
+func TestCopyDownloadInstanceToLocal(t *testing.T) {
+	srv := newFakeCopyServer()
+	srv.files[fileKey("f", "i", "/bin/tool")] = fakeFile{name: "tool", mode: 0o755, data: []byte("payload")}
+	client := dialFake(t, srv)
+
+	dir := t.TempDir()
+	res, err := Copy(context.Background(), client,
+		ResolvedEndpoint{Fleet: "f", Instance: "i", Path: "/bin/tool"},
+		ResolvedEndpoint{Local: true, Path: dir + "/"},
+		passthroughPolicy{})
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	wantPath := filepath.Join(dir, "tool")
+	if res.DestPath != wantPath || res.Written != 7 {
+		t.Fatalf("result = %+v, want %s 7", res, wantPath)
+	}
+	data, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(data) != "payload" {
+		t.Fatalf("downloaded %q, want payload", data)
+	}
+	fi, _ := os.Stat(wantPath)
+	if fi.Mode().Perm() != 0o755 {
+		t.Fatalf("mode = %o, want 0755", fi.Mode().Perm())
+	}
+}
+
+func TestCopyRelayInstanceToInstance(t *testing.T) {
+	srv := newFakeCopyServer()
+	srv.files[fileKey("f", "i1", "/a/out.bin")] = fakeFile{name: "out.bin", mode: 0o644, data: []byte("relayed")}
+	client := dialFake(t, srv)
+
+	res, err := Copy(context.Background(), client,
+		ResolvedEndpoint{Fleet: "f", Instance: "i1", Path: "/a/out.bin"},
+		ResolvedEndpoint{Fleet: "f", Instance: "i2", Path: "/tmp/"},
+		passthroughPolicy{})
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if len(srv.intos) != 1 {
+		t.Fatalf("want 1 CopyInto, got %d", len(srv.intos))
+	}
+	got := srv.intos[0]
+	if got.instance != "i2" || got.name != "out.bin" || string(got.data) != "relayed" {
+		t.Fatalf("relayed CopyInto = %+v, want i2 out.bin relayed", got)
+	}
+	if res.DestPath != "/tmp/out.bin" || res.Written != 7 {
+		t.Fatalf("result = %+v, want /tmp/out.bin 7", res)
+	}
+}
+
+func TestCopyLocalToLocal(t *testing.T) {
+	srv := newFakeCopyServer()
+	client := dialFake(t, srv)
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.txt")
+	dst := filepath.Join(dir, "b.txt")
+	if err := os.WriteFile(src, []byte("local copy"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	res, err := Copy(context.Background(), client,
+		ResolvedEndpoint{Local: true, Path: src},
+		ResolvedEndpoint{Local: true, Path: dst},
+		passthroughPolicy{})
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if res.DestPath != dst || res.Written != 10 {
+		t.Fatalf("result = %+v, want %s 10", res, dst)
+	}
+	data, _ := os.ReadFile(dst)
+	if string(data) != "local copy" {
+		t.Fatalf("copied %q, want local copy", data)
+	}
+}

--- a/internal/fleetclient/copyengine_test.go
+++ b/internal/fleetclient/copyengine_test.go
@@ -199,6 +199,31 @@ func TestCopyDownloadInstanceToLocal(t *testing.T) {
 	}
 }
 
+// TestCopyDownloadSanitizesServerName ensures a malicious server-provided file
+// name cannot steer a directory destination outside it: the name is reduced to a
+// basename, so a traversal name lands inside the destination directory.
+func TestCopyDownloadSanitizesServerName(t *testing.T) {
+	srv := newFakeCopyServer()
+	srv.files[fileKey("f", "i", "/evil")] = fakeFile{name: "../../../etc/passwd", mode: 0o644, data: []byte("x")}
+	client := dialFake(t, srv)
+
+	dir := t.TempDir()
+	res, err := Copy(context.Background(), client,
+		ResolvedEndpoint{Fleet: "f", Instance: "i", Path: "/evil"},
+		ResolvedEndpoint{Local: true, Path: dir + "/"},
+		passthroughPolicy{})
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	want := filepath.Join(dir, "passwd")
+	if res.DestPath != want {
+		t.Fatalf("traversal name not contained: DestPath = %q, want %q", res.DestPath, want)
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("file not written inside dest dir: %v", err)
+	}
+}
+
 func TestCopyRelayInstanceToInstance(t *testing.T) {
 	srv := newFakeCopyServer()
 	srv.files[fileKey("f", "i1", "/a/out.bin")] = fakeFile{name: "out.bin", mode: 0o644, data: []byte("relayed")}

--- a/internal/fleetclient/copyfile.go
+++ b/internal/fleetclient/copyfile.go
@@ -1,93 +1,30 @@
 package fleetclient
 
 import (
-	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
 )
 
-// CopyFileTo pulls fleet/instance:srcPath from the server (the CopyFile RPC)
-// and writes it to dest on the local machine. dest may be an existing
-// directory (or end in a path separator), in which case the file keeps its
-// source basename inside it; an existing destination file is overwritten —
-// scp semantics, so re-copying an iterated build always lands in the same
-// place. The bytes go to a temp file in the destination directory first and
-// are renamed into place on success, so a half-finished copy never replaces a
-// previous good one. Returns the final local path and the bytes written.
-func CopyFileTo(ctx context.Context, svc fleetgrpc.FleetServiceClient, fleetName, instanceName, srcPath, dest string) (string, int64, error) {
-	stream, err := svc.CopyFile(ctx, &fleetgrpc.CopyFileRequest{
-		Fleet:    fleetName,
-		Instance: instanceName,
-		Path:     srcPath,
-	})
-	if err != nil {
-		return "", 0, err
-	}
+// copyfile.go holds the host CLI's local-path policy for `fleet copy`: a process
+// run directly on a machine resolves local paths relative to its own cwd. The
+// in-instance form's policy (the human's home / downloads folder) lives in the
+// TUI, which runs the delegated copy. Both implement CopyLocalPolicy so the one
+// engine in copyengine.go serves both.
 
-	// The first chunk must be the meta frame (name/mode/size).
-	first, err := stream.Recv()
-	if err != nil {
-		return "", 0, err
-	}
-	meta := first.GetMeta()
-	if meta == nil {
-		return "", 0, fmt.Errorf("copy %s/%s:%s: server sent no file metadata", fleetName, instanceName, srcPath)
-	}
+// HostLocalPolicy resolves local paths for a `fleet` process run directly on a
+// machine: a source is read as given (relative to the cwd), and a destination
+// follows scp's rule that an empty or directory dest keeps the source basename.
+type HostLocalPolicy struct{}
 
-	destPath, err := ResolveCopyDest(dest, meta.GetName())
-	if err != nil {
-		return "", 0, err
-	}
+// ResolveSrc returns the source path unchanged — the os layer resolves a
+// relative path against the process cwd, which is what the user means.
+func (HostLocalPolicy) ResolveSrc(path string) string { return path }
 
-	mode := os.FileMode(meta.GetMode()).Perm()
-	if mode == 0 {
-		mode = 0o644
-	}
-	tmp, err := os.CreateTemp(filepath.Dir(destPath), "."+filepath.Base(destPath)+".fleetcopy-*")
-	if err != nil {
-		return "", 0, err
-	}
-	defer func() {
-		// Best-effort cleanup on every early-error path; succeeds-into-rename
-		// leaves nothing for these to do.
-		_ = tmp.Close()
-		_ = os.Remove(tmp.Name())
-	}()
-	if err := tmp.Chmod(mode); err != nil {
-		return "", 0, err
-	}
-
-	var written int64
-	for {
-		chunk, err := stream.Recv()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return "", 0, err
-		}
-		data := chunk.GetData()
-		if len(data) == 0 {
-			continue
-		}
-		n, err := tmp.Write(data)
-		written += int64(n)
-		if err != nil {
-			return "", 0, err
-		}
-	}
-	if err := tmp.Close(); err != nil {
-		return "", 0, err
-	}
-	if err := os.Rename(tmp.Name(), destPath); err != nil {
-		return "", 0, err
-	}
-	return destPath, written, nil
+// ResolveDest applies ResolveCopyDest (cwd-relative, scp dest semantics).
+func (HostLocalPolicy) ResolveDest(dest, srcName string) (string, error) {
+	return ResolveCopyDest(dest, srcName)
 }
 
 // ResolveCopyDest resolves the local destination path for a copied file named

--- a/internal/fleetcopy/fleetcopy.go
+++ b/internal/fleetcopy/fleetcopy.go
@@ -63,9 +63,9 @@ func Request(cfg Config, out io.Writer, src, dst string) error {
 		return err
 	}
 	if dst != "" {
-		fmt.Fprintf(out, "Asked the host fleet to copy %s -> %s.\n", src, dst)
+		fmt.Fprintf(out, "Asked the host fleet to copy %s -> %s (approve it in your fleet TUI if it touches your machine).\n", src, dst)
 	} else {
-		fmt.Fprintf(out, "Asked the host fleet to copy %s — it will land in your downloads folder.\n", src)
+		fmt.Fprintf(out, "Asked the host fleet to copy %s — it will land in your downloads folder once approved in your fleet TUI.\n", src)
 	}
 	return nil
 }

--- a/internal/fleetcopy/fleetcopy.go
+++ b/internal/fleetcopy/fleetcopy.go
@@ -1,17 +1,19 @@
-// Package fleetcopy is the in-instance half of `fleet copy` (alias fc): it
-// asks the HOST fleet to copy a file out of this instance onto the user's
-// machine. Like the `fleet launch` TUI (internal/launchtui), the in-container
-// process cannot reach the user's disk itself, so it writes a file.copy
-// envelope to the control socket fleet bind-mounts into the instance; the
-// server turns it into a Watch FileCopy event and the connected fleet TUI
-// pulls the bytes over the CopyFile RPC into its local downloads folder.
+// Package fleetcopy is the in-instance half of scp-style `fleet copy` (alias
+// fc): it asks the connected HOST fleet TUI to perform a copy between two
+// endpoints on the in-container caller's behalf. Like the `fleet launch` TUI
+// (internal/launchtui), the in-container process cannot reach the host fleetd
+// over gRPC — only the control socket fleet bind-mounts into the instance — so
+// it writes a file.copy envelope naming the two endpoints; the server turns it
+// into a Watch FileCopy event and the connected TUI runs the generic copy engine
+// against the host fleet (with its own disk as the "local" side). This is what
+// lets `fc` reach the user's machine even when the instance is fully remote, and
+// lets it copy between sibling instances of the user's fleet.
 package fleetcopy
 
 import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/control"
 )
@@ -44,40 +46,26 @@ func InInstance() bool {
 	return err == nil && fi.IsDir()
 }
 
-// Request resolves the file locally (fast feedback on typos — the send itself
-// is fire-and-forget) and asks the host fleet to copy it out via the control
-// socket, exactly like `fleet launch` asks for a browser open. dest is the
-// requested destination on the user's machine, passed through verbatim ("" =
-// the user's downloads folder) — only the receiving client can interpret a
-// path on its own filesystem.
-func Request(cfg Config, out io.Writer, path, dest string) error {
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return err
-	}
-	fi, err := os.Stat(abs)
-	if err != nil {
-		return err
-	}
-	if fi.IsDir() {
-		return fmt.Errorf("%s is a directory — only single files can be copied", path)
-	}
-	if !fi.Mode().IsRegular() {
-		return fmt.Errorf("%s is not a regular file", path)
-	}
-
+// Request asks the connected host fleet TUI to copy from src to dst (endpoints
+// as typed inside the instance), passed through verbatim over the control
+// socket. It is a pure signal — fire-and-forget, like `fleet launch` asking for
+// a browser open: the in-container process can resolve neither the user's-machine
+// paths nor the host fleet's instances, so it does not validate the endpoints;
+// the TUI performs the copy and surfaces any error there. An empty dst is the
+// download shorthand (deliver to the user's downloads folder).
+func Request(cfg Config, out io.Writer, src, dst string) error {
 	client, err := control.Dial(cfg.socketPath())
 	if err != nil {
-		return fmt.Errorf("not connected to a host fleet — copying out of an instance needs a running fleet TUI on the host")
+		return fmt.Errorf("not connected to a host fleet — `fc` needs a running fleet TUI on the host")
 	}
 	defer client.Close()
-	if err := client.CopyFile(abs, dest); err != nil {
+	if err := client.CopyFile(src, dst); err != nil {
 		return err
 	}
-	if dest != "" {
-		fmt.Fprintf(out, "Asked the host fleet to copy %s — it will land at %s on your machine.\n", abs, dest)
+	if dst != "" {
+		fmt.Fprintf(out, "Asked the host fleet to copy %s -> %s.\n", src, dst)
 	} else {
-		fmt.Fprintf(out, "Asked the host fleet to copy %s — it will land in your downloads folder.\n", abs)
+		fmt.Fprintf(out, "Asked the host fleet to copy %s — it will land in your downloads folder.\n", src)
 	}
 	return nil
 }

--- a/internal/fleetcopy/fleetcopy_test.go
+++ b/internal/fleetcopy/fleetcopy_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"net"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,15 +11,11 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/control"
 )
 
-// TestRequestSendsEnvelope round-trips the in-instance form against a fake
-// host listener: the sent envelope is a file.copy naming the absolute path.
+// TestRequestSendsEnvelope round-trips the in-instance form against a fake host
+// listener: the sent envelope is a file.copy naming the two endpoints verbatim,
+// as typed inside the instance (no local resolution — it is a pure signal).
 func TestRequestSendsEnvelope(t *testing.T) {
 	dir := t.TempDir()
-	file := filepath.Join(dir, "tool")
-	if err := os.WriteFile(file, []byte("bytes"), 0o755); err != nil {
-		t.Fatalf("write fixture: %v", err)
-	}
-
 	socket := filepath.Join(dir, "fleet.sock")
 	ln, err := net.Listen("unix", socket)
 	if err != nil {
@@ -40,7 +35,7 @@ func TestRequestSendsEnvelope(t *testing.T) {
 	}()
 
 	var out bytes.Buffer
-	if err := Request(Config{SocketPath: socket}, &out, file, "~/builds/tool"); err != nil {
+	if err := Request(Config{SocketPath: socket}, &out, ":build/tool", "~/builds/tool"); err != nil {
 		t.Fatalf("Request: %v", err)
 	}
 	env := <-got
@@ -51,36 +46,64 @@ func TestRequestSendsEnvelope(t *testing.T) {
 	if err := json.Unmarshal(env.Payload, &payload); err != nil {
 		t.Fatalf("payload: %v", err)
 	}
-	if payload.Path != file {
-		t.Fatalf("payload path = %q, want %q", payload.Path, file)
+	if payload.Src != ":build/tool" {
+		t.Fatalf("payload src = %q, want :build/tool (verbatim)", payload.Src)
 	}
-	if payload.Dest != "~/builds/tool" {
-		t.Fatalf("payload dest = %q, want ~/builds/tool (passed through verbatim)", payload.Dest)
+	if payload.Dst != "~/builds/tool" {
+		t.Fatalf("payload dst = %q, want ~/builds/tool (verbatim)", payload.Dst)
 	}
-	if !strings.Contains(out.String(), file) || !strings.Contains(out.String(), "~/builds/tool") {
-		t.Fatalf("confirmation %q does not name the file and destination", out.String())
+	if !strings.Contains(out.String(), ":build/tool") || !strings.Contains(out.String(), "~/builds/tool") {
+		t.Fatalf("confirmation %q does not name the endpoints", out.String())
 	}
 }
 
-// TestRequestErrors covers the fast local failures: a missing file, a
-// directory, and no host listener.
-func TestRequestErrors(t *testing.T) {
+// TestRequestDownloadShorthand confirms the 1-arg form sends an empty dst and
+// the confirmation mentions the downloads folder.
+func TestRequestDownloadShorthand(t *testing.T) {
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "fleet.sock")
+	ln, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	got := make(chan control.Envelope, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var env control.Envelope
+		_ = json.NewDecoder(conn).Decode(&env)
+		got <- env
+	}()
+
+	var out bytes.Buffer
+	if err := Request(Config{SocketPath: socket}, &out, ":out.bin", ""); err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	var payload control.CopyFilePayload
+	if err := json.Unmarshal((<-got).Payload, &payload); err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+	if payload.Src != ":out.bin" || payload.Dst != "" {
+		t.Fatalf("payload = %+v, want src=:out.bin dst empty", payload)
+	}
+	if !strings.Contains(out.String(), "downloads folder") {
+		t.Fatalf("confirmation %q does not mention the downloads folder", out.String())
+	}
+}
+
+// TestRequestNoListener covers the only failure Request still reports locally:
+// no host TUI connected. It no longer stats the source (which may be a file on
+// the user's machine, unreachable from in-container) — that is the host TUI's job.
+func TestRequestNoListener(t *testing.T) {
 	dir := t.TempDir()
 	cfg := Config{SocketPath: filepath.Join(dir, "absent.sock")}
 
 	var out bytes.Buffer
-	if err := Request(cfg, &out, filepath.Join(dir, "ghost"), ""); !os.IsNotExist(err) {
-		t.Fatalf("missing file: want IsNotExist, got %v", err)
-	}
-	if err := Request(cfg, &out, dir, ""); err == nil || !strings.Contains(err.Error(), "directory") {
-		t.Fatalf("directory: want directory error, got %v", err)
-	}
-
-	file := filepath.Join(dir, "tool")
-	if err := os.WriteFile(file, []byte("bytes"), 0o755); err != nil {
-		t.Fatalf("write fixture: %v", err)
-	}
-	if err := Request(cfg, &out, file, ""); err == nil || !strings.Contains(err.Error(), "not connected to a host fleet") {
+	if err := Request(cfg, &out, ":tool", ""); err == nil || !strings.Contains(err.Error(), "not connected to a host fleet") {
 		t.Fatalf("no listener: want not-connected error, got %v", err)
 	}
 }

--- a/internal/fleetlaunch/fleet.rc
+++ b/internal/fleetlaunch/fleet.rc
@@ -14,7 +14,14 @@
 # `fl <name>` launches one directly by (a unique prefix of) its name.
 alias fl='fleet launch'
 
-# fc — shorthand for Fleet Copy. `fc <path>` copies that file out of this
-# instance to your machine's downloads folder — even when the deployment is
-# fully remote; `fc <path> <dest>` drops it at dest on your machine instead.
+# fc — shorthand for Fleet Copy, scp-style and bidirectional. A plain path is a
+# file on your machine (where the fleet TUI runs); `:path` is a file in THIS
+# instance; `[fleet/]instance:path` is any instance in your fleet. Direction
+# follows which side is which — all of these work even on a fully remote
+# deployment:
+#   fc :build/out ~/Downloads/   copy this instance's file to your machine
+#   fc report.csv :/tmp/         copy a file from your machine into this instance
+#   fc :out.bin other:/tmp/      copy this instance's file into another instance
+# With a single `:`/instance source (e.g. `fc :build/out`) the file lands in
+# your downloads folder.
 alias fc='fleet copy'

--- a/internal/server/control.go
+++ b/internal/server/control.go
@@ -39,10 +39,10 @@ type controlRegistry struct {
 	onOpen func(fleetName, instanceName, url string)
 
 	// onCopy is invoked for each decoded file.copy envelope, tagged with the
-	// originating instance. dest is the requested destination on the user's
-	// machine ("" = downloads folder), passed through verbatim. Same
+	// originating instance. src/dst are the scp endpoints as typed inside the
+	// instance, passed through verbatim (the TUI runs the copy). Same
 	// concurrency/non-blocking contract as onOpen.
-	onCopy func(fleetName, instanceName, path, dest string)
+	onCopy func(fleetName, instanceName, src, dst string)
 
 	// gated reports whether to keep control sockets open at all: only while a
 	// browser-capable client (a TUI / Watch subscriber) is attached. With no
@@ -57,7 +57,7 @@ type controlRegistry struct {
 // newControlRegistry creates an empty registry. onOpen is invoked per received
 // browser.open envelope, onCopy per file.copy envelope; gated decides whether
 // any sockets should be open (nil means always on).
-func newControlRegistry(onOpen func(fleetName, instanceName, url string), onCopy func(fleetName, instanceName, path, dest string), gated func() bool) *controlRegistry {
+func newControlRegistry(onOpen func(fleetName, instanceName, url string), onCopy func(fleetName, instanceName, src, dst string), gated func() bool) *controlRegistry {
 	return &controlRegistry{
 		onOpen:  onOpen,
 		onCopy:  onCopy,
@@ -155,11 +155,11 @@ func (r *controlRegistry) syncRunning(st *state.State) {
 				}
 			case control.TypeCopyFile:
 				var payload control.CopyFilePayload
-				if json.Unmarshal(env.Payload, &payload) != nil || payload.Path == "" {
+				if json.Unmarshal(env.Payload, &payload) != nil || payload.Src == "" {
 					return
 				}
 				if r.onCopy != nil {
-					r.onCopy(fName, iName, payload.Path, payload.Dest)
+					r.onCopy(fName, iName, payload.Src, payload.Dst)
 				}
 			}
 		})

--- a/internal/server/control_test.go
+++ b/internal/server/control_test.go
@@ -17,7 +17,7 @@ type openEvent struct {
 
 // copyEvent is one decoded file.copy the registry forwarded via onCopy.
 type copyEvent struct {
-	fleet, instance, path, dest string
+	fleet, instance, src, dst string
 }
 
 // waitForSocket polls path until it exists or the deadline passes.
@@ -60,9 +60,9 @@ func TestControlSyncRoundTrip(t *testing.T) {
 		case events <- openEvent{f, i, url}:
 		default:
 		}
-	}, func(f, i, path, dest string) {
+	}, func(f, i, src, dst string) {
 		select {
-		case copies <- copyEvent{f, i, path, dest}:
+		case copies <- copyEvent{f, i, src, dst}:
 		default:
 		}
 	}, nil)
@@ -102,12 +102,12 @@ func TestControlSyncRoundTrip(t *testing.T) {
 	}
 
 	// A file.copy envelope on the same socket dispatches to onCopy, carrying
-	// the requested destination through verbatim.
+	// the two endpoints through verbatim.
 	const (
-		wantPath = "/workspaces/repo/bin/tool"
-		wantDest = "~/builds/tool"
+		wantSrc = ":bin/tool"
+		wantDst = "~/builds/tool"
 	)
-	if err := client.CopyFile(wantPath, wantDest); err != nil {
+	if err := client.CopyFile(wantSrc, wantDst); err != nil {
 		t.Fatalf("CopyFile: %v", err)
 	}
 	select {
@@ -115,8 +115,8 @@ func TestControlSyncRoundTrip(t *testing.T) {
 		if ev.fleet != fleetName || ev.instance != instanceName {
 			t.Errorf("copy event = (%q,%q), want (%q,%q)", ev.fleet, ev.instance, fleetName, instanceName)
 		}
-		if ev.path != wantPath || ev.dest != wantDest {
-			t.Errorf("copy event = (%q,%q), want (%q,%q)", ev.path, ev.dest, wantPath, wantDest)
+		if ev.src != wantSrc || ev.dst != wantDst {
+			t.Errorf("copy event = (%q,%q), want (%q,%q)", ev.src, ev.dst, wantSrc, wantDst)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for file.copy on onCopy")

--- a/internal/server/copy.go
+++ b/internal/server/copy.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+	"sync/atomic"
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
@@ -281,12 +282,17 @@ func (s *service) CopyInto(stream grpc.ClientStreamingServer[fleetgrpc.CopyIntoC
 	return stream.SendAndClose(&fleetgrpc.CopyIntoReply{Path: finalPath, Written: open.GetSize()})
 }
 
+// copyIntoSeq makes the temp name below unique within this process regardless of
+// the RNG, so two concurrent uploads into one directory never collide even if
+// crypto/rand degrades (a failed Read would otherwise leave the bytes zeroed).
+var copyIntoSeq atomic.Uint64
+
 // copyIntoTempName returns a hidden, unique basename to extract an upload into
 // before the atomic rename onto its real destination.
 func copyIntoTempName() string {
 	var b [8]byte
 	_, _ = rand.Read(b[:])
-	return fmt.Sprintf(".fleetcopy-%x", b[:])
+	return fmt.Sprintf(".fleetcopy-%d-%x", copyIntoSeq.Add(1), b[:])
 }
 
 // moveContainerFile renames from→to within dir inside the instance — the atomic

--- a/internal/server/copy.go
+++ b/internal/server/copy.go
@@ -293,7 +293,9 @@ func copyIntoTempName() string {
 // publish step that replaces any existing destination only once the upload is
 // fully written.
 func (s *service) moveContainerFile(inst *fleet.Instance, dir, from, to string) error {
-	cmd := copyIntoExecCommand(inst, []string{"mv", "-f", path.Join(dir, from), path.Join(dir, to)})
+	// `--` so a destination basename beginning with '-' is treated as a path,
+	// not an mv flag.
+	cmd := copyIntoExecCommand(inst, []string{"mv", "-f", "--", path.Join(dir, from), path.Join(dir, to)})
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -308,7 +310,7 @@ func (s *service) moveContainerFile(inst *fleet.Instance, dir, from, to string) 
 // removeContainerFile best-effort deletes a leftover temp file inside the
 // instance after a failed upload.
 func (s *service) removeContainerFile(inst *fleet.Instance, dir, name string) {
-	_ = copyIntoExecCommand(inst, []string{"rm", "-f", path.Join(dir, name)}).Run()
+	_ = copyIntoExecCommand(inst, []string{"rm", "-f", "--", path.Join(dir, name)}).Run()
 }
 
 // resolveCopyIntoDest resolves the destination dir + final basename inside the

--- a/internal/server/copy.go
+++ b/internal/server/copy.go
@@ -3,25 +3,39 @@ package server
 import (
 	"archive/tar"
 	"bytes"
+	"crypto/rand"
+	"fmt"
 	"io"
+	"os"
+	"os/exec"
 	"path"
 	"strings"
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
 	"github.com/BenjaminBenetti/fleet-man/internal/backendutil"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-// copy.go implements the CopyFile RPC behind `fleet copy` and the in-instance
-// `fc` shorthand: stream one file out of an instance to the client.
+// copy.go implements the two halves of scp-style `fleet copy` (and the
+// in-instance `fc` shorthand): CopyFile streams a file OUT of an instance to the
+// client, CopyInto streams a file INTO an instance from the client.
 //
-// The file is read through the backend with a single container exec — `tar` to
-// stdout — so the file's metadata (mode, size) and bytes arrive in one
-// consistent stream with no shell quoting (argv goes straight to exec) and no
-// stat/cat race. -h dereferences a symlinked source so the client receives the
-// real content.
+// Both move bytes through the backend with a single container exec and a `tar`
+// pipe, so the file's metadata (mode, size) and bytes ride one consistent
+// stream with no shell quoting (argv goes straight to exec) and no stat/cat
+// race. OUT runs `tar -chf -` to stdout (-h dereferences a symlinked source so
+// the client receives the real content); IN runs `tar -xf -` from stdin into
+// the destination directory, preserving the file mode.
+//
+// Backend caveat (shared by both directions, pre-existing): the codespaces
+// backend allocates a PTY for exec, whose line discipline mangles binary tar —
+// on stdin (IN) a 0x04 byte reads as EOF, truncating the upload. The strict size
+// check below turns such a truncation into a clean InvalidArgument rather than a
+// silent partial write. devcontainer (the default) and coder exec without a PTY
+// and over a clean binary channel, so both directions work there.
 
 // copyChunkSize is the data-frame payload size. Comfortably under gRPC's 4MB
 // default message cap while keeping per-frame overhead negligible.
@@ -143,4 +157,251 @@ func streamTarFile(filePath string, r io.Reader, send func(*fleetgrpc.CopyFileCh
 			return status.Errorf(codes.Internal, "read %q: %v", filePath, readErr)
 		}
 	}
+}
+
+// copyIntoExecCommand builds the host-side container exec used by CopyInto.
+// Package var so tests can stub the whole backend layer (mirrors
+// exec_stream.go's buildExecCommand). ExecCommandQuiet because the handler
+// drives the command with Start/Wait (not Run/Output), so the wrapper's
+// completion log never fires anyway, and a copy already logs nothing per frame.
+var copyIntoExecCommand = func(inst *fleet.Instance, argv []string) *exec.Cmd {
+	return backendutil.NewForInstance(inst, false).ExecCommandQuiet(inst.WorkspaceDir, argv).Cmd
+}
+
+// CopyInto streams the file in the client's chunks INTO the instance. The first
+// chunk carries the open header (instance, dest, name, mode, size); the rest
+// carry data. The server resolves dest inside the container, extracts a one-file
+// tar (built here from the streamed bytes) with `tar -xf - -C <dir>` under a
+// temporary name, then renames it into place — so a truncated or oversized
+// stream (the declared size is a hard cap) fails the RPC without ever clobbering
+// an existing destination, the same atomicity the download direction has. Only
+// single regular files; the mode is preserved.
+func (s *service) CopyInto(stream grpc.ClientStreamingServer[fleetgrpc.CopyIntoChunk, fleetgrpc.CopyIntoReply]) error {
+	first, err := stream.Recv()
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "copy into: no open header: %v", err)
+	}
+	open := first.GetOpen()
+	if open == nil {
+		return status.Error(codes.InvalidArgument, "copy into: first chunk must be the open header")
+	}
+	inst, err := resolveServerInstance(open.GetFleet(), open.GetInstance())
+	if err != nil {
+		return err
+	}
+	if inst.Status != fleet.StatusRunning {
+		return status.Errorf(codes.FailedPrecondition, "instance %s/%s is not running", open.GetFleet(), open.GetInstance())
+	}
+	if err := validateCopyName(open.GetName()); err != nil {
+		return err
+	}
+	if open.GetSize() < 0 {
+		return status.Errorf(codes.InvalidArgument, "copy into: negative size %d", open.GetSize())
+	}
+
+	finalDir, finalName, err := s.resolveCopyIntoDest(inst, open.GetDest(), open.GetName())
+	if err != nil {
+		return err
+	}
+
+	mode := os.FileMode(open.GetMode()).Perm()
+	if mode == 0 {
+		mode = 0o644
+	}
+
+	// Extract under a hidden temporary name and rename into place only on a clean
+	// finish, so a half-written upload never replaces a previous good file.
+	tempName := copyIntoTempName()
+
+	cmd := copyIntoExecCommand(inst, []string{"tar", "-xf", "-", "-C", finalDir})
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return status.Errorf(codes.Internal, "pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return status.Errorf(codes.Internal, "start copy: %v", err)
+	}
+
+	ctx := stream.Context()
+	finished := make(chan struct{})
+	// On client disconnect, kill tar AND close stdin so a write blocked on a full
+	// pipe unblocks (the inverse of CopyFile, where the active side is stdout).
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = cmd.Process.Kill()
+			_ = stdin.Close()
+		case <-finished:
+		}
+	}()
+
+	writeErr := writeCopyIntoTar(stdin, stream, tempName, mode, open.GetSize())
+	// EOF to tar. A no-op if the killer already closed it; harmless after a
+	// write error (tar already saw a short archive).
+	_ = stdin.Close()
+	waitErr := cmd.Wait()
+	close(finished)
+
+	tarMsg := strings.TrimSpace(stderr.String())
+	if writeErr != nil || waitErr != nil {
+		// Never leave the temp file behind on a failed upload.
+		s.removeContainerFile(inst, finalDir, tempName)
+		if writeErr != nil {
+			// A size mismatch is the client's fault and already a clean status.
+			if status.Code(writeErr) == codes.InvalidArgument {
+				return writeErr
+			}
+			// Otherwise the write likely hit EPIPE because tar died first — tar's
+			// own stderr (e.g. a missing directory) is the real cause.
+			if tarMsg != "" {
+				return status.Errorf(codes.Internal, "write %q to %s/%s: %s", finalName, open.GetFleet(), open.GetInstance(), tarMsg)
+			}
+			return writeErr
+		}
+		if tarMsg != "" {
+			return status.Errorf(codes.Internal, "write %q to %s/%s: %s", finalName, open.GetFleet(), open.GetInstance(), tarMsg)
+		}
+		return status.Errorf(codes.Internal, "write %q to %s/%s: %v", finalName, open.GetFleet(), open.GetInstance(), waitErr)
+	}
+
+	// Publish the fully-written file with an atomic rename.
+	if err := s.moveContainerFile(inst, finalDir, tempName, finalName); err != nil {
+		s.removeContainerFile(inst, finalDir, tempName)
+		return status.Errorf(codes.Internal, "finalize %q in %s/%s: %v", finalName, open.GetFleet(), open.GetInstance(), err)
+	}
+
+	finalPath := path.Join(finalDir, finalName)
+	if !path.IsAbs(finalPath) {
+		// A relative dest resolved against the workspace folder (the exec cwd);
+		// report the absolute path the file actually landed at.
+		finalPath = path.Join(inst.WorkspaceDir, finalDir, finalName)
+	}
+	return stream.SendAndClose(&fleetgrpc.CopyIntoReply{Path: finalPath, Written: open.GetSize()})
+}
+
+// copyIntoTempName returns a hidden, unique basename to extract an upload into
+// before the atomic rename onto its real destination.
+func copyIntoTempName() string {
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	return fmt.Sprintf(".fleetcopy-%x", b[:])
+}
+
+// moveContainerFile renames from→to within dir inside the instance — the atomic
+// publish step that replaces any existing destination only once the upload is
+// fully written.
+func (s *service) moveContainerFile(inst *fleet.Instance, dir, from, to string) error {
+	cmd := copyIntoExecCommand(inst, []string{"mv", "-f", path.Join(dir, from), path.Join(dir, to)})
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return fmt.Errorf("%s", msg)
+		}
+		return err
+	}
+	return nil
+}
+
+// removeContainerFile best-effort deletes a leftover temp file inside the
+// instance after a failed upload.
+func (s *service) removeContainerFile(inst *fleet.Instance, dir, name string) {
+	_ = copyIntoExecCommand(inst, []string{"rm", "-f", path.Join(dir, name)}).Run()
+}
+
+// resolveCopyIntoDest resolves the destination dir + final basename inside the
+// container, scp-style: an empty dest (or a dest that is an existing directory)
+// keeps the source name; otherwise dest is the full target path. A trailing
+// slash forces directory intent, so a non-existent one is a clean error rather
+// than silently writing a file named like the missing directory. The chosen
+// directory is probed for existence so a missing one is NotFound, not a folded
+// tar failure.
+func (s *service) resolveCopyIntoDest(inst *fleet.Instance, dest, name string) (finalDir, finalName string, err error) {
+	if dest == "" {
+		return ".", name, nil
+	}
+	if s.probeContainerDir(inst, dest) {
+		return dest, name, nil
+	}
+	if strings.HasSuffix(dest, "/") {
+		return "", "", status.Errorf(codes.NotFound, "destination directory %q does not exist", strings.TrimRight(dest, "/"))
+	}
+	finalDir = path.Dir(dest)
+	finalName = path.Base(dest)
+	if err := validateCopyName(finalName); err != nil {
+		return "", "", err
+	}
+	if finalDir != "." && !s.probeContainerDir(inst, finalDir) {
+		return "", "", status.Errorf(codes.NotFound, "destination directory %q does not exist", finalDir)
+	}
+	return finalDir, finalName, nil
+}
+
+// probeContainerDir reports whether dir is an existing directory inside the
+// instance, via a `test -d` exec (argv straight to exec, exit code only).
+func (s *service) probeContainerDir(inst *fleet.Instance, dir string) bool {
+	return copyIntoExecCommand(inst, []string{"test", "-d", dir}).Run() == nil
+}
+
+// copyIntoChunkReceiver is the read half of the CopyInto stream — abstracted so
+// writeCopyIntoTar is unit-testable without a real gRPC stream.
+type copyIntoChunkReceiver interface {
+	Recv() (*fleetgrpc.CopyIntoChunk, error)
+}
+
+// writeCopyIntoTar drains the client's data chunks into w as a single-file tar
+// archive named name with the given mode. It enforces size exactly: a stream
+// that ends short or overruns is an InvalidArgument (so a truncated upload never
+// lands as a silent partial file), and any other write failure surfaces verbatim.
+func writeCopyIntoTar(w io.Writer, stream copyIntoChunkReceiver, name string, mode os.FileMode, size int64) error {
+	tw := tar.NewWriter(w)
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Mode:     int64(mode.Perm()),
+		Size:     size,
+		Typeflag: tar.TypeReg,
+	}); err != nil {
+		return status.Errorf(codes.Internal, "tar header: %v", err)
+	}
+
+	var written int64
+	for {
+		chunk, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return status.Errorf(codes.Internal, "recv: %v", err)
+		}
+		data := chunk.GetData()
+		if len(data) == 0 {
+			continue
+		}
+		written += int64(len(data))
+		if written > size {
+			return status.Errorf(codes.InvalidArgument, "copy into: stream exceeds declared size %d", size)
+		}
+		if _, err := tw.Write(data); err != nil {
+			return status.Errorf(codes.Internal, "tar write: %v", err)
+		}
+	}
+	if written != size {
+		return status.Errorf(codes.InvalidArgument, "copy into: stream ended early — got %d of %d bytes", written, size)
+	}
+	if err := tw.Close(); err != nil {
+		return status.Errorf(codes.Internal, "tar close: %v", err)
+	}
+	return nil
+}
+
+// validateCopyName rejects a basename that is empty, a path-traversal token, or
+// contains a separator — a single-file copy must never create or escape into
+// subdirectories from the name alone.
+func validateCopyName(name string) error {
+	if name == "" || name == "." || name == ".." || strings.ContainsRune(name, '/') {
+		return status.Errorf(codes.InvalidArgument, "invalid file name %q", name)
+	}
+	return nil
 }

--- a/internal/server/copyinto_test.go
+++ b/internal/server/copyinto_test.go
@@ -1,0 +1,271 @@
+package server
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeChunkReceiver replays canned CopyInto chunks for writeCopyIntoTar tests.
+type fakeChunkReceiver struct {
+	chunks []*fleetgrpc.CopyIntoChunk
+	i      int
+}
+
+func (f *fakeChunkReceiver) Recv() (*fleetgrpc.CopyIntoChunk, error) {
+	if f.i >= len(f.chunks) {
+		return nil, io.EOF
+	}
+	c := f.chunks[f.i]
+	f.i++
+	return c, nil
+}
+
+func dataChunk(b string) *fleetgrpc.CopyIntoChunk {
+	return &fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Data{Data: []byte(b)}}
+}
+
+func TestWriteCopyIntoTarRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	rcv := &fakeChunkReceiver{chunks: []*fleetgrpc.CopyIntoChunk{dataChunk("hello "), dataChunk("world")}}
+	if err := writeCopyIntoTar(&buf, rcv, "tool", 0o755, 11); err != nil {
+		t.Fatalf("writeCopyIntoTar: %v", err)
+	}
+	tr := tar.NewReader(&buf)
+	hdr, err := tr.Next()
+	if err != nil {
+		t.Fatalf("tar Next: %v", err)
+	}
+	if hdr.Name != "tool" || hdr.Mode != 0o755 || hdr.Size != 11 {
+		t.Fatalf("header = name=%q mode=%o size=%d, want tool 0755 11", hdr.Name, hdr.Mode, hdr.Size)
+	}
+	body, _ := io.ReadAll(tr)
+	if string(body) != "hello world" {
+		t.Fatalf("body = %q, want hello world", body)
+	}
+}
+
+func TestWriteCopyIntoTarSizeMismatch(t *testing.T) {
+	// Stream ends short of the declared size.
+	short := &fakeChunkReceiver{chunks: []*fleetgrpc.CopyIntoChunk{dataChunk("hi")}}
+	if err := writeCopyIntoTar(io.Discard, short, "f", 0o644, 10); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("short stream: want InvalidArgument, got %v", err)
+	}
+	// Stream overruns the declared size.
+	over := &fakeChunkReceiver{chunks: []*fleetgrpc.CopyIntoChunk{dataChunk("too much data")}}
+	if err := writeCopyIntoTar(io.Discard, over, "f", 0o644, 4); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("over stream: want InvalidArgument, got %v", err)
+	}
+}
+
+func TestValidateCopyName(t *testing.T) {
+	for _, bad := range []string{"", ".", "..", "a/b", "/abs", "sub/file"} {
+		if err := validateCopyName(bad); status.Code(err) != codes.InvalidArgument {
+			t.Errorf("validateCopyName(%q): want InvalidArgument, got %v", bad, err)
+		}
+	}
+	for _, ok := range []string{"tool", "out.bin", "a.tar.gz"} {
+		if err := validateCopyName(ok); err != nil {
+			t.Errorf("validateCopyName(%q): unexpected error %v", ok, err)
+		}
+	}
+}
+
+// stubCopyIntoExec runs the CopyInto exec (test -d, tar -xf -) on the host with
+// the command's cwd set to the instance's WorkspaceDir — so a real temp dir
+// stands in for the container filesystem, no backend required.
+func stubCopyIntoExec(t *testing.T) {
+	t.Helper()
+	orig := copyIntoExecCommand
+	copyIntoExecCommand = func(inst *fleet.Instance, argv []string) *exec.Cmd {
+		cmd := exec.Command(argv[0], argv[1:]...)
+		cmd.Dir = inst.WorkspaceDir
+		return cmd
+	}
+	t.Cleanup(func() { copyIntoExecCommand = orig })
+}
+
+func seedCopyIntoInstance(t *testing.T, ws string) {
+	t.Helper()
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Instances: []*fleet.Instance{
+			{Name: "i1", Backend: fleet.BackendDevcontainer, WorkspaceDir: ws, ContainerID: "c1", Status: fleet.StatusRunning},
+		}},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+}
+
+func sendCopyInto(t *testing.T, stream fleetgrpc.FleetService_CopyIntoClient, open *fleetgrpc.CopyIntoOpen, body string) (*fleetgrpc.CopyIntoReply, error) {
+	t.Helper()
+	if err := stream.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Open{Open: open}}); err != nil {
+		return nil, err
+	}
+	if body != "" {
+		if err := stream.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Data{Data: []byte(body)}}); err != nil {
+			return nil, err
+		}
+	}
+	return stream.CloseAndRecv()
+}
+
+// TestCopyIntoWritesFileToDir exercises the full handler over a real bufconn,
+// with the exec stubbed onto the host: a file streamed into an existing
+// directory lands at dir/name with the requested mode.
+func TestCopyIntoWritesFileToDir(t *testing.T) {
+	isolateFleetDir(t)
+	ws := t.TempDir()
+	dst := filepath.Join(ws, "sub")
+	if err := os.Mkdir(dst, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seedCopyIntoInstance(t, ws)
+	stubCopyIntoExec(t)
+
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+
+	stream, err := client.CopyInto(context.Background())
+	if err != nil {
+		t.Fatalf("CopyInto: %v", err)
+	}
+	reply, err := sendCopyInto(t, stream,
+		&fleetgrpc.CopyIntoOpen{Fleet: "alpha", Instance: "i1", Dest: dst, Name: "tool", Mode: 0o755, Size: 5}, "hello")
+	if err != nil {
+		t.Fatalf("CloseAndRecv: %v", err)
+	}
+	want := filepath.Join(dst, "tool")
+	if reply.GetPath() != want || reply.GetWritten() != 5 {
+		t.Fatalf("reply = %v, want path=%s written=5", reply, want)
+	}
+	got, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("written %q, want hello", got)
+	}
+	if fi, _ := os.Stat(want); fi.Mode().Perm() != 0o755 {
+		t.Fatalf("mode = %o, want 0755", fi.Mode().Perm())
+	}
+}
+
+// TestCopyIntoEmptyDestUsesWorkspace confirms an empty dest extracts into the
+// workspace folder (the exec cwd) keeping the source name.
+func TestCopyIntoEmptyDestUsesWorkspace(t *testing.T) {
+	isolateFleetDir(t)
+	ws := t.TempDir()
+	seedCopyIntoInstance(t, ws)
+	stubCopyIntoExec(t)
+
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+
+	stream, err := client.CopyInto(context.Background())
+	if err != nil {
+		t.Fatalf("CopyInto: %v", err)
+	}
+	reply, err := sendCopyInto(t, stream,
+		&fleetgrpc.CopyIntoOpen{Fleet: "alpha", Instance: "i1", Dest: "", Name: "out.bin", Mode: 0o644, Size: 3}, "abc")
+	if err != nil {
+		t.Fatalf("CloseAndRecv: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(ws, "out.bin")); err != nil || string(got) != "abc" {
+		t.Fatalf("workspace file = %q (err %v), want abc", got, err)
+	}
+	if reply.GetWritten() != 3 {
+		t.Fatalf("written = %d, want 3", reply.GetWritten())
+	}
+}
+
+// TestCopyIntoSizeMismatchPreservesExisting is the atomicity guarantee: a
+// truncated upload (declared size > bytes streamed) fails the RPC and leaves a
+// pre-existing destination file untouched, with no temp file left behind.
+func TestCopyIntoSizeMismatchPreservesExisting(t *testing.T) {
+	isolateFleetDir(t)
+	ws := t.TempDir()
+	dst := filepath.Join(ws, "sub")
+	if err := os.Mkdir(dst, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := filepath.Join(dst, "tool")
+	if err := os.WriteFile(existing, []byte("ORIGINAL"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	seedCopyIntoInstance(t, ws)
+	stubCopyIntoExec(t)
+
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+
+	stream, err := client.CopyInto(context.Background())
+	if err != nil {
+		t.Fatalf("CopyInto: %v", err)
+	}
+	// Declare 10 bytes but stream only 3 — a short upload.
+	_, err = sendCopyInto(t, stream,
+		&fleetgrpc.CopyIntoOpen{Fleet: "alpha", Instance: "i1", Dest: dst, Name: "tool", Mode: 0o644, Size: 10}, "abc")
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("short upload: want InvalidArgument, got %v", err)
+	}
+	if got, _ := os.ReadFile(existing); string(got) != "ORIGINAL" {
+		t.Fatalf("existing file clobbered: %q, want ORIGINAL", got)
+	}
+	entries, _ := os.ReadDir(dst)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".fleetcopy-") {
+			t.Fatalf("temp file leaked: %s", e.Name())
+		}
+	}
+}
+
+// TestCopyIntoMissingDirIsNotFound confirms a non-existent destination directory
+// is reported cleanly (before any tar extraction).
+func TestCopyIntoMissingDirIsNotFound(t *testing.T) {
+	isolateFleetDir(t)
+	ws := t.TempDir()
+	seedCopyIntoInstance(t, ws)
+	stubCopyIntoExec(t)
+
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+
+	stream, err := client.CopyInto(context.Background())
+	if err != nil {
+		t.Fatalf("CopyInto: %v", err)
+	}
+	_, err = sendCopyInto(t, stream,
+		&fleetgrpc.CopyIntoOpen{Fleet: "alpha", Instance: "i1", Dest: filepath.Join(ws, "nope") + "/", Name: "x", Size: 1}, "y")
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("missing dir: want NotFound, got %v", err)
+	}
+}
+
+// TestCopyIntoUnknownInstance fails fast with NotFound before any exec.
+func TestCopyIntoUnknownInstance(t *testing.T) {
+	isolateFleetDir(t)
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+
+	stream, err := client.CopyInto(context.Background())
+	if err != nil {
+		t.Fatalf("CopyInto: %v", err)
+	}
+	_, err = sendCopyInto(t, stream,
+		&fleetgrpc.CopyIntoOpen{Fleet: "ghost", Instance: "x", Dest: "/tmp", Name: "f", Size: 1}, "z")
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("unknown instance: want NotFound, got %v", err)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -85,9 +85,9 @@ func Serve(ctx context.Context) error {
 	// socket and turns received browser.open envelopes (from an in-container
 	// `fleet launch` TUI) into BrowserOpen events the connected client execs
 	// locally, and file.copy envelopes (from an in-container `fleet copy` / fc)
-	// into FileCopy events the connected client downloads from. Runs
-	// unconditionally (cheap: only running instances get a listener) and tears
-	// down when hubCtx is cancelled.
+	// into FileCopy events the connected client performs the scp-style copy for.
+	// Runs unconditionally (cheap: only running instances get a listener) and
+	// tears down when hubCtx is cancelled.
 	controlReg := newControlRegistry(func(fleetName, instanceName, url string) {
 		svc.hub.post(func(h *hub) {
 			h.broadcastBrowserOpen(&fleetgrpc.BrowserOpen{
@@ -96,13 +96,13 @@ func Serve(ctx context.Context) error {
 				Instance: instanceName,
 			})
 		})
-	}, func(fleetName, instanceName, path, dest string) {
+	}, func(fleetName, instanceName, src, dst string) {
 		svc.hub.post(func(h *hub) {
 			h.broadcastFileCopy(&fleetgrpc.FileCopy{
 				Fleet:    fleetName,
 				Instance: instanceName,
-				Path:     path,
-				Dest:     dest,
+				Src:      src,
+				Dst:      dst,
 			})
 		})
 	}, svc.hub.hasSubscribers)

--- a/internal/server/watch_grpc_test.go
+++ b/internal/server/watch_grpc_test.go
@@ -217,11 +217,14 @@ func TestWatchStreamsFileCopy(t *testing.T) {
 	// copies — discrete events must arrive in order, not conflated.
 	time.Sleep(100 * time.Millisecond)
 	svc.hub.post(func(h *hub) {
-		h.broadcastFileCopy(&fleetgrpc.FileCopy{Fleet: "alpha", Instance: "i1", Path: "/ws/bin/tool", Dest: "~/builds/tool"})
-		h.broadcastFileCopy(&fleetgrpc.FileCopy{Fleet: "alpha", Instance: "i1", Path: "/ws/bin/tool2"})
+		h.broadcastFileCopy(&fleetgrpc.FileCopy{Fleet: "alpha", Instance: "i1", Src: ":bin/tool", Dst: "~/builds/tool"})
+		h.broadcastFileCopy(&fleetgrpc.FileCopy{Fleet: "alpha", Instance: "i1", Src: "report.csv", Dst: ":/tmp/"})
 	})
 
-	for _, wantPath := range []string{"/ws/bin/tool", "/ws/bin/tool2"} {
+	for _, want := range []struct{ src, dst string }{
+		{":bin/tool", "~/builds/tool"},
+		{"report.csv", ":/tmp/"},
+	} {
 		ev, err := stream.Recv()
 		if err != nil {
 			t.Fatalf("Recv: %v", err)
@@ -230,11 +233,8 @@ func TestWatchStreamsFileCopy(t *testing.T) {
 		if fc == nil {
 			t.Fatalf("want FileCopy event, got %v", ev)
 		}
-		if fc.GetFleet() != "alpha" || fc.GetInstance() != "i1" || fc.GetPath() != wantPath {
-			t.Fatalf("FileCopy = %v, want alpha/i1 %s", fc, wantPath)
-		}
-		if wantPath == "/ws/bin/tool" && fc.GetDest() != "~/builds/tool" {
-			t.Fatalf("FileCopy dest = %q, want ~/builds/tool", fc.GetDest())
+		if fc.GetFleet() != "alpha" || fc.GetInstance() != "i1" || fc.GetSrc() != want.src || fc.GetDst() != want.dst {
+			t.Fatalf("FileCopy = %v, want alpha/i1 src=%s dst=%s", fc, want.src, want.dst)
 		}
 	}
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -139,6 +139,12 @@ type model struct {
 	releaseNotesVersion string
 	releaseNotesBody    string
 
+	// Delegated-copy confirmation: an in-container `fc` that touches a host path
+	// is queued here until the human allows/denies it; copySessionAllow remembers
+	// instances the human cleared for the lifetime of this TUI. See copyconfirm.go.
+	pendingCopyConfirms []copyRequest
+	copySessionAllow    map[string]bool
+
 	// Pending exec after quit: after a successful update the TUI
 	// quits, then Run() replaces the current process with the new
 	// fleet binary via syscall.Exec so the new fleet is NOT nested
@@ -191,6 +197,7 @@ func newModel() model {
 		agentSpinner:       agentSpinnerModel,
 		inHostTmux:         os.Getenv("TMUX") != "",
 		armadaStatus:       make(map[string]armadaStatus),
+		copySessionAllow:   make(map[string]bool),
 		bootGateway:        os.Getenv("FLEET_GATEWAY"),
 		bootToken:          os.Getenv("FLEET_TOKEN"),
 		bootServer:         os.Getenv("FLEET_SERVER"),
@@ -737,6 +744,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// 2.6 Delegated-copy confirmation — while a host-touching `fc` is pending it
+	// swallows all key input: allow/deny resolves it, every other key is ignored
+	// so it can't fall through to the active page. See copyconfirm.go.
+	if m.copyConfirmShowing() {
+		if key, ok := msg.(tea.KeyMsg); ok {
+			return m, tea.Batch(spinCmd, m.resolveCopyConfirm(key.String()))
+		}
+	}
+
 	// 3. Shared-only messages — return early
 	switch msg := msg.(type) {
 	case stateChangedMsg:
@@ -819,13 +835,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.gen != m.watchGen {
 			return m, spinCmd
 		}
-		// An in-container `fleet copy` (fc) delegated a copy to this TUI; run it
-		// against the host fleet in the background, with this machine as local.
+		// An in-container `fleet copy` (fc) delegated a copy to this TUI. A copy
+		// that touches a host path is gated behind a confirmation (unless the
+		// instance is session-allowed); one purely between instances runs straight
+		// away. See copyconfirm.go.
 		if msg.fleet == "" || msg.instance == "" || msg.src == "" {
 			return m, spinCmd
 		}
-		m.message = fmt.Sprintf("Copying %s -> %s...", msg.src, copyDstLabel(msg.dst))
-		return m, tea.Batch(spinCmd, copyForInstanceCmd(msg.fleet, msg.instance, msg.src, msg.dst))
+		cmd := m.requestCopy(copyRequest{fleet: msg.fleet, instance: msg.instance, src: msg.src, dst: msg.dst})
+		return m, tea.Batch(spinCmd, cmd)
 
 	case fileCopyDoneMsg:
 		if msg.err != nil {
@@ -1250,6 +1268,10 @@ func (m model) View() string {
 	// Release notes overlay takes over the whole screen, centered.
 	if m.releaseNotesShowing() {
 		return m.viewReleaseNotes() + "\x1b[0J"
+	}
+	// Delegated-copy confirmation overlay (host-touching `fc`).
+	if m.copyConfirmShowing() {
+		return m.viewCopyConfirm() + "\x1b[0J"
 	}
 	return m.currentPage.View(&m) + "\x1b[0J"
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -819,20 +819,19 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.gen != m.watchGen {
 			return m, spinCmd
 		}
-		// An in-container `fleet copy` (fc) asked the host to copy a file out of
-		// the instance; pull it to this machine in the background (the requested
-		// destination, or the downloads folder).
-		if msg.fleet == "" || msg.instance == "" || msg.path == "" {
+		// An in-container `fleet copy` (fc) delegated a copy to this TUI; run it
+		// against the host fleet in the background, with this machine as local.
+		if msg.fleet == "" || msg.instance == "" || msg.src == "" {
 			return m, spinCmd
 		}
-		m.message = fmt.Sprintf("Copying %s from %s/%s...", msg.path, msg.fleet, msg.instance)
-		return m, tea.Batch(spinCmd, copyInstanceFileCmd(msg.fleet, msg.instance, msg.path, msg.dest))
+		m.message = fmt.Sprintf("Copying %s -> %s...", msg.src, copyDstLabel(msg.dst))
+		return m, tea.Batch(spinCmd, copyForInstanceCmd(msg.fleet, msg.instance, msg.src, msg.dst))
 
 	case fileCopyDoneMsg:
 		if msg.err != nil {
-			m.message = fmt.Sprintf("Copy of %s failed: %v", msg.path, msg.err)
+			m.message = fmt.Sprintf("Copy of %s failed: %v", msg.src, msg.err)
 		} else {
-			m.message = fmt.Sprintf("Copied %s -> %s", msg.path, msg.dest)
+			m.message = fmt.Sprintf("Copied %s -> %s", msg.src, msg.dest)
 		}
 		return m, spinCmd
 

--- a/internal/tui/copyconfirm.go
+++ b/internal/tui/copyconfirm.go
@@ -1,0 +1,145 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetclient"
+)
+
+// copyconfirm.go gates delegated in-instance `fc` copies behind a host-side
+// confirmation. A file.copy control envelope lets an in-container process drive a
+// copy that touches the human's machine — reading a host file into the instance
+// or writing one out. Anything inside the container (including untrusted code or
+// a coding agent) can send one, so before performing a copy that touches a host
+// path the TUI asks the human to allow it. "Allow for session" remembers the
+// originating instance in memory, so repeated copies from a box the human trusts
+// don't re-prompt while the TUI stays open.
+
+// copyRequest is one delegated copy awaiting (or cleared for) host-side action.
+type copyRequest struct {
+	fleet, instance, src, dst string
+}
+
+func (r copyRequest) instanceKey() string { return r.fleet + "/" + r.instance }
+
+// copyTouchesHost reports whether either endpoint is a path on this (the host)
+// machine — the only case that needs confirmation. A copy purely between
+// instances never reads or writes the human's disk.
+func copyTouchesHost(src, dst string) bool {
+	return fleetclient.ParseCopyEndpoint(src).Kind == fleetclient.CopyLocal ||
+		fleetclient.ParseCopyEndpoint(dst).Kind == fleetclient.CopyLocal
+}
+
+// copyConfirmShowing reports whether a host-copy confirmation is pending.
+func (m *model) copyConfirmShowing() bool {
+	return len(m.pendingCopyConfirms) > 0
+}
+
+// requestCopy decides what to do with a delegated copy: run it now when it does
+// not touch the host, or the originating instance is already session-allowed;
+// otherwise queue it for confirmation. Returns the command to run (nil while a
+// request is queued for the human to confirm).
+func (m *model) requestCopy(req copyRequest) tea.Cmd {
+	if !copyTouchesHost(req.src, req.dst) || m.copySessionAllow[req.instanceKey()] {
+		return m.startConfirmedCopy(req)
+	}
+	m.pendingCopyConfirms = append(m.pendingCopyConfirms, req)
+	return nil
+}
+
+// resolveCopyConfirm handles a keypress while the confirmation is showing: allow
+// once, allow for the session, or deny (any other key is swallowed). Returns the
+// command to run, if any.
+func (m *model) resolveCopyConfirm(key string) tea.Cmd {
+	if !m.copyConfirmShowing() {
+		return nil
+	}
+	req := m.pendingCopyConfirms[0]
+	switch key {
+	case "a", "y", "enter":
+		m.pendingCopyConfirms = m.pendingCopyConfirms[1:]
+		return m.startConfirmedCopy(req)
+	case "s":
+		m.copySessionAllow[req.instanceKey()] = true
+		// Run this one plus every other queued request from the now-trusted
+		// instance; keep the rest queued for their own confirmation.
+		cmds := []tea.Cmd{m.startConfirmedCopy(req)}
+		remaining := append([]copyRequest(nil), m.pendingCopyConfirms[1:]...)
+		m.pendingCopyConfirms = nil
+		for _, r := range remaining {
+			if r.instanceKey() == req.instanceKey() {
+				cmds = append(cmds, m.startConfirmedCopy(r))
+			} else {
+				m.pendingCopyConfirms = append(m.pendingCopyConfirms, r)
+			}
+		}
+		return tea.Batch(cmds...)
+	case "d", "n", "esc":
+		m.pendingCopyConfirms = m.pendingCopyConfirms[1:]
+		m.message = fmt.Sprintf("Denied copy %s -> %s from %s", req.src, copyDstLabel(req.dst), req.instanceKey())
+		return nil
+	}
+	return nil
+}
+
+// startConfirmedCopy sets the status line and returns the background copy command.
+func (m *model) startConfirmedCopy(req copyRequest) tea.Cmd {
+	m.message = fmt.Sprintf("Copying %s -> %s...", req.src, copyDstLabel(req.dst))
+	return copyForInstanceCmd(req.fleet, req.instance, req.src, req.dst)
+}
+
+// copyConfirmHostEffects describes, for the human, which host paths a pending
+// copy would read or write — the whole reason the prompt exists.
+func copyConfirmHostEffects(req copyRequest) []string {
+	var effects []string
+	if fleetclient.ParseCopyEndpoint(req.src).Kind == fleetclient.CopyLocal {
+		effects = append(effects, "reads "+req.src+" on THIS machine")
+	}
+	switch {
+	case req.dst == "":
+		effects = append(effects, "writes to your downloads folder on THIS machine")
+	case fleetclient.ParseCopyEndpoint(req.dst).Kind == fleetclient.CopyLocal:
+		effects = append(effects, "writes "+req.dst+" on THIS machine")
+	}
+	return effects
+}
+
+// viewCopyConfirm renders the centered confirmation overlay for the first
+// pending request.
+func (m model) viewCopyConfirm() string {
+	req := m.pendingCopyConfirms[0]
+
+	boxWidth := 64
+	if m.width > 0 && boxWidth > m.width-4 {
+		boxWidth = m.width - 4
+	}
+	boxWidth = max(boxWidth, 24)
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("203")).
+		Padding(1, 2).
+		Width(boxWidth)
+
+	title := dialogTitle.Render("⚠ Copy request from " + req.instanceKey())
+	path := dialogLabel.Render(req.src + "  →  " + copyDstLabel(req.dst))
+	effects := dialogHint.Render(strings.Join(copyConfirmHostEffects(req), "\n"))
+	hint := dialogLabel.Render("[a]llow once    [s] allow for session    [d]eny")
+
+	content := title + "\n\n" + path + "\n" + effects + "\n\n" + hint
+	if extra := len(m.pendingCopyConfirms) - 1; extra > 0 {
+		content += "\n" + dialogHint.Render(fmt.Sprintf("(%d more request(s) queued)", extra))
+	}
+
+	width, height := m.width, m.height
+	if width <= 0 {
+		width = boxWidth + 4
+	}
+	if height <= 0 {
+		height = lipgloss.Height(box.Render(content))
+	}
+	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, box.Render(content))
+}

--- a/internal/tui/copyconfirm_test.go
+++ b/internal/tui/copyconfirm_test.go
@@ -1,0 +1,101 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCopyTouchesHost(t *testing.T) {
+	cases := []struct {
+		src, dst string
+		want     bool
+	}{
+		{"report.csv", "alpha:/tmp/", true}, // local source (upload from host)
+		{"alpha:/out", "./here", true},      // local dest (download to host)
+		{":out.bin", "", true},              // download shorthand → host downloads
+		{":out", "other:/tmp/", false},      // self → another instance, no host path
+		{"a:x", "b:y", false},               // instance → instance
+	}
+	for _, tc := range cases {
+		if got := copyTouchesHost(tc.src, tc.dst); got != tc.want {
+			t.Errorf("copyTouchesHost(%q,%q) = %v, want %v", tc.src, tc.dst, got, tc.want)
+		}
+	}
+}
+
+func TestRequestCopyGating(t *testing.T) {
+	m := &model{copySessionAllow: map[string]bool{}}
+
+	// A copy purely between instances runs immediately, no prompt.
+	if cmd := m.requestCopy(copyRequest{fleet: "f", instance: "i", src: ":a", dst: "other:/b"}); cmd == nil {
+		t.Fatal("instance→instance copy should run immediately (non-nil cmd)")
+	}
+	if m.copyConfirmShowing() {
+		t.Fatal("instance→instance copy should not queue a confirmation")
+	}
+
+	// A host-touching copy is queued for confirmation.
+	if cmd := m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "secret.txt", dst: ":/tmp/"}); cmd != nil {
+		t.Fatal("host-touching copy should queue (nil cmd), not run")
+	}
+	if !m.copyConfirmShowing() || len(m.pendingCopyConfirms) != 1 {
+		t.Fatalf("host-touching copy should queue exactly one, got %d", len(m.pendingCopyConfirms))
+	}
+
+	// Once the instance is session-allowed, host-touching copies run immediately.
+	m.copySessionAllow["f/i"] = true
+	if cmd := m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "x.txt", dst: ":/tmp/"}); cmd == nil {
+		t.Fatal("session-allowed host copy should run immediately")
+	}
+	if len(m.pendingCopyConfirms) != 1 {
+		t.Fatalf("session-allowed copy should not enqueue; pending = %d", len(m.pendingCopyConfirms))
+	}
+}
+
+func TestResolveCopyConfirmAllowOnce(t *testing.T) {
+	m := &model{copySessionAllow: map[string]bool{}}
+	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "a.txt", dst: ":/tmp/"})
+
+	if cmd := m.resolveCopyConfirm("a"); cmd == nil {
+		t.Fatal("allow-once should return a copy command")
+	}
+	if m.copyConfirmShowing() {
+		t.Fatal("queue should be empty after allow-once")
+	}
+	if m.copySessionAllow["f/i"] {
+		t.Fatal("allow-once must NOT set the session allowance")
+	}
+}
+
+func TestResolveCopyConfirmSessionDrainsSameInstance(t *testing.T) {
+	m := &model{copySessionAllow: map[string]bool{}}
+	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "a.txt", dst: ":/tmp/"})
+	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "b.txt", dst: ":/tmp/"})
+	m.requestCopy(copyRequest{fleet: "f", instance: "j", src: "c.txt", dst: ":/tmp/"})
+
+	if cmd := m.resolveCopyConfirm("s"); cmd == nil {
+		t.Fatal("session allow should return command(s) to run")
+	}
+	if !m.copySessionAllow["f/i"] {
+		t.Fatal("session allow must record the instance")
+	}
+	// Both f/i requests cleared; the f/j request stays queued for its own prompt.
+	if len(m.pendingCopyConfirms) != 1 || m.pendingCopyConfirms[0].instanceKey() != "f/j" {
+		t.Fatalf("only the other instance's request should remain, got %+v", m.pendingCopyConfirms)
+	}
+}
+
+func TestResolveCopyConfirmDeny(t *testing.T) {
+	m := &model{copySessionAllow: map[string]bool{}}
+	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "a.txt", dst: ":/tmp/"})
+
+	if cmd := m.resolveCopyConfirm("d"); cmd != nil {
+		t.Fatal("deny should not return a copy command")
+	}
+	if m.copyConfirmShowing() {
+		t.Fatal("queue should be empty after deny")
+	}
+	if !strings.Contains(m.message, "Denied") {
+		t.Fatalf("deny should report it; message = %q", m.message)
+	}
+}

--- a/internal/tui/filecopy.go
+++ b/internal/tui/filecopy.go
@@ -14,70 +14,124 @@ import (
 
 // filecopy.go is the client half of the in-instance `fleet copy` (fc) feature:
 // a file.copy control envelope arrives as a Watch FileCopy event
-// (watchFileCopyMsg), and THIS client pulls the bytes over the CopyFile RPC and
-// writes them to its local downloads folder. The split mirrors BrowserOpen —
-// the server only names the file; the machine the user is sitting at fetches
-// it, which is what makes fc deliver to the local machine even when the fleet
-// server (and the instance) are fully remote.
+// (watchFileCopyMsg) naming two scp endpoints, and THIS client runs the generic
+// copy engine against the host fleet with its own disk as the "local" side. The
+// split mirrors BrowserOpen — the in-container caller can't reach the host fleetd
+// or the user's disk, so the machine the user is sitting at performs the copy,
+// which is what makes fc work (in either direction) even when the fleet server
+// and the instance are fully remote.
 
-// fileCopyTimeout bounds one pull. Generous — a copied artifact can be a large
+// fileCopyTimeout bounds one copy. Generous — a copied artifact can be a large
 // build output crossing a WAN tunnel — while still unsticking a wedged stream.
 const fileCopyTimeout = 15 * time.Minute
 
-// fileCopyDoneMsg reports a finished (or failed) background file pull.
+// fileCopyDoneMsg reports a finished (or failed) background copy.
 type fileCopyDoneMsg struct {
-	path string // in-instance source path (for the failure message)
-	dest string // local path written (empty on failure)
+	src  string // source endpoint as typed inside the instance (for messages)
+	dst  string // destination endpoint as typed inside the instance
+	dest string // final path written (empty on failure)
 	err  error
 }
 
-// copyInstanceFileCmd pulls fleet/instance:path to this machine off the UI
-// thread — to the requested destination when the in-instance sender named one,
-// the local downloads folder otherwise.
-func copyInstanceFileCmd(fleetName, instanceName, path, requestedDest string) tea.Cmd {
+// copyForInstanceCmd runs the copy an in-instance `fc` delegated, off the UI
+// thread. src/dst are the endpoints as typed inside the instance; origFleet/
+// origInstance identify the sender, used to resolve a `:path` (self) endpoint and
+// to default the fleet of a bare instance reference.
+func copyForInstanceCmd(origFleet, origInstance, src, dst string) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), fileCopyTimeout)
 		defer cancel()
 		conn, err := fleetclient.Dial(ctx)
 		if err != nil {
-			return fileCopyDoneMsg{path: path, err: err}
+			return fileCopyDoneMsg{src: src, dst: dst, err: err}
 		}
 		defer conn.Close()
-		dest, _, err := fleetclient.CopyFileTo(ctx, conn.Service(), fleetName, instanceName, path, resolveRequestedDest(requestedDest))
+		res, err := fleetclient.Copy(ctx, conn.Service(),
+			resolveTUIEndpoint(src, origFleet, origInstance),
+			resolveTUIEndpoint(dst, origFleet, origInstance),
+			tuiLocalPolicy{})
 		if err != nil {
-			return fileCopyDoneMsg{path: path, err: err}
+			return fileCopyDoneMsg{src: src, dst: dst, err: err}
 		}
-		return fileCopyDoneMsg{path: path, dest: dest}
+		return fileCopyDoneMsg{src: src, dst: dst, dest: res.DestPath}
 	}
 }
 
-// resolveRequestedDest maps the dest string typed inside the instance onto
-// this machine's filesystem, scp-style: empty means the downloads folder, an
-// absolute path is used as-is, and `~/` or a relative path resolve against
-// this user's home — the instance's cwd means nothing here, so home is the
-// only sensible anchor (it is also what scp does for relative remote paths).
-func resolveRequestedDest(dest string) string {
-	if dest == "" {
-		return downloadsDir()
+// copyDstLabel renders a destination for the status line — the empty 1-arg
+// download shorthand reads as the downloads folder.
+func copyDstLabel(dst string) string {
+	if dst == "" {
+		return "your downloads folder"
 	}
+	return dst
+}
+
+// resolveTUIEndpoint turns a typed endpoint into a ResolvedEndpoint for a copy
+// the TUI runs on a sender's behalf: a plain path is local (this machine), `:path`
+// is the sender's own instance, and a bare instance reference defaults to the
+// sender's fleet (a sibling in the user's fleet).
+func resolveTUIEndpoint(arg, origFleet, origInstance string) fleetclient.ResolvedEndpoint {
+	ep := fleetclient.ParseCopyEndpoint(arg)
+	switch ep.Kind {
+	case fleetclient.CopySelf:
+		return fleetclient.ResolvedEndpoint{Fleet: origFleet, Instance: origInstance, Path: ep.Path}
+	case fleetclient.CopyInstance:
+		fleetName := ep.Fleet
+		if fleetName == "" {
+			fleetName = origFleet
+		}
+		return fleetclient.ResolvedEndpoint{Fleet: fleetName, Instance: ep.Instance, Path: ep.Path}
+	default:
+		return fleetclient.ResolvedEndpoint{Local: true, Path: ep.Path}
+	}
+}
+
+// tuiLocalPolicy resolves typed local paths on the human's machine for a
+// delegated in-instance copy. The instance's cwd means nothing here, so a
+// relative or `~/` path resolves against this user's home (what scp does for
+// relative remote paths); an empty destination lands in the downloads folder; a
+// directory destination keeps the source's name.
+type tuiLocalPolicy struct{}
+
+func (tuiLocalPolicy) ResolveSrc(path string) string { return resolveLocalPath(path) }
+
+func (tuiLocalPolicy) ResolveDest(dest, name string) (string, error) {
+	if dest == "" {
+		return filepath.Join(downloadsDir(), name), nil
+	}
+	resolved := resolveLocalPath(dest)
+	if strings.HasSuffix(dest, "/") {
+		return filepath.Join(resolved, name), nil
+	}
+	if fi, err := os.Stat(resolved); err == nil && fi.IsDir() {
+		return filepath.Join(resolved, name), nil
+	}
+	return resolved, nil
+}
+
+// resolveLocalPath maps a typed local path onto this machine's filesystem,
+// scp-style: an absolute path is used as-is, while `~/` and relative paths
+// resolve against this user's home — the only sensible anchor, since the
+// instance's cwd is meaningless on this machine.
+func resolveLocalPath(path string) string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return dest
+		return path
 	}
 	switch {
-	case dest == "~":
+	case path == "~":
 		return home
-	case strings.HasPrefix(dest, "~/"):
-		return filepath.Join(home, dest[2:])
-	case !filepath.IsAbs(dest):
-		return filepath.Join(home, dest)
+	case strings.HasPrefix(path, "~/"):
+		return filepath.Join(home, path[2:])
+	case !filepath.IsAbs(path):
+		return filepath.Join(home, path)
 	}
-	return dest
+	return path
 }
 
-// downloadsDir picks where fc-copied files land: ~/Downloads when it exists
-// (the conventional per-user download folder), otherwise the home directory,
-// falling back to the current directory when even home is unknown.
+// downloadsDir picks where a 1-arg `fc` download lands: ~/Downloads when it
+// exists (the conventional per-user download folder), otherwise the home
+// directory, falling back to the current directory when even home is unknown.
 func downloadsDir() string {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/tui/filecopy_test.go
+++ b/internal/tui/filecopy_test.go
@@ -3,18 +3,19 @@ package tui
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetclient"
 )
 
-func TestResolveRequestedDest(t *testing.T) {
+func TestResolveLocalPath(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
 	cases := []struct {
 		name string
-		dest string
+		path string
 		want string
 	}{
-		{"empty means downloads folder", "", home}, // temp home has no Downloads dir
 		{"absolute used as-is", "/abs/target", "/abs/target"},
 		{"bare tilde is home", "~", home},
 		{"tilde-slash resolves against home", "~/builds/tool", filepath.Join(home, "builds/tool")},
@@ -22,8 +23,59 @@ func TestResolveRequestedDest(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := resolveRequestedDest(tc.dest); got != tc.want {
-				t.Errorf("resolveRequestedDest(%q) = %q, want %q", tc.dest, got, tc.want)
+			if got := resolveLocalPath(tc.path); got != tc.want {
+				t.Errorf("resolveLocalPath(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTUILocalPolicyResolveDest covers the human-machine dest policy: empty goes
+// to the downloads folder (no Downloads dir in the temp home, so home itself),
+// a directory keeps the source name, and a file path is used as-is.
+func TestTUILocalPolicyResolveDest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	policy := tuiLocalPolicy{}
+
+	cases := []struct {
+		name, dest, src, want string
+	}{
+		{"empty means downloads", "", "tool", filepath.Join(home, "tool")},
+		{"trailing slash keeps name", "~/builds/", "tool", filepath.Join(home, "builds", "tool")},
+		{"file path used as-is", "~/out.bin", "tool", filepath.Join(home, "out.bin")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := policy.ResolveDest(tc.dest, tc.src)
+			if err != nil {
+				t.Fatalf("ResolveDest: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("ResolveDest(%q,%q) = %q, want %q", tc.dest, tc.src, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveTUIEndpoint covers how a delegated copy resolves endpoints against
+// the originating instance: self is the sender, a bare instance defaults to the
+// sender's fleet, and a plain path is local to this (the TUI's) machine.
+func TestResolveTUIEndpoint(t *testing.T) {
+	cases := []struct {
+		arg  string
+		want fleetclient.ResolvedEndpoint
+	}{
+		{":build/out", fleetclient.ResolvedEndpoint{Fleet: "myfleet", Instance: "self", Path: "build/out"}},
+		{"other:/tmp/x", fleetclient.ResolvedEndpoint{Fleet: "myfleet", Instance: "other", Path: "/tmp/x"}},
+		{"two/other:/tmp/x", fleetclient.ResolvedEndpoint{Fleet: "two", Instance: "other", Path: "/tmp/x"}},
+		{"report.csv", fleetclient.ResolvedEndpoint{Local: true, Path: "report.csv"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.arg, func(t *testing.T) {
+			got := resolveTUIEndpoint(tc.arg, "myfleet", "self")
+			if got != tc.want {
+				t.Errorf("resolveTUIEndpoint(%q) = %+v, want %+v", tc.arg, got, tc.want)
 			}
 		})
 	}

--- a/internal/tui/watch.go
+++ b/internal/tui/watch.go
@@ -102,8 +102,8 @@ type watchBrowserOpenMsg struct {
 	gen                           int
 }
 type watchFileCopyMsg struct {
-	fleet, instance, path, dest string
-	gen                         int
+	fleet, instance, src, dst string
+	gen                       int
 }
 type remoteMcpStatusMsg struct {
 	status *fleetgrpc.RemoteMcpStatus
@@ -222,8 +222,8 @@ func watchOnce(ctx context.Context, program *tea.Program, gen int) bool {
 			program.Send(watchFileCopyMsg{
 				fleet:    fc.GetFleet(),
 				instance: fc.GetInstance(),
-				path:     fc.GetPath(),
-				dest:     fc.GetDest(),
+				src:      fc.GetSrc(),
+				dst:      fc.GetDst(),
 				gen:      gen,
 			})
 		case *fleetgrpc.Event_RemoteMcpStatus:


### PR DESCRIPTION
## Summary

Closes #164. `fleet copy` (alias `fc`) was one-directional — it could only pull a file *out* of an instance. It's now a generic, scp-style copy that works in **both directions and between instances**, built as a single engine rather than per-direction patches.

Each of the two arguments is an endpoint, parsed uniformly:

- `[fleet/]instance:path` — a file inside an instance (reachable even on a remote fleet)
- a plain path — a file on the orchestrating machine
- `:path` — a file in the **current** instance (in-instance form)

Direction is inferred from which side is local vs an instance. One engine (`fleetclient.Copy`) dispatches all four combinations:

| src → dst | mechanism |
|---|---|
| local → instance | **new `CopyInto` client-streaming RPC** (`tar -xf -` into the container) |
| instance → local | `CopyFile` (unchanged) |
| instance → instance | relay one `CopyFile` stream into one `CopyInto` stream |
| local → local | a plain file copy |

```
fleet copy alpha:bin/tool ./tool          # download
fleet copy ./tool alpha:/usr/local/bin/   # upload
fleet copy alpha:a beta:b                 # between instances
fc :build/out ~/Downloads/                # this instance → your machine
fc report.csv :/tmp/                      # your machine → this instance
fc :out other/inst:/tmp/                  # this instance → another
```

## Notable decisions / behavior changes

- **Atomic upload.** The server extracts into a temp name and `mv`s it into place, so a truncated/oversized stream fails the RPC without ever clobbering an existing destination — the same atomicity the download direction already had. The declared size is a hard cap; the destination directory is probed up front for clean errors; the basename is validated.
- **In-instance `fc` now always delegates to the host TUI.** The container can't reach the host fleetd over gRPC (only the control socket is bind-mounted), so `fc` sends `{src,dst}` over the control socket and the connected TUI runs the same engine against the **host** fleet with its own disk as "local". This is a deliberate change from the previous behavior where the in-instance colon form resolved against a nested fleet — instance names now resolve against the user's own fleet, which is what makes `fc foo other-instance:/tmp/` mean what you'd expect. As with the old out-direction, it needs a host TUI attached.
- **Backend caveat (pre-existing, shared with the out-direction):** the codespaces backend allocates a PTY for exec, whose line discipline can mangle binary data on stdin; the strict size check turns any resulting truncation into a clean error rather than a silent partial write. devcontainer (default) and coder exec over a clean binary channel.

## Breaking (internal, single-binary)

- proto `FileCopy` fields `path`/`dest` → `src`/`dst`; control `CopyFilePayload` `Path`/`Dest` → `Src`/`Dst`. All consumers updated in lockstep.

## Tests

- New: endpoint parser, engine combos (over an in-process gRPC server), `CopyInto` handler (real `tar`/`test` exec) incl. the atomicity guarantee, TUI/host local-path policies, control round-trip, watch event.
- Integration `025_copy.sh` extended with upload, directory-upload, missing-dir/missing-local failure, and instance→instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)