### PR TITLE
feat/auggie-agent-detection — detect the auggie coding agent

### DIFF
--- a/fleetgrpc/runtime.pb.go
+++ b/fleetgrpc/runtime.pb.go
@@ -95,6 +95,7 @@ const (
 	AgentTool_AGENT_TOOL_CODEX       AgentTool = 3
 	AgentTool_AGENT_TOOL_GEMINI      AgentTool = 4
 	AgentTool_AGENT_TOOL_COPILOT     AgentTool = 5
+	AgentTool_AGENT_TOOL_AUGGIE      AgentTool = 6
 )
 
 // Enum value maps for AgentTool.
@@ -106,6 +107,7 @@ var (
 		3: "AGENT_TOOL_CODEX",
 		4: "AGENT_TOOL_GEMINI",
 		5: "AGENT_TOOL_COPILOT",
+		6: "AGENT_TOOL_AUGGIE",
 	}
 	AgentTool_value = map[string]int32{
 		"AGENT_TOOL_UNSPECIFIED": 0,
@@ -114,6 +116,7 @@ var (
 		"AGENT_TOOL_CODEX":       3,
 		"AGENT_TOOL_GEMINI":      4,
 		"AGENT_TOOL_COPILOT":     5,
+		"AGENT_TOOL_AUGGIE":      6,
 	}
 )
 
@@ -551,14 +554,15 @@ const file_runtime_proto_rawDesc = "" +
 	"\x1dLIVE_CONTAINER_STATUS_RUNNING\x10\x01\x12!\n" +
 	"\x1dLIVE_CONTAINER_STATUS_STOPPED\x10\x02\x12!\n" +
 	"\x1dLIVE_CONTAINER_STATUS_MISSING\x10\x03\x12!\n" +
-	"\x1dLIVE_CONTAINER_STATUS_UNKNOWN\x10\x04*\x98\x01\n" +
+	"\x1dLIVE_CONTAINER_STATUS_UNKNOWN\x10\x04*\xaf\x01\n" +
 	"\tAgentTool\x12\x1a\n" +
 	"\x16AGENT_TOOL_UNSPECIFIED\x10\x00\x12\x13\n" +
 	"\x0fAGENT_TOOL_NONE\x10\x01\x12\x15\n" +
 	"\x11AGENT_TOOL_CLAUDE\x10\x02\x12\x14\n" +
 	"\x10AGENT_TOOL_CODEX\x10\x03\x12\x15\n" +
 	"\x11AGENT_TOOL_GEMINI\x10\x04\x12\x16\n" +
-	"\x12AGENT_TOOL_COPILOT\x10\x05*\x87\x01\n" +
+	"\x12AGENT_TOOL_COPILOT\x10\x05\x12\x15\n" +
+	"\x11AGENT_TOOL_AUGGIE\x10\x06*\x87\x01\n" +
 	"\rAgentActivity\x12\x1e\n" +
 	"\x1aAGENT_ACTIVITY_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aAGENT_ACTIVITY_NOT_RUNNING\x10\x01\x12\x1a\n" +

--- a/fleetgrpc/runtime.proto
+++ b/fleetgrpc/runtime.proto
@@ -46,6 +46,7 @@ enum AgentTool {
   AGENT_TOOL_CODEX = 3;
   AGENT_TOOL_GEMINI = 4;
   AGENT_TOOL_COPILOT = 5;
+  AGENT_TOOL_AUGGIE = 6;
 }
 
 // AgentActivity mirrors internal/agentdetect.State — the three-state activity

--- a/internal/agentdetect/auggie_detector.go
+++ b/internal/agentdetect/auggie_detector.go
@@ -1,0 +1,56 @@
+package agentdetect
+
+import (
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// ===========================================
+// AuggieHookDetector
+// ===========================================
+
+// AuggieHookDetector derives auggie's run state from the state file the
+// in-container auggie-state-hook script writes on every lifecycle event
+// we register (SessionStart, PromptSubmit, PreToolUse, PostToolUse,
+// Notification, Stop).
+//
+// It is the Augment CLI peer of ClaudeHookDetector and shares the same
+// "<state> <unix-secs>" wire format, so it reuses ParseClaudeStateFile
+// to decode the file. Stateless by design: every Detect call inspects
+// only the latest state-file contents from the capture.
+//
+// Fallback semantics for the "no signal" cases (file absent, empty, or
+// unparseable) match Claude's: the activity tracker only routes
+// captures here after the agent-tool probe confirms auggie is alive, so
+// an empty state file means "auggie is running but has not emitted a
+// hook event yet" — the safe display is StateWaiting (auggie exists,
+// idle) rather than StateNotRunning (which would contradict the probe).
+type AuggieHookDetector struct{}
+
+// ===========================================
+// Constructors
+// ===========================================
+
+// NewAuggieHookDetector returns a fresh detector instance. The type
+// holds no state; a constructor is provided for symmetry with the rest
+// of the package.
+func NewAuggieHookDetector() *AuggieHookDetector {
+	return &AuggieHookDetector{}
+}
+
+// ===========================================
+// Detector implementation
+// ===========================================
+
+// Detect reads the auggie state file out of the capture's ExtraFiles
+// and decodes it. The time argument is unused — the hook script stamps
+// each transition; the detector reports the most recent value.
+func (d *AuggieHookDetector) Detect(capture backend.AllSessions, _ time.Time) State {
+	content := capture.ExtraFiles[AuggieStateFilePath]
+	reading, ok := ParseClaudeStateFile(content)
+	if !ok {
+		return StateWaiting
+	}
+	return reading.State
+}

--- a/internal/agentdetect/auggie_detector_test.go
+++ b/internal/agentdetect/auggie_detector_test.go
@@ -1,0 +1,85 @@
+package agentdetect
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// TestCaptureScriptCoversAuggieStatePath is the cross-package contract
+// test for auggie: the auggie state file must live under the directory
+// the backend's CaptureAllScript scans (the /tmp/fleet-man/*-state
+// glob), otherwise Detect() would always see empty ExtraFiles and
+// indefinitely report StateWaiting.
+func TestCaptureScriptCoversAuggieStatePath(t *testing.T) {
+	if !strings.Contains(backend.CaptureAllScript, ClaudeStateDir) {
+		t.Errorf("backend.CaptureAllScript does not reference the state dir %q", ClaudeStateDir)
+	}
+	if !strings.HasPrefix(AuggieStateFilePath, ClaudeStateDir+"/") {
+		t.Errorf("AuggieStateFilePath %q is not under the state dir %q",
+			AuggieStateFilePath, ClaudeStateDir)
+	}
+	if !strings.HasSuffix(AuggieStateFilePath, "-state") {
+		t.Errorf("AuggieStateFilePath %q does not end in -state, so the *-state glob misses it",
+			AuggieStateFilePath)
+	}
+}
+
+// TestAuggieHookDetector_DecodesState exercises the round-trip from
+// state-file content to the detector's reported State for every shape
+// the file can take in the wild. The fallback for "no signal" content
+// is StateWaiting, matching Claude.
+func TestAuggieHookDetector_DecodesState(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    State
+	}{
+		{"working", "working 1700000000\n", StateWorking},
+		{"waiting", "waiting 1700000000\n", StateWaiting},
+		{"empty content (no signal yet)", "", StateWaiting},
+		{"unparseable content", "garbled@#$\n", StateWaiting},
+		{"unknown sentinel from script", "unknown 100\n", StateWaiting},
+		{"missing timestamp", "working\n", StateWaiting},
+	}
+
+	detector := NewAuggieHookDetector()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			capture := captureWithFile(AuggieStateFilePath, tc.content)
+			got := detector.Detect(capture, time.Now())
+			if got != tc.want {
+				t.Errorf("Detect = %d, want %d (content=%q)", got, tc.want, tc.content)
+			}
+		})
+	}
+}
+
+// TestAuggieHookDetector_HandlesNilExtraFiles verifies the detector
+// tolerates a capture where ExtraFiles was never populated.
+func TestAuggieHookDetector_HandlesNilExtraFiles(t *testing.T) {
+	detector := NewAuggieHookDetector()
+	capture := backend.AllSessions{OK: true} // ExtraFiles is nil
+	if got := detector.Detect(capture, time.Now()); got != StateWaiting {
+		t.Errorf("Detect with nil ExtraFiles = %d, want StateWaiting", got)
+	}
+}
+
+// TestAuggieHookDetector_IgnoresOtherFiles guards against the detector
+// reading another tool's state file. Only the auggie-specific path
+// counts — a Claude state file present must not leak into auggie state.
+func TestAuggieHookDetector_IgnoresOtherFiles(t *testing.T) {
+	detector := NewAuggieHookDetector()
+	capture := backend.AllSessions{
+		ExtraFiles: map[string]string{
+			ClaudeStateFilePath:          "working 1700000000",
+			"/tmp/fleet-man/codex-state": "working 1700000000",
+		},
+		OK: true,
+	}
+	if got := detector.Detect(capture, time.Now()); got != StateWaiting {
+		t.Errorf("Detect = %d, want StateWaiting (auggie file absent)", got)
+	}
+}

