### PR TITLE
feat/agents-settings-group — group agent-tool mounts under a collapsible Agents section

### DIFF
--- a/integration/tests/290_tui_layout_preset.sh
+++ b/integration/tests/290_tui_layout_preset.sh
@@ -43,7 +43,9 @@ tui_wait_for "Edit fleet" 5
 tui_assert_contains "Layouts (0)" "Layouts section header missing"
 
 info "expanding Layouts and starting preset creation"
-for _ in 1 2 3 4 5 6; do tui_send j; sleep 0.1; done
+# From the dialog's top row (the collapsed Agents header, issue #184), Layouts
+# is 4 rows down: Agents → GitHub CLI → Home dir → Prefer Fleet Launch → Layouts.
+for _ in 1 2 3 4; do tui_send j; sleep 0.1; done
 tui_send l
 tui_wait_for "+ Layout Preset" 5
 tui_send j

--- a/integration/tests/291_tui_layout_preset_restart.sh
+++ b/integration/tests/291_tui_layout_preset_restart.sh
@@ -34,7 +34,9 @@ tui_send k
 sleep 0.3
 tui_send e
 tui_wait_for "Edit fleet" 5
-for _ in 1 2 3 4 5 6; do tui_send j; sleep 0.1; done
+# From the dialog's top row (the collapsed Agents header, issue #184), Layouts
+# is 4 rows down: Agents → GitHub CLI → Home dir → Prefer Fleet Launch → Layouts.
+for _ in 1 2 3 4; do tui_send j; sleep 0.1; done
 tui_send l
 tui_wait_for "+ Layout Preset" 5
 tui_send j
@@ -91,7 +93,8 @@ tui_wait_for "Edit fleet" 5
 tui_assert_contains "Layouts (1)" "preset count lost after restart — the layout preset did not persist"
 
 info "expanding Layouts to confirm the preset row survived"
-for _ in 1 2 3 4 5 6; do tui_send j; sleep 0.1; done
+# Layouts is 4 rows below the collapsed Agents header (issue #184).
+for _ in 1 2 3 4; do tui_send j; sleep 0.1; done
 tui_send l
 sleep 0.5
 tui_assert_contains "src (1 pane)" "preset row missing after restart"

