### PR TITLE
fix/poststart-on-instance-start — run devcontainer postStartCommand when an instance starts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,13 @@
   "privileged": true,
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
-  "postStartCommand": "bash ${containerWorkspaceFolder}/.devcontainer/setup.sh",
+  // Object form runs each entry in parallel. `setup` is the real provisioning
+  // step; `timestamp` appends the UTC time to /tmp/fleet-poststart.log on every
+  // postStart so you can confirm the hook re-fires on each `fleet start` (#179).
+  "postStartCommand": {
+    "setup": "bash ${containerWorkspaceFolder}/.devcontainer/setup.sh",
+    "timestamp": "date -u >> /tmp/fleet-poststart.log"
+  },
   // Configure tool-specific properties.
   // "customizations": {},
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/integration/fixture/.devcontainer/devcontainer.json
+++ b/integration/fixture/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
   "name": "fleet-man integration fixture",
   "image": "mcr.microsoft.com/devcontainers/base:debian-12",
-  "postCreateCommand": "sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends tmux"
+  "postCreateCommand": "sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends tmux",
+  "postStartCommand": "echo poststart >> $HOME/.fleet-poststart.log"
 }

--- a/integration/tests/030_stop_start.sh
+++ b/integration/tests/030_stop_start.sh
@@ -13,6 +13,19 @@ container_id=$(grep -oE '"container_id":\s*"[^"]+"' "${HOME}/.fleet/state.json" 
 [ -n "${container_id}" ] || fail "could not read container_id from state.json"
 info "container id: ${container_id}"
 
+# The fixture devcontainer.json appends a line to ~/.fleet-poststart.log every
+# time postStartCommand runs. Counting the lines lets us prove the devcontainer
+# postStart hook fires on each start — the regression behind issue #179.
+count_poststart() {
+  "${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- \
+    sh -c 'cat "$HOME/.fleet-poststart.log" 2>/dev/null | wc -l | tr -d " "'
+}
+
+# postStart runs once as part of the initial `up`.
+poststart_create=$(count_poststart)
+info "poststart count after create: ${poststart_create}"
+assert_equals "1" "${poststart_create}" "postStart should run once during create"
+
 # --- stop ---
 info "fleet stop alpha"
 stop_out=$("${FLEET_BIN}" stop "${FIXTURE_REPO_NAME}/alpha")
@@ -49,5 +62,12 @@ assert_contains "${ls_after_start}" "running" "ls should report running status"
 # exec works again after start.
 echo_out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- sh -c "echo back-online")
 assert_equals "back-online" "${echo_out}" "exec after start"
+
+# Issue #179: starting a stopped instance must re-run the devcontainer
+# postStartCommand, just like every other devcontainer tool. The marker now
+# holds a second line.
+poststart_restart=$(count_poststart)
+info "poststart count after restart: ${poststart_restart}"
+assert_equals "2" "${poststart_restart}" "postStart must re-run when the instance is started (#179)"
 
 pass "stop + start"

--- a/internal/backend/devcontainer/devcontainer_backend.go
+++ b/internal/backend/devcontainer/devcontainer_backend.go
@@ -340,12 +340,81 @@ func (devcontainerBackend *DevcontainerBackend) Stop(containerID string) error {
 	return cmd.Run()
 }
 
-// Start starts an existing container by ID.
+// Start starts an existing container by ID and then fires the devcontainer
+// postStartCommand lifecycle hook so a resumed instance behaves like one
+// brought up by any other devcontainer tool (issue #179). A bare `docker
+// start` leaves postStartCommand un-run because docker knows nothing about
+// devcontainer lifecycle, so we follow it with `devcontainer
+// run-user-commands` (see runPostStart). The post-start step is best-effort:
+// the container is already running, so a hook failure is logged rather than
+// reverting the instance to stopped and desyncing fleet's state from docker.
 func (devcontainerBackend *DevcontainerBackend) Start(containerID string) error {
 	cmd := exec.Command("docker", "start", containerID)
 	cmd.Stdout = io.Discard
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	devcontainerBackend.runPostStart(containerID)
+	return nil
+}
+
+// runPostStart re-runs the devcontainer postStartCommand (and postAttachCommand)
+// for a just-started container via `devcontainer run-user-commands`. That
+// subcommand re-runs only the lifecycle commands whose markers are stale
+// relative to the container's start time — postStart and postAttach — while
+// leaving the create-time commands (onCreate/updateContent/postCreate)
+// untouched, because their markers are pinned to the unchanged container
+// creation time. It never recreates the container, so the instance keeps its
+// identity (unlike `up`, which could rebuild on config drift).
+//
+// The workspace folder is recovered from the container's
+// `devcontainer.local_folder` label — the same label the CLI stamps at `up`
+// time — so Start needs only the container ID. Best-effort: a missing label or
+// a non-zero exit is logged (output already teed to fleet.log) and swallowed,
+// since the container is running regardless.
+func (devcontainerBackend *DevcontainerBackend) runPostStart(containerID string) {
+	workspaceDir := workspaceFolderForContainer(containerID)
+	if workspaceDir == "" {
+		flog.Warn("devcontainer post-start skipped: container has no workspace-folder label", "container", containerID)
+		return
+	}
+
+	cmd := exec.Command("devcontainer", runUserCommandsArgs(workspaceDir)...)
+	// Tee output to the process stdio so the postStart script's output (and
+	// any failure detail) reaches the log file under the TUI's background
+	// process, exactly like up().
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	start := time.Now()
+	if err := cmd.Run(); err != nil {
+		flog.Warn("devcontainer post-start failed", "container", containerID, "workspace", workspaceDir, "ms", flog.MillisSince(start), "err", err)
+		return
+	}
+	flog.Info("devcontainer post-start ran", "container", containerID, "workspace", workspaceDir, "ms", flog.MillisSince(start))
+}
+
+// runUserCommandsArgs builds the `devcontainer run-user-commands` argument list
+// for a just-started workspace, threading the SSH agent socket through with
+// --remote-env so a postStart hook that talks to git/ssh sees the same agent
+// the workspace was created with — mirroring devcontainer exec.
+func runUserCommandsArgs(workspaceDir string) []string {
+	args := []string{"run-user-commands", "--workspace-folder", workspaceDir}
+	args = append(args, sshExecArgs()...)
+	return args
+}
+
+// workspaceFolderForContainer returns the host workspace folder a container was
+// provisioned from, read from the `devcontainer.local_folder` label the CLI
+// stamps at `up` time (and that Clone re-applies to cloned containers). Returns
+// "" when the inspect fails or the label is absent.
+func workspaceFolderForContainer(containerID string) string {
+	inspected, err := inspectContainer(containerID)
+	if err != nil || inspected.Config.Labels == nil {
+		return ""
+	}
+	return inspected.Config.Labels[devcontainerLocalFolderLabel]
 }
 
 // Stats returns CPU and memory usage for the given container IDs.