--- a/internal/agentdetect/auggie_hook_script.go
+++ b/internal/agentdetect/auggie_hook_script.go
@@ -1,0 +1,36 @@
+package agentdetect
+
+import _ "embed"
+
+// ===========================================
+// Embedded hook script
+// ===========================================
+//
+// auggie-state-hook is the Augment CLI counterpart to the Claude hook
+// script. auggie invokes it on every lifecycle event we register a
+// hook for; the script writes a single line of "<state> <unix-secs>"
+// to AuggieStateFilePath inside the container, which the host then
+// reads via the existing capture path (the /tmp/fleet-man/*-state
+// glob in backend.CaptureAllScript picks it up automatically).
+//
+// The script is embedded into the fleet-man binary at build time so
+// there is exactly one source of truth and shipping fleet-man drops
+// nothing else on the user's host.
+
+// AuggieHookScript is the embedded shell script that runs as the
+// command for every fleet-man-managed auggie hook entry.
+//
+//go:embed auggie_hook_script.sh
+var AuggieHookScript []byte
+
+// ===========================================
+// Container-side paths
+// ===========================================
+
+// AuggieStateFilePath is the absolute path inside each container of
+// the single-line state file the auggie hook script writes. It shares
+// the fleet-man state directory (ClaudeStateDir == /tmp/fleet-man)
+// with the other hook-based detectors so the capture script's
+// /tmp/fleet-man/*-state glob captures it without per-tool wiring. The
+// host reads this path back to derive auggie's run state.
+const AuggieStateFilePath = ClaudeStateDir + "/auggie-state"

--- a/internal/agentdetect/auggie_hook_script.sh
+++ b/internal/agentdetect/auggie_hook_script.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# fleet-man-state-hook (auggie) — Augment CLI lifecycle event handler.
+#
+# Invoked by auggie via the hook entries fleet-man installs in
+# ~/.augment/settings.json. Writes a single-line "<state> <unix-secs>"
+# file that the host reads back via the capture path to derive the
+# activity tracker's per-container view of auggie's run state.
+#
+# auggie identifies the firing event two ways (we prefer the first):
+#
+#   1. The AUGMENT_HOOK_EVENT environment variable, set on every hook
+#      invocation. This is robust regardless of how auggie spawns the
+#      command (shell vs execFile).
+#   2. The first positional argument, which we also wire into each
+#      hook entry's "args" as a belt-and-suspenders fallback.
+#
+# Stdin receives a JSON event payload from auggie. We drain it without
+# parsing because fleet-man only cares which event fired, not the
+# per-event details — and not draining risks SIGPIPE on the auggie
+# side once the pipe buffer fills.
+#
+# Output file format:
+#
+#   <state> <unix-secs>\n
+#
+#   state    one of: working, waiting, unknown
+#   secs     seconds since epoch when this event was processed
+#
+# State mapping rationale:
+#
+#   PromptSubmit / PreToolUse / PostToolUse → working
+#       auggie is mid-turn: the user just kicked it off, a tool is
+#       about to run, or a tool just finished and auggie is
+#       processing the result.
+#
+#   SessionStart / Notification / Stop → waiting
+#       auggie just launched and is idle (SessionStart), finished its
+#       turn (Stop), or paused for user attention (Notification).
+#
+# Environment overrides (test/debug only):
+#
+#   FLEET_MAN_STATE_DIR — alternate state directory. Defaults to
+#                        /tmp/fleet-man. The host reads from the
+#                        default; overriding it in production will
+#                        decouple the writer and reader.
+
+set -eu
+
+# Drain stdin so auggie never blocks on a write to our pipe.
+cat > /dev/null
+
+EVENT="${AUGMENT_HOOK_EVENT:-${1:-unknown}}"
+STATE_DIR="${FLEET_MAN_STATE_DIR:-/tmp/fleet-man}"
+STATE_FILE="${STATE_DIR}/auggie-state"
+
+case "$EVENT" in
+  PromptSubmit|PreToolUse|PostToolUse) STATE="working" ;;
+  SessionStart|Notification|Stop)      STATE="waiting" ;;
+  *)                                   STATE="unknown" ;;
+esac
+
+NOW=$(date +%s)
+mkdir -p "$STATE_DIR"
+
+# Atomic write: same-directory tmp + rename, so a concurrent reader
+# never sees a half-written line.
+TMP="${STATE_FILE}.tmp.$$"
+printf '%s %s\n' "$STATE" "$NOW" > "$TMP"
+mv -f "$TMP" "$STATE_FILE"