--- a/internal/tui/dialog_edit_fleet.go
+++ b/internal/tui/dialog_edit_fleet.go
@@ -16,10 +16,11 @@ import (
 
 // editFleetRow identifies a focusable row in the edit-fleet dialog.
 const (
-	editFleetRowClaude = iota
-	editFleetRowCodex
+	editFleetRowAgents = iota // collapsible section header (issue #184)
+	editFleetRowClaude        // child of Agents; only navigable when expanded
+	editFleetRowCodex         // child of Agents; only navigable when expanded
+	editFleetRowAuggie        // child of Agents; only navigable when expanded
 	editFleetRowGh
-	editFleetRowAuggie
 	editFleetRowHomeDir
 	editFleetRowPreferFleetLaunch
 	editFleetRowLayouts      // collapsible section header (issue #150)
@@ -113,6 +114,24 @@ func (fleetPage *fleetPage) enabledCacheCount() int {
 	return n
 }
 
+// enabledAgentCount returns how many of the agent-tool mounts (Claude / Codex /
+// Auggie) are currently toggled on, for the count shown in the Agents section
+// header. GitHub CLI is intentionally excluded — it is a supporting tool, not a
+// coding agent, and stays a top-level mount row (issue #184).
+func (fleetPage *fleetPage) enabledAgentCount() int {
+	n := 0
+	for _, on := range []bool{
+		fleetPage.editFleet.claudeMount,
+		fleetPage.editFleet.codexMount,
+		fleetPage.editFleet.auggieMount,
+	} {
+		if on {
+			n++
+		}
+	}
+	return n
+}
+
 // cacheRowFocused reports whether the dialog cursor is currently on the row for
 // cache kind k (used so the [Delete cache] button only highlights its own row).
 func (fleetPage *fleetPage) cacheRowFocused(k cacheKind) bool {
@@ -121,19 +140,21 @@ func (fleetPage *fleetPage) cacheRowFocused(k cacheKind) bool {
 }
 
 // visibleEditFleetRows returns the edit-fleet dialog's navigable rows in display
-// order. The custom-mount child rows appear only while that section is expanded
-// (one per mount, then the add row); the Buildkit row only appears while the
-// Caching section is expanded.
+// order. The agent-tool rows (Claude / Codex / Auggie) appear only while the
+// Agents section is expanded; the custom-mount child rows appear only while that
+// section is expanded (one per mount, then the add row); the Buildkit row only
+// appears while the Caching section is expanded.
 func (fleetPage *fleetPage) visibleEditFleetRows() []int {
-	rows := []int{
-		editFleetRowClaude,
-		editFleetRowCodex,
+	rows := []int{editFleetRowAgents}
+	if fleetPage.editFleet.agentsExpanded {
+		rows = append(rows, editFleetRowClaude, editFleetRowCodex, editFleetRowAuggie)
+	}
+	rows = append(rows,
 		editFleetRowGh,
-		editFleetRowAuggie,
 		editFleetRowHomeDir,
 		editFleetRowPreferFleetLaunch,
 		editFleetRowLayouts,
-	}
+	)
 	if fleetPage.editFleet.layoutsExpanded {
 		for i := range fleetPage.editFleet.layoutPresets {
 			rows = append(rows, editFleetRowLayoutPresetBase+i)
@@ -263,7 +284,8 @@ func (fleetPage *fleetPage) openEditFleetDialog(m *model) tea.Cmd {
 	fleetPage.editFleet.imageCache = f.Settings.ImageCacheServer
 	fleetPage.editFleet.preferFleetLaunch = f.Settings.PreferFleetLaunchEnabled()
 	fleetPage.editFleet.preferFleetLaunchSet = f.Settings.PreferFleetLaunchSet()
-	fleetPage.dlg.row = editFleetRowClaude
+	fleetPage.dlg.row = editFleetRowAgents
+	fleetPage.editFleet.agentsExpanded = false
 	fleetPage.editFleet.detecting = false
 	fleetPage.dlg.fieldActive = false
 	fleetPage.editFleet.cachingExpanded = false
@@ -405,6 +427,16 @@ func (fleetPage *fleetPage) updateEditFleet(m *model, msg tea.Msg) tea.Cmd {
 		switch keyMsg.String() {
 		case " ", "left", "right", "h", "l", "x", "enter":
 			return fleetPage.toggleEditFleetRow(m)
+		}
+		return nil
+	case editFleetRowAgents:
+		switch keyMsg.String() {
+		case " ", "enter":
+			fleetPage.editFleet.agentsExpanded = !fleetPage.editFleet.agentsExpanded
+		case "right", "l":
+			fleetPage.editFleet.agentsExpanded = true
+		case "left", "h":
+			fleetPage.editFleet.agentsExpanded = false
 		}
 		return nil
 	case editFleetRowCustomMounts:
@@ -1008,10 +1040,15 @@ func (fleetPage *fleetPage) closeEditFleet(_ *model) {
 // ===========================================
 
 // editFleetState holds the edit-fleet settings dialog: the shared-mount and
-// caching toggles plus the collapsible Caching / Custom-mounts / Layouts
-// sections. Every change is instant-saved; the layout-preset capture flow
-// itself lives in fleetPage.lpFlow while mode == viewLayoutPreset.
+// caching toggles plus the collapsible Agents / Caching / Custom-mounts /
+// Layouts sections. Every change is instant-saved; the layout-preset capture
+// flow itself lives in fleetPage.lpFlow while mode == viewLayoutPreset.
 type editFleetState struct {
+	// Agents section. The coding-agent mounts (Claude / Codex / Auggie) live
+	// under a collapsible "Agents" header (issue #184); GitHub CLI stays a
+	// top-level mount row since it is a supporting tool, not a coding agent.
+	agentsExpanded bool // ▼ Agents expanded, revealing the agent-tool rows
+
 	claudeMount       bool
 	codexMount        bool
 	ghMount           bool
@@ -1079,14 +1116,20 @@ func (fleetPage *fleetPage) renderEditFleet(m *model) string {
 
 	for _, row := range fleetPage.visibleEditFleetRows() {
 		switch row {
+		case editFleetRowAgents:
+			arrow := "▶ "
+			if fleetPage.editFleet.agentsExpanded {
+				arrow = "▼ "
+			}
+			d.WriteString(marker(row) + dialogLabel.Render(fmt.Sprintf("%sAgents (%d)", arrow, fleetPage.enabledAgentCount())))
 		case editFleetRowClaude:
-			d.WriteString(marker(row) + checkbox(fleetPage.editFleet.claudeMount) + " " + dialogLabel.Render("Claude Code mount"))
+			d.WriteString(marker(row) + "  " + checkbox(fleetPage.editFleet.claudeMount) + " " + dialogLabel.Render("Claude Code mount"))
 		case editFleetRowCodex:
-			d.WriteString(marker(row) + checkbox(fleetPage.editFleet.codexMount) + " " + dialogLabel.Render("Codex mount"))
+			d.WriteString(marker(row) + "  " + checkbox(fleetPage.editFleet.codexMount) + " " + dialogLabel.Render("Codex mount"))
+		case editFleetRowAuggie:
+			d.WriteString(marker(row) + "  " + checkbox(fleetPage.editFleet.auggieMount) + " " + dialogLabel.Render("Auggie mount"))
 		case editFleetRowGh:
 			d.WriteString(marker(row) + checkbox(fleetPage.editFleet.ghMount) + " " + dialogLabel.Render("GitHub CLI mount"))
-		case editFleetRowAuggie:
-			d.WriteString(marker(row) + checkbox(fleetPage.editFleet.auggieMount) + " " + dialogLabel.Render("Auggie mount"))
 		case editFleetRowHomeDir:
 			// Text input when focused, dim static text otherwise; append a
 			// spinner + status while an auto-detect runs.
@@ -1318,6 +1361,11 @@ func (fleetPage *fleetPage) editFleetHint() string {
 		return "[enter] Edit  [l/→] Buttons  [j/k] Select  [q/esc] Save & Close"
 	}
 	switch fleetPage.dlg.row {
+	case editFleetRowAgents:
+		if fleetPage.editFleet.agentsExpanded {
+			return "[h/←] Collapse  [j/k] Select  [q/esc] Save & Close"
+		}
+		return "[l/→/space] Expand  [j/k] Select  [q/esc] Save & Close"
 	case editFleetRowCustomMounts:
 		if fleetPage.editFleet.customMountsExpanded {
 			return "[h/←] Collapse  [j/k] Select  [q/esc] Save & Close"

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -743,8 +743,10 @@ func TestEditFleetTogglesAndSavesSettings(t *testing.T) {
 		t.Fatalf("expected mounts off by default; got claude=%v codex=%v", fp.editFleet.claudeMount, fp.editFleet.codexMount)
 	}
 
-	// Toggle Claude (cursor starts on row 0), move down, toggle Codex — each
+	// The agent mounts live under the collapsible Agents group (issue #184):
+	// expand it, land on Claude and toggle, move down to Codex and toggle — each
 	// toggle saves instantly.
+	navigateToClaudeRow(t, fp, m)
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace})
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyDown})
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace})
@@ -795,6 +797,29 @@ func TestEditFleetSavesPreferFleetLaunch(t *testing.T) {
 
 	if !f.Settings.PreferFleetLaunchEnabled() {
 		t.Fatalf("Settings.PreferFleetLaunch = %v, want enabled (instant-save)", f.Settings.PreferFleetLaunch)
+	}
+}
+
+// navigateToClaudeRow expands the Agents section (assumes the dialog is already
+// open, cursor on the Agents header) and lands the cursor on the Claude Code
+// mount row. The agent-tool mounts moved into a collapsible Agents group in
+// issue #184, so they are no longer reachable until that group is expanded.
+func navigateToClaudeRow(t *testing.T, fp *fleetPage, m *model) {
+	t.Helper()
+	guard := 0
+	for fp.dlg.row != editFleetRowAgents {
+		fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyUp})
+		if guard++; guard > 20 {
+			t.Fatal("never reached Agents header")
+		}
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}}) // expand
+	if !fp.editFleet.agentsExpanded {
+		t.Fatal("Agents section should expand on l")
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyDown}) // into Claude row
+	if fp.dlg.row != editFleetRowClaude {
+		t.Fatalf("dialogRow = %d, want claude row", fp.dlg.row)
 	}
 }
 
@@ -881,6 +906,41 @@ func TestEditFleetCachingExpandCollapse(t *testing.T) {
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
 	if fp.editFleet.cachingExpanded {
 		t.Fatal("h should collapse Caching")
+	}
+}
+
+// TestEditFleetAgentsExpandCollapse verifies the Agents section starts collapsed
+// (hiding the agent-tool rows), opens with the cursor on its header, expands /
+// collapses with l/h, and leaves GitHub CLI as a top-level row (issue #184).
+func TestEditFleetAgentsExpandCollapse(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stubFleetSettingsSave(t)
+	f := &fleet.Fleet{Name: "alpha"}
+	fp := newFleetPage()
+	fp.rows = []row{{kind: rowFleetHeader, fleetName: "alpha"}}
+	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}}, fleetPage: fp}
+
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	if fp.editFleet.agentsExpanded {
+		t.Fatal("Agents should start collapsed")
+	}
+	if fp.dlg.row != editFleetRowAgents {
+		t.Fatalf("dialogRow = %d, want Agents header on open", fp.dlg.row)
+	}
+	if slices.Contains(fp.visibleEditFleetRows(), editFleetRowClaude) {
+		t.Fatal("Claude row should be hidden while Agents is collapsed")
+	}
+	// GitHub CLI is a top-level row, navigable regardless of the Agents state.
+	if !slices.Contains(fp.visibleEditFleetRows(), editFleetRowGh) {
+		t.Fatal("GitHub CLI mount should remain a top-level row")
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if !fp.editFleet.agentsExpanded || !slices.Contains(fp.visibleEditFleetRows(), editFleetRowClaude) {
+		t.Fatal("l should expand Agents and reveal the Claude row")
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	if fp.editFleet.agentsExpanded {
+		t.Fatal("h should collapse Agents")
 	}
 }
 
@@ -1274,6 +1334,7 @@ func TestEditFleetHomedirDetectedFillsEmptyInput(t *testing.T) {
 	}
 
 	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	navigateToClaudeRow(t, fp, m)
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace}) // toggle Claude → kicks detect
 	if !fp.editFleet.detecting {
 		t.Fatalf("expected dialogDetecting to be true after toggle-on")
@@ -1305,6 +1366,7 @@ func TestEditFleetHomedirDetectedRespectsUserInput(t *testing.T) {
 	}
 
 	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	navigateToClaudeRow(t, fp, m)
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace}) // toggle Claude → kicks detect
 	fp.homedirInput.SetValue("/custom/path")              // simulate user typing while detect runs
 
