### PR TITLE
fix/fleet-copy-local-cwd-and-host-prefix — cwd-local paths, host: prefix, and recursive directory copy

### DIFF
--- a/fleetgrpc/exec.pb.go
+++ b/fleetgrpc/exec.pb.go
@@ -801,11 +801,11 @@ func (x *ForwardOpen) GetRemotePort() int32 {
 	return 0
 }
 
-// CopyFile streams one file out of an instance to the client (the `fleet copy` /
-// in-instance `fc` feature). The server reads the file through the backend (a
-// tar pipe over container exec, so metadata + bytes arrive in one exec) and
-// streams it back: the FIRST chunk carries `meta`, every following chunk carries
-// `data`. Only regular files are supported — a directory is an InvalidArgument.
+// CopyFile streams a file OR directory out of an instance to the client (the
+// `fleet copy` / in-instance `fc` feature). The server reads through the backend
+// (a tar pipe over container exec) and streams it back: the FIRST chunk carries
+// `meta`, every following chunk carries `data`. For a file the data is the raw
+// bytes; for a directory (meta.is_dir) it is a tar the client extracts in Go.
 // Works unchanged over the remote gateway, which is the headline use case:
 // pulling a built binary out of a fully remote deployment onto the local machine.
 type CopyFileRequest struct {
@@ -954,11 +954,18 @@ func (*CopyFileChunk_Data) isCopyFileChunk_Msg() {}
 
 type CopyFileMeta struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// name is the source file's basename — the default local filename.
+	// name is the source's basename — the default local name.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// mode is the source file's permission bits (so an executable stays runnable).
-	Mode          uint32 `protobuf:"varint,2,opt,name=mode,proto3" json:"mode,omitempty"`
-	Size          int64  `protobuf:"varint,3,opt,name=size,proto3" json:"size,omitempty"`
+	// Unused when is_dir.
+	Mode uint32 `protobuf:"varint,2,opt,name=mode,proto3" json:"mode,omitempty"`
+	// size is the file's byte count. Unused when is_dir.
+	Size int64 `protobuf:"varint,3,opt,name=size,proto3" json:"size,omitempty"`
+	// is_dir marks a recursive directory copy: the data frames then carry a tar of
+	// the directory (`tar -C <path> -cf - .`) instead of raw file bytes, and the
+	// client extracts it in Go — skipping symlinks/special files and the `./` root
+	// entry, sanitizing entry names. mode/size are unused.
+	IsDir         bool `protobuf:"varint,4,opt,name=is_dir,json=isDir,proto3" json:"is_dir,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1014,15 +1021,22 @@ func (x *CopyFileMeta) GetSize() int64 {
 	return 0
 }
 
-// CopyInto streams one file INTO an instance — the reverse of CopyFile, the
-// other half of scp-style `fleet copy`. It is CLIENT-streaming: the FIRST chunk
-// MUST carry `open` (which instance, the destination, and the file's
-// name/mode/size); every following chunk carries `data`. The server resolves the
-// destination inside the container (an existing directory keeps the source
-// basename; otherwise `dest` is the target path) and writes the bytes through
-// the backend with a single `tar -xf -` exec — the mirror of CopyFile's
-// `tar -chf -` read — preserving the file mode. Works unchanged over the remote
-// gateway: pushing a local file into a fully remote deployment.
+func (x *CopyFileMeta) GetIsDir() bool {
+	if x != nil {
+		return x.IsDir
+	}
+	return false
+}
+
+// CopyInto streams a file OR directory INTO an instance — the reverse of
+// CopyFile, the other half of scp-style `fleet copy`. It is CLIENT-streaming: the
+// FIRST chunk MUST carry `open` (which instance, the destination, and the
+// source's name/mode/size or is_dir); every following chunk carries `data`. The
+// server resolves the destination inside the container and writes through the
+// backend with a `tar -xf -` exec. For a file the data is the raw bytes (written
+// atomically via a temp name + rename); for a directory (open.is_dir) it is a tar
+// of the directory's contents extracted in place. Works unchanged over the remote
+// gateway: pushing a local file or tree into a fully remote deployment.
 type CopyIntoChunk struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Msg:
@@ -1118,11 +1132,19 @@ type CopyIntoOpen struct {
 	Name string `protobuf:"bytes,4,opt,name=name,proto3" json:"name,omitempty"`
 	// mode is the file's permission bits to set on the written file (the perm bits
 	// are honoured; a 0 mode defaults to 0644). setuid/setgid/sticky are stripped.
+	// Unused when is_dir.
 	Mode uint32 `protobuf:"varint,5,opt,name=mode,proto3" json:"mode,omitempty"`
 	// size is the source file's byte count — needed up front for the tar header,
 	// and enforced as a hard cap so a truncated or oversized stream fails cleanly
-	// rather than leaving a partial file.
-	Size          int64 `protobuf:"varint,6,opt,name=size,proto3" json:"size,omitempty"`
+	// rather than leaving a partial file. Unused when is_dir.
+	Size int64 `protobuf:"varint,6,opt,name=size,proto3" json:"size,omitempty"`
+	// is_dir marks a recursive directory copy: the data frames then carry a tar of
+	// the directory's CONTENTS (entries relative to the dir root, no symlinks or
+	// special files, built by the client in Go), and the server resolves a target
+	// directory and extracts it there with `tar -xf -` (an in-place merge, like
+	// `cp -r`). mode/size are unused. NOT supported on the codespaces backend (its
+	// exec PTY can silently corrupt a binary tar) — a FailedPrecondition there.
+	IsDir         bool `protobuf:"varint,7,opt,name=is_dir,json=isDir,proto3" json:"is_dir,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1197,6 +1219,13 @@ func (x *CopyIntoOpen) GetSize() int64 {
 		return x.Size
 	}
 	return 0