--- a/internal/agentdetect/auggie_hook_script_test.go
+++ b/internal/agentdetect/auggie_hook_script_test.go
@@ -1,0 +1,151 @@
+package agentdetect
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAuggieHookScript_RunnableEndToEnd executes the embedded auggie
+// hook script in a real subprocess, identifying the event via the
+// AUGMENT_HOOK_EVENT environment variable the way auggie does, then
+// parses the resulting state file. This locks the wire-format contract
+// between the script and the shared parser.
+func TestAuggieHookScript_RunnableEndToEnd(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh not available on this host: %v", err)
+	}
+
+	cases := []struct {
+		event     string
+		wantOK    bool
+		wantState State
+	}{
+		{"SessionStart", true, StateWaiting},
+		{"PromptSubmit", true, StateWorking},
+		{"PreToolUse", true, StateWorking},
+		{"PostToolUse", true, StateWorking},
+		{"Notification", true, StateWaiting},
+		{"Stop", true, StateWaiting},
+		{"SomeUnknownEvent", false, StateNotRunning},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.event, func(t *testing.T) {
+			tmp := t.TempDir()
+			scriptPath := filepath.Join(tmp, "auggie-state-hook.sh")
+			stateDir := filepath.Join(tmp, "state")
+
+			if err := os.WriteFile(scriptPath, AuggieHookScript, 0o755); err != nil {
+				t.Fatalf("write script: %v", err)
+			}
+
+			// No positional arg: the script must read AUGMENT_HOOK_EVENT.
+			cmd := exec.Command(sh, scriptPath)
+			cmd.Env = append(os.Environ(),
+				"FLEET_MAN_STATE_DIR="+stateDir,
+				"AUGMENT_HOOK_EVENT="+tc.event,
+			)
+			// Simulate auggie piping a JSON event payload — the script
+			// must drain stdin without parsing.
+			cmd.Stdin = strings.NewReader(`{"hook_event_name":"` + tc.event + `","cwd":"/x"}`)
+
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("script exited non-zero: %v\noutput: %s", err, out)
+			}
+
+			content, err := os.ReadFile(filepath.Join(stateDir, "auggie-state"))
+			if err != nil {
+				t.Fatalf("read state file: %v", err)
+			}
+
+			reading, ok := ParseClaudeStateFile(string(content))
+			if ok != tc.wantOK {
+				t.Errorf("parser ok=%v, want %v (raw=%q)", ok, tc.wantOK, content)
+			}
+			if ok && reading.State != tc.wantState {
+				t.Errorf("state=%d, want %d (raw=%q)", reading.State, tc.wantState, content)
+			}
+		})
+	}
+}
+
+// TestAuggieHookScript_ArgFallback verifies the script falls back to
+// the first positional argument when AUGMENT_HOOK_EVENT is empty/unset.
+// auggie also wires the event name into each hook entry's "args", so
+// this path matters if a future spawn mode does not set the env var.
+func TestAuggieHookScript_ArgFallback(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh not available: %v", err)
+	}
+
+	tmp := t.TempDir()
+	scriptPath := filepath.Join(tmp, "auggie-state-hook.sh")
+	stateDir := filepath.Join(tmp, "state")
+	if err := os.WriteFile(scriptPath, AuggieHookScript, 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	// Event supplied as argv; AUGMENT_HOOK_EVENT explicitly empty so the
+	// ${VAR:-${1:-unknown}} default chain reaches the positional arg.
+	cmd := exec.Command(sh, scriptPath, "PreToolUse")
+	cmd.Env = append(os.Environ(), "FLEET_MAN_STATE_DIR="+stateDir, "AUGMENT_HOOK_EVENT=")
+	cmd.Stdin = strings.NewReader("{}")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("script failed: %v\noutput: %s", err, out)
+	}
+
+	content, err := os.ReadFile(filepath.Join(stateDir, "auggie-state"))
+	if err != nil {
+		t.Fatalf("read state file: %v", err)
+	}
+	reading, ok := ParseClaudeStateFile(string(content))
+	if !ok || reading.State != StateWorking {
+		t.Errorf("arg fallback failed: state=%d ok=%v raw=%q", reading.State, ok, content)
+	}
+}
+
+// TestAuggieHookScript_AtomicReplace verifies a second run replaces the
+// file rather than appending (the script writes via mv).
+func TestAuggieHookScript_AtomicReplace(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh not available: %v", err)
+	}
+
+	tmp := t.TempDir()
+	scriptPath := filepath.Join(tmp, "auggie-state-hook.sh")
+	stateDir := filepath.Join(tmp, "state")
+	if err := os.WriteFile(scriptPath, AuggieHookScript, 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	run := func(event string) {
+		cmd := exec.Command(sh, scriptPath)
+		cmd.Env = append(os.Environ(), "FLEET_MAN_STATE_DIR="+stateDir, "AUGMENT_HOOK_EVENT="+event)
+		cmd.Stdin = strings.NewReader("{}")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("script(%s) failed: %v\noutput: %s", event, err, out)
+		}
+	}
+
+	run("PreToolUse")
+	run("Stop")
+
+	content, err := os.ReadFile(filepath.Join(stateDir, "auggie-state"))
+	if err != nil {
+		t.Fatalf("read state file: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(content), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected 1 line after second run, got %d: %q", len(lines), content)
+	}
+	reading, ok := ParseClaudeStateFile(string(content))
+	if !ok || reading.State != StateWaiting {
+		t.Errorf("second write did not replace first: state=%d ok=%v raw=%q", reading.State, ok, content)
+	}
+}

--- a/internal/agentdetect/auggie_provisioner.go
+++ b/internal/agentdetect/auggie_provisioner.go
@@ -1,0 +1,136 @@
+package agentdetect
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// ===========================================
+// AuggieProvisioner
+// ===========================================
+//
+// AuggieProvisioner is the Augment CLI counterpart to
+// ClaudeProvisioner. It installs the two pieces of in-container state
+// fleet-man needs to read auggie's run state from hooks:
+//
+//   1. The state-writing shell script at $HOME/AuggieScriptSuffix,
+//      copied from the AuggieHookScript bytes embedded in the binary
+//      and made executable.
+//
+//   2. Hook entries in ~/.augment/settings.json that point at that
+//      script for every event we care about, merged into the user's
+//      existing settings via InjectAuggieHooks.
+//
+// Idempotent and atomic with the same guarantees as ClaudeProvisioner:
+// the script is rewritten verbatim, InjectAuggieHooks is idempotent on
+// its own output, and settings.json is written via same-directory tmp
+// + rename so a reader never sees a partial document.
+
+// AuggieProvisioner orchestrates installation of the in-container
+// auggie state-hook script and hook entries.
+type AuggieProvisioner struct {
+	exec ContainerExecutor
+}
+
+// ===========================================
+// Constructors
+// ===========================================
+
+// NewAuggieProvisioner returns a provisioner that runs commands inside
+// the target container via the given executor.
+func NewAuggieProvisioner(exec ContainerExecutor) *AuggieProvisioner {
+	return &AuggieProvisioner{exec: exec}
+}
+
+// ===========================================
+// Public API
+// ===========================================
+
+// Provision drops the hook script and edits ~/.augment/settings.json.
+// Errors are wrapped with phase context so a partial failure tells the
+// caller which step did not complete; the caller may surface them as
+// warnings rather than aborting container creation.
+func (p *AuggieProvisioner) Provision() error {
+	scriptPath, err := p.resolveScriptPath()
+	if err != nil {
+		return fmt.Errorf("resolve script path: %w", err)
+	}
+	if err := p.dropHookScript(scriptPath); err != nil {
+		return fmt.Errorf("install hook script: %w", err)
+	}
+	if err := p.injectSettings(scriptPath); err != nil {
+		return fmt.Errorf("edit settings.json: %w", err)
+	}
+	return nil
+}
+
+// ===========================================
+// Private helpers
+// ===========================================
+
+// resolveScriptPath asks the container for $HOME and joins it with
+// AuggieScriptSuffix to produce the absolute path the hook script will
+// be dropped at and that settings.json will reference.
+func (p *AuggieProvisioner) resolveScriptPath() (string, error) {
+	out, err := p.exec.Run([]string{"sh", "-c", "echo \"$HOME\""}, nil)
+	if err != nil {
+		return "", err
+	}
+	home := strings.TrimSpace(string(out))
+	if home == "" {
+		return "", fmt.Errorf("container reported empty $HOME")
+	}
+	return path.Join(home, AuggieScriptSuffix), nil
+}
+
+// dropHookScript writes the embedded hook script bytes to scriptPath
+// and sets the executable bit, mkdir-ing the parent first. All three
+// operations are bundled into one shell invocation to minimise
+// round-trips to the container exec layer.
+func (p *AuggieProvisioner) dropHookScript(scriptPath string) error {
+	parentDir := path.Dir(scriptPath)
+	script := fmt.Sprintf(
+		`mkdir -p %q && cat > %q && chmod +x %q`,
+		parentDir, scriptPath, scriptPath,
+	)
+	_, err := p.exec.Run([]string{"sh", "-c", script}, AuggieHookScript)
+	return err
+}
+
+// injectSettings reads the current ~/.augment/settings.json (or treats
+// it as absent), passes it through InjectAuggieHooks, and writes the
+// result back atomically.
+func (p *AuggieProvisioner) injectSettings(scriptPath string) error {
+	current, err := p.readSettings()
+	if err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+	updated, err := InjectAuggieHooks(current, scriptPath)
+	if err != nil {
+		return fmt.Errorf("compute: %w", err)
+	}
+	if err := p.writeSettings(updated); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	return nil
+}
+
+// readSettings cats ~/.augment/settings.json. A missing file produces
+// empty bytes (treated by InjectAuggieHooks as "the file does not
+// exist"), not an error.
+func (p *AuggieProvisioner) readSettings() ([]byte, error) {
+	const script = `if [ -f "$HOME/.augment/settings.json" ]; then cat "$HOME/.augment/settings.json"; fi`
+	return p.exec.Run([]string{"sh", "-c", script}, nil)
+}
+
+// writeSettings writes content to ~/.augment/settings.json atomically:
+// same-directory tmp file then rename. mkdir of ~/.augment handles the
+// first-time case where auggie has never been run in this container.
+func (p *AuggieProvisioner) writeSettings(content []byte) error {
+	const script = `mkdir -p "$HOME/.augment" && ` +
+		`cat > "$HOME/.augment/settings.json.tmp" && ` +
+		`mv "$HOME/.augment/settings.json.tmp" "$HOME/.augment/settings.json"`
+	_, err := p.exec.Run([]string{"sh", "-c", script}, content)
+	return err
+}

