### PR TITLE
feat/layout-preset-reorder — reorder layout presets via a [move] button

### DIFF
--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -1323,6 +1323,8 @@ func (fleetPage *fleetPage) moveEditFleetRow(delta int) {
 	fleetPage.dialogMountRemoveConfirm = false
 	fleetPage.dialogPresetRemoveFocused = false
 	fleetPage.dialogPresetRemoveConfirm = false
+	fleetPage.dialogPresetMoveFocused = false
+	fleetPage.dialogPresetMoving = false
 	fleetPage.syncEditFleetFocus()
 }
 
@@ -1425,6 +1427,8 @@ func (fleetPage *fleetPage) openEditFleetDialog(m *model) tea.Cmd {
 	fleetPage.dialogLayoutPresets = slices.Clone(f.Settings.LayoutPresets)
 	fleetPage.dialogPresetRemoveFocused = false
 	fleetPage.dialogPresetRemoveConfirm = false
+	fleetPage.dialogPresetMoveFocused = false
+	fleetPage.dialogPresetMoving = false
 	fleetPage.lpFlow = nil
 
 	fleetPage.homedirInput.SetValue(f.Settings.HomeDir)
@@ -1491,6 +1495,13 @@ func (fleetPage *fleetPage) updateEditFleet(m *model, msg tea.Msg) tea.Cmd {
 		var cmd tea.Cmd
 		fleetPage.customMountInput, cmd = fleetPage.customMountInput.Update(msg)
 		return cmd
+	}
+
+	// Layout-preset reorder sub-mode: up/down drag the focused preset instead of
+	// moving the dialog cursor, so it must be handled before the generic
+	// navigation below.
+	if fleetPage.dialogPresetMoving {
+		return fleetPage.updatePresetMove(m, keyMsg)
 	}
 
 	switch keyMsg.String() {
@@ -1817,15 +1828,36 @@ func (fleetPage *fleetPage) updateLayoutPresetRow(m *model, keyMsg tea.KeyMsg) t
 		}
 		return nil
 	}
+	// Horizontal sub-cursor over the row's buttons: row → [remove] → [move].
 	switch keyMsg.String() {
 	case "right", "l":
-		fleetPage.dialogPresetRemoveFocused = true
+		switch {
+		case fleetPage.dialogPresetMoveFocused:
+			// Already at the rightmost button.
+		case fleetPage.dialogPresetRemoveFocused:
+			fleetPage.dialogPresetRemoveFocused = false
+			fleetPage.dialogPresetRemoveConfirm = false
+			fleetPage.dialogPresetMoveFocused = true
+		default:
+			fleetPage.dialogPresetRemoveFocused = true
+		}
 		return nil
 	case "left", "h":
-		fleetPage.dialogPresetRemoveFocused = false
-		fleetPage.dialogPresetRemoveConfirm = false
+		switch {
+		case fleetPage.dialogPresetMoveFocused:
+			fleetPage.dialogPresetMoveFocused = false
+			fleetPage.dialogPresetRemoveFocused = true
+		case fleetPage.dialogPresetRemoveFocused:
+			fleetPage.dialogPresetRemoveFocused = false
+			fleetPage.dialogPresetRemoveConfirm = false
+		}
 		return nil
 	case "enter", " ":
+		if fleetPage.dialogPresetMoveFocused {
+			// Start the reorder sub-mode; up/down now drag this preset.
+			fleetPage.dialogPresetMoving = true
+			return nil
+		}
 		if fleetPage.dialogPresetRemoveFocused {
 			if !fleetPage.dialogPresetRemoveConfirm {
 				fleetPage.dialogPresetRemoveConfirm = true // first Enter: arm confirm
@@ -1834,10 +1866,57 @@ func (fleetPage *fleetPage) updateLayoutPresetRow(m *model, keyMsg tea.KeyMsg) t
 			fleetPage.dialogPresetRemoveConfirm = false // second Enter: remove
 			return fleetPage.removeLayoutPreset(m, idx)
 		}
-		// Row focused (not the remove button) → open the editor.
+		// Row focused (no button) → open the editor.
 		fleetPage.openLayoutPresetEdit(idx)
 		return nil
 	}
+	return nil
+}
+
+// updatePresetMove handles keys while the preset reorder sub-mode is active
+// (entered with Enter on the [move] button). up/k and down/j drag the focused
+// preset one slot, persisting on each swap (instant-save); any other navigation
+// key — Enter, esc, q, h/l — commits the new order by leaving the sub-mode.
+func (fleetPage *fleetPage) updatePresetMove(m *model, keyMsg tea.KeyMsg) tea.Cmd {
+	switch keyMsg.String() {
+	case "up", "k":
+		return fleetPage.movePreset(m, -1)
+	case "down", "j":
+		return fleetPage.movePreset(m, 1)
+	case "ctrl+c":
+		fleetPage.closeEditFleet(m)
+		return nil
+	default:
+		// Enter/space/esc/q/h/l (and anything else) leave the reorder sub-mode,
+		// keeping the cursor on the [move] button of the preset's new position.
+		fleetPage.dialogPresetMoving = false
+		return nil
+	}
+}
+
+// movePreset swaps the focused preset with its neighbour delta slots away and
+// persists the new order (instant-save), reverting on RPC failure. The dialog
+// cursor follows the moved row so the user can keep dragging. Reordering the
+// LayoutPresets slice is exactly what changes the layout-cycling order.
+func (fleetPage *fleetPage) movePreset(m *model, delta int) tea.Cmd {
+	idx := fleetPage.dialogRow - editFleetRowLayoutPresetBase
+	target := idx + delta
+	if idx < 0 || idx >= len(fleetPage.dialogLayoutPresets) {
+		return nil
+	}
+	if target < 0 || target >= len(fleetPage.dialogLayoutPresets) {
+		return nil // already at an edge — nothing to do
+	}
+	prev := fleetPage.dialogLayoutPresets
+	next := slices.Clone(prev)
+	next[idx], next[target] = next[target], next[idx]
+	fleetPage.dialogLayoutPresets = next
+	if err := fleetPage.persistFleetSettings(m); err != nil {
+		fleetPage.dialogLayoutPresets = prev
+		m.message = fmt.Sprintf("Failed to save: %v", err)
+		return nil
+	}
+	fleetPage.dialogRow = editFleetRowLayoutPresetBase + target
 	return nil
 }
 
