### PR TITLE
chore/tidy-cli-help — terse, unix-style CLI help text

### DIFF
--- a/internal/cli/copy.go
+++ b/internal/cli/copy.go
@@ -27,30 +27,24 @@ import (
 // The HELP text is tailored to where the command runs.
 func newCopyCmd() *cobra.Command {
 	use := "copy <src> <dst>"
-	short := "Copy a file to, from, or between fleet instances, scp-style"
-	long := "Copy a single file between your machine and a fleet instance — or between\n" +
-		"two instances — scp-style. A plain path is a file on this machine\n" +
-		"(cwd-relative); `[fleet/]instance:path` is a file inside an instance (reachable\n" +
-		"even on a remote fleet). Direction follows which side is which:\n\n" +
-		"  fleet copy alpha:bin/tool ./tool         # download out of an instance\n" +
-		"  fleet copy ./tool alpha:/usr/local/bin/  # upload into an instance\n" +
-		"  fleet copy alpha:a beta:b                # copy between two instances\n\n" +
-		"A relative instance path resolves against the workspace folder; a directory\n" +
-		"destination keeps the source's name. Given a single instance source the file\n" +
-		"downloads to the current directory."
+	short := "Copy files to, from, and between instances"
+	long := "Copy a single file between your machine and an instance, or between two\n" +
+		"instances. A plain path is local (cwd-relative); [fleet/]instance:path is a\n" +
+		"file inside an instance. Direction follows which side is which.\n\n" +
+		"  fleet copy alpha:bin/tool ./tool         download from an instance\n" +
+		"  fleet copy ./tool alpha:/usr/local/bin/  upload to an instance\n" +
+		"  fleet copy alpha:a beta:b                between two instances\n\n" +
+		"A relative instance path is relative to the workspace folder; a directory\n" +
+		"destination keeps the source name. A lone instance source downloads to the cwd."
 	if fleetcopy.InInstance() {
-		short = "Copy a file to or from this instance via your fleet TUI (shorthand: fc)"
-		long = "Copy a single file between THIS instance and your machine — or another\n" +
-			"instance — scp-style. The copy is performed by the fleet TUI on your machine,\n" +
-			"so it works even when this instance lives on a remote server.\n\n" +
-			"A plain path is a file in THIS instance (cwd-relative); `host:path` is a file\n" +
-			"on your machine (where the TUI runs); `[fleet/]instance:path` is any instance\n" +
-			"in your fleet:\n\n" +
-			"  fc ./build/out host:~/Downloads/   # copy this instance's file to your machine\n" +
-			"  fc host:report.csv /tmp/           # copy a file from your machine into this instance\n" +
-			"  fc ./out.bin other:/tmp/           # copy this instance's file into another instance\n\n" +
-			"Given a single non-host source the file lands in your downloads folder. A copy\n" +
-			"that touches your machine asks for confirmation in the fleet TUI."
+		long = "Copy a single file between this instance and your machine, or another\n" +
+			"instance. A plain path is in this instance (cwd-relative); host:path is on\n" +
+			"your machine; [fleet/]instance:path is any instance in your fleet.\n\n" +
+			"  fc ./build/out host:~/Downloads/  this instance -> your machine\n" +
+			"  fc host:report.csv /tmp/          your machine  -> this instance\n" +
+			"  fc ./out.bin other:/tmp/          this instance -> another instance\n\n" +
+			"A lone source downloads to your downloads folder. A copy that touches your\n" +
+			"machine asks for confirmation in the fleet TUI."
 	}
 
 	return &cobra.Command{

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -23,7 +23,7 @@ func newLaunchCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "launch [name|list]",
-		Short: "Open the in-instance Fleet Launch grid (or list/launch its links and apps)",
+		Short: "Open an instance's links and apps",
 		Long: "Open a terminal UI, inside an instance, that lists the links and apps " +
 			"configured in customizations.fleet.fleetLaunch and drives the host browser " +
 			"to them over the control socket fleet mounts into the instance.\n\n" +

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -40,7 +40,7 @@ func newListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list [fleet]",
 		Aliases: []string{"ls"},
-		Short:   "List devcontainer instances",
+		Short:   "List instances",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			st, err := fetchFleetState(cmd.Context())

--- a/internal/cli/portforward.go
+++ b/internal/cli/portforward.go
@@ -109,7 +109,7 @@ func newPortForwardRemoveCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "remove <instance> <local-port>",
 		Aliases: []string{"rm"},
-		Short:   "Remove a port forward (for use with TUI-managed forwards)",
+		Short:   "Remove a port forward",
 		Long:    "Note: CLI-started forwards run in the foreground and are stopped with Ctrl+C.\nThis command is primarily for scripting and will list active TUI forwards.",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/rebuild.go
+++ b/internal/cli/rebuild.go
@@ -14,7 +14,7 @@ func newRebuildCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "rebuild <name>",
 		Aliases: []string{"rb"},
-		Short:   "Rebuild an instance's container in place (preserves the workspace)",
+		Short:   "Rebuild an instance's container",
 		Long: "Tear down and reprovision an instance's container without recreating the instance — " +
 			"handy after editing devcontainer.json. The workspace (git checkout and uncommitted edits) " +
 			"is preserved. Only backends with a rebuild primitive are supported (devcontainer, codespaces).",

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -22,7 +22,7 @@ func NewRootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "fleet",
 		Short: "Manage fleets of devcontainers",
-		Long:  "fleet-man is a CLI/TUI tool for spawning and managing fleets of devcontainers from a repo.",
+		Long:  "Spawn and manage fleets of devcontainers from a git repo.\nRun without a command to open the TUI.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if runDoctor {
 				return doctor.Run()

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -11,7 +11,7 @@ import (
 func newStartCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "start <name>",
-		Short: "Start an existing stopped devcontainer instance",
+		Short: "Start a stopped instance",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target, err := fleet.Resolve(args[0], "")

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -10,7 +10,7 @@ import (
 func newStatusCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
-		Short: "Show fleet-wide status summary",
+		Short: "Show fleet status",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			st, err := fetchFleetState(cmd.Context())

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -11,7 +11,7 @@ import (
 func newStopCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "stop <name>",
-		Short: "Stop a devcontainer instance without removing it",
+		Short: "Stop an instance without removing it",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target, err := fleet.Resolve(args[0], "")

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -22,7 +22,7 @@ import (
 func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
-		Short: "Print the fleet binary version",
+		Short: "Print the fleet version",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Fprintln(cmd.OutOrStdout(), version.Version)


### PR DESCRIPTION
## Summary

`fleet --help` read as marketing copy, not a unix tool. This tightens the root description and subcommand summaries to be short and to the point, the way `git`/`docker`/`scp` write theirs: imperative, no trailing periods, no mechanism details or marketing parentheticals in the one-liners, and `instance` instead of `devcontainer instance`.

```
Before                                                  After
------------------------------------------------------  --------------------------------
fleet-man is a CLI/TUI tool for spawning and managing   Spawn and manage fleets of
fleets of devcontainers from a repo.                    devcontainers from a git repo.
                                                        Run without a command to open the TUI.

copy   Copy a file to or from this instance via your    copy   Copy files to, from, and
       fleet TUI (shorthand: fc)                               between instances
launch Open the in-instance Fleet Launch grid (or       launch Open an instance's links and apps
       list/launch its links and apps)
rebuild Rebuild an instance's container in place         rebuild Rebuild an instance's container
        (preserves the workspace)
list   List devcontainer instances                      list   List instances
start  Start an existing stopped devcontainer instance  start  Start a stopped instance
status Show fleet-wide status summary                   status Show fleet status
stop   Stop a devcontainer instance without removing it stop   Stop an instance without removing it
version Print the fleet binary version                  version Print the fleet version
```

The `fleet copy --help` long help was also trimmed (kept the endpoint rules + examples — `git`/`scp` man pages have examples — but cut the prose). No behavior change; help strings only.

> **Note:** stacked on #176 (`fix/fleet-copy-local-cwd-and-host-prefix`) because it also tidies `copy.go`'s help — base is that branch for a clean diff. Merge #176 first; this retargets to `main` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)