--- a/internal/agentdetect/auggie_provisioner_test.go
+++ b/internal/agentdetect/auggie_provisioner_test.go
@@ -1,0 +1,141 @@
+package agentdetect
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestAuggieProvision_FreshContainer covers the common case: a new
+// container with no ~/.augment/settings.json. The provisioner queries
+// $HOME, drops the auggie hook script, reads (empty), and writes a
+// freshly-generated settings.json under ~/.augment.
+func TestAuggieProvision_FreshContainer(t *testing.T) {
+	exec := &fakeExec{
+		responses: []fakeResponse{
+			{stdout: []byte(homeStdout), err: nil}, // query home
+			{stdout: nil, err: nil},                // drop script
+			{stdout: nil, err: nil},                // read settings (empty)
+			{stdout: nil, err: nil},                // write settings
+		},
+	}
+	if err := NewAuggieProvisioner(exec).Provision(); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	if len(exec.calls) != 4 {
+		t.Fatalf("expected 4 exec calls, got %d", len(exec.calls))
+	}
+	wantKinds := []string{"query-home", "drop-script", "read-settings", "write-settings"}
+	for i, want := range wantKinds {
+		if got := callKind(exec.calls[i]); got != want {
+			t.Errorf("call %d kind = %q, want %q", i, got, want)
+		}
+	}
+
+	// The hook script payload must be the embedded auggie bytes.
+	if !bytes.Equal(exec.calls[1].stdin, AuggieHookScript) {
+		t.Errorf("drop-script stdin does not match embedded AuggieHookScript")
+	}
+
+	// The drop-script command references the resolved absolute path.
+	expectedScriptPath := "/home/test/" + AuggieScriptSuffix
+	if dropBody := exec.calls[1].args[2]; !strings.Contains(dropBody, expectedScriptPath) {
+		t.Errorf("drop-script missing resolved path %q:\n%s", expectedScriptPath, dropBody)
+	}
+
+	// Read and write must target ~/.augment/settings.json, not ~/.claude.
+	if body := exec.calls[2].args[2]; !strings.Contains(body, ".augment/settings.json") {
+		t.Errorf("read does not target ~/.augment/settings.json:\n%s", body)
+	}
+	if body := exec.calls[3].args[2]; !strings.Contains(body, ".augment/settings.json") {
+		t.Errorf("write does not target ~/.augment/settings.json:\n%s", body)
+	}
+
+	// The written settings.json must register every managed event,
+	// each pointing at the resolved script path.
+	written := exec.calls[3].stdin
+	hooks := parseHooks(t, written)
+	for _, event := range auggieManagedEvents {
+		group := fleetManAuggieGroup(t, hooks, event.name)
+		hook := group["hooks"].([]any)[0].(map[string]any)
+		if hook["command"] != expectedScriptPath {
+			t.Errorf("%s command = %v, want %q", event.name, hook["command"], expectedScriptPath)
+		}
+	}
+}
+
+// TestAuggieProvision_PreservesExistingSettings verifies user content
+// round-trips through the provisioner unchanged.
+func TestAuggieProvision_PreservesExistingSettings(t *testing.T) {
+	existing := []byte(`{"model":"x","hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/u/audit.sh"}]}]}}`)
+	exec := &fakeExec{
+		responses: []fakeResponse{
+			{stdout: []byte(homeStdout), err: nil},
+			{stdout: nil, err: nil},
+			{stdout: existing, err: nil},
+			{stdout: nil, err: nil},
+		},
+	}
+	if err := NewAuggieProvisioner(exec).Provision(); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	written := string(exec.calls[3].stdin)
+	if !strings.Contains(written, `"model"`) || !strings.Contains(written, "/u/audit.sh") {
+		t.Errorf("user content dropped from output:\n%s", written)
+	}
+}
+
+// TestAuggieProvision_Idempotent runs the provisioner twice (second
+// read replays the first write) and asserts byte-for-byte stability.
+func TestAuggieProvision_Idempotent(t *testing.T) {
+	first := &fakeExec{
+		responses: []fakeResponse{
+			{stdout: []byte(homeStdout), err: nil},
+			{stdout: nil, err: nil},
+			{stdout: nil, err: nil},
+			{stdout: nil, err: nil},
+		},
+	}
+	if err := NewAuggieProvisioner(first).Provision(); err != nil {
+		t.Fatalf("first Provision: %v", err)
+	}
+	firstWritten := first.calls[3].stdin
+
+	second := &fakeExec{
+		responses: []fakeResponse{
+			{stdout: []byte(homeStdout), err: nil},
+			{stdout: nil, err: nil},
+			{stdout: firstWritten, err: nil},
+			{stdout: nil, err: nil},
+		},
+	}
+	if err := NewAuggieProvisioner(second).Provision(); err != nil {
+		t.Fatalf("second Provision: %v", err)
+	}
+	if !bytes.Equal(firstWritten, second.calls[3].stdin) {
+		t.Errorf("not idempotent\nfirst:  %s\nsecond: %s", firstWritten, second.calls[3].stdin)
+	}
+}
+
+// TestAuggieProvision_DropFailureSkipsSettings verifies the provisioner
+// short-circuits when the script-drop fails: settings are untouched.
+func TestAuggieProvision_DropFailureSkipsSettings(t *testing.T) {
+	exec := &fakeExec{
+		responses: []fakeResponse{
+			{stdout: []byte(homeStdout), err: nil},
+			{stdout: nil, err: errors.New("chmod denied")},
+		},
+	}
+	err := NewAuggieProvisioner(exec).Provision()
+	if err == nil {
+		t.Fatal("expected error from drop failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "install hook script") {
+		t.Errorf("error not phase-tagged: %v", err)
+	}
+	if len(exec.calls) != 2 {
+		t.Errorf("expected 2 calls (home, drop), got %d", len(exec.calls))
+	}
+}

--- a/internal/agentdetect/auggie_settings.go
+++ b/internal/agentdetect/auggie_settings.go
@@ -1,0 +1,233 @@
+package agentdetect
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ===========================================
+// Auggie (Augment CLI) settings.json injection
+// ===========================================
+//
+// fleet-man detects auggie's run state by installing hooks into the
+// container's ~/.augment/settings.json that fire on lifecycle events
+// (SessionStart, PromptSubmit, PreToolUse, PostToolUse, Notification,
+// Stop) and write a single-line state file the host then reads.
+//
+// The reconciliation rules mirror claude_settings.go exactly — strict
+// edit-in-place on an untyped map so unrelated keys round-trip, with
+// fleet-man's own entries recognised solely by the command path
+// (AuggieScriptSuffix). Two details differ from Claude's settings,
+// both dictated by auggie's native schema:
+//
+//   - Matcher: auggie matches a hook group against the tool name by
+//     treating "matcher" as a REGEX (default ".*"). Claude's "*" is an
+//     invalid regex there, so tool events use ".*". Only the tool
+//     events (PreToolUse/PostToolUse) carry a matcher at all; the
+//     lifecycle events (SessionStart/PromptSubmit/Notification/Stop)
+//     use auggie's matcher-less group shape.
+//   - Event identity: auggie tells the hook which event fired via the
+//     AUGMENT_HOOK_EVENT environment variable, so our "command" is
+//     just the script path. We still pass the event name in "args" as
+//     a self-describing fallback; ownership is matched on "command".
+//
+// Hook entries fleet-man manages have this canonical shape (tool
+// events also carry "matcher": ".*"):
+//
+//   {
+//     "hooks": [
+//       {"type": "command", "command": "<AuggieScriptSuffix path>", "args": ["<Event>"]}
+//     ]
+//   }
+
+// ===========================================
+// Constants
+// ===========================================
+
+// AuggieScriptSuffix is the home-relative path of the auggie
+// state-writing hook script, the auggie counterpart to
+// FleetManScriptSuffix. Suffix-based recognition (rather than
+// full-path equality) lets us identify "our" entries without knowing
+// the absolute path, so an entry written under a different $HOME is
+// still recognised and updated rather than duplicated.
+const AuggieScriptSuffix = ".fleet/scripts/auggie-state-hook.sh"
+
+// auggieHookEvent pairs an auggie lifecycle event with whether its
+// native settings schema accepts a tool-name matcher. Tool events
+// (PreToolUse/PostToolUse) do; the lifecycle events do not.
+type auggieHookEvent struct {
+	name       string
+	hasMatcher bool
+}
+
+// auggieManagedEvents lists the auggie lifecycle events fleet-man
+// installs handlers for. Order governs first-insert order; subsequent
+// reconciliations preserve whatever position our entry already holds.
+var auggieManagedEvents = []auggieHookEvent{
+	{name: "SessionStart", hasMatcher: false},
+	{name: "PromptSubmit", hasMatcher: false},
+	{name: "PreToolUse", hasMatcher: true},
+	{name: "PostToolUse", hasMatcher: true},
+	{name: "Notification", hasMatcher: false},
+	{name: "Stop", hasMatcher: false},
+}
+
+// ===========================================
+// Public API
+// ===========================================
+
+// InjectAuggieHooks upserts fleet-man's state-writing hook entries
+// into an auggie settings.json document, returning the new bytes.
+//
+// current is the current contents of settings.json. nil, an empty
+// slice, or whitespace-only input is treated as "the file does not
+// exist yet" and yields a fresh document containing only our hooks.
+//
+// scriptPath is the absolute path of the in-container hook script,
+// computed by the provisioner from the container's $HOME plus
+// AuggieScriptSuffix.
+//
+// The guarantees match InjectFleetManHooks: foreign keys/entries are
+// preserved exactly, the transformation is idempotent and
+// position-stable, and nothing is written to disk (the caller owns the
+// atomic write). An error is returned only when current is non-empty
+// and not valid JSON, or when the parsed structure conflicts with the
+// schema in a way we cannot safely repair.
+func InjectAuggieHooks(current []byte, scriptPath string) ([]byte, error) {
+	root := map[string]any{}
+	trimmed := bytes.TrimSpace(current)
+	if len(trimmed) > 0 {
+		if err := json.Unmarshal(trimmed, &root); err != nil {
+			return nil, fmt.Errorf("parse settings.json: %w", err)
+		}
+	}
+
+	hooks, err := getOrCreateHooksMap(root)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, event := range auggieManagedEvents {
+		if err := auggieUpsertEvent(hooks, event, scriptPath); err != nil {
+			return nil, err
+		}
+	}
+
+	root["hooks"] = hooks
+
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal settings.json: %w", err)
+	}
+	return append(out, '\n'), nil
+}
+
+// ===========================================
+// Private Helpers
+// ===========================================
+
+// auggieUpsertEvent reconciles fleet-man's group inside the array at
+// hooks[event.name], replacing our existing group in place (collapsing
+// duplicates) or appending it after all foreign entries. Foreign
+// groups pass through unchanged. Returns an error if hooks[event] is
+// present with a non-array type.
+func auggieUpsertEvent(hooks map[string]any, event auggieHookEvent, scriptPath string) error {
+	raw, present := hooks[event.name]
+	var groups []any
+	if present && raw != nil {
+		existing, ok := raw.([]any)
+		if !ok {
+			return fmt.Errorf(`hooks[%q] must be a JSON array, got %T`, event.name, raw)
+		}
+		groups = existing
+	}
+
+	desired := auggieDesiredGroup(event, scriptPath)
+
+	result := make([]any, 0, len(groups)+1)
+	foundOurs := false
+	for _, group := range groups {
+		if isAuggieGroup(group) {
+			if !foundOurs {
+				result = append(result, desired)
+				foundOurs = true
+			}
+			continue
+		}
+		result = append(result, group)
+	}
+	if !foundOurs {
+		result = append(result, desired)
+	}
+	hooks[event.name] = result
+	return nil
+}
+
+// auggieDesiredGroup returns the canonical fleet-man hook group for the
+// given event. Tool events carry the match-all ".*" regex matcher;
+// lifecycle events use auggie's matcher-less group shape. A fresh map
+// is built every call so later mutations cannot bleed into shared
+// state.
+func auggieDesiredGroup(event auggieHookEvent, scriptPath string) map[string]any {
+	group := map[string]any{
+		"hooks": []any{
+			map[string]any{
+				"type":    "command",
+				"command": scriptPath,
+				"args":    []any{event.name},
+			},
+		},
+	}
+	if event.hasMatcher {
+		group["matcher"] = ".*"
+	}
+	return group
+}
+
+// isAuggieGroup reports whether the given hook group belongs to
+// fleet-man, identified by the command path of any of its inner hooks.
+// Robust to malformed entries: anything not matching the expected
+// shape returns false (treat as foreign, leave alone).
+func isAuggieGroup(group any) bool {
+	groupMap, ok := group.(map[string]any)
+	if !ok {
+		return false
+	}
+	inner, ok := groupMap["hooks"].([]any)
+	if !ok {
+		return false
+	}
+	for _, hookEntry := range inner {
+		hookMap, ok := hookEntry.(map[string]any)
+		if !ok {
+			continue
+		}
+		command, ok := hookMap["command"].(string)
+		if !ok {
+			continue
+		}
+		if isAuggieCommand(command) {
+			return true
+		}
+	}
+	return false
+}
+
+// isAuggieCommand reports whether a hook command string was installed
+// by fleet-man, matched by the home-relative AuggieScriptSuffix so
+// entries written under a different $HOME are still recognised. The
+// leading token is taken (defensive against a command that carries
+// trailing arguments inline) before suffix-matching.
+func isAuggieCommand(command string) bool {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return false
+	}
+	first := command
+	if idx := strings.IndexAny(command, " \t"); idx >= 0 {
+		first = command[:idx]
+	}
+	return strings.HasSuffix(first, "/"+AuggieScriptSuffix)
+}