@@ -2061,6 +2140,8 @@ func (fleetPage *fleetPage) closeEditFleet(_ *model) {
 	fleetPage.mode = viewNormal
 	fleetPage.dialogDeleteCacheConfirm = false
 	fleetPage.dialogCacheButtonFocused = false
+	fleetPage.dialogPresetMoveFocused = false
+	fleetPage.dialogPresetMoving = false
 	// Clear the in-flight flag too: a wipe RPC may still be running, but its
 	// deleteCacheDoneMsg is matched on fleet name and only updates the message,
 	// so the dialog must not reopen showing a stale "Clearing…" spinner.

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -85,6 +85,8 @@ type fleetPage struct {
 	dialogLayoutPresets       []fleet.LayoutPreset // working copy of the fleet's layout presets (instant-save)
 	dialogPresetRemoveFocused bool                 // horizontal sub-cursor: on the [remove] button vs the preset row (mirrors dialogCacheButtonFocused)
 	dialogPresetRemoveConfirm bool                 // inline "[remove?]" confirm armed on the focused preset row
+	dialogPresetMoveFocused   bool                 // horizontal sub-cursor: on the [move] button (right of [remove])
+	dialogPresetMoving        bool                 // reorder sub-mode: j/k drag the focused preset up/down (instant-save)
 	lpFlow                    *layoutPresetFlow    // open preset creation/edit flow (nil unless mode == viewLayoutPreset)
 
 	// New-session dialog template cycling: the fleet's presets snapshotted at
@@ -2218,7 +2220,7 @@ func (fleetPage *fleetPage) renderLayoutPresetRow(row int, marker func(int) stri
 	}
 	p := fleetPage.dialogLayoutPresets[idx]
 	label := fmt.Sprintf("%s (%s)", p.Name, paneCountLabel(p.PaneCount()))
-	return marker(row) + "  " + label + "   " + fleetPage.renderRemovePresetButton(row)
+	return marker(row) + "  " + label + "   " + fleetPage.renderRemovePresetButton(row) + " " + fleetPage.renderMovePresetButton(row)
 }
 
 // renderRemovePresetButton renders the [remove] affordance next to an existing
@@ -2235,6 +2237,21 @@ func (fleetPage *fleetPage) renderRemovePresetButton(row int) string {
 		return selectedStyle.Render("[remove]")
 	}
 	return dimStyle.Render("[remove]")
+}
+
+// renderMovePresetButton renders the [move] affordance to the right of [remove].
+// It is dim unless the horizontal sub-cursor is on it; once the user presses
+// Enter to start dragging, it shows a highlighted "[moving]" so it is obvious
+// that j/k now reorder the preset rather than navigate the dialog.
+func (fleetPage *fleetPage) renderMovePresetButton(row int) string {
+	focused := fleetPage.dialogRow == row && fleetPage.dialogPresetMoveFocused
+	if focused && fleetPage.dialogPresetMoving {
+		return selectedStyle.Render("[moving]")
+	}
+	if focused {
+		return selectedStyle.Render("[move]")
+	}
+	return dimStyle.Render("[move]")
 }
 
 // renderRemoveMountButton renders the [remove] affordance next to an existing