--- a/internal/backend/devcontainer/devcontainer_test.go
+++ b/internal/backend/devcontainer/devcontainer_test.go
@@ -158,6 +158,29 @@ func TestDevcontainerUpArgsUpdateRemoteUserUID(t *testing.T) {
 	}
 }
 
+func TestRunUserCommandsArgs(t *testing.T) {
+	t.Run("without ssh agent", func(t *testing.T) {
+		t.Setenv("SSH_AUTH_SOCK", "")
+		got := runUserCommandsArgs("/ws/alpha")
+		want := []string{"run-user-commands", "--workspace-folder", "/ws/alpha"}
+		if !slices.Equal(got, want) {
+			t.Fatalf("runUserCommandsArgs() = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("with ssh agent threads remote-env", func(t *testing.T) {
+		t.Setenv("SSH_AUTH_SOCK", "/tmp/agent.sock")
+		got := runUserCommandsArgs("/ws/alpha")
+		want := []string{
+			"run-user-commands", "--workspace-folder", "/ws/alpha",
+			"--remote-env", "SSH_AUTH_SOCK=" + containerSSHSocketPath,
+		}
+		if !slices.Equal(got, want) {
+			t.Fatalf("runUserCommandsArgs() = %#v, want %#v", got, want)
+		}
+	})
+}
+
 func TestForwardStdioCommandArgv(t *testing.T) {
 	cmd, ok := New().ForwardStdioCommand("cid123", 8080)
 	if !ok {


### PR DESCRIPTION
## Summary

Closes #179. Starting a stopped instance never ran the devcontainer
`postStartCommand`, because the devcontainer backend's `Start` did a bare
`docker start` — and docker knows nothing about devcontainer lifecycle. Other
devcontainer tools (VS Code, the CLI) run `postStartCommand` on every start;
fleet now matches.

After `docker start` succeeds, `Start` invokes `devcontainer run-user-commands`,
which re-runs only the start-gated lifecycle commands (`postStartCommand`,
`postAttachCommand`) and skips the create-time commands
(`onCreate`/`updateContent`/`postCreate`): the CLI gates those on the container's
unchanged *creation* time, while `postStart`'s marker is compared against the
refreshed *start* time. Unlike `up`, `run-user-commands` never recreates the
container, so the instance keeps its ID (no rebuild on config drift). The
workspace folder is recovered from the container's `devcontainer.local_folder`
label, so `Start` still needs only the container ID.

The hook is **best-effort**: the container is already running, so a failure is
logged (its output teed to `fleet.log`) rather than reverting the instance to
stopped and desyncing fleet's state from docker — consistent with the rest of
the start path (buildkit/cache reconnection, fleet-launch staging).

Codespaces and coder are unaffected: they run `postStart` natively (GitHub-side
and via the agent startup script, respectively).

## Changes

- `internal/backend/devcontainer/devcontainer_backend.go` — `Start` now fires
  `runPostStart` after `docker start`; new `runUserCommandsArgs` (SSH agent
  threaded through via `--remote-env`) and `workspaceFolderForContainer` helpers.
- `internal/backend/devcontainer/devcontainer_test.go` — unit test for
  `runUserCommandsArgs` (with/without SSH agent).
- `integration/fixture/.devcontainer/devcontainer.json` — fixture gains a
  `postStartCommand` that appends a marker line.
- `integration/tests/030_stop_start.sh` — asserts the marker count goes from 1
  (create) to 2 (restart), proving postStart re-runs on start.