--- a/internal/agentdetect/auggie_settings_test.go
+++ b/internal/agentdetect/auggie_settings_test.go
@@ -1,0 +1,212 @@
+package agentdetect
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// auggieTestScriptPath is a stable absolute path ending in the auggie
+// suffix, used across the injection tests.
+const auggieTestScriptPath = "/home/test/" + AuggieScriptSuffix
+
+// mustInjectAuggie runs InjectAuggieHooks against auggieTestScriptPath
+// and fails the test on error.
+func mustInjectAuggie(t *testing.T, input []byte) []byte {
+	t.Helper()
+	out, err := InjectAuggieHooks(input, auggieTestScriptPath)
+	if err != nil {
+		t.Fatalf("InjectAuggieHooks(%q) returned error: %v", input, err)
+	}
+	return out
+}
+
+// parseHooks unmarshals settings.json bytes and returns the "hooks"
+// object, failing the test if the document is not the expected shape.
+func parseHooks(t *testing.T, doc []byte) map[string]any {
+	t.Helper()
+	var root map[string]any
+	if err := json.Unmarshal(doc, &root); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, doc)
+	}
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("hooks is not an object: %T", root["hooks"])
+	}
+	return hooks
+}
+
+// fleetManAuggieGroup returns the single fleet-man-owned group for the
+// given event from a parsed hooks map (or fails if absent/duplicated).
+func fleetManAuggieGroup(t *testing.T, hooks map[string]any, event string) map[string]any {
+	t.Helper()
+	arr, ok := hooks[event].([]any)
+	if !ok {
+		t.Fatalf("hooks[%q] is not an array: %T", event, hooks[event])
+	}
+	var found map[string]any
+	for _, g := range arr {
+		if isAuggieGroup(g) {
+			if found != nil {
+				t.Fatalf("hooks[%q] has more than one fleet-man group", event)
+			}
+			found = g.(map[string]any)
+		}
+	}
+	if found == nil {
+		t.Fatalf("hooks[%q] has no fleet-man group", event)
+	}
+	return found
+}
+
+// TestInjectAuggieHooks_FreshShape verifies the canonical structure a
+// fresh injection produces: every managed event present, tool events
+// carrying the ".*" regex matcher, lifecycle events matcher-less, and
+// each inner hook pointing at the script with the event in "args".
+func TestInjectAuggieHooks_FreshShape(t *testing.T) {
+	out := mustInjectAuggie(t, nil)
+
+	// auggie's matcher is a regex; Claude's "*" would be invalid there.
+	if bytes.Contains(out, []byte(`"matcher": "*"`)) {
+		t.Errorf("output uses the invalid-regex matcher \"*\":\n%s", out)
+	}
+
+	hooks := parseHooks(t, out)
+
+	withMatcher := map[string]bool{
+		"SessionStart": false,
+		"PromptSubmit": false,
+		"PreToolUse":   true,
+		"PostToolUse":  true,
+		"Notification": false,
+		"Stop":         false,
+	}
+
+	for event, wantMatcher := range withMatcher {
+		group := fleetManAuggieGroup(t, hooks, event)
+
+		matcher, hasMatcher := group["matcher"]
+		if wantMatcher {
+			if !hasMatcher {
+				t.Errorf("%s: expected a matcher, got none", event)
+			} else if matcher != ".*" {
+				t.Errorf("%s: matcher = %v, want \".*\"", event, matcher)
+			}
+		} else if hasMatcher {
+			t.Errorf("%s: lifecycle event should have no matcher, got %v", event, matcher)
+		}
+
+		inner, ok := group["hooks"].([]any)
+		if !ok || len(inner) != 1 {
+			t.Fatalf("%s: inner hooks malformed: %v", event, group["hooks"])
+		}
+		hook := inner[0].(map[string]any)
+		if hook["type"] != "command" {
+			t.Errorf("%s: type = %v, want command", event, hook["type"])
+		}
+		if hook["command"] != auggieTestScriptPath {
+			t.Errorf("%s: command = %v, want %q", event, hook["command"], auggieTestScriptPath)
+		}
+		// The event identity rides in args, NOT appended to command.
+		args, ok := hook["args"].([]any)
+		if !ok || len(args) != 1 || args[0] != event {
+			t.Errorf("%s: args = %v, want [%q]", event, hook["args"], event)
+		}
+	}
+}
+
+// TestInjectAuggieHooks_Idempotent verifies running the function on its
+// own output is a no-op.
+func TestInjectAuggieHooks_Idempotent(t *testing.T) {
+	first := mustInjectAuggie(t, nil)
+	second := mustInjectAuggie(t, first)
+	if !bytes.Equal(first, second) {
+		t.Errorf("not idempotent\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+// TestInjectAuggieHooks_PreservesForeignContent verifies user keys and
+// foreign hook entries round-trip untouched.
+func TestInjectAuggieHooks_PreservesForeignContent(t *testing.T) {
+	existing := []byte(`{
+  "model": "augment-default",
+  "hooks": {
+    "PreToolUse": [
+      {"matcher": "Bash", "hooks": [{"type": "command", "command": "/u/audit.sh"}]}
+    ],
+    "Stop": [
+      {"hooks": [{"type": "command", "command": "/u/onstop.sh"}]}
+    ]
+  }
+}`)
+	out := mustInjectAuggie(t, existing)
+
+	if !bytes.Contains(out, []byte(`"model"`)) || !bytes.Contains(out, []byte("augment-default")) {
+		t.Errorf("user model key dropped:\n%s", out)
+	}
+	if !bytes.Contains(out, []byte("/u/audit.sh")) {
+		t.Errorf("foreign PreToolUse hook dropped:\n%s", out)
+	}
+	if !bytes.Contains(out, []byte("/u/onstop.sh")) {
+		t.Errorf("foreign Stop hook dropped:\n%s", out)
+	}
+
+	// Our entry should sit alongside the foreign ones, not replace them.
+	hooks := parseHooks(t, out)
+	preArr := hooks["PreToolUse"].([]any)
+	if len(preArr) != 2 {
+		t.Errorf("PreToolUse should have foreign + ours = 2 groups, got %d", len(preArr))
+	}
+}
+
+// TestInjectAuggieHooks_ReplacesStaleEntryAcrossHome verifies that a
+// prior fleet-man entry written under a DIFFERENT $HOME is recognised
+// by suffix and updated in place rather than duplicated.
+func TestInjectAuggieHooks_ReplacesStaleEntryAcrossHome(t *testing.T) {
+	stalePath := "/home/other/" + AuggieScriptSuffix
+	existing := []byte(`{
+  "hooks": {
+    "Stop": [
+      {"hooks": [{"type": "command", "command": "` + stalePath + `", "args": ["Stop"]}]}
+    ]
+  }
+}`)
+	out := mustInjectAuggie(t, existing)
+
+	hooks := parseHooks(t, out)
+	arr := hooks["Stop"].([]any)
+	if len(arr) != 1 {
+		t.Fatalf("Stop should have exactly one (updated) fleet-man group, got %d:\n%s", len(arr), out)
+	}
+	group := fleetManAuggieGroup(t, hooks, "Stop")
+	hook := group["hooks"].([]any)[0].(map[string]any)
+	if hook["command"] != auggieTestScriptPath {
+		t.Errorf("stale command not updated: %v", hook["command"])
+	}
+	if bytes.Contains(out, []byte(stalePath)) {
+		t.Errorf("stale path still present after update:\n%s", out)
+	}
+}
+
+// TestInjectAuggieHooks_RejectsMalformedInput verifies invalid JSON is
+// surfaced as an error rather than silently overwriting the file.
+func TestInjectAuggieHooks_RejectsMalformedInput(t *testing.T) {
+	if _, err := InjectAuggieHooks([]byte(`{not json`), auggieTestScriptPath); err == nil {
+		t.Fatal("expected error on malformed input, got nil")
+	}
+}
+
+// TestCaptureAllScript_AuggieHookPathInLockstep guards against drift
+// between AuggieScriptSuffix and the literal embedded in
+// backend.CaptureAllScript. The capture script checks the auggie hook
+// is installed and re-provisions when it is gone; if the paths drift,
+// the self-heal would either never fire or fire forever.
+func TestCaptureAllScript_AuggieHookPathInLockstep(t *testing.T) {
+	want := "/" + AuggieScriptSuffix
+	if !strings.Contains(backend.CaptureAllScript, want) {
+		t.Errorf("backend.CaptureAllScript does not reference %q — it must check the same path the provisioner installs to", want)
+	}
+}

--- a/internal/agentdetect/factory.go
+++ b/internal/agentdetect/factory.go
@@ -16,6 +16,8 @@ func NewDetector(tool state.AgentTool) Detector {
 	switch tool {
 	case state.AgentToolClaude:
 		return NewClaudeHookDetector()
+	case state.AgentToolAuggie:
+		return NewAuggieHookDetector()
 	default:
 		return NewTmuxPaneChangeDetector()
 	}

--- a/internal/backend/all_sessions.go
+++ b/internal/backend/all_sessions.go
@@ -12,13 +12,14 @@ package backend
 //     /tmp/fleet-man/*-state files present at capture time. Detectors
 //     read their own state file by path; missing entries simply mean
 //     the file did not exist.
-//   - ClaudeHookMissing is true only when CaptureAllScript explicitly
-//     observed that the Claude state-detection hook script is gone
-//     from the container. Default false means "no signal to act on" —
-//     a transient capture failure does NOT trigger re-provisioning.
+//   - HookScriptMissing is true only when CaptureAllScript explicitly
+//     observed that a fleet-man state-detection hook script (Claude
+//     Code's or auggie's) is gone from the container. Default false
+//     means "no signal to act on" — a transient capture failure does
+//     NOT trigger re-provisioning.
 type AllSessions struct {
 	Sessions          map[string]ScreenCapture // sessionName → capture
 	ExtraFiles        map[string]string        // containerPath → contents
-	ClaudeHookMissing bool
+	HookScriptMissing bool
 	OK                bool
 }

--- a/internal/backend/capture.go
+++ b/internal/backend/capture.go
@@ -12,11 +12,12 @@ const sessionMarker = "\x1eFLEET_SESSION_8f4a2b1c\x1e"
 // payload type so the parser knows which map the body belongs to.
 const fileMarker = "\x1eFLEET_FILE_8f4a2b1c\x1e"
 
-// hookMissingMarker is emitted by CaptureAllScript when the Claude
-// state-detection hook script is not present (or not executable) in
-// the container. The host uses this signal to re-install the script
-// — without it, fleet-man's Claude detector silently sticks at
-// "waiting" because Claude has no way to write the state file.
+// hookMissingMarker is emitted by CaptureAllScript when any fleet-man
+// state-detection hook script (Claude Code's or auggie's) is not
+// present (or not executable) in the container. The host uses this
+// signal to re-install the scripts — without them, the corresponding
+// hook detector silently sticks at "waiting" because the agent has no
+// way to write its state file.
 const hookMissingMarker = "\x1eFLEET_HOOK_MISSING_8f4a2b1c\x1e"
 
 // CaptureAllScript runs every per-container read fleet-man needs in a
@@ -24,12 +25,13 @@ const hookMissingMarker = "\x1eFLEET_HOOK_MISSING_8f4a2b1c\x1e"
 //
 //  1. List tmux sessions and capture each pane's visible content.
 //  2. Cat any /tmp/fleet-man/*-state files written by in-container
-//     hook scripts (today: Claude Code's fleet-man-state-hook).
-//  3. Verify the Claude state-detection hook script is still present
-//     in $HOME, emitting a marker line when it is not so the host can
-//     re-provision it. The path matches FleetManScriptSuffix in the
-//     agentdetect package; the literal is duplicated here because the
-//     backend package cannot import agentdetect.
+//     hook scripts (Claude Code's and auggie's state-hook scripts).
+//  3. Verify the state-detection hook scripts (Claude Code's and
+//     auggie's) are still present in $HOME, emitting a marker line when
+//     either is not so the host can re-provision them. The paths match
+//     FleetManScriptSuffix / AuggieScriptSuffix in the agentdetect
+//     package; the literals are duplicated here because the backend
+//     package cannot import agentdetect.
 //
 // Each block is preceded by a marker line so the Go side can
 // demultiplex back into typed maps. The script is tolerant of
@@ -49,7 +51,7 @@ for f in /tmp/fleet-man/*-state; do
   printf '\036FLEET_FILE_8f4a2b1c\036%s\n' "$f"
   cat "$f" 2>/dev/null || true
 done
-if [ ! -x "$HOME/.fleet/scripts/claude-state-hook.sh" ]; then
+if [ ! -x "$HOME/.fleet/scripts/claude-state-hook.sh" ] || [ ! -x "$HOME/.fleet/scripts/auggie-state-hook.sh" ]; then
   printf '\036FLEET_HOOK_MISSING_8f4a2b1c\036\n'
 fi
 `
@@ -59,8 +61,9 @@ fi
 //
 //   - sessions:    tmux sessionName → ScreenCapture
 //   - files:       containerPath    → file contents
-//   - hookMissing: true when the Claude hook-script absence marker
-//     was present in the output (default false: assume
+//   - hookMissing: true when the hook-script absence marker was
+//     present in the output, i.e. a fleet-man hook script (Claude
+//     Code's or auggie's) is missing (default false: assume
 //     installed unless we have direct evidence otherwise,
 //     so a parse with no markers does not trigger
 //     unnecessary re-provisioning)

--- a/internal/backend/coder/coder_backend.go
+++ b/internal/backend/coder/coder_backend.go
@@ -227,7 +227,7 @@ func (coderBackend *CoderBackend) CaptureAllSessions(containerID string) backend
 	return backend.AllSessions{
 		Sessions:          sessions,
 		ExtraFiles:        files,
-		ClaudeHookMissing: hookMissing,
+		HookScriptMissing: hookMissing,
 		OK:                true,
 	}
 }

--- a/internal/backend/coder/parse_test.go
+++ b/internal/backend/coder/parse_test.go
@@ -17,6 +17,7 @@ func TestParseToolProbeOutput(t *testing.T) {
 		{"copilot", "copilot\n", "copilot", true},
 		{"codex", "codex\n", "codex", true},
 		{"gemini", "gemini\n", "gemini", true},
+		{"auggie", "auggie\n", "auggie", true},
 		{"no-agent", "-\n", "", true},
 		{"empty", "", "", false},
 	}

--- a/internal/backend/codespaces/codespaces_backend.go
+++ b/internal/backend/codespaces/codespaces_backend.go
@@ -254,7 +254,7 @@ func (codespacesBackend *CodespacesBackend) CaptureAllSessions(containerID strin
 	return backend.AllSessions{
 		Sessions:          sessions,
 		ExtraFiles:        files,
-		ClaudeHookMissing: hookMissing,
+		HookScriptMissing: hookMissing,
 		OK:                true,
 	}
 }

--- a/internal/backend/devcontainer/devcontainer_backend.go
+++ b/internal/backend/devcontainer/devcontainer_backend.go
@@ -433,7 +433,7 @@ func (devcontainerBackend *DevcontainerBackend) CaptureAllSessions(containerID s
 	return backend.AllSessions{
 		Sessions:          sessions,
 		ExtraFiles:        files,
-		ClaudeHookMissing: hookMissing,
+		HookScriptMissing: hookMissing,
 		OK:                true,
 	}
 }

--- a/internal/backend/devcontainer/devcontainer_test.go
+++ b/internal/backend/devcontainer/devcontainer_test.go
@@ -67,6 +67,7 @@ func TestParseToolProbeOutput(t *testing.T) {
 		{"copilot detected", "copilot\n", "copilot", true},
 		{"codex detected", "codex\n", "codex", true},
 		{"gemini detected", "gemini\n", "gemini", true},
+		{"auggie detected", "auggie\n", "auggie", true},
 		{"no agent", "-\n", "", true},
 		{"empty output", "", "", false},
 		{"whitespace only", "  \n", "", false},

--- a/internal/backend/tool_probe.go
+++ b/internal/backend/tool_probe.go
@@ -6,7 +6,7 @@ import "strings"
 // a container. It runs a single `ps` scan, excludes the probe's own
 // process group to avoid self-matching, and checks every command-line
 // field against all tool names at once. Priority order: claude,
-// copilot, codex, gemini.
+// copilot, codex, gemini, auggie.
 //
 // The matching pattern (^|/)t($|[-./]) recognises:
 //   - standalone binaries: `claude`, `/usr/local/bin/claude`
@@ -20,11 +20,12 @@ import "strings"
 const ToolProbeScript = `MY_PGID=$(ps -o pgid= -p $$ 2>/dev/null | tr -d ' \t\n\r')
 ps -eo pid,pgid,args --no-headers 2>/dev/null | awk -v pgid="$MY_PGID" '
 BEGIN {
-  n = 4
+  n = 5
   tools[1] = "claude"
   tools[2] = "copilot"
   tools[3] = "codex"
   tools[4] = "gemini"
+  tools[5] = "auggie"
 }
 $2 == pgid { next }
 {

--- a/internal/backend/tool_probe_test.go
+++ b/internal/backend/tool_probe_test.go
@@ -13,6 +13,7 @@ func TestParseToolProbeOutput(t *testing.T) {
 		{"copilot detected", "copilot\n", "copilot", true},
 		{"codex detected", "codex\n", "codex", true},
 		{"gemini detected", "gemini\n", "gemini", true},
+		{"auggie detected", "auggie\n", "auggie", true},
 		{"no agent", "-\n", "", true},
 		{"empty output (exec failure)", "", "", false},
 		{"whitespace only (exec failure)", "  \n", "", false},

--- a/internal/configutil/configutil.go
+++ b/internal/configutil/configutil.go
@@ -49,4 +49,5 @@ const (
 	AgentToolClaude  = state.AgentToolClaude
 	AgentToolGemini  = state.AgentToolGemini
 	AgentToolCopilot = state.AgentToolCopilot
+	AgentToolAuggie  = state.AgentToolAuggie
 )

--- a/internal/create/provision.go
+++ b/internal/create/provision.go
@@ -131,13 +131,17 @@ func finishProvision(instanceBackend backend.Backend, fleetName, instanceName, w
 	// non-fatal — the instance is still usable.
 	runStartupScripts(instanceBackend, wsDir, fleetName, instanceName)
 
-	// Install Claude Code state-detection hooks. Runs after the startup scripts
-	// so any per-fleet Claude Code install above has had a chance to land before
-	// we drop our hooks alongside it. Non-fatal: the per-instance Detector falls
-	// back to a safe default. We always install (regardless of which agent the
-	// user actually runs) because the cost of unused hooks is negligible.
+	// Install the agent state-detection hooks (Claude Code, auggie). Runs after
+	// the startup scripts so any per-fleet agent install above has had a chance
+	// to land before we drop our hooks alongside it. Non-fatal: the per-instance
+	// Detector falls back to a safe default. We always install (regardless of
+	// which agent the user actually runs) because the cost of unused hooks is
+	// negligible.
 	executor := agentdetect.NewBackendExecutor(instanceBackend, wsDir)
 	if err := agentdetect.NewClaudeProvisioner(executor).Provision(); err != nil {
 		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("claude hook install failed: %v", err))
+	}
+	if err := agentdetect.NewAuggieProvisioner(executor).Provision(); err != nil {
+		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("auggie hook install failed: %v", err))
 	}
 }

--- a/internal/server/convert_runtime.go
+++ b/internal/server/convert_runtime.go
@@ -40,6 +40,8 @@ func agentToolToProto(t state.AgentTool) fleetgrpc.AgentTool {
 		return fleetgrpc.AgentTool_AGENT_TOOL_GEMINI
 	case state.AgentToolCopilot:
 		return fleetgrpc.AgentTool_AGENT_TOOL_COPILOT
+	case state.AgentToolAuggie:
+		return fleetgrpc.AgentTool_AGENT_TOOL_AUGGIE
 	default:
 		return fleetgrpc.AgentTool_AGENT_TOOL_UNSPECIFIED
 	}

--- a/internal/server/runtime_poller.go
+++ b/internal/server/runtime_poller.go
@@ -230,13 +230,15 @@ func statsActivityPass(h *hub) {
 		}
 	}
 
-	// Re-install a missing Claude hook server-side (moved off the TUI's capture
+	// Re-install missing agent hooks server-side (moved off the TUI's capture
 	// poll). Fire-and-forget, dedup'd per container so a slow provision doesn't
-	// stack across 3s ticks. Failures are surfaced as a per-instance warning
-	// (the same ~/.fleet/logs/*.warn file the TUI reads).
+	// stack across 3s ticks. Both the Claude and auggie hook scripts are dropped
+	// together at create time and the capture marker fires when either is gone,
+	// so we re-provision both (each is idempotent). Failures are surfaced as a
+	// per-instance warning (the same ~/.fleet/logs/*.warn file the TUI reads).
 	for _, it := range items {
 		c, ok := captures[it.containerID]
-		if !ok || !c.OK || !c.ClaudeHookMissing {
+		if !ok || !c.OK || !c.HookScriptMissing {
 			continue
 		}
 		if _, busy := h.reprovisioning.LoadOrStore(it.containerID, struct{}{}); busy {
@@ -249,6 +251,9 @@ func statsActivityPass(h *hub) {
 			executor := agentdetect.NewBackendExecutor(b, wsDir)
 			if err := agentdetect.NewClaudeProvisioner(executor).Provision(); err != nil {
 				state.WriteWarn(fleetName, instanceName, fmt.Sprintf("claude hook reinstall failed: %v", err))
+			}
+			if err := agentdetect.NewAuggieProvisioner(executor).Provision(); err != nil {
+				state.WriteWarn(fleetName, instanceName, fmt.Sprintf("auggie hook reinstall failed: %v", err))
 			}
 		}()
 	}

--- a/internal/state/agent_tool.go
+++ b/internal/state/agent_tool.go
@@ -8,6 +8,7 @@ const (
 	AgentToolClaude  AgentTool = "claude"
 	AgentToolGemini  AgentTool = "gemini"
 	AgentToolCopilot AgentTool = "copilot"
+	AgentToolAuggie  AgentTool = "auggie"
 )
 
 // validAgentTools enumerates the set of recognised agent tools so unknown
@@ -17,4 +18,5 @@ var validAgentTools = map[AgentTool]struct{}{
 	AgentToolClaude:  {},
 	AgentToolGemini:  {},
 	AgentToolCopilot: {},
+	AgentToolAuggie:  {},
 }

--- a/internal/state/config_test.go
+++ b/internal/state/config_test.go
@@ -48,6 +48,7 @@ func TestLoadConfigPreservesValidToolSelections(t *testing.T) {
 		{name: "claude", tool: AgentToolClaude},
 		{name: "gemini", tool: AgentToolGemini},
 		{name: "copilot", tool: AgentToolCopilot},
+		{name: "auggie", tool: AgentToolAuggie},
 	}
 
 	for _, tt := range tests {

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -153,6 +153,8 @@ func agentToolLabelProto(tool fleetgrpc.AgentTool) string {
 		return "Gemini"
 	case fleetgrpc.AgentTool_AGENT_TOOL_COPILOT:
 		return "Copilot"
+	case fleetgrpc.AgentTool_AGENT_TOOL_AUGGIE:
+		return "Auggie"
 	default:
 		return "Claude Code"
 	}


### PR DESCRIPTION
## Summary

Closes #178 — auggie (the Augment CLI) was an install/mount option but fleet never detected it as a running agent. This adds full agent detection for auggie: identification via the `ps` tool probe, and **exact run/stop state via auggie's native hook system** (not the generic heuristic).

### Detection wiring
- **backend** (`tool_probe.go`): `auggie` added to the `ps`-scan tool list.
- **state** (`agent_tool.go`): `AgentToolAuggie` enum + `validAgentTools`; re-exported from `configutil`.
- **proto** (`runtime.proto`): `AGENT_TOOL_AUGGIE = 6` (regenerated `runtime.pb.go`).
- **server** (`convert_runtime.go`) + **tui** (`render.go`): maps the tool through and renders the "Auggie" label.

### Hook-based run/stop detector (Claude-style)
auggie exposes a `settings.json` hook system (events `SessionStart`, `PromptSubmit`, `PreToolUse`, `PostToolUse`, `Notification`, `Stop`) and sets `AUGMENT_HOOK_EVENT` on every invocation, so we read an exact working/waiting signal instead of diffing tmux panes.

- `auggie_hook_script.{sh,go}` — embedded state-hook; writes `/tmp/fleet-man/auggie-state` in the shared `<state> <unix-secs>` format (auto-captured by the existing `*-state` glob).
- `auggie_settings.go` — `InjectAuggieHooks` into `~/.augment/settings.json`. Matches auggie's native schema, which differs from Claude's: matcher is a **regex** (`.*`, since Claude's `*` is an invalid regex) and only tool events carry one; the event rides in `args`; ownership keyed on the command path for idempotent re-injection across `$HOME` changes.
- `auggie_provisioner.go` — drops script + injects settings (idempotent, atomic).
- `auggie_detector.go` + factory — `AuggieHookDetector`; absent/unparseable → `StateWaiting` (same safe default as Claude).
- `provision.go` installs auggie hooks at create time; self-heal generalized (`ClaudeHookMissing` → `HookScriptMissing`, both scripts checked, both re-provisioned).

### Notes for review
- The detector relies on auggie firing its lifecycle hooks in interactive sessions; if they don't fire, it shows **waiting** (safe, but less informative than the old pane-diff heuristic). Worth a manual smoke-test in a live instance.
- Hook schema/execution model was verified against the installed auggie binary (v0.29.0) and the official docs (docs.augmentcode.com/cli/hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)