@@ -2333,13 +2350,19 @@ func (fleetPage *fleetPage) editFleetHint() string {
 		if fleetPage.dialogRow == fleetPage.layoutPresetAddRow() {
 			return "[enter] New preset  [j/k] Select  [q/esc] Save & Close"
 		}
+		if fleetPage.dialogPresetMoving {
+			return "[j/k] Move  [enter/esc] Done"
+		}
+		if fleetPage.dialogPresetMoveFocused {
+			return "[enter] Move  [h/←] Back  [esc] Close"
+		}
 		if fleetPage.dialogPresetRemoveFocused {
 			if fleetPage.dialogPresetRemoveConfirm {
 				return "[enter] Confirm remove  [esc] Cancel"
 			}
-			return "[enter] Remove  [h/←] Back  [esc] Close"
+			return "[enter] Remove  [l/→] Move  [h/←] Back  [esc] Close"
 		}
-		return "[enter] Edit  [l/→] Remove button  [j/k] Select  [q/esc] Save & Close"
+		return "[enter] Edit  [l/→] Buttons  [j/k] Select  [q/esc] Save & Close"
 	}
 	switch fleetPage.dialogRow {
 	case editFleetRowCustomMounts:

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -1051,6 +1051,128 @@ func TestEditFleetPresetRowEnterEdits(t *testing.T) {
 	}
 }
 