+}
+
+func (x *CopyIntoOpen) GetIsDir() bool {
+	if x != nil {
+		return x.IsDir
+	}
+	return false
 }
 
 type CopyIntoReply struct {
@@ -1829,22 +1858,24 @@ const file_exec_proto_rawDesc = "" +
 	"\rCopyFileChunk\x12-\n" +
 	"\x04meta\x18\x01 \x01(\v2\x17.fleetgrpc.CopyFileMetaH\x00R\x04meta\x12\x14\n" +
 	"\x04data\x18\x02 \x01(\fH\x00R\x04dataB\x05\n" +
-	"\x03msg\"J\n" +
+	"\x03msg\"a\n" +
 	"\fCopyFileMeta\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04mode\x18\x02 \x01(\rR\x04mode\x12\x12\n" +
-	"\x04size\x18\x03 \x01(\x03R\x04size\"[\n" +
+	"\x04size\x18\x03 \x01(\x03R\x04size\x12\x15\n" +
+	"\x06is_dir\x18\x04 \x01(\bR\x05isDir\"[\n" +
 	"\rCopyIntoChunk\x12-\n" +
 	"\x04open\x18\x01 \x01(\v2\x17.fleetgrpc.CopyIntoOpenH\x00R\x04open\x12\x14\n" +
 	"\x04data\x18\x02 \x01(\fH\x00R\x04dataB\x05\n" +
-	"\x03msg\"\x90\x01\n" +
+	"\x03msg\"\xa7\x01\n" +
 	"\fCopyIntoOpen\x12\x14\n" +
 	"\x05fleet\x18\x01 \x01(\tR\x05fleet\x12\x1a\n" +
 	"\binstance\x18\x02 \x01(\tR\binstance\x12\x12\n" +
 	"\x04dest\x18\x03 \x01(\tR\x04dest\x12\x12\n" +
 	"\x04name\x18\x04 \x01(\tR\x04name\x12\x12\n" +
 	"\x04mode\x18\x05 \x01(\rR\x04mode\x12\x12\n" +
-	"\x04size\x18\x06 \x01(\x03R\x04size\"=\n" +
+	"\x04size\x18\x06 \x01(\x03R\x04size\x12\x15\n" +
+	"\x06is_dir\x18\a \x01(\bR\x05isDir\"=\n" +
 	"\rCopyIntoReply\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x18\n" +
 	"\awritten\x18\x02 \x01(\x03R\awritten\"M\n" +

--- a/fleetgrpc/exec.proto
+++ b/fleetgrpc/exec.proto
@@ -114,11 +114,11 @@ message ForwardOpen {
   int32 remote_port = 3;
 }
 
-// CopyFile streams one file out of an instance to the client (the `fleet copy` /
-// in-instance `fc` feature). The server reads the file through the backend (a
-// tar pipe over container exec, so metadata + bytes arrive in one exec) and
-// streams it back: the FIRST chunk carries `meta`, every following chunk carries
-// `data`. Only regular files are supported — a directory is an InvalidArgument.
+// CopyFile streams a file OR directory out of an instance to the client (the
+// `fleet copy` / in-instance `fc` feature). The server reads through the backend
+// (a tar pipe over container exec) and streams it back: the FIRST chunk carries
+// `meta`, every following chunk carries `data`. For a file the data is the raw
+// bytes; for a directory (meta.is_dir) it is a tar the client extracts in Go.
 // Works unchanged over the remote gateway, which is the headline use case:
 // pulling a built binary out of a fully remote deployment onto the local machine.
 message CopyFileRequest {
@@ -137,22 +137,29 @@ message CopyFileChunk {
 }
 
 message CopyFileMeta {
-  // name is the source file's basename — the default local filename.
+  // name is the source's basename — the default local name.
   string name = 1;
   // mode is the source file's permission bits (so an executable stays runnable).
+  // Unused when is_dir.
   uint32 mode = 2;
+  // size is the file's byte count. Unused when is_dir.
   int64 size = 3;
+  // is_dir marks a recursive directory copy: the data frames then carry a tar of
+  // the directory (`tar -C <path> -cf - .`) instead of raw file bytes, and the
+  // client extracts it in Go — skipping symlinks/special files and the `./` root
+  // entry, sanitizing entry names. mode/size are unused.
+  bool is_dir = 4;
 }
 
-// CopyInto streams one file INTO an instance — the reverse of CopyFile, the
-// other half of scp-style `fleet copy`. It is CLIENT-streaming: the FIRST chunk
-// MUST carry `open` (which instance, the destination, and the file's
-// name/mode/size); every following chunk carries `data`. The server resolves the
-// destination inside the container (an existing directory keeps the source
-// basename; otherwise `dest` is the target path) and writes the bytes through
-// the backend with a single `tar -xf -` exec — the mirror of CopyFile's
-// `tar -chf -` read — preserving the file mode. Works unchanged over the remote
-// gateway: pushing a local file into a fully remote deployment.
+// CopyInto streams a file OR directory INTO an instance — the reverse of
+// CopyFile, the other half of scp-style `fleet copy`. It is CLIENT-streaming: the
+// FIRST chunk MUST carry `open` (which instance, the destination, and the
+// source's name/mode/size or is_dir); every following chunk carries `data`. The
+// server resolves the destination inside the container and writes through the
+// backend with a `tar -xf -` exec. For a file the data is the raw bytes (written
+// atomically via a temp name + rename); for a directory (open.is_dir) it is a tar
+// of the directory's contents extracted in place. Works unchanged over the remote
+// gateway: pushing a local file or tree into a fully remote deployment.
 message CopyIntoChunk {
   oneof msg {
     CopyIntoOpen open = 1;
@@ -172,11 +179,19 @@ message CopyIntoOpen {
   string name = 4;
   // mode is the file's permission bits to set on the written file (the perm bits
   // are honoured; a 0 mode defaults to 0644). setuid/setgid/sticky are stripped.
+  // Unused when is_dir.
   uint32 mode = 5;
   // size is the source file's byte count — needed up front for the tar header,
   // and enforced as a hard cap so a truncated or oversized stream fails cleanly
-  // rather than leaving a partial file.
+  // rather than leaving a partial file. Unused when is_dir.
   int64 size = 6;
+  // is_dir marks a recursive directory copy: the data frames then carry a tar of
+  // the directory's CONTENTS (entries relative to the dir root, no symlinks or
+  // special files, built by the client in Go), and the server resolves a target
+  // directory and extracts it there with `tar -xf -` (an in-place merge, like
+  // `cp -r`). mode/size are unused. NOT supported on the codespaces backend (its
+  // exec PTY can silently corrupt a binary tar) — a FailedPrecondition there.
+  bool is_dir = 7;
 }
 
 message CopyIntoReply {

--- a/integration/tests/025_copy.sh
+++ b/integration/tests/025_copy.sh
@@ -64,6 +64,12 @@ info "fleet copy into an instance directory keeps the source basename"
 "${FLEET_BIN}" copy "${workdir}/up.bin" "${FIXTURE_REPO_NAME}/alpha:/tmp/updir/"
 assert_equals "uploaded-bytes" "$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- cat /tmp/updir/up.bin)" "directory upload basename"
 
+info "the host: prefix names the host machine (same as a plain path on the host)"
+"${FLEET_BIN}" copy "host:${workdir}/up.bin" "${FIXTURE_REPO_NAME}/alpha:/tmp/hostpfx.bin"
+assert_equals "uploaded-bytes" "$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- cat /tmp/hostpfx.bin)" "host: prefix upload content"
+"${FLEET_BIN}" copy "${FIXTURE_REPO_NAME}/alpha:/tmp/hostpfx.bin" "host:${workdir}/from-host-pfx.bin"
+assert_equals "uploaded-bytes" "$(cat "${workdir}/from-host-pfx.bin")" "host: prefix download content"
+
 info "fleet copy into a non-existent instance directory fails"
 set +e
 "${FLEET_BIN}" copy "${workdir}/up.bin" "${FIXTURE_REPO_NAME}/alpha:/tmp/no-such-dir/" >/dev/null 2>&1

--- a/integration/tests/025_copy.sh
+++ b/integration/tests/025_copy.sh
@@ -41,15 +41,6 @@ if [ -e "${workdir}/nope" ]; then
   fail "failed copy must not leave a destination file"
 fi
 
-info "fleet copy of a directory fails"
-set +e
-"${FLEET_BIN}" copy "${FIXTURE_REPO_NAME}/alpha:/tmp" "${workdir}/dir-nope" >/dev/null 2>&1
-rc=$?
-set -e
-if [ "${rc}" -eq 0 ]; then
-  fail "expected non-zero exit copying a directory, got 0"
-fi
-
 # ---- the reverse direction: copy a local file INTO an instance ----
 
 info "fleet copy <local> alpha:/tmp/up.bin uploads into the instance, keeping mode"
@@ -93,5 +84,24 @@ fi
 info "fleet copy alpha:path alpha:path2 relays between two instance paths"
 "${FLEET_BIN}" copy "${FIXTURE_REPO_NAME}/alpha:/tmp/up.bin" "${FIXTURE_REPO_NAME}/alpha:/tmp/relayed.bin"
 assert_equals "uploaded-bytes" "$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- cat /tmp/relayed.bin)" "relayed file content"
+
+# ---- recursive directory copy (all four directions) ----
+
+info "upload a directory tree into the instance"
+mkdir -p "${workdir}/tree/sub"
+printf 'top' > "${workdir}/tree/top.txt"
+printf 'nested' > "${workdir}/tree/sub/nested.txt"
+"${FLEET_BIN}" copy "${workdir}/tree" "${FIXTURE_REPO_NAME}/alpha:/tmp/uptree"
+assert_equals "top" "$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- cat /tmp/uptree/top.txt)" "uploaded dir top file"
+assert_equals "nested" "$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- cat /tmp/uptree/sub/nested.txt)" "uploaded dir nested file"
+
+info "download a directory tree out of the instance"
+"${FLEET_BIN}" copy "${FIXTURE_REPO_NAME}/alpha:/tmp/uptree" "${workdir}/downtree"
+assert_equals "top" "$(cat "${workdir}/downtree/top.txt")" "downloaded dir top file"
+assert_equals "nested" "$(cat "${workdir}/downtree/sub/nested.txt")" "downloaded dir nested file"
+
+info "relay a directory tree between two instance paths"
+"${FLEET_BIN}" copy "${FIXTURE_REPO_NAME}/alpha:/tmp/uptree" "${FIXTURE_REPO_NAME}/alpha:/tmp/relaytree"
+assert_equals "nested" "$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- cat /tmp/relaytree/sub/nested.txt)" "relayed dir nested file"
 
 pass "copy"

--- a/internal/cli/copy.go
+++ b/internal/cli/copy.go
@@ -27,30 +27,24 @@ import (
 // The HELP text is tailored to where the command runs.
 func newCopyCmd() *cobra.Command {
 	use := "copy <src> <dst>"
-	short := "Copy a file to, from, or between fleet instances, scp-style"
-	long := "Copy a single file between your machine and a fleet instance — or between\n" +
-		"two instances — scp-style. A plain path is a file on this machine\n" +
-		"(cwd-relative); `[fleet/]instance:path` is a file inside an instance (reachable\n" +
-		"even on a remote fleet). Direction follows which side is which:\n\n" +
-		"  fleet copy alpha:bin/tool ./tool         # download out of an instance\n" +
-		"  fleet copy ./tool alpha:/usr/local/bin/  # upload into an instance\n" +
-		"  fleet copy alpha:a beta:b                # copy between two instances\n\n" +
-		"A relative instance path resolves against the workspace folder; a directory\n" +
-		"destination keeps the source's name. Given a single instance source the file\n" +
-		"downloads to the current directory."
+	short := "Copy files to, from, and between instances"
+	long := "Copy a file or directory between your machine and an instance, or between two\n" +
+		"instances. A plain path is local (cwd-relative); [fleet/]instance:path is a\n" +
+		"file inside an instance. Direction follows which side is which.\n\n" +
+		"  fleet copy alpha:bin/tool ./tool         download from an instance\n" +
+		"  fleet copy ./tool alpha:/usr/local/bin/  upload to an instance\n" +
+		"  fleet copy alpha:a beta:b                between two instances\n\n" +
+		"A relative instance path is relative to the workspace folder; a directory\n" +
+		"destination keeps the source name. A lone instance source downloads to the cwd."
 	if fleetcopy.InInstance() {
-		short = "Copy a file to or from this instance via your fleet TUI (shorthand: fc)"
-		long = "Copy a single file between THIS instance and your machine — or another\n" +
-			"instance — scp-style. The copy is performed by the fleet TUI on your machine,\n" +
-			"so it works even when this instance lives on a remote server.\n\n" +
-			"A plain path is a file in THIS instance (cwd-relative); `host:path` is a file\n" +
-			"on your machine (where the TUI runs); `[fleet/]instance:path` is any instance\n" +
-			"in your fleet:\n\n" +
-			"  fc ./build/out host:~/Downloads/   # copy this instance's file to your machine\n" +
-			"  fc host:report.csv /tmp/           # copy a file from your machine into this instance\n" +
-			"  fc ./out.bin other:/tmp/           # copy this instance's file into another instance\n\n" +
-			"Given a single non-host source the file lands in your downloads folder. A copy\n" +
-			"that touches your machine asks for confirmation in the fleet TUI."
+		long = "Copy a file or directory between this instance and your machine, or another\n" +
+			"instance. A plain path is in this instance (cwd-relative); host:path is on\n" +
+			"your machine; [fleet/]instance:path is any instance in your fleet.\n\n" +
+			"  fc ./build/out host:~/Downloads/  this instance -> your machine\n" +
+			"  fc host:report.csv /tmp/          your machine  -> this instance\n" +
+			"  fc ./out.bin other:/tmp/          this instance -> another instance\n\n" +
+			"A lone source downloads to your downloads folder. A copy that touches your\n" +
+			"machine asks for confirmation in the fleet TUI."
 	}
 
 	return &cobra.Command{
@@ -119,7 +113,7 @@ func requireDownloadSource(src, dst string) error {
 	}
 	switch fleetclient.ParseCopyEndpoint(src).Kind {
 	case fleetclient.CopyLocal, fleetclient.CopyHost:
-		return fmt.Errorf("a destination is required: %q is a path on your machine, so name where it should go (e.g. an instance:/path)", src)
+		return fmt.Errorf("destination required: %q is on your machine", src)
 	}
 	return nil
 }
@@ -158,7 +152,7 @@ func resolveHostEndpoint(arg string) (fleetclient.ResolvedEndpoint, error) {
 	case fleetclient.CopyLocal, fleetclient.CopyHost:
 		return fleetclient.ResolvedEndpoint{Local: true, Path: ep.Path}, nil
 	case fleetclient.CopySelf:
-		return fleetclient.ResolvedEndpoint{}, fmt.Errorf("`:path` means the current instance and only works inside one — name the fleet/instance instead (got %q)", arg)
+		return fleetclient.ResolvedEndpoint{}, fmt.Errorf("`:path` only works inside an instance (got %q)", arg)
 	default:
 		if ep.Fleet != "" {
 			return fleetclient.ResolvedEndpoint{Fleet: ep.Fleet, Instance: ep.Instance, Path: ep.Path}, nil

--- a/internal/cli/copy.go
+++ b/internal/cli/copy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path/filepath"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetclient"
@@ -13,10 +14,11 @@ import (
 
 // newCopyCmd creates the `fleet copy` command (aliased `cp`; inside an instance
 // the staged fleet.rc also provides `fc`). It is a generic, scp-style copy: each
-// of the two arguments is an endpoint — `[fleet/]instance:path` (a file inside an
-// instance), a plain path (a file on the orchestrating machine), or `:path` (the
-// current instance) — and the direction is inferred from which side is which. The
-// same command copies out of, into, and between instances.
+// of the two arguments is an endpoint and the direction is inferred from which
+// side is which. A plain path is local to the machine the command runs on
+// (cwd-relative): the host for `fleet copy`, THIS instance for in-instance `fc`.
+// `host:path` is the host machine, and `[fleet/]instance:path` is a named
+// instance. The same command copies out of, into, and between instances.
 //
 // Where the copy is performed depends only on where the command runs, not on the
 // direction: a host invocation drives the fleet server directly; an in-instance
@@ -27,9 +29,9 @@ func newCopyCmd() *cobra.Command {
 	use := "copy <src> <dst>"
 	short := "Copy a file to, from, or between fleet instances, scp-style"
 	long := "Copy a single file between your machine and a fleet instance — or between\n" +
-		"two instances — scp-style. Each path is either `[fleet/]instance:path` (a file\n" +
-		"inside an instance, reachable even on a remote fleet) or a plain local path;\n" +
-		"the direction follows which side is which:\n\n" +
+		"two instances — scp-style. A plain path is a file on this machine\n" +
+		"(cwd-relative); `[fleet/]instance:path` is a file inside an instance (reachable\n" +
+		"even on a remote fleet). Direction follows which side is which:\n\n" +
 		"  fleet copy alpha:bin/tool ./tool         # download out of an instance\n" +
 		"  fleet copy ./tool alpha:/usr/local/bin/  # upload into an instance\n" +
 		"  fleet copy alpha:a beta:b                # copy between two instances\n\n" +
@@ -37,17 +39,18 @@ func newCopyCmd() *cobra.Command {
 		"destination keeps the source's name. Given a single instance source the file\n" +
 		"downloads to the current directory."
 	if fleetcopy.InInstance() {
-		short = "Copy a file to or from an instance via your fleet TUI (shorthand: fc)"
-		long = "Copy a single file between your machine and an instance — or between two\n" +
-			"instances — scp-style. The copy is performed by the fleet TUI on your\n" +
-			"machine, so it works even when this instance lives on a remote server.\n\n" +
-			"A plain path is a file on your machine (where the TUI runs); `:path` is a\n" +
-			"file in THIS instance; `[fleet/]instance:path` is any instance in your fleet:\n\n" +
-			"  fc :bin/tool ~/Downloads/   # copy this instance's file to your machine\n" +
-			"  fc report.csv :/tmp/        # copy a file from your machine into this instance\n" +
-			"  fc :out.bin other:/tmp/     # copy this instance's file into another instance\n\n" +
-			"Given a single `:`/instance source the file lands in your downloads folder.\n" +
-			"Needs the fleet TUI connected on the other end."
+		short = "Copy a file to or from this instance via your fleet TUI (shorthand: fc)"
+		long = "Copy a single file between THIS instance and your machine — or another\n" +
+			"instance — scp-style. The copy is performed by the fleet TUI on your machine,\n" +
+			"so it works even when this instance lives on a remote server.\n\n" +
+			"A plain path is a file in THIS instance (cwd-relative); `host:path` is a file\n" +
+			"on your machine (where the TUI runs); `[fleet/]instance:path` is any instance\n" +
+			"in your fleet:\n\n" +
+			"  fc ./build/out host:~/Downloads/   # copy this instance's file to your machine\n" +
+			"  fc host:report.csv /tmp/           # copy a file from your machine into this instance\n" +
+			"  fc ./out.bin other:/tmp/           # copy this instance's file into another instance\n\n" +
+			"Given a single non-host source the file lands in your downloads folder. A copy\n" +
+			"that touches your machine asks for confirmation in the fleet TUI."
 	}
 
 	return &cobra.Command{
@@ -66,20 +69,59 @@ func newCopyCmd() *cobra.Command {
 	}
 }
 
-// runCopy validates the arguments and routes the copy: in-instance invocations
-// delegate to the connected host TUI; host invocations drive the fleet server
-// directly. The single-argument form is a download shorthand, so a lone source
-// must name an instance — a lone local path has no destination.
+// runCopy routes the copy: in-instance invocations rewrite their plain (this-
+// instance) paths to absolute self endpoints and delegate to the connected host
+// TUI; host invocations drive the fleet server directly. The single-argument
+// form is a download shorthand, so a lone source must be a remote (instance)
+// endpoint — a lone path on your own machine has nowhere to go.
 func runCopy(ctx context.Context, out io.Writer, src, dst string) error {
-	if dst == "" && fleetclient.ParseCopyEndpoint(src).Kind == fleetclient.CopyLocal {
-		return fmt.Errorf("a destination is required: %q is a local file, so name where it should go (e.g. `fleet copy %s instance:/path`)", src, src)
-	}
 	if fleetcopy.InInstance() {
+		// A plain path typed inside an instance is THAT instance's file, relative
+		// to the cwd; resolve it here (only this process knows its cwd) so the TUI
+		// reads/writes the instance, not the host.
+		src = rewriteInstanceLocal(src)
+		dst = rewriteInstanceLocal(dst)
+		if err := requireDownloadSource(src, dst); err != nil {
+			return err
+		}
 		// The container can't reach the host fleetd over gRPC; ask the connected
-		// TUI to perform the copy against the host fleet (its disk is "local").
+		// TUI to perform the copy against the host fleet.
 		return fleetcopy.Request(fleetcopy.Config{}, out, src, dst)
 	}
+	if err := requireDownloadSource(src, dst); err != nil {
+		return err
+	}
 	return hostCopy(ctx, out, src, dst)
+}
+
+// rewriteInstanceLocal turns a plain (cwd-relative) path typed inside an instance
+// into a `:absolute` self endpoint, so the host TUI resolves it against THIS
+// instance rather than the host's disk. host:/instance:/: forms (and the empty
+// 1-arg dst) pass through unchanged.
+func rewriteInstanceLocal(arg string) string {
+	if arg == "" || fleetclient.ParseCopyEndpoint(arg).Kind != fleetclient.CopyLocal {
+		return arg
+	}
+	abs, err := filepath.Abs(arg)
+	if err != nil {
+		return arg // best-effort; the TUI surfaces an unresolvable path as an error
+	}
+	return ":" + abs
+}
+
+// requireDownloadSource enforces the 1-arg download shorthand: with no
+// destination the file is delivered to your machine's downloads folder, so the
+// source must be a remote (instance) endpoint — a path on your own machine
+// (plain or host:) has no destination.
+func requireDownloadSource(src, dst string) error {
+	if dst != "" {
+		return nil
+	}
+	switch fleetclient.ParseCopyEndpoint(src).Kind {
+	case fleetclient.CopyLocal, fleetclient.CopyHost:
+		return fmt.Errorf("a destination is required: %q is a path on your machine, so name where it should go (e.g. an instance:/path)", src)
+	}
+	return nil
 }
 
 // hostCopy resolves both endpoints against the host fleet and runs the generic
@@ -107,13 +149,13 @@ func hostCopy(ctx context.Context, out io.Writer, src, dst string) error {
 }
 
 // resolveHostEndpoint turns a typed argument into a ResolvedEndpoint for the host
-// form: a local path stays local, an instance reference resolves its fleet (a
-// bare instance infers it from the cwd, like the rest of the CLI), and `:path`
-// (self) is rejected — there is no current instance when run on a host.
+// form: a plain or `host:` path is the host's own disk, an instance reference
+// resolves its fleet (a bare instance infers it from the cwd, like the rest of
+// the CLI), and `:path` (self) is rejected — there is no current instance on a host.
 func resolveHostEndpoint(arg string) (fleetclient.ResolvedEndpoint, error) {
 	ep := fleetclient.ParseCopyEndpoint(arg)
 	switch ep.Kind {
-	case fleetclient.CopyLocal:
+	case fleetclient.CopyLocal, fleetclient.CopyHost:
 		return fleetclient.ResolvedEndpoint{Local: true, Path: ep.Path}, nil
 	case fleetclient.CopySelf:
 		return fleetclient.ResolvedEndpoint{}, fmt.Errorf("`:path` means the current instance and only works inside one — name the fleet/instance instead (got %q)", arg)

--- a/internal/cli/copy_test.go
+++ b/internal/cli/copy_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -21,6 +22,9 @@ func TestResolveHostEndpoint(t *testing.T) {
 		{"/abs/tool", fleetclient.ResolvedEndpoint{Local: true, Path: "/abs/tool"}},
 		{"tool.txt", fleetclient.ResolvedEndpoint{Local: true, Path: "tool.txt"}},
 		{"", fleetclient.ResolvedEndpoint{Local: true, Path: ""}},
+		// `host:` is the same machine as a plain path on the host.
+		{"host:/tmp/x", fleetclient.ResolvedEndpoint{Local: true, Path: "/tmp/x"}},
+		{"host:rel.txt", fleetclient.ResolvedEndpoint{Local: true, Path: "rel.txt"}},
 		{"myfleet/alpha:/bin/tool", fleetclient.ResolvedEndpoint{Fleet: "myfleet", Instance: "alpha", Path: "/bin/tool"}},
 		{"myfleet/alpha:rel/path", fleetclient.ResolvedEndpoint{Fleet: "myfleet", Instance: "alpha", Path: "rel/path"}},
 	}
@@ -42,5 +46,55 @@ func TestResolveHostEndpoint(t *testing.T) {
 func TestResolveHostEndpointRejectsSelf(t *testing.T) {
 	if _, err := resolveHostEndpoint(":build/tool"); err == nil || !strings.Contains(err.Error(), "inside") {
 		t.Fatalf("self on host: want error mentioning inside-an-instance, got %v", err)
+	}
+}
+
+// TestRewriteInstanceLocal confirms that a plain (this-instance) path typed
+// inside an instance is rewritten to an absolute `:` self endpoint, while
+// host:/instance:/: forms and the empty 1-arg dst pass through unchanged.
+func TestRewriteInstanceLocal(t *testing.T) {
+	mustAbs := func(p string) string {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			t.Fatalf("Abs(%q): %v", p, err)
+		}
+		return abs
+	}
+	cases := []struct{ arg, want string }{
+		{"foo.txt", ":" + mustAbs("foo.txt")},
+		{"./sub/bar", ":" + mustAbs("./sub/bar")},
+		{"/abs/already", ":/abs/already"},
+		{"", ""},
+		{"host:/tmp/x", "host:/tmp/x"},
+		{"alpha:/p", "alpha:/p"},
+		{":build/out", ":build/out"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.arg, func(t *testing.T) {
+			if got := rewriteInstanceLocal(tc.arg); got != tc.want {
+				t.Errorf("rewriteInstanceLocal(%q) = %q, want %q", tc.arg, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRequireDownloadSource enforces the 1-arg shorthand: a lone source must be a
+// remote (instance/self) endpoint; a path on your own machine has no destination.
+func TestRequireDownloadSource(t *testing.T) {
+	// With a destination, anything is allowed.
+	if err := requireDownloadSource("host:/tmp/x", "alpha:/p"); err != nil {
+		t.Fatalf("2-arg should never error: %v", err)
+	}
+	// 1-arg remote sources are valid (download to downloads folder).
+	for _, src := range []string{"alpha:/bin/tool", ":build/out", "myfleet/beta:/p"} {
+		if err := requireDownloadSource(src, ""); err != nil {
+			t.Errorf("1-arg %q should be allowed, got %v", src, err)
+		}
+	}
+	// 1-arg own-machine sources are rejected.
+	for _, src := range []string{"./file", "plain.txt", "host:/tmp/x", "/abs/file"} {
+		if err := requireDownloadSource(src, ""); err == nil {
+			t.Errorf("1-arg %q should require a destination", src)
+		}
 	}
 }

--- a/internal/fleetclient/copyendpoint.go
+++ b/internal/fleetclient/copyendpoint.go
@@ -7,22 +7,29 @@ import (
 )
 
 // copyendpoint.go classifies the two arguments of a scp-style `fleet copy`. An
-// endpoint is one of three kinds; direction is inferred from which side is local
-// vs an instance. The parser is shared by the CLI (host form) and is mirrored by
-// the in-instance form, so a path means the same thing everywhere.
+// endpoint is one of a few kinds; direction is inferred from which side is which.
+// The parser is shared by the CLI (host form) and the in-instance form, so a
+// path means the same thing everywhere: a plain path is local to the machine the
+// command runs on (the host for `fleet copy`, the instance for in-instance `fc`),
+// and `host:` is the explicit way to reach the host from inside an instance.
 
 // CopyEndpointKind classifies one side of a copy.
 type CopyEndpointKind int
 
 const (
-	// CopyLocal is a plain path on the orchestrating client's own disk.
+	// CopyLocal is a plain path on the machine the command runs on (cwd-relative).
+	// For `fleet copy` that's the host; for in-instance `fc` it's that instance.
 	CopyLocal CopyEndpointKind = iota
 	// CopyInstance is `[fleet/]instance:path` — a path inside a named instance.
 	CopyInstance
-	// CopySelf is `:path` — a path inside the CURRENT instance. Only meaningful
-	// in the in-instance form, where the originating instance is known; the host
-	// form rejects it (there is no "current" instance).
+	// CopySelf is `:path` — a path inside the CURRENT instance (workspace-relative).
+	// Only meaningful in the in-instance form, where the originating instance is
+	// known; the host form rejects it (there is no "current" instance).
 	CopySelf
+	// CopyHost is `host:path` — a path on the HOST machine (where the fleet TUI
+	// runs). It is how an in-instance `fc` reaches the human's disk; on the host
+	// itself it is the same machine as a plain path.
+	CopyHost
 )
 
 // CopyEndpoint is one parsed side of a copy.
@@ -39,6 +46,7 @@ type CopyEndpoint struct {
 //     "C:\file" is local, not an instance named "C"), always forces a LOCAL path
 //     (a local filename containing a colon is still reachable, spelled
 //     "./name:with:colon"),
+//   - "host:path" is the HOST machine,
 //   - ":path" (empty prefix, non-empty path) is the CURRENT instance (SELF),
 //   - "[fleet/]instance:path" is a named INSTANCE,
 //   - anything else — including a malformed instance ref or an empty path after
@@ -55,6 +63,9 @@ func ParseCopyEndpoint(arg string) CopyEndpoint {
 	}
 	if i == 0 {
 		return CopyEndpoint{Kind: CopySelf, Path: path}
+	}
+	if arg[:i] == "host" {
+		return CopyEndpoint{Kind: CopyHost, Path: path}
 	}
 	parts := strings.Split(arg[:i], "/")
 	if len(parts) > 2 || slices.Contains(parts, "") {

--- a/internal/fleetclient/copyendpoint_test.go
+++ b/internal/fleetclient/copyendpoint_test.go
@@ -14,6 +14,12 @@ func TestParseCopyEndpoint(t *testing.T) {
 		// Self references (the current instance).
 		{":path", CopyEndpoint{Kind: CopySelf, Path: "path"}},
 		{":bin/tool", CopyEndpoint{Kind: CopySelf, Path: "bin/tool"}},
+		// Host references (the machine where the TUI runs).
+		{"host:/tmp/x", CopyEndpoint{Kind: CopyHost, Path: "/tmp/x"}},
+		{"host:report.csv", CopyEndpoint{Kind: CopyHost, Path: "report.csv"}},
+		{"host:~/Downloads/", CopyEndpoint{Kind: CopyHost, Path: "~/Downloads/"}},
+		// A fleet literally named "host" still works via the slash form.
+		{"host/inst:/p", CopyEndpoint{Kind: CopyInstance, Fleet: "host", Instance: "inst", Path: "/p"}},
 		// Plain local paths — a leading /, . or ~ always forces local.
 		{"bin/tool", CopyEndpoint{Kind: CopyLocal, Path: "bin/tool"}},
 		{"/abs/path", CopyEndpoint{Kind: CopyLocal, Path: "/abs/path"}},

--- a/internal/fleetclient/copyengine.go
+++ b/internal/fleetclient/copyengine.go
@@ -1,6 +1,7 @@
 package fleetclient
 
 import (
+	"archive/tar"
 	"context"
 	"fmt"
 	"io"
@@ -80,6 +81,9 @@ func uploadLocalToInstance(ctx context.Context, svc fleetgrpc.FleetServiceClient
 	if err != nil {
 		return CopyResult{}, err
 	}
+	if fi.IsDir() {
+		return uploadDirToInstance(ctx, svc, srcPath, dst)
+	}
 	if err := requireRegularFile(srcPath, fi); err != nil {
 		return CopyResult{}, err
 	}
@@ -129,6 +133,42 @@ func uploadLocalToInstance(ctx context.Context, svc fleetgrpc.FleetServiceClient
 	return CopyResult{DestPath: reply.GetPath(), Written: reply.GetWritten()}, nil
 }
 
+// uploadDirToInstance streams a tar of srcDir's contents into dst over CopyInto
+// (open.is_dir). The tar is built in Go (skipping symlinks/specials and the root)
+// and the server extracts it in place. As with the file path, a Send error is
+// the server closing — CloseAndRecv carries the real status.
+func uploadDirToInstance(ctx context.Context, svc fleetgrpc.FleetServiceClient, srcPath string, dst ResolvedEndpoint) (CopyResult, error) {
+	stream, err := svc.CopyInto(ctx)
+	if err != nil {
+		return CopyResult{}, err
+	}
+	sendErr := stream.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Open{Open: &fleetgrpc.CopyIntoOpen{
+		Fleet:    dst.Fleet,
+		Instance: dst.Instance,
+		Dest:     dst.Path,
+		Name:     filepath.Base(srcPath),
+		IsDir:    true,
+	}}})
+	var written int64
+	if sendErr == nil {
+		tw := tar.NewWriter(copyChunkWriter{send: func(b []byte) error {
+			return stream.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Data{Data: b}})
+		}})
+		written, sendErr = writeTarTreeFromWalk(tw, srcPath)
+		if sendErr == nil {
+			sendErr = tw.Close()
+		}
+	}
+	reply, recvErr := stream.CloseAndRecv()
+	if recvErr != nil {
+		return CopyResult{}, recvErr
+	}
+	if sendErr != nil && sendErr != io.EOF {
+		return CopyResult{}, sendErr
+	}
+	return CopyResult{DestPath: reply.GetPath(), Written: written}, nil
+}
+
 // downloadInstanceToLocal pulls src over the CopyFile RPC and writes it to the
 // path the policy resolves for the source basename. The bytes go to a temp file
 // in the destination directory first and are renamed into place on success, so a
@@ -158,6 +198,24 @@ func downloadInstanceToLocal(ctx context.Context, svc fleetgrpc.FleetServiceClie
 	if err != nil {
 		return CopyResult{}, err
 	}
+
+	if meta.GetIsDir() {
+		// The remaining data frames are a tar of the directory; extract it under
+		// destPath in Go, skipping symlinks/specials and sanitizing entry names.
+		r := &copyChunkReader{recv: func() ([]byte, error) {
+			chunk, err := stream.Recv()
+			if err != nil {
+				return nil, err
+			}
+			return chunk.GetData(), nil
+		}}
+		written, err := extractTarTree(r, destPath)
+		if err != nil {
+			return CopyResult{}, err
+		}
+		return CopyResult{DestPath: destPath, Written: written}, nil
+	}
+
 	mode := os.FileMode(meta.GetMode()).Perm()
 	if mode == 0 {
 		mode = 0o644
@@ -205,8 +263,10 @@ func downloadInstanceToLocal(ctx context.Context, svc fleetgrpc.FleetServiceClie
 }
 
 // relayInstanceToInstance copies between two instances without touching local
-// disk: the source's CopyFile stream is pumped straight into the destination's
-// CopyInto stream, with the source meta (name/mode/size) seeding the open header.
+// disk: the source's CopyFile stream feeds the destination's CopyInto stream,
+// with the source meta seeding the open header. A file is pumped raw; a directory
+// (meta.is_dir) is transformed in Go through filterTarTree, so the destination
+// receives the same clean (no symlinks/specials/root) tar the upload path builds.
 func relayInstanceToInstance(ctx context.Context, svc fleetgrpc.FleetServiceClient, src, dst ResolvedEndpoint) (CopyResult, error) {
 	out, err := svc.CopyFile(ctx, &fleetgrpc.CopyFileRequest{Fleet: src.Fleet, Instance: src.Instance, Path: src.Path})
 	if err != nil {
@@ -234,44 +294,79 @@ func relayInstanceToInstance(ctx context.Context, svc fleetgrpc.FleetServiceClie
 		Name:     meta.GetName(),
 		Mode:     meta.GetMode(),
 		Size:     meta.GetSize(),
+		IsDir:    meta.GetIsDir(),
 	}}})
-	for sendErr == nil {
-		chunk, recvErr := out.Recv()
-		if recvErr == io.EOF {
-			break
+
+	if meta.GetIsDir() {
+		if sendErr == nil {
+			r := &copyChunkReader{recv: func() ([]byte, error) {
+				chunk, err := out.Recv()
+				if err != nil {
+					return nil, err
+				}
+				return chunk.GetData(), nil
+			}}
+			tw := tar.NewWriter(copyChunkWriter{send: func(b []byte) error {
+				return in.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Data{Data: b}})
+			}})
+			_, sendErr = filterTarTree(tw, tar.NewReader(r))
+			if sendErr == nil {
+				sendErr = tw.Close()
+			}
 		}
-		if recvErr != nil {
-			return CopyResult{}, recvErr
-		}
-		if data := chunk.GetData(); len(data) > 0 {
-			sendErr = in.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Data{Data: data}})
+	} else {
+		for sendErr == nil {
+			chunk, recvErr := out.Recv()
+			if recvErr == io.EOF {
+				break
+			}
+			if recvErr != nil {
+				return CopyResult{}, recvErr
+			}
+			if data := chunk.GetData(); len(data) > 0 {
+				sendErr = in.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Data{Data: data}})
+			}
 		}
 	}
-	reply, err := in.CloseAndRecv()
-	if err != nil {
-		return CopyResult{}, err
+
+	reply, recvErr := in.CloseAndRecv()
+	if recvErr != nil {
+		return CopyResult{}, recvErr
+	}
+	if sendErr != nil && sendErr != io.EOF {
+		return CopyResult{}, sendErr
 	}
 	return CopyResult{DestPath: reply.GetPath(), Written: reply.GetWritten()}, nil
 }
 
 // copyLocalToLocal copies one local file to another on the orchestrator's disk —
-// the degenerate case where neither endpoint is an instance. Bytes are streamed
-// (not slurped) so a large file doesn't balloon memory, and written through a
-// temp file renamed into place on success, so a failed copy never leaves a
-// partial — matching the atomicity of the instance directions.
+// the degenerate case where neither endpoint is an instance. A regular file is
+// streamed through a temp file renamed into place (atomic); a directory is copied
+// recursively in place (non-atomic, like the instance directions).
 func copyLocalToLocal(srcPath, dstTyped string, policy CopyLocalPolicy) (CopyResult, error) {
+	fi, err := os.Stat(srcPath)
+	if err != nil {
+		return CopyResult{}, err
+	}
+	if fi.IsDir() {
+		destPath, err := policy.ResolveDest(dstTyped, filepath.Base(srcPath))
+		if err != nil {
+			return CopyResult{}, err
+		}
+		written, err := copyTreeLocal(srcPath, destPath)
+		if err != nil {
+			return CopyResult{}, err
+		}
+		return CopyResult{DestPath: destPath, Written: written}, nil
+	}
+	if err := requireRegularFile(srcPath, fi); err != nil {
+		return CopyResult{}, err
+	}
 	in, err := os.Open(srcPath)
 	if err != nil {
 		return CopyResult{}, err
 	}
 	defer in.Close()
-	fi, err := in.Stat()
-	if err != nil {
-		return CopyResult{}, err
-	}
-	if err := requireRegularFile(srcPath, fi); err != nil {
-		return CopyResult{}, err
-	}
 	destPath, err := policy.ResolveDest(dstTyped, filepath.Base(srcPath))
 	if err != nil {
 		return CopyResult{}, err
@@ -301,12 +396,10 @@ func copyLocalToLocal(srcPath, dstTyped string, policy CopyLocalPolicy) (CopyRes
 	return CopyResult{DestPath: destPath, Written: written}, nil
 }
 
-// requireRegularFile rejects a local source that is a directory or special file —
-// only single regular files can be copied, matching the instance side.
+// requireRegularFile rejects a local source that is a special file (named pipe,
+// device, socket). Directories are handled separately and never reach here; a
+// symlink is followed by the os.Stat the callers already did.
 func requireRegularFile(path string, fi os.FileInfo) error {
-	if fi.IsDir() {
-		return fmt.Errorf("%s is a directory — only single files can be copied", path)
-	}
 	if !fi.Mode().IsRegular() {
 		return fmt.Errorf("%s is not a regular file", path)
 	}

--- a/internal/fleetclient/copyengine_test.go
+++ b/internal/fleetclient/copyengine_test.go
@@ -1,6 +1,8 @@
 package fleetclient
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"io"
 	"net"
@@ -18,6 +20,118 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 )
 
+// contentsTar builds a tar of dir's contents (the wire format for a dir copy).
+func contentsTar(t *testing.T, dir string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if _, err := writeTarTreeFromWalk(tw, dir); err != nil {
+		t.Fatalf("build tar: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// seedTree writes a small fixture tree under dir and returns it.
+func seedTree(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("aaa"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sub/b.txt"), []byte("bbbb"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCopyUploadDirToInstance(t *testing.T) {
+	srv := newFakeCopyServer()
+	client := dialFake(t, srv)
+
+	src := t.TempDir()
+	seedTree(t, src)
+
+	res, err := Copy(context.Background(), client,
+		ResolvedEndpoint{Local: true, Path: src},
+		ResolvedEndpoint{Fleet: "f", Instance: "i", Path: "/dst"},
+		passthroughPolicy{})
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if res.Written != 7 { // "aaa" + "bbbb"
+		t.Errorf("written = %d, want 7", res.Written)
+	}
+	if len(srv.intos) != 1 || !srv.intos[0].isDir {
+		t.Fatalf("want one is_dir CopyInto, got %+v", srv.intos)
+	}
+	// The captured tar must extract back to the same tree.
+	out := filepath.Join(t.TempDir(), "extracted")
+	if _, err := extractTarTree(bytes.NewReader(srv.intos[0].data), out); err != nil {
+		t.Fatalf("extract captured tar: %v", err)
+	}
+	if got, _ := os.ReadFile(filepath.Join(out, "sub/b.txt")); string(got) != "bbbb" {
+		t.Errorf("round-tripped sub/b.txt = %q, want bbbb", got)
+	}
+}
+
+func TestCopyDownloadDirToLocal(t *testing.T) {
+	srv := newFakeCopyServer()
+	src := t.TempDir()
+	seedTree(t, src)
+	srv.files[fileKey("f", "i", "/proj")] = fakeFile{name: "proj", isDir: true, data: contentsTar(t, src)}
+	client := dialFake(t, srv)
+
+	dst := t.TempDir()
+	res, err := Copy(context.Background(), client,
+		ResolvedEndpoint{Fleet: "f", Instance: "i", Path: "/proj"},
+		ResolvedEndpoint{Local: true, Path: dst + "/"}, // existing dir → dst/proj
+		passthroughPolicy{})
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	wantRoot := filepath.Join(dst, "proj")
+	if res.DestPath != wantRoot {
+		t.Errorf("DestPath = %q, want %q", res.DestPath, wantRoot)
+	}
+	if got, _ := os.ReadFile(filepath.Join(wantRoot, "a.txt")); string(got) != "aaa" {
+		t.Errorf("downloaded a.txt = %q, want aaa", got)
+	}
+	if got, _ := os.ReadFile(filepath.Join(wantRoot, "sub/b.txt")); string(got) != "bbbb" {
+		t.Errorf("downloaded sub/b.txt = %q, want bbbb", got)
+	}
+}
+
+func TestCopyRelayDirInstanceToInstance(t *testing.T) {
+	srv := newFakeCopyServer()
+	src := t.TempDir()
+	seedTree(t, src)
+	srv.files[fileKey("f", "i1", "/proj")] = fakeFile{name: "proj", isDir: true, data: contentsTar(t, src)}
+	client := dialFake(t, srv)
+
+	_, err := Copy(context.Background(), client,
+		ResolvedEndpoint{Fleet: "f", Instance: "i1", Path: "/proj"},
+		ResolvedEndpoint{Fleet: "f", Instance: "i2", Path: "/tmp"},
+		passthroughPolicy{})
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if len(srv.intos) != 1 || !srv.intos[0].isDir {
+		t.Fatalf("relay must propagate is_dir, got %+v", srv.intos)
+	}
+	// The relayed (filtered) tar still carries the tree.
+	out := filepath.Join(t.TempDir(), "relayed")
+	if _, err := extractTarTree(bytes.NewReader(srv.intos[0].data), out); err != nil {
+		t.Fatalf("extract relayed tar: %v", err)
+	}
+	if got, _ := os.ReadFile(filepath.Join(out, "sub/b.txt")); string(got) != "bbbb" {
+		t.Errorf("relayed sub/b.txt = %q, want bbbb", got)
+	}
+}
+
 // fakeCopyServer is an in-memory FleetService exposing just CopyFile + CopyInto,
 // so the generic engine can be driven through every direction over the REAL
 // generated streaming code without a backend/container. Files are keyed
@@ -31,9 +145,10 @@ type fakeCopyServer struct {
 }
 
 type fakeFile struct {
-	name string
-	mode uint32
-	data []byte
+	name  string
+	mode  uint32
+	data  []byte
+	isDir bool
 }
 
 type capturedInto struct {
@@ -41,6 +156,7 @@ type capturedInto struct {
 	mode                        uint32
 	size                        int64
 	data                        []byte
+	isDir                       bool
 }
 
 func newFakeCopyServer() *fakeCopyServer { return &fakeCopyServer{files: map[string]fakeFile{}} }
@@ -55,7 +171,7 @@ func (f *fakeCopyServer) CopyFile(req *fleetgrpc.CopyFileRequest, stream grpc.Se
 		return status.Errorf(codes.NotFound, "no file %s", req.GetPath())
 	}
 	if err := stream.Send(&fleetgrpc.CopyFileChunk{Msg: &fleetgrpc.CopyFileChunk_Meta{Meta: &fleetgrpc.CopyFileMeta{
-		Name: file.name, Mode: file.mode, Size: int64(len(file.data)),
+		Name: file.name, Mode: file.mode, Size: int64(len(file.data)), IsDir: file.isDir,
 	}}}); err != nil {
 		return err
 	}
@@ -92,7 +208,7 @@ func (f *fakeCopyServer) CopyInto(stream grpc.ClientStreamingServer[fleetgrpc.Co
 	f.mu.Lock()
 	f.intos = append(f.intos, capturedInto{
 		fleet: open.GetFleet(), instance: open.GetInstance(), dest: dest,
-		name: open.GetName(), mode: open.GetMode(), size: open.GetSize(), data: data,
+		name: open.GetName(), mode: open.GetMode(), size: open.GetSize(), data: data, isDir: open.GetIsDir(),
 	})
 	f.files[fileKey(open.GetFleet(), open.GetInstance(), finalPath)] = fakeFile{
 		name: open.GetName(), mode: open.GetMode(), data: data,

--- a/internal/fleetclient/copytree.go
+++ b/internal/fleetclient/copytree.go
@@ -1,0 +1,316 @@
+package fleetclient
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// copytree.go is the Go-side tar layer for recursive directory copies. The server
+// stays a plain `tar` in/out; ALL of the safety work happens here in the client
+// (which may be the host CLI or the host TUI), so it is consistent across every
+// transport: symlinks and special files are SKIPPED (the simplest safe choice —
+// no symlink-escape, no loops), the `./` root entry is dropped (so a merge never
+// rewrites the destination directory's own mode), and entry names are sanitized
+// so a malicious/compromised server can never escape the target on extract.
+//
+// Directory copies are an in-place MERGE (cp -r semantics) and are NOT atomic.
+
+// copyChunkWriter adapts the gRPC stream's Send into an io.Writer for a
+// tar.Writer, splitting writes to copyChunkSize so no frame exceeds the gRPC cap.
+// The bytes are safe to reuse after Send returns (gRPC marshals synchronously).
+type copyChunkWriter struct {
+	send func([]byte) error
+}
+
+func (w copyChunkWriter) Write(p []byte) (int, error) {
+	total := 0
+	for len(p) > 0 {
+		n := min(len(p), copyChunkSize)
+		if err := w.send(p[:n]); err != nil {
+			return total, err
+		}
+		p = p[n:]
+		total += n
+	}
+	return total, nil
+}
+
+// copyChunkReader adapts the gRPC stream's data frames into an io.Reader for a
+// tar.Reader. recv returns the next frame's bytes, or a non-nil error (io.EOF at
+// the end) that is surfaced only once the buffered bytes are drained.
+type copyChunkReader struct {
+	recv func() ([]byte, error)
+	buf  []byte
+	err  error
+}
+
+func (r *copyChunkReader) Read(p []byte) (int, error) {
+	for len(r.buf) == 0 {
+		if r.err != nil {
+			return 0, r.err
+		}
+		data, err := r.recv()
+		r.buf = data
+		if err != nil {
+			r.err = err
+		}
+	}
+	n := copy(p, r.buf)
+	r.buf = r.buf[n:]
+	return n, nil
+}
+
+// copyableTarEntry reports whether a tar entry should be copied: regular files
+// and directories only (symlinks, hardlinks, devices and fifos are skipped), and
+// never the `./` root entry.
+func copyableTarEntry(hdr *tar.Header) bool {
+	if hdr.Typeflag != tar.TypeReg && hdr.Typeflag != tar.TypeDir {
+		return false
+	}
+	return tarSlashName(hdr.Name) != ""
+}
+
+// tarSlashName cleans a tar entry name to a slash-separated path relative to the
+// archive root, with traversal confined: a leading "/" or any ".." is collapsed
+// so the result can never escape. Backslashes are folded to "/" so a malicious
+// name can't traverse on a Windows client. The root entry collapses to "".
+func tarSlashName(name string) string {
+	clean := path.Clean("/" + strings.ReplaceAll(name, `\`, "/"))
+	return strings.TrimPrefix(clean, "/")
+}
+
+// extractTarTree extracts the tar on r into targetRoot, creating it first. It
+// skips symlinks/special files and the root entry, and writes every entry through
+// an os.Root rooted at targetRoot — so no name (../, absolute) and no on-disk
+// symlink at ANY path component can escape it. Returns the total regular-file
+// bytes written. A truncated archive surfaces as an error (Go's tar.Reader errors
+// on a short body, unlike GNU tar).
+func extractTarTree(r io.Reader, targetRoot string) (int64, error) {
+	root, err := openDestRoot(targetRoot)
+	if err != nil {
+		return 0, err
+	}
+	defer root.Close()
+
+	tr := tar.NewReader(r)
+	var written int64
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return written, err
+		}
+		if !copyableTarEntry(hdr) {
+			continue
+		}
+		name := filepath.FromSlash(tarSlashName(hdr.Name))
+		mode := os.FileMode(hdr.Mode).Perm()
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if mode == 0 {
+				mode = 0o755
+			}
+			if err := root.MkdirAll(name, mode|0o700); err != nil {
+				return written, err
+			}
+		case tar.TypeReg:
+			if parent := filepath.Dir(name); parent != "." {
+				if err := root.MkdirAll(parent, 0o755); err != nil {
+					return written, err
+				}
+			}
+			if mode == 0 {
+				mode = 0o644
+			}
+			n, err := writeRootFile(root, name, tr, mode)
+			written += n
+			if err != nil {
+				return written, err
+			}
+		}
+	}
+	return written, nil
+}
+
+// openDestRoot creates targetRoot (rejecting it if it is itself a symlink) and
+// returns an os.Root confining all subsequent writes to it — the boundary that
+// stops a write from following an intermediate symlink out of the destination.
+func openDestRoot(targetRoot string) (*os.Root, error) {
+	if fi, err := os.Lstat(targetRoot); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("refusing to copy into %s: it is a symlink", targetRoot)
+	}
+	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
+		return nil, err
+	}
+	return os.OpenRoot(targetRoot)
+}
+
+// writeTarTreeFromWalk walks srcDir and writes a tar of its CONTENTS to tw
+// (entries relative to srcDir, no root entry), copying regular files and
+// directories and SKIPPING symlinks/special files. Returns the regular-file bytes.
+func writeTarTreeFromWalk(tw *tar.Writer, srcDir string) (int64, error) {
+	var written int64
+	err := filepath.WalkDir(srcDir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if p == srcDir {
+			return nil // the root — its contents go in, not the dir itself
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && !info.Mode().IsRegular() {
+			return nil // skip symlinks and special files
+		}
+		rel, err := filepath.Rel(srcDir, p)
+		if err != nil {
+			return err
+		}
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		hdr.Name = filepath.ToSlash(rel)
+		if d.IsDir() {
+			hdr.Name += "/"
+		}
+		hdr.Uid, hdr.Gid, hdr.Uname, hdr.Gname = 0, 0, "", ""
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() {
+			n, err := copyFileInto(tw, p)
+			written += n
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return written, err
+}
+
+// filterTarTree copies the tar on tr to tw, keeping only regular files and
+// directories (no symlinks/specials, no root entry) and re-emitting names as
+// clean, root-relative paths. Used by the instance→instance relay to turn the
+// source's raw `tar -C dir -cf - .` stream into the clean tar the destination
+// server extracts. Returns the regular-file bytes.
+func filterTarTree(tw *tar.Writer, tr *tar.Reader) (int64, error) {
+	var written int64
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return written, nil
+		}
+		if err != nil {
+			return written, err
+		}
+		if !copyableTarEntry(hdr) {
+			continue
+		}
+		name := tarSlashName(hdr.Name)
+		if hdr.Typeflag == tar.TypeDir {
+			name += "/"
+		}
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     name,
+			Mode:     hdr.Mode,
+			Size:     hdr.Size,
+			ModTime:  hdr.ModTime,
+			Typeflag: hdr.Typeflag,
+		}); err != nil {
+			return written, err
+		}
+		if hdr.Typeflag == tar.TypeReg {
+			n, err := io.Copy(tw, tr)
+			written += n
+			if err != nil {
+				return written, err
+			}
+		}
+	}
+}
+
+// copyTreeLocal recursively copies srcDir to targetRoot on the local disk (the
+// local→local degenerate case), with the SAME skip-symlinks/specials contract as
+// the transport directions and the SAME os.Root confinement on the destination.
+// In-place merge, non-atomic. Returns file bytes.
+func copyTreeLocal(srcDir, targetRoot string) (int64, error) {
+	root, err := openDestRoot(targetRoot)
+	if err != nil {
+		return 0, err
+	}
+	defer root.Close()
+
+	var written int64
+	err = filepath.WalkDir(srcDir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if p == srcDir {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && !info.Mode().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(srcDir, p)
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return root.MkdirAll(rel, info.Mode().Perm()|0o700)
+		}
+		src, err := os.Open(p)
+		if err != nil {
+			return err
+		}
+		n, werr := writeRootFile(root, rel, src, info.Mode().Perm())
+		_ = src.Close()
+		written += n
+		return werr
+	})
+	return written, err
+}
+
+// writeRootFile writes r's bytes to name (relative to root) with mode, confined
+// to the os.Root so it can never follow a symlink out of the destination.
+func writeRootFile(root *os.Root, name string, r io.Reader, mode os.FileMode) (int64, error) {
+	f, err := root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return 0, err
+	}
+	n, copyErr := io.Copy(f, r)
+	closeErr := f.Close()
+	if copyErr != nil {
+		return n, copyErr
+	}
+	return n, closeErr
+}
+
+// copyFileInto copies the file at p into w.
+func copyFileInto(w io.Writer, p string) (int64, error) {
+	f, err := os.Open(p)
+	if err != nil {
+		return 0, err
+	}
+	n, copyErr := io.Copy(w, f)
+	closeErr := f.Close()
+	if copyErr != nil {
+		return n, copyErr
+	}
+	return n, closeErr
+}

--- a/internal/fleetclient/copytree_test.go
+++ b/internal/fleetclient/copytree_test.go
@@ -1,0 +1,281 @@
+package fleetclient
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestTarTreeRoundTrip builds a tar from a directory and extracts it, asserting
+// the tree (files, modes, dotfiles, empty dirs) round-trips and symlinks are
+// skipped on both ends.
+func TestTarTreeRoundTrip(t *testing.T) {
+	src := t.TempDir()
+	write := func(rel string, mode os.FileMode, content string) {
+		p := filepath.Join(src, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("file.txt", 0o644, "hello")
+	write("exec.sh", 0o755, "#!/bin/sh\n")
+	write(".dotfile", 0o600, "secret")
+	write("sub/nested.txt", 0o644, "nested")
+	if err := os.MkdirAll(filepath.Join(src, "empty"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("file.txt", filepath.Join(src, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if _, err := writeTarTreeFromWalk(tw, src); err != nil {
+		t.Fatalf("writeTarTreeFromWalk: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "out")
+	if _, err := extractTarTree(&buf, dst); err != nil {
+		t.Fatalf("extractTarTree: %v", err)
+	}
+
+	check := func(rel, content string, mode os.FileMode) {
+		got, err := os.ReadFile(filepath.Join(dst, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if string(got) != content {
+			t.Errorf("%s = %q, want %q", rel, got, content)
+		}
+		fi, _ := os.Stat(filepath.Join(dst, rel))
+		if fi.Mode().Perm() != mode {
+			t.Errorf("%s mode = %o, want %o", rel, fi.Mode().Perm(), mode)
+		}
+	}
+	check("file.txt", "hello", 0o644)
+	check("exec.sh", "#!/bin/sh\n", 0o755)
+	check(".dotfile", "secret", 0o600)
+	check("sub/nested.txt", "nested", 0o644)
+	if fi, err := os.Stat(filepath.Join(dst, "empty")); err != nil || !fi.IsDir() {
+		t.Errorf("empty dir not recreated: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(dst, "link")); !os.IsNotExist(err) {
+		t.Errorf("symlink should have been skipped, got %v", err)
+	}
+}
+
+// TestExtractTarTreeRejectsTraversal feeds a hand-built malicious archive and
+// asserts no file lands outside targetRoot (the security contract — the server
+// fully controls the tar bytes over the gateway).
+func TestExtractTarTreeRejectsTraversal(t *testing.T) {
+	root := t.TempDir()
+	targetRoot := filepath.Join(root, "target")
+	outside := filepath.Join(root, "OUTSIDE")
+	if err := os.Mkdir(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	entries := []struct {
+		name string
+		typ  byte
+		body string
+	}{
+		{"../OUTSIDE/escaped.txt", tar.TypeReg, "pwn"},     // parent traversal
+		{"/etc/whatever", tar.TypeReg, "pwn"},              // absolute
+		{"sub/../../OUTSIDE/escaped2.txt", tar.TypeReg, "pwn"}, // mid traversal
+		{"evil", tar.TypeSymlink, ""},                      // symlink (skipped)
+		{"ok.txt", tar.TypeReg, "fine"},                    // legit
+	}
+	for _, e := range entries {
+		hdr := &tar.Header{Name: e.name, Typeflag: e.typ, Mode: 0o644, Size: int64(len(e.body))}
+		if e.typ == tar.TypeSymlink {
+			hdr.Linkname = outside
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if e.body != "" {
+			if _, err := tw.Write([]byte(e.body)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	tw.Close()
+
+	if _, err := extractTarTree(&buf, targetRoot); err != nil {
+		t.Fatalf("extractTarTree: %v", err)
+	}
+	// Nothing escaped into OUTSIDE.
+	if ents, _ := os.ReadDir(outside); len(ents) != 0 {
+		t.Fatalf("files escaped targetRoot into OUTSIDE: %v", ents)
+	}
+	// The legit file landed inside; confined traversal names land inside too.
+	if _, err := os.Stat(filepath.Join(targetRoot, "ok.txt")); err != nil {
+		t.Errorf("legit entry not written: %v", err)
+	}
+}
+
+// TestExtractTarTreeRejectsSymlinkedParent confirms a write can't follow a
+// pre-existing on-disk symlink at an intermediate path component out of the
+// target (the in-place-merge escape os.Root closes).
+func TestExtractTarTreeRejectsSymlinkedParent(t *testing.T) {
+	base := t.TempDir()
+	targetRoot := filepath.Join(base, "target")
+	evil := filepath.Join(base, "EVIL")
+	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(evil, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-plant a symlink inside targetRoot pointing outside it (a merge target
+	// could already contain this).
+	if err := os.Symlink(evil, filepath.Join(targetRoot, "sub")); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	_ = tw.WriteHeader(&tar.Header{Name: "sub/pwned.txt", Typeflag: tar.TypeReg, Mode: 0o644, Size: 3})
+	_, _ = tw.Write([]byte("pwn"))
+	tw.Close()
+
+	// The extract must fail (escape refused), and nothing lands in EVIL.
+	if _, err := extractTarTree(&buf, targetRoot); err == nil {
+		t.Fatal("expected an error extracting through a symlinked parent")
+	}
+	if _, err := os.Stat(filepath.Join(evil, "pwned.txt")); !os.IsNotExist(err) {
+		t.Fatalf("write escaped through the symlink into EVIL: %v", err)
+	}
+}
+
+// TestExtractTarTreeSkipsRootEntry confirms the `./` root entry never rewrites an
+// existing targetRoot's mode (a merge must not mutate the destination dir).
+func TestExtractTarTreeSkipsRootEntry(t *testing.T) {
+	targetRoot := filepath.Join(t.TempDir(), "target")
+	if err := os.Mkdir(targetRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	// `tar -C dir -cf - .` emits the root as "./" with the source dir's mode.
+	_ = tw.WriteHeader(&tar.Header{Name: "./", Typeflag: tar.TypeDir, Mode: 0o700})
+	_ = tw.WriteHeader(&tar.Header{Name: "./inner.txt", Typeflag: tar.TypeReg, Mode: 0o644, Size: 2})
+	_, _ = tw.Write([]byte("hi"))
+	tw.Close()
+
+	if _, err := extractTarTree(&buf, targetRoot); err != nil {
+		t.Fatalf("extractTarTree: %v", err)
+	}
+	if fi, _ := os.Stat(targetRoot); fi.Mode().Perm() != 0o755 {
+		t.Errorf("targetRoot mode changed to %o, want 0755 (root entry must be skipped)", fi.Mode().Perm())
+	}
+	if got, _ := os.ReadFile(filepath.Join(targetRoot, "inner.txt")); string(got) != "hi" {
+		t.Errorf("inner.txt = %q, want hi", got)
+	}
+}
+
+func TestTarSlashName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{".", ""},
+		{"./", ""},
+		{"./sub/file", "sub/file"},
+		{"sub/file", "sub/file"},
+		{"../escape", "escape"},
+		{"../../etc/passwd", "etc/passwd"},
+		{"/abs/path", "abs/path"},
+		{"a/b/../../../c", "c"},
+		{`..\windows\escape`, "windows/escape"},
+	}
+	for _, tc := range cases {
+		if got := tarSlashName(tc.in); got != tc.want {
+			t.Errorf("tarSlashName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestFilterTarTree confirms the relay transform drops symlinks/specials and the
+// root, and re-emits clean root-relative names.
+func TestFilterTarTree(t *testing.T) {
+	var in bytes.Buffer
+	tw := tar.NewWriter(&in)
+	_ = tw.WriteHeader(&tar.Header{Name: "./", Typeflag: tar.TypeDir, Mode: 0o755})
+	_ = tw.WriteHeader(&tar.Header{Name: "./keep.txt", Typeflag: tar.TypeReg, Mode: 0o644, Size: 4})
+	_, _ = tw.Write([]byte("keep"))
+	_ = tw.WriteHeader(&tar.Header{Name: "./link", Typeflag: tar.TypeSymlink, Linkname: "/etc/passwd"})
+	_ = tw.WriteHeader(&tar.Header{Name: "./sub/", Typeflag: tar.TypeDir, Mode: 0o755})
+	tw.Close()
+
+	var out bytes.Buffer
+	otw := tar.NewWriter(&out)
+	if _, err := filterTarTree(otw, tar.NewReader(&in)); err != nil {
+		t.Fatalf("filterTarTree: %v", err)
+	}
+	otw.Close()
+
+	var names []string
+	tr := tar.NewReader(&out)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		names = append(names, hdr.Name)
+	}
+	want := []string{"keep.txt", "sub/"}
+	if len(names) != len(want) {
+		t.Fatalf("filtered names = %v, want %v (root + symlink dropped)", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Errorf("name[%d] = %q, want %q", i, names[i], want[i])
+		}
+	}
+}
+
+// TestCopyTreeLocal exercises the local→local recursive copy.
+func TestCopyTreeLocal(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "a.txt"), []byte("aaa"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(src, "d"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "d/b.txt"), []byte("bbb"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("a.txt", filepath.Join(src, "sl")); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "copy")
+	written, err := copyTreeLocal(src, dst)
+	if err != nil {
+		t.Fatalf("copyTreeLocal: %v", err)
+	}
+	if written != 6 {
+		t.Errorf("written = %d, want 6", written)
+	}
+	if got, _ := os.ReadFile(filepath.Join(dst, "d/b.txt")); string(got) != "bbb" {
+		t.Errorf("d/b.txt = %q, want bbb", got)
+	}
+	if _, err := os.Lstat(filepath.Join(dst, "sl")); !os.IsNotExist(err) {
+		t.Errorf("symlink should be skipped, got %v", err)
+	}
+}

--- a/internal/fleetcopy/fleetcopy.go
+++ b/internal/fleetcopy/fleetcopy.go
@@ -63,9 +63,9 @@ func Request(cfg Config, out io.Writer, src, dst string) error {
 		return err
 	}
 	if dst != "" {
-		fmt.Fprintf(out, "Asked the host fleet to copy %s -> %s (approve it in your fleet TUI if it touches your machine).\n", src, dst)
+		fmt.Fprintf(out, "Copying %s -> %s\n", src, dst)
 	} else {
-		fmt.Fprintf(out, "Asked the host fleet to copy %s — it will land in your downloads folder once approved in your fleet TUI.\n", src)
+		fmt.Fprintf(out, "Copying %s -> downloads\n", src)
 	}
 	return nil
 }

--- a/internal/fleetcopy/fleetcopy_test.go
+++ b/internal/fleetcopy/fleetcopy_test.go
@@ -90,8 +90,8 @@ func TestRequestDownloadShorthand(t *testing.T) {
 	if payload.Src != ":out.bin" || payload.Dst != "" {
 		t.Fatalf("payload = %+v, want src=:out.bin dst empty", payload)
 	}
-	if !strings.Contains(out.String(), "downloads folder") {
-		t.Fatalf("confirmation %q does not mention the downloads folder", out.String())
+	if !strings.Contains(out.String(), "downloads") {
+		t.Fatalf("confirmation %q does not mention downloads", out.String())
 	}
 }
 

--- a/internal/fleetlaunch/fleet.rc
+++ b/internal/fleetlaunch/fleet.rc
@@ -15,13 +15,14 @@
 alias fl='fleet launch'
 
 # fc — shorthand for Fleet Copy, scp-style and bidirectional. A plain path is a
-# file on your machine (where the fleet TUI runs); `:path` is a file in THIS
-# instance; `[fleet/]instance:path` is any instance in your fleet. Direction
-# follows which side is which — all of these work even on a fully remote
-# deployment:
-#   fc :build/out ~/Downloads/   copy this instance's file to your machine
-#   fc report.csv :/tmp/         copy a file from your machine into this instance
-#   fc :out.bin other:/tmp/      copy this instance's file into another instance
-# With a single `:`/instance source (e.g. `fc :build/out`) the file lands in
-# your downloads folder.
+# file in THIS instance (relative to your cwd); `host:path` is a file on your
+# machine (where the fleet TUI runs); `[fleet/]instance:path` is any instance in
+# your fleet. Direction follows which side is which — all work even on a fully
+# remote deployment:
+#   fc ./build/out host:~/Downloads/   copy this instance's file to your machine
+#   fc host:report.csv /tmp/           copy a file from your machine into this instance
+#   fc ./out.bin other:/tmp/           copy this instance's file into another instance
+# With a single non-host source (e.g. `fc ./build/out`) the file lands in your
+# downloads folder. A copy that touches your machine asks for confirmation in
+# the fleet TUI.
 alias fc='fleet copy'

--- a/internal/server/copy.go
+++ b/internal/server/copy.go
@@ -57,6 +57,13 @@ func (s *service) CopyFile(req *fleetgrpc.CopyFileRequest, stream grpc.ServerStr
 		return status.Errorf(codes.InvalidArgument, "invalid file path %q", filePath)
 	}
 
+	// A directory source is a recursive copy: stream a tar of its contents that
+	// the client extracts in Go. Everything else falls through to the single-file
+	// path below (a missing path also falls through, so tar reports NotFound).
+	if s.probeContainerDir(inst, filePath) {
+		return s.copyDirOut(inst, req, filePath, base, stream)
+	}
+
 	cmd := backendutil.NewForInstance(inst, false).ExecCommand(inst.WorkspaceDir,
 		[]string{"tar", "-chf", "-", "-C", path.Dir(filePath), base})
 	var stderr bytes.Buffer
@@ -160,6 +167,85 @@ func streamTarFile(filePath string, r io.Reader, send func(*fleetgrpc.CopyFileCh
 	}
 }
 
+// copyDirOut streams a tar of the directory at filePath to the client (meta with
+// is_dir, then raw tar data). The client extracts it in Go — skipping
+// symlinks/special files and the `./` root, sanitizing entry names — so the
+// server side stays a plain `tar -C <dir> -cf - .` with no -h (internal symlinks
+// are archived as links, never followed). Refused on the codespaces backend,
+// whose exec PTY mangles binary tar.
+func (s *service) copyDirOut(inst *fleet.Instance, req *fleetgrpc.CopyFileRequest, filePath, base string, stream grpc.ServerStreamingServer[fleetgrpc.CopyFileChunk]) error {
+	if inst.Backend == fleet.BackendCodespaces {
+		return status.Errorf(codes.FailedPrecondition, "copying a directory is not supported on the codespaces backend")
+	}
+	if err := stream.Send(&fleetgrpc.CopyFileChunk{Msg: &fleetgrpc.CopyFileChunk_Meta{Meta: &fleetgrpc.CopyFileMeta{
+		Name:  base,
+		IsDir: true,
+	}}}); err != nil {
+		return err
+	}
+
+	cmd := backendutil.NewForInstance(inst, false).ExecCommand(inst.WorkspaceDir,
+		[]string{"tar", "-C", filePath, "-cf", "-", "."})
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return status.Errorf(codes.Internal, "pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return status.Errorf(codes.Internal, "start copy: %v", err)
+	}
+
+	ctx := stream.Context()
+	finished := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = cmd.Process.Kill()
+		case <-finished:
+		}
+	}()
+
+	streamErr := streamRawTar(stdout, stream.Send)
+	if streamErr != nil {
+		_ = cmd.Process.Kill()
+	}
+	_, _ = io.Copy(io.Discard, stdout)
+	waitErr := cmd.Wait()
+	close(finished)
+
+	if streamErr != nil {
+		return streamErr
+	}
+	if waitErr != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return status.Errorf(codes.Internal, "read %q in %s/%s: %s", filePath, req.GetFleet(), req.GetInstance(), msg)
+		}
+		return status.Errorf(codes.Internal, "read %q in %s/%s: %v", filePath, req.GetFleet(), req.GetInstance(), waitErr)
+	}
+	return nil
+}
+
+// streamRawTar forwards the raw bytes on r as CopyFileChunk data frames — the
+// directory case, where the bytes are an opaque tar the client decodes.
+func streamRawTar(r io.Reader, send func(*fleetgrpc.CopyFileChunk) error) error {
+	buf := make([]byte, copyChunkSize)
+	for {
+		n, readErr := r.Read(buf)
+		if n > 0 {
+			if err := send(&fleetgrpc.CopyFileChunk{Msg: &fleetgrpc.CopyFileChunk_Data{Data: buf[:n]}}); err != nil {
+				return err
+			}
+		}
+		if readErr == io.EOF {
+			return nil
+		}
+		if readErr != nil {
+			return status.Errorf(codes.Internal, "read tar: %v", readErr)
+		}
+	}
+}
+
 // copyIntoExecCommand builds the host-side container exec used by CopyInto.
 // Package var so tests can stub the whole backend layer (mirrors
 // exec_stream.go's buildExecCommand). ExecCommandQuiet because the handler
@@ -192,6 +278,9 @@ func (s *service) CopyInto(stream grpc.ClientStreamingServer[fleetgrpc.CopyIntoC
 	}
 	if inst.Status != fleet.StatusRunning {
 		return status.Errorf(codes.FailedPrecondition, "instance %s/%s is not running", open.GetFleet(), open.GetInstance())
+	}
+	if open.GetIsDir() {
+		return s.copyDirInto(inst, open, stream)
 	}
 	if err := validateCopyName(open.GetName()); err != nil {
 		return err
@@ -280,6 +369,134 @@ func (s *service) CopyInto(stream grpc.ClientStreamingServer[fleetgrpc.CopyIntoC
 		finalPath = path.Join(inst.WorkspaceDir, finalDir, finalName)
 	}
 	return stream.SendAndClose(&fleetgrpc.CopyIntoReply{Path: finalPath, Written: open.GetSize()})
+}
+
+// copyDirInto extracts the client's tar of directory contents into the instance.
+// It resolves a target directory (an existing dest is copied INTO; otherwise dest
+// IS the directory), creates it, and pipes the data to `tar -xf - -C <dir>` — an
+// in-place merge (cp -r semantics), NOT atomic: a failed extract can leave a
+// partial tree. A broken client stream or a non-zero tar fails the RPC loudly.
+// Refused on the codespaces backend, whose exec PTY can silently corrupt the tar.
+func (s *service) copyDirInto(inst *fleet.Instance, open *fleetgrpc.CopyIntoOpen, stream grpc.ClientStreamingServer[fleetgrpc.CopyIntoChunk, fleetgrpc.CopyIntoReply]) error {
+	if inst.Backend == fleet.BackendCodespaces {
+		return status.Errorf(codes.FailedPrecondition, "copying a directory is not supported on the codespaces backend")
+	}
+	if err := validateCopyName(open.GetName()); err != nil {
+		return err
+	}
+	targetRoot, err := s.resolveCopyIntoDirDest(inst, open.GetDest(), open.GetName())
+	if err != nil {
+		return err
+	}
+	if err := s.mkdirContainerDir(inst, targetRoot); err != nil {
+		return err
+	}
+
+	cmd := copyIntoExecCommand(inst, []string{"tar", "-xf", "-", "-C", targetRoot})
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return status.Errorf(codes.Internal, "pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return status.Errorf(codes.Internal, "start copy: %v", err)
+	}
+
+	ctx := stream.Context()
+	finished := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = cmd.Process.Kill()
+			_ = stdin.Close()
+		case <-finished:
+		}
+	}()
+
+	written, pumpErr := pumpCopyIntoData(stdin, stream)
+	_ = stdin.Close()
+	waitErr := cmd.Wait()
+	close(finished)
+
+	if pumpErr != nil || waitErr != nil {
+		_ = cmd.Process.Kill()
+		tarMsg := strings.TrimSpace(stderr.String())
+		if tarMsg != "" {
+			return status.Errorf(codes.Internal, "extract into %s/%s: %s", open.GetFleet(), open.GetInstance(), tarMsg)
+		}
+		if pumpErr != nil {
+			return status.Errorf(codes.Internal, "extract into %s/%s: %v", open.GetFleet(), open.GetInstance(), pumpErr)
+		}
+		return status.Errorf(codes.Internal, "extract into %s/%s: %v", open.GetFleet(), open.GetInstance(), waitErr)
+	}
+
+	finalPath := targetRoot
+	if !path.IsAbs(finalPath) {
+		finalPath = path.Join(inst.WorkspaceDir, targetRoot)
+	}
+	return stream.SendAndClose(&fleetgrpc.CopyIntoReply{Path: finalPath, Written: written})
+}
+
+// resolveCopyIntoDirDest resolves the target directory inside the container for a
+// recursive copy: an empty dest puts the tree at <workspace>/name; an existing
+// directory dest is copied INTO (dest/name); otherwise dest IS the directory to
+// create. The target's parent must already exist (matching cp -r), else NotFound.
+func (s *service) resolveCopyIntoDirDest(inst *fleet.Instance, dest, name string) (string, error) {
+	var targetRoot string
+	switch {
+	case dest == "":
+		targetRoot = name
+	case s.probeContainerDir(inst, dest):
+		targetRoot = path.Join(dest, name)
+	default:
+		targetRoot = dest
+	}
+	parent := path.Dir(targetRoot)
+	if parent != "." && parent != "/" && !s.probeContainerDir(inst, parent) {
+		return "", status.Errorf(codes.NotFound, "destination directory %q does not exist", parent)
+	}
+	return targetRoot, nil
+}
+
+// mkdirContainerDir creates dir (and only its missing leaf — the parent is
+// checked separately) inside the instance; `-p` makes it idempotent for the
+// merge-into-existing case.
+func (s *service) mkdirContainerDir(inst *fleet.Instance, dir string) error {
+	cmd := copyIntoExecCommand(inst, []string{"mkdir", "-p", "--", dir})
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return status.Errorf(codes.Internal, "create %q: %s", dir, msg)
+		}
+		return status.Errorf(codes.Internal, "create %q: %v", dir, err)
+	}
+	return nil
+}
+
+// pumpCopyIntoData drains the client's data chunks straight into w (the tar
+// extract's stdin), returning the bytes written and the first stream/write error.
+func pumpCopyIntoData(w io.Writer, stream copyIntoChunkReceiver) (int64, error) {
+	var n int64
+	for {
+		chunk, err := stream.Recv()
+		if err == io.EOF {
+			return n, nil
+		}
+		if err != nil {
+			return n, err
+		}
+		data := chunk.GetData()
+		if len(data) == 0 {
+			continue
+		}
+		m, werr := w.Write(data)
+		n += int64(m)
+		if werr != nil {
+			return n, werr
+		}
+	}
 }
 
 // copyIntoSeq makes the temp name below unique within this process regardless of

--- a/internal/server/copyinto_test.go
+++ b/internal/server/copyinto_test.go
@@ -121,6 +121,120 @@ func sendCopyInto(t *testing.T, stream fleetgrpc.FleetService_CopyIntoClient, op
 	return stream.CloseAndRecv()
 }
 
+// seedCodespacesInstance seeds a running codespaces instance (the backend whose
+// exec PTY makes directory copy unsafe, so the server refuses it).
+func seedCodespacesInstance(t *testing.T, ws string) {
+	t.Helper()
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Instances: []*fleet.Instance{
+			{Name: "i1", Backend: fleet.BackendCodespaces, WorkspaceDir: ws, ContainerID: "c1", Status: fleet.StatusRunning},
+		}},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+}
+
+// TestCopyIntoDirExtracts exercises the full dir IN handler over a real bufconn
+// with the exec stubbed onto the host: a tar of contents lands as a tree under
+// the resolved target directory.
+func TestCopyIntoDirExtracts(t *testing.T) {
+	isolateFleetDir(t)
+	ws := t.TempDir()
+	seedCopyIntoInstance(t, ws)
+	stubCopyIntoExec(t)
+
+	body := tarArchive(t,
+		&tar.Header{Name: "a.txt", Typeflag: tar.TypeReg, Mode: 0o644, Size: 3},
+		&tar.Header{Name: "sub/", Typeflag: tar.TypeDir, Mode: 0o755},
+		&tar.Header{Name: "sub/b.txt", Typeflag: tar.TypeReg, Mode: 0o644, Size: 4},
+	)
+
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+	stream, err := client.CopyInto(context.Background())
+	if err != nil {
+		t.Fatalf("CopyInto: %v", err)
+	}
+	// dest empty → the tree lands at <workspace>/proj.
+	if err := stream.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Open{Open: &fleetgrpc.CopyIntoOpen{
+		Fleet: "alpha", Instance: "i1", Name: "proj", IsDir: true,
+	}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Data{Data: body.Bytes()}}); err != nil {
+		t.Fatal(err)
+	}
+	reply, err := stream.CloseAndRecv()
+	if err != nil {
+		t.Fatalf("CloseAndRecv: %v", err)
+	}
+	if reply.GetPath() != filepath.Join(ws, "proj") {
+		t.Errorf("reply path = %q, want %s/proj", reply.GetPath(), ws)
+	}
+	for _, rel := range []string{"proj/a.txt", "proj/sub/b.txt"} {
+		if _, err := os.Stat(filepath.Join(ws, rel)); err != nil {
+			t.Errorf("expected %s extracted: %v", rel, err)
+		}
+	}
+}
+
+// TestCopyIntoDirCodespacesGate confirms the IN dir path is refused on codespaces.
+func TestCopyIntoDirCodespacesGate(t *testing.T) {
+	isolateFleetDir(t)
+	seedCodespacesInstance(t, t.TempDir())
+
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+	stream, err := client.CopyInto(context.Background())
+	if err != nil {
+		t.Fatalf("CopyInto: %v", err)
+	}
+	_, err = sendCopyInto(t, stream,
+		&fleetgrpc.CopyIntoOpen{Fleet: "alpha", Instance: "i1", Name: "proj", IsDir: true}, "")
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("codespaces dir IN: want FailedPrecondition, got %v", err)
+	}
+}
+
+// TestCopyFileDirCodespacesGate confirms the OUT dir path is refused on
+// codespaces (reached once the `test -d` probe — stubbed onto the host — sees a
+// real directory).
+func TestCopyFileDirCodespacesGate(t *testing.T) {
+	isolateFleetDir(t)
+	ws := t.TempDir()
+	if err := os.Mkdir(filepath.Join(ws, "adir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seedCodespacesInstance(t, ws)
+	stubCopyIntoExec(t) // the dir probe uses copyIntoExecCommand
+
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+	stream, err := client.CopyFile(context.Background(), &fleetgrpc.CopyFileRequest{Fleet: "alpha", Instance: "i1", Path: filepath.Join(ws, "adir")})
+	if err != nil {
+		t.Fatalf("CopyFile: %v", err)
+	}
+	if _, err := stream.Recv(); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("codespaces dir OUT: want FailedPrecondition, got %v", err)
+	}
+}
+
+// TestStreamRawTar confirms the raw-tar OUT streamer chunks its input verbatim.
+func TestStreamRawTar(t *testing.T) {
+	in := bytes.Repeat([]byte("z"), copyChunkSize+100)
+	var got []byte
+	err := streamRawTar(bytes.NewReader(in), func(c *fleetgrpc.CopyFileChunk) error {
+		got = append(got, c.GetData()...)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("streamRawTar: %v", err)
+	}
+	if !bytes.Equal(got, in) {
+		t.Errorf("streamRawTar truncated/altered the stream (%d vs %d bytes)", len(got), len(in))
+	}
+}
+
 // TestCopyIntoWritesFileToDir exercises the full handler over a real bufconn,
 // with the exec stubbed onto the host: a file streamed into an existing
 // directory lands at dir/name with the requested mode.

--- a/internal/tui/copyconfirm.go
+++ b/internal/tui/copyconfirm.go
@@ -28,10 +28,20 @@ func (r copyRequest) instanceKey() string { return r.fleet + "/" + r.instance }
 
 // copyTouchesHost reports whether either endpoint is a path on this (the host)
 // machine — the only case that needs confirmation. A copy purely between
-// instances never reads or writes the human's disk.
+// instances never reads or writes the human's disk. The host machine is named
+// `host:`; an empty dst (the 1-arg download shorthand → downloads folder) also
+// writes here, and a bare local path is treated as host-side defensively (the
+// in-instance `fc` rewrites its own this-instance plain paths to `:` self).
 func copyTouchesHost(src, dst string) bool {
-	return fleetclient.ParseCopyEndpoint(src).Kind == fleetclient.CopyLocal ||
-		fleetclient.ParseCopyEndpoint(dst).Kind == fleetclient.CopyLocal
+	return endpointIsHost(src) || endpointIsHost(dst)
+}
+
+func endpointIsHost(arg string) bool {
+	switch fleetclient.ParseCopyEndpoint(arg).Kind {
+	case fleetclient.CopyHost, fleetclient.CopyLocal:
+		return true
+	}
+	return false
 }
 
 // copyConfirmShowing reports whether a host-copy confirmation is pending.
@@ -96,13 +106,13 @@ func (m *model) startConfirmedCopy(req copyRequest) tea.Cmd {
 // copy would read or write — the whole reason the prompt exists.
 func copyConfirmHostEffects(req copyRequest) []string {
 	var effects []string
-	if fleetclient.ParseCopyEndpoint(req.src).Kind == fleetclient.CopyLocal {
+	if endpointIsHost(req.src) {
 		effects = append(effects, "reads "+req.src+" on THIS machine")
 	}
 	switch {
 	case req.dst == "":
 		effects = append(effects, "writes to your downloads folder on THIS machine")
-	case fleetclient.ParseCopyEndpoint(req.dst).Kind == fleetclient.CopyLocal:
+	case endpointIsHost(req.dst):
 		effects = append(effects, "writes "+req.dst+" on THIS machine")
 	}
 	return effects

--- a/internal/tui/copyconfirm_test.go
+++ b/internal/tui/copyconfirm_test.go
@@ -10,11 +10,12 @@ func TestCopyTouchesHost(t *testing.T) {
 		src, dst string
 		want     bool
 	}{
-		{"report.csv", "alpha:/tmp/", true}, // local source (upload from host)
-		{"alpha:/out", "./here", true},      // local dest (download to host)
-		{":out.bin", "", true},              // download shorthand → host downloads
-		{":out", "other:/tmp/", false},      // self → another instance, no host path
-		{"a:x", "b:y", false},               // instance → instance
+		{"host:report.csv", "alpha:/tmp/", true}, // host source (upload from host)
+		{"alpha:/out", "host:/here", true},       // host dest (download to host)
+		{":out.bin", "", true},                   // download shorthand → host downloads
+		{"plain.txt", "alpha:/tmp/", true},       // bare path treated as host (defensive)
+		{":out", "other:/tmp/", false},           // self → another instance, no host path
+		{"a:x", "b:y", false},                    // instance → instance
 	}
 	for _, tc := range cases {
 		if got := copyTouchesHost(tc.src, tc.dst); got != tc.want {
@@ -35,7 +36,7 @@ func TestRequestCopyGating(t *testing.T) {
 	}
 
 	// A host-touching copy is queued for confirmation.
-	if cmd := m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "secret.txt", dst: ":/tmp/"}); cmd != nil {
+	if cmd := m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "host:secret.txt", dst: ":/tmp/"}); cmd != nil {
 		t.Fatal("host-touching copy should queue (nil cmd), not run")
 	}
 	if !m.copyConfirmShowing() || len(m.pendingCopyConfirms) != 1 {
@@ -44,7 +45,7 @@ func TestRequestCopyGating(t *testing.T) {
 
 	// Once the instance is session-allowed, host-touching copies run immediately.
 	m.copySessionAllow["f/i"] = true
-	if cmd := m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "x.txt", dst: ":/tmp/"}); cmd == nil {
+	if cmd := m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "host:x.txt", dst: ":/tmp/"}); cmd == nil {
 		t.Fatal("session-allowed host copy should run immediately")
 	}
 	if len(m.pendingCopyConfirms) != 1 {
@@ -54,7 +55,7 @@ func TestRequestCopyGating(t *testing.T) {
 
 func TestResolveCopyConfirmAllowOnce(t *testing.T) {
 	m := &model{copySessionAllow: map[string]bool{}}
-	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "a.txt", dst: ":/tmp/"})
+	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "host:a.txt", dst: ":/tmp/"})
 
 	if cmd := m.resolveCopyConfirm("a"); cmd == nil {
 		t.Fatal("allow-once should return a copy command")
@@ -69,9 +70,9 @@ func TestResolveCopyConfirmAllowOnce(t *testing.T) {
 
 func TestResolveCopyConfirmSessionDrainsSameInstance(t *testing.T) {
 	m := &model{copySessionAllow: map[string]bool{}}
-	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "a.txt", dst: ":/tmp/"})
-	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "b.txt", dst: ":/tmp/"})
-	m.requestCopy(copyRequest{fleet: "f", instance: "j", src: "c.txt", dst: ":/tmp/"})
+	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "host:a.txt", dst: ":/tmp/"})
+	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "host:b.txt", dst: ":/tmp/"})
+	m.requestCopy(copyRequest{fleet: "f", instance: "j", src: "host:c.txt", dst: ":/tmp/"})
 
 	if cmd := m.resolveCopyConfirm("s"); cmd == nil {
 		t.Fatal("session allow should return command(s) to run")
@@ -87,7 +88,7 @@ func TestResolveCopyConfirmSessionDrainsSameInstance(t *testing.T) {
 
 func TestResolveCopyConfirmDeny(t *testing.T) {
 	m := &model{copySessionAllow: map[string]bool{}}
-	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "a.txt", dst: ":/tmp/"})
+	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "host:a.txt", dst: ":/tmp/"})
 
 	if cmd := m.resolveCopyConfirm("d"); cmd != nil {
 		t.Fatal("deny should not return a copy command")

--- a/internal/tui/filecopy.go
+++ b/internal/tui/filecopy.go
@@ -82,6 +82,9 @@ func resolveTUIEndpoint(arg, origFleet, origInstance string) fleetclient.Resolve
 		}
 		return fleetclient.ResolvedEndpoint{Fleet: fleetName, Instance: ep.Instance, Path: ep.Path}
 	default:
+		// CopyHost is this (the host TUI's) machine; CopyLocal shouldn't reach here
+		// (the in-instance `fc` rewrites its plain paths to `:` self endpoints), but
+		// fall back to the host's disk for it too — the empty 1-arg dst lands here.
 		return fleetclient.ResolvedEndpoint{Local: true, Path: ep.Path}
 	}
 }

--- a/internal/tui/filecopy_test.go
+++ b/internal/tui/filecopy_test.go
@@ -69,6 +69,9 @@ func TestResolveTUIEndpoint(t *testing.T) {
 		{":build/out", fleetclient.ResolvedEndpoint{Fleet: "myfleet", Instance: "self", Path: "build/out"}},
 		{"other:/tmp/x", fleetclient.ResolvedEndpoint{Fleet: "myfleet", Instance: "other", Path: "/tmp/x"}},
 		{"two/other:/tmp/x", fleetclient.ResolvedEndpoint{Fleet: "two", Instance: "other", Path: "/tmp/x"}},
+		// host: (and, defensively, a bare path) resolve to this machine's disk.
+		{"host:report.csv", fleetclient.ResolvedEndpoint{Local: true, Path: "report.csv"}},
+		{"host:/tmp/x", fleetclient.ResolvedEndpoint{Local: true, Path: "/tmp/x"}},
 		{"report.csv", fleetclient.ResolvedEndpoint{Local: true, Path: "report.csv"}},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

Follow-ups to the bidirectional `fleet copy` / `fc` work (#174). Three things, all in the copy path:

### 1. Plain paths are cwd-local; new `host:` prefix
A plain path now means a file on the machine the command runs on, relative to its cwd — the host for `fleet copy`, and **this instance** for in-instance `fc` (previously an in-instance plain path resolved against the host's disk, which was surprising). `host:path` reaches the host machine from inside an instance.

```
fc ./build/out host:~/Downloads/   # this instance -> your machine
fc host:report.csv /tmp/           # your machine  -> this instance
fc ./cp-me.txt other:/tmp/         # this instance -> another instance
```

### 2. Recursive directory copy
`fleet copy` / `fc` now copies **directories** recursively in all four directions (upload, download, instance-to-instance relay, local-to-local). A new proto `is_dir` flag selects a tar path; the single-file path is unchanged.

- The server stays a plain `tar` in/out; **all** the tar safety is done in Go on the client (`copytree.go`): symlinks/special files and the `./` root entry are skipped, and every entry is written through an **`os.Root`** rooted at the target — so no `..`/absolute name and no on-disk symlink at any path component can escape it.
- **Refused on the codespaces backend** (its exec PTY can silently corrupt binary tar), and **non-atomic** (cp -r-style in-place merge; fails loudly, never silently, on devcontainer/coder).

### 3. Tidy `fc` messages/help
Trimmed the in-instance confirmation to just `Copying SRC -> DST` (no "approve it in your TUI…" monologue) and shortened two over-explained errors.

## Tests

Endpoint parsing, host/TUI resolution, the message tidy, the engine across all four transports over an in-process server, server-side dir extract with real `tar`/`mkdir`, both codespaces gates, and security tests (path traversal, symlink-entry skip, intermediate-symlink escape, root-entry skip). Integration `025_copy.sh` covers upload/download/relay for both files and directories.

> Manually tested; not run through the automated review/QA bots by request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)