@@ -1332,6 +1394,7 @@ func TestEditFleetHomedirDetectedIgnoresStaleFleet(t *testing.T) {
 	}
 
 	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	navigateToClaudeRow(t, fp, m)
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace})
 
 	// Result for a different fleet — must be ignored, and must not
@@ -1398,6 +1461,7 @@ func TestEditFleetEscKeepsInstantSaves(t *testing.T) {
 	}
 
 	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	navigateToClaudeRow(t, fp, m)
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace}) // toggle claude on → saved now
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyEsc})   // just closes
 
@@ -1422,6 +1486,7 @@ func TestEditFleetPreservesPFLNilOnUnrelatedEdit(t *testing.T) {
 	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}}, fleetPage: fp}
 
 	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	navigateToClaudeRow(t, fp, m)
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeySpace}) // toggle Claude (unrelated)
 
 	if !f.Settings.ClaudeCodeMount {
@@ -1696,13 +1761,22 @@ func TestEditFleetDialogVimKeysAndActiveHomedir(t *testing.T) {
 	fp := newFleetPage()
 	fp.mode = viewEditFleet
 	fp.dlg.fleet = "alpha"
-	fp.dlg.row = editFleetRowClaude
+	fp.dlg.row = editFleetRowAgents
 	m := &model{
 		st:        &state.State{Fleets: map[string]*fleet.Fleet{"alpha": f}},
 		fleetPage: fp,
 	}
 
-	// j moves down through the flat rows; l toggles the focused checkbox.
+	// Expand the Agents group so its agent-tool rows become navigable; j moves
+	// down through them, then on to the flat rows; l toggles the focused checkbox.
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}}) // expand Agents
+	if !fp.editFleet.agentsExpanded {
+		t.Fatal("l should expand the Agents group")
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if fp.dlg.row != editFleetRowClaude {
+		t.Fatalf("dialogRow = %d, want claude row", fp.dlg.row)
+	}
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	if fp.dlg.row != editFleetRowCodex {
 		t.Fatalf("dialogRow = %d, want codex row", fp.dlg.row)
@@ -1712,20 +1786,20 @@ func TestEditFleetDialogVimKeysAndActiveHomedir(t *testing.T) {
 		t.Fatal("l should toggle selected codex row")
 	}
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-	if fp.dlg.row != editFleetRowGh {
-		t.Fatalf("dialogRow = %d, want gh row", fp.dlg.row)
-	}
-	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
-	if !fp.editFleet.ghMount {
-		t.Fatal("l should toggle selected gh row")
-	}
-	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	if fp.dlg.row != editFleetRowAuggie {
 		t.Fatalf("dialogRow = %d, want auggie row", fp.dlg.row)
 	}
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
 	if !fp.editFleet.auggieMount {
 		t.Fatal("l should toggle selected auggie row")
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if fp.dlg.row != editFleetRowGh {
+		t.Fatalf("dialogRow = %d, want gh row", fp.dlg.row)
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if !fp.editFleet.ghMount {
+		t.Fatal("l should toggle selected gh row")
 	}
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	if fp.dlg.row != editFleetRowHomeDir {
@@ -1749,14 +1823,14 @@ func TestEditFleetDialogVimKeysAndActiveHomedir(t *testing.T) {
 		t.Fatal("esc should leave the home-dir field")
 	}
 
-	// k now navigates UP (field inactive): home-dir → auggie → gh.
-	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
-	if fp.dlg.row != editFleetRowAuggie {
-		t.Fatalf("dialogRow = %d, want auggie row after inactive k", fp.dlg.row)
-	}
+	// k now navigates UP (field inactive): home-dir → gh → auggie.
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
 	if fp.dlg.row != editFleetRowGh {
-		t.Fatalf("dialogRow = %d, want gh row after second inactive k", fp.dlg.row)
+		t.Fatalf("dialogRow = %d, want gh row after inactive k", fp.dlg.row)
+	}
+	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if fp.dlg.row != editFleetRowAuggie {
+		t.Fatalf("dialogRow = %d, want auggie row after second inactive k", fp.dlg.row)
 	}
 	fp.updateEditFleet(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 	if fp.mode != viewNormal {


### PR DESCRIPTION
## Summary

Closes #184.

The edit-fleet settings dialog presented "Claude Code mount", "Codex mount", and "Auggie mount" as flat top-level rows. Those names have aged out of meaning — today they simply mean "include coding agent X in this environment". This groups them under a new collapsible **Agents** section, mirroring the existing **Layouts** / **Caching** groups, to de-clutter the dialog and make the grouping intent clear.

- New `Agents` collapsible header (`▶`/`▼`, `l`/`h`/space to expand-collapse) with the same UX as the other section headers; it shows a count of enabled agent mounts and starts collapsed.
- Claude Code / Codex / Auggie mounts become indented children of the Agents group, navigable only while it is expanded.
- **GitHub CLI mount stays a top-level row** — it is a supporting tool, not a coding agent.
- The dialog now opens with the cursor on the Agents header.

Tests covering the agent-mount rows were updated for the new navigation, and a new `TestEditFleetAgentsExpandCollapse` covers the expand/collapse behavior and that GitHub CLI remains top-level.