+// presetNames extracts the ordered names of the working preset list, the order
+// that drives layout cycling.
+func presetNames(presets []fleet.LayoutPreset) []string {
+	names := make([]string, len(presets))
+	for i, p := range presets {
+		names[i] = p.Name
+	}
+	return names
+}
+
+// TestEditFleetPresetMoveReorders verifies the [move] button: →/l reaches it
+// past [remove], Enter starts the reorder sub-mode, and j/k then drag the
+// focused preset (cursor following it), changing the persisted cycling order.
+func TestEditFleetPresetMoveReorders(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
+
+	f := &fleet.Fleet{Name: "alpha", Settings: fleet.FleetSettings{
+		LayoutPresets: []fleet.LayoutPreset{
+			{Name: "a", PaneCommands: []string{"htop"}},
+			{Name: "b", PaneCommands: []string{"top"}},
+			{Name: "c", PaneCommands: []string{"vi"}},
+		},
+	}}
+	fp := newFleetPage()
+	fp.rows = []row{{kind: rowFleetHeader, fleetName: "alpha"}}
+	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}}, fleetPage: fp}
+
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	navigateToFirstPresetRow(t, fp, m) // cursor on "a"
+
+	// →/l walks the sub-cursor row → [remove] → [move].
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if !fp.dialogPresetRemoveFocused {
+		t.Fatal("first l should focus the remove button")
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if !fp.dialogPresetMoveFocused || fp.dialogPresetRemoveFocused {
+		t.Fatalf("second l should focus the move button; move=%v remove=%v", fp.dialogPresetMoveFocused, fp.dialogPresetRemoveFocused)
+	}
+
+	// Enter starts the reorder sub-mode (does NOT open the editor).
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if !fp.dialogPresetMoving {
+		t.Fatal("enter on the move button should start the reorder sub-mode")
+	}
+	if fp.mode != viewEditFleet {
+		t.Fatalf("enter on the move button must not open the editor; mode=%v", fp.mode)
+	}
+
+	// Drag "a" down one slot; the cursor follows it to the new position.
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if got := presetNames(fp.dialogLayoutPresets); !slices.Equal(got, []string{"b", "a", "c"}) {
+		t.Fatalf("after one down move, order = %v, want [b a c]", got)
+	}
+	if fp.dialogRow != editFleetRowLayoutPresetBase+1 {
+		t.Fatalf("cursor should follow the moved preset to slot 1; dialogRow=%d", fp.dialogRow)
+	}
+	if !fp.dialogPresetMoving {
+		t.Fatal("still dragging — the sub-mode should stay active across moves")
+	}
+
+	// Drag it down once more: [b c a].
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if got := presetNames(fp.dialogLayoutPresets); !slices.Equal(got, []string{"b", "c", "a"}) {
+		t.Fatalf("after second down move, order = %v, want [b c a]", got)
+	}
+
+	// Enter commits by leaving the sub-mode; the reordered list is persisted.
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if fp.dialogPresetMoving {
+		t.Fatal("enter should leave the reorder sub-mode")
+	}
+	if got := presetNames(f.Settings.LayoutPresets); !slices.Equal(got, []string{"b", "c", "a"}) {
+		t.Fatalf("persisted order = %v, want [b c a]", got)
+	}
+}
+
+// TestEditFleetPresetMoveAtTopEdgeNoop verifies dragging the first preset up is
+// a no-op (it stays put) and does not exit the reorder sub-mode.
+func TestEditFleetPresetMoveAtTopEdgeNoop(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
+
+	f := &fleet.Fleet{Name: "alpha", Settings: fleet.FleetSettings{
+		LayoutPresets: []fleet.LayoutPreset{
+			{Name: "a", PaneCommands: []string{"htop"}},
+			{Name: "b", PaneCommands: []string{"top"}},
+		},
+	}}
+	fp := newFleetPage()
+	fp.rows = []row{{kind: rowFleetHeader, fleetName: "alpha"}}
+	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}}, fleetPage: fp}
+
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	navigateToFirstPresetRow(t, fp, m) // cursor on "a" (top)
+
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}}) // [remove]
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}}) // [move]
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEnter})                     // start moving
+
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyUp}) // up at the top edge
+	if got := presetNames(fp.dialogLayoutPresets); !slices.Equal(got, []string{"a", "b"}) {
+		t.Fatalf("up at the top edge should be a no-op; order = %v", got)
+	}
+	if fp.dialogRow != editFleetRowLayoutPresetBase {
+		t.Fatalf("cursor should stay on the top preset; dialogRow=%d", fp.dialogRow)
+	}
+	if !fp.dialogPresetMoving {
+		t.Fatal("an edge no-op must not leave the reorder sub-mode")
+	}
+
+	// esc leaves the sub-mode without closing the dialog.
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEsc})
+	if fp.dialogPresetMoving {
+		t.Fatal("esc should leave the reorder sub-mode")
+	}
+	if fp.mode != viewEditFleet {
+		t.Fatalf("esc while dragging should not close the dialog; mode=%v", fp.mode)
+	}
+}
+
 // TestCreateSessionBlankNameWithTemplateUsesTemplateName verifies that creating
 // a session from a selected template with no name typed defaults the session
 // name to the template's name (not the generic "session-N").


### PR DESCRIPTION
## Summary

Closes #175. Adds the ability to re-order a fleet's layout presets, which is what drives the layout-cycling order surfaced in the new-session dialog and under Fleet Edit.

Each preset row in the edit-fleet **Layouts** section now shows a `[move]` affordance to the right of `[remove]`:

```
<preset name> (N panes)   [remove] [move]
```

- `→`/`l` walks the horizontal sub-cursor: row → `[remove]` → `[move]`; `←`/`h` walks back.
- `Enter` on `[move]` starts a reorder sub-mode (the button shows `[moving]`).
- In that sub-mode `j`/`k` (or `↑`/`↓`) drag the focused preset one slot at a time, the cursor following it. Each swap persists immediately (instant-save), matching the rest of the dialog; edge moves are no-ops.
- `Enter`/`esc` leave the sub-mode (the dialog stays open).

Reordering simply swaps entries in the `LayoutPresets` slice, which `NormalizeLayoutPresets` preserves order-wise and which the new-session dialog cycles by index — so the new order is exactly the new cycling order.