### PR TITLE
feat/auto-tag-pr-status — show live GitHub PR status as an instance auto tag

### DIFF
--- a/fleetgrpc/runtime.pb.go
+++ b/fleetgrpc/runtime.pb.go
@@ -201,6 +201,112 @@ func (AgentActivity) EnumDescriptor() ([]byte, []int) {
 	return file_runtime_proto_rawDescGZIP(), []int{2}
 }
 
+// PrSignal is the three-state colour shared by the auto-tag indicators:
+// green = good, yellow = in-progress/neutral, red = needs attention.
+type PrSignal int32
+
+const (
+	PrSignal_PR_SIGNAL_UNSPECIFIED PrSignal = 0
+	PrSignal_PR_SIGNAL_GREEN       PrSignal = 1
+	PrSignal_PR_SIGNAL_YELLOW      PrSignal = 2
+	PrSignal_PR_SIGNAL_RED         PrSignal = 3
+)
+
+// Enum value maps for PrSignal.
+var (
+	PrSignal_name = map[int32]string{
+		0: "PR_SIGNAL_UNSPECIFIED",
+		1: "PR_SIGNAL_GREEN",
+		2: "PR_SIGNAL_YELLOW",
+		3: "PR_SIGNAL_RED",
+	}
+	PrSignal_value = map[string]int32{
+		"PR_SIGNAL_UNSPECIFIED": 0,
+		"PR_SIGNAL_GREEN":       1,
+		"PR_SIGNAL_YELLOW":      2,
+		"PR_SIGNAL_RED":         3,
+	}
+)
+
+func (x PrSignal) Enum() *PrSignal {
+	p := new(PrSignal)
+	*p = x
+	return p
+}
+
+func (x PrSignal) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PrSignal) Descriptor() protoreflect.EnumDescriptor {
+	return file_runtime_proto_enumTypes[3].Descriptor()
+}
+
+func (PrSignal) Type() protoreflect.EnumType {
+	return &file_runtime_proto_enumTypes[3]
+}
+
+func (x PrSignal) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PrSignal.Descriptor instead.
+func (PrSignal) EnumDescriptor() ([]byte, []int) {
+	return file_runtime_proto_rawDescGZIP(), []int{3}
+}
+
+// PrReviewState is the aggregate review decision across an instance's open PRs,
+// driving the "[Changes Requested | Approved]" element. UNSPECIFIED means no
+// decision has landed yet, in which case the TUI hides that element.
+type PrReviewState int32
+
+const (
+	PrReviewState_PR_REVIEW_STATE_UNSPECIFIED       PrReviewState = 0
+	PrReviewState_PR_REVIEW_STATE_APPROVED          PrReviewState = 1
+	PrReviewState_PR_REVIEW_STATE_CHANGES_REQUESTED PrReviewState = 2
+)
+
+// Enum value maps for PrReviewState.
+var (
+	PrReviewState_name = map[int32]string{
+		0: "PR_REVIEW_STATE_UNSPECIFIED",
+		1: "PR_REVIEW_STATE_APPROVED",
+		2: "PR_REVIEW_STATE_CHANGES_REQUESTED",
+	}
+	PrReviewState_value = map[string]int32{
+		"PR_REVIEW_STATE_UNSPECIFIED":       0,
+		"PR_REVIEW_STATE_APPROVED":          1,
+		"PR_REVIEW_STATE_CHANGES_REQUESTED": 2,
+	}
+)
+
+func (x PrReviewState) Enum() *PrReviewState {
+	p := new(PrReviewState)
+	*p = x
+	return p
+}
+
+func (x PrReviewState) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PrReviewState) Descriptor() protoreflect.EnumDescriptor {
+	return file_runtime_proto_enumTypes[4].Descriptor()
+}
+
+func (PrReviewState) Type() protoreflect.EnumType {
+	return &file_runtime_proto_enumTypes[4]
+}
+
+func (x PrReviewState) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PrReviewState.Descriptor instead.
+func (PrReviewState) EnumDescriptor() ([]byte, []int) {
+	return file_runtime_proto_rawDescGZIP(), []int{4}
+}
+
 // ContainerStats mirrors internal/backend.ContainerStats (the dim mcpu/MB in the
 // instance row).
 type ContainerStats struct {
@@ -381,6 +487,104 @@ func (x *ForwardedPort) GetLabel() string {
 	return ""
 }
 
+// PrStatus is the aggregated GitHub pull-request state for an instance's
+// workspace repo PLUS any nested subrepos, computed by running `gh` inside the
+// container. It drives the "auto tag" the TUI renders in the tag slot when an
+// instance has no user-set tag. It is absent (nil) when gh is missing or
+// unauthenticated inside the instance, or when no PR is open — the TUI then
+// shows no auto-tag, preserving today's behaviour.
+type PrStatus struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Open PRs counted across the workspace repo and every subrepo. The PR
+	// indicator renders "PR" for 1 and "PRxN" for N>1; 0 means no auto-tag.
+	OpenCount int32 `protobuf:"varint,1,opt,name=open_count,json=openCount,proto3" json:"open_count,omitempty"`
+	// Colour for the [PR]/[PRxN] indicator: green when every PR is mergeable,
+	// red on any check failure or changes-requested, yellow otherwise.
+	PrSignal PrSignal `protobuf:"varint,2,opt,name=pr_signal,json=prSignal,proto3,enum=fleetgrpc.PrSignal" json:"pr_signal,omitempty"`
+	// The [Changes Requested | Approved] element (UNSPECIFIED hides it).
+	Review PrReviewState `protobuf:"varint,3,opt,name=review,proto3,enum=fleetgrpc.PrReviewState" json:"review,omitempty"`
+	// Successful + total checks summed across all open PRs (the "x/x").
+	ChecksPassed int32 `protobuf:"varint,4,opt,name=checks_passed,json=checksPassed,proto3" json:"checks_passed,omitempty"`
+	ChecksTotal  int32 `protobuf:"varint,5,opt,name=checks_total,json=checksTotal,proto3" json:"checks_total,omitempty"`
+	// Colour for the [Checks x/x] indicator: green when all passed, red on any
+	// failure, yellow while any are still pending.
+	ChecksSignal  PrSignal `protobuf:"varint,6,opt,name=checks_signal,json=checksSignal,proto3,enum=fleetgrpc.PrSignal" json:"checks_signal,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PrStatus) Reset() {
+	*x = PrStatus{}
+	mi := &file_runtime_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PrStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PrStatus) ProtoMessage() {}
+
+func (x *PrStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_runtime_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PrStatus.ProtoReflect.Descriptor instead.
+func (*PrStatus) Descriptor() ([]byte, []int) {
+	return file_runtime_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *PrStatus) GetOpenCount() int32 {
+	if x != nil {
+		return x.OpenCount
+	}
+	return 0
+}
+
+func (x *PrStatus) GetPrSignal() PrSignal {
+	if x != nil {
+		return x.PrSignal
+	}
+	return PrSignal_PR_SIGNAL_UNSPECIFIED
+}
+
+func (x *PrStatus) GetReview() PrReviewState {
+	if x != nil {
+		return x.Review
+	}
+	return PrReviewState_PR_REVIEW_STATE_UNSPECIFIED
+}
+
+func (x *PrStatus) GetChecksPassed() int32 {
+	if x != nil {
+		return x.ChecksPassed
+	}
+	return 0
+}
+
+func (x *PrStatus) GetChecksTotal() int32 {
+	if x != nil {
+		return x.ChecksTotal
+	}
+	return 0
+}
+
+func (x *PrStatus) GetChecksSignal() PrSignal {
+	if x != nil {
+		return x.ChecksSignal
+	}
+	return PrSignal_PR_SIGNAL_UNSPECIFIED
+}
+
 // InstanceRuntime is the live view of ONE instance: everything the TUI renders
 // that isn't persisted. Keyed by (fleet, instance) so the client joins it to the
 // persisted Instance of the same name. Any sub-field may be zero/absent until
@@ -409,14 +613,18 @@ type InstanceRuntime struct {
 	// is no local workspace (cloud backends) or it hasn't been resolved yet.
 	CurrentBranch *string `protobuf:"bytes,9,opt,name=current_branch,json=currentBranch,proto3,oneof" json:"current_branch,omitempty"`
 	// When the server last refreshed this snapshot.
-	UpdatedAt     *timestamppb.Timestamp `protobuf:"bytes,10,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	UpdatedAt *timestamppb.Timestamp `protobuf:"bytes,10,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	// Aggregated GitHub PR state — the "auto tag" shown when the instance has no
+	// user-set tag. nil until first probed, or when gh is unavailable / no PR is
+	// open (see PrStatus).
+	PrStatus      *PrStatus `protobuf:"bytes,11,opt,name=pr_status,json=prStatus,proto3" json:"pr_status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *InstanceRuntime) Reset() {
 	*x = InstanceRuntime{}
-	mi := &file_runtime_proto_msgTypes[3]
+	mi := &file_runtime_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -428,7 +636,7 @@ func (x *InstanceRuntime) String() string {
 func (*InstanceRuntime) ProtoMessage() {}
 
 func (x *InstanceRuntime) ProtoReflect() protoreflect.Message {
-	mi := &file_runtime_proto_msgTypes[3]
+	mi := &file_runtime_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -441,7 +649,7 @@ func (x *InstanceRuntime) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InstanceRuntime.ProtoReflect.Descriptor instead.
 func (*InstanceRuntime) Descriptor() ([]byte, []int) {
-	return file_runtime_proto_rawDescGZIP(), []int{3}
+	return file_runtime_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *InstanceRuntime) GetFleet() string {
@@ -514,6 +722,13 @@ func (x *InstanceRuntime) GetUpdatedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *InstanceRuntime) GetPrStatus() *PrStatus {
+	if x != nil {
+		return x.PrStatus
+	}
+	return nil
+}
+
 var File_runtime_proto protoreflect.FileDescriptor
 
 const file_runtime_proto_rawDesc = "" +
@@ -532,7 +747,15 @@ const file_runtime_proto_rawDesc = "" +
 	"\vremote_port\x18\x02 \x01(\x05R\n" +
 	"remotePort\x12\x19\n" +
 	"\x05label\x18\x03 \x01(\tH\x00R\x05label\x88\x01\x01B\b\n" +
-	"\x06_label\"\xa2\x04\n" +
+	"\x06_label\"\x8f\x02\n" +
+	"\bPrStatus\x12\x1d\n" +
+	"\n" +
+	"open_count\x18\x01 \x01(\x05R\topenCount\x120\n" +
+	"\tpr_signal\x18\x02 \x01(\x0e2\x13.fleetgrpc.PrSignalR\bprSignal\x120\n" +
+	"\x06review\x18\x03 \x01(\x0e2\x18.fleetgrpc.PrReviewStateR\x06review\x12#\n" +
+	"\rchecks_passed\x18\x04 \x01(\x05R\fchecksPassed\x12!\n" +
+	"\fchecks_total\x18\x05 \x01(\x05R\vchecksTotal\x128\n" +
+	"\rchecks_signal\x18\x06 \x01(\x0e2\x13.fleetgrpc.PrSignalR\fchecksSignal\"\xd4\x04\n" +
 	"\x0fInstanceRuntime\x12\x14\n" +
 	"\x05fleet\x18\x01 \x01(\tR\x05fleet\x12\x1a\n" +
 	"\binstance\x18\x02 \x01(\tR\binstance\x12?\n" +
@@ -547,8 +770,9 @@ const file_runtime_proto_rawDesc = "" +
 	"\x0ecurrent_branch\x18\t \x01(\tH\x00R\rcurrentBranch\x88\x01\x01\x129\n" +
 	"\n" +
 	"updated_at\x18\n" +
-	" \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAtB\x11\n" +
-	"\x0f_current_branchJ\x04\b\v\x10\x15*\xc8\x01\n" +
+	" \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\x120\n" +
+	"\tpr_status\x18\v \x01(\v2\x13.fleetgrpc.PrStatusR\bprStatusB\x11\n" +
+	"\x0f_current_branchJ\x04\b\f\x10\x15*\xc8\x01\n" +
 	"\x13LiveContainerStatus\x12%\n" +
 	"!LIVE_CONTAINER_STATUS_UNSPECIFIED\x10\x00\x12!\n" +
 	"\x1dLIVE_CONTAINER_STATUS_RUNNING\x10\x01\x12!\n" +
@@ -567,7 +791,16 @@ const file_runtime_proto_rawDesc = "" +
 	"\x1aAGENT_ACTIVITY_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aAGENT_ACTIVITY_NOT_RUNNING\x10\x01\x12\x1a\n" +
 	"\x16AGENT_ACTIVITY_WORKING\x10\x02\x12\x1a\n" +
-	"\x16AGENT_ACTIVITY_WAITING\x10\x03B:Z8github.com/BenjaminBenetti/fleet-man/fleetgrpc;fleetgrpcb\x06proto3"
+	"\x16AGENT_ACTIVITY_WAITING\x10\x03*c\n" +
+	"\bPrSignal\x12\x19\n" +
+	"\x15PR_SIGNAL_UNSPECIFIED\x10\x00\x12\x13\n" +
+	"\x0fPR_SIGNAL_GREEN\x10\x01\x12\x14\n" +
+	"\x10PR_SIGNAL_YELLOW\x10\x02\x12\x11\n" +
+	"\rPR_SIGNAL_RED\x10\x03*u\n" +
+	"\rPrReviewState\x12\x1f\n" +
+	"\x1bPR_REVIEW_STATE_UNSPECIFIED\x10\x00\x12\x1c\n" +
+	"\x18PR_REVIEW_STATE_APPROVED\x10\x01\x12%\n" +
+	"!PR_REVIEW_STATE_CHANGES_REQUESTED\x10\x02B:Z8github.com/BenjaminBenetti/fleet-man/fleetgrpc;fleetgrpcb\x06proto3"
 
 var (
 	file_runtime_proto_rawDescOnce sync.Once
@@ -581,31 +814,38 @@ func file_runtime_proto_rawDescGZIP() []byte {
 	return file_runtime_proto_rawDescData
 }
 
-var file_runtime_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_runtime_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_runtime_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_runtime_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_runtime_proto_goTypes = []any{
 	(LiveContainerStatus)(0),      // 0: fleetgrpc.LiveContainerStatus
 	(AgentTool)(0),                // 1: fleetgrpc.AgentTool
 	(AgentActivity)(0),            // 2: fleetgrpc.AgentActivity
-	(*ContainerStats)(nil),        // 3: fleetgrpc.ContainerStats
-	(*TmuxSession)(nil),           // 4: fleetgrpc.TmuxSession
-	(*ForwardedPort)(nil),         // 5: fleetgrpc.ForwardedPort
-	(*InstanceRuntime)(nil),       // 6: fleetgrpc.InstanceRuntime
-	(*timestamppb.Timestamp)(nil), // 7: google.protobuf.Timestamp
+	(PrSignal)(0),                 // 3: fleetgrpc.PrSignal
+	(PrReviewState)(0),            // 4: fleetgrpc.PrReviewState
+	(*ContainerStats)(nil),        // 5: fleetgrpc.ContainerStats
+	(*TmuxSession)(nil),           // 6: fleetgrpc.TmuxSession
+	(*ForwardedPort)(nil),         // 7: fleetgrpc.ForwardedPort
+	(*PrStatus)(nil),              // 8: fleetgrpc.PrStatus
+	(*InstanceRuntime)(nil),       // 9: fleetgrpc.InstanceRuntime
+	(*timestamppb.Timestamp)(nil), // 10: google.protobuf.Timestamp
 }
 var file_runtime_proto_depIdxs = []int32{
-	0, // 0: fleetgrpc.InstanceRuntime.live_status:type_name -> fleetgrpc.LiveContainerStatus
-	1, // 1: fleetgrpc.InstanceRuntime.agent_tool:type_name -> fleetgrpc.AgentTool
-	2, // 2: fleetgrpc.InstanceRuntime.agent_activity:type_name -> fleetgrpc.AgentActivity
-	3, // 3: fleetgrpc.InstanceRuntime.stats:type_name -> fleetgrpc.ContainerStats
-	4, // 4: fleetgrpc.InstanceRuntime.sessions:type_name -> fleetgrpc.TmuxSession
-	5, // 5: fleetgrpc.InstanceRuntime.forwarded_ports:type_name -> fleetgrpc.ForwardedPort
-	7, // 6: fleetgrpc.InstanceRuntime.updated_at:type_name -> google.protobuf.Timestamp
-	7, // [7:7] is the sub-list for method output_type
-	7, // [7:7] is the sub-list for method input_type
-	7, // [7:7] is the sub-list for extension type_name
-	7, // [7:7] is the sub-list for extension extendee
-	0, // [0:7] is the sub-list for field type_name
+	3,  // 0: fleetgrpc.PrStatus.pr_signal:type_name -> fleetgrpc.PrSignal
+	4,  // 1: fleetgrpc.PrStatus.review:type_name -> fleetgrpc.PrReviewState
+	3,  // 2: fleetgrpc.PrStatus.checks_signal:type_name -> fleetgrpc.PrSignal
+	0,  // 3: fleetgrpc.InstanceRuntime.live_status:type_name -> fleetgrpc.LiveContainerStatus
+	1,  // 4: fleetgrpc.InstanceRuntime.agent_tool:type_name -> fleetgrpc.AgentTool
+	2,  // 5: fleetgrpc.InstanceRuntime.agent_activity:type_name -> fleetgrpc.AgentActivity
+	5,  // 6: fleetgrpc.InstanceRuntime.stats:type_name -> fleetgrpc.ContainerStats
+	6,  // 7: fleetgrpc.InstanceRuntime.sessions:type_name -> fleetgrpc.TmuxSession
+	7,  // 8: fleetgrpc.InstanceRuntime.forwarded_ports:type_name -> fleetgrpc.ForwardedPort
+	10, // 9: fleetgrpc.InstanceRuntime.updated_at:type_name -> google.protobuf.Timestamp
+	8,  // 10: fleetgrpc.InstanceRuntime.pr_status:type_name -> fleetgrpc.PrStatus
+	11, // [11:11] is the sub-list for method output_type
+	11, // [11:11] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_runtime_proto_init() }
@@ -614,14 +854,14 @@ func file_runtime_proto_init() {
 		return
 	}
 	file_runtime_proto_msgTypes[2].OneofWrappers = []any{}
-	file_runtime_proto_msgTypes[3].OneofWrappers = []any{}
+	file_runtime_proto_msgTypes[4].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_runtime_proto_rawDesc), len(file_runtime_proto_rawDesc)),
-			NumEnums:      3,
-			NumMessages:   4,
+			NumEnums:      5,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/fleetgrpc/runtime.proto
+++ b/fleetgrpc/runtime.proto
@@ -83,6 +83,47 @@ message ForwardedPort {
   optional string label = 3;
 }
 
+// PrSignal is the three-state colour shared by the auto-tag indicators:
+// green = good, yellow = in-progress/neutral, red = needs attention.
+enum PrSignal {
+  PR_SIGNAL_UNSPECIFIED = 0;
+  PR_SIGNAL_GREEN = 1;
+  PR_SIGNAL_YELLOW = 2;
+  PR_SIGNAL_RED = 3;
+}
+
+// PrReviewState is the aggregate review decision across an instance's open PRs,
+// driving the "[Changes Requested | Approved]" element. UNSPECIFIED means no
+// decision has landed yet, in which case the TUI hides that element.
+enum PrReviewState {
+  PR_REVIEW_STATE_UNSPECIFIED = 0;
+  PR_REVIEW_STATE_APPROVED = 1;
+  PR_REVIEW_STATE_CHANGES_REQUESTED = 2;
+}
+
+// PrStatus is the aggregated GitHub pull-request state for an instance's
+// workspace repo PLUS any nested subrepos, computed by running `gh` inside the
+// container. It drives the "auto tag" the TUI renders in the tag slot when an
+// instance has no user-set tag. It is absent (nil) when gh is missing or
+// unauthenticated inside the instance, or when no PR is open — the TUI then
+// shows no auto-tag, preserving today's behaviour.
+message PrStatus {
+  // Open PRs counted across the workspace repo and every subrepo. The PR
+  // indicator renders "PR" for 1 and "PRxN" for N>1; 0 means no auto-tag.
+  int32 open_count = 1;
+  // Colour for the [PR]/[PRxN] indicator: green when every PR is mergeable,
+  // red on any check failure or changes-requested, yellow otherwise.
+  PrSignal pr_signal = 2;
+  // The [Changes Requested | Approved] element (UNSPECIFIED hides it).
+  PrReviewState review = 3;
+  // Successful + total checks summed across all open PRs (the "x/x").
+  int32 checks_passed = 4;
+  int32 checks_total = 5;
+  // Colour for the [Checks x/x] indicator: green when all passed, red on any
+  // failure, yellow while any are still pending.
+  PrSignal checks_signal = 6;
+}
+
 // InstanceRuntime is the live view of ONE instance: everything the TUI renders
 // that isn't persisted. Keyed by (fleet, instance) so the client joins it to the
 // persisted Instance of the same name. Any sub-field may be zero/absent until
@@ -119,5 +160,10 @@ message InstanceRuntime {
   // When the server last refreshed this snapshot.
   google.protobuf.Timestamp updated_at = 10;
 
-  reserved 11 to 20;
+  // Aggregated GitHub PR state — the "auto tag" shown when the instance has no
+  // user-set tag. nil until first probed, or when gh is unavailable / no PR is
+  // open (see PrStatus).
+  PrStatus pr_status = 11;
+
+  reserved 12 to 20;
 }

--- a/internal/server/pr_status.go
+++ b/internal/server/pr_status.go
@@ -276,12 +276,26 @@ func runProbeWithTimeout(cmd *backend.Cmd, timeout time.Duration) ([]byte, error
 		}
 		return buf.Bytes(), nil
 	case <-time.After(timeout):
-		if raw.Process != nil {
-			// Negative pid signals the whole process group (see above).
-			_ = syscall.Kill(-raw.Process.Pid, syscall.SIGKILL)
+		// Re-check done non-blockingly before signalling: the goroutine's Wait()
+		// may have reaped the process right at the deadline, and a reaped PID can
+		// be reused — group-killing it could then hit an unrelated process. While
+		// Wait() has NOT returned, the process is unreaped, so its PID/pgid can't
+		// have been reused and the group kill is safe.
+		select {
+		case err := <-done:
+			if err != nil {
+				return nil, err
+			}
+			return buf.Bytes(), nil
+		default:
+			if raw.Process != nil {
+				// Negative pid signals the whole process group (see above), so
+				// children that inherited our stdout pipe die too.
+				_ = syscall.Kill(-raw.Process.Pid, syscall.SIGKILL)
+			}
+			<-done
+			return nil, fmt.Errorf("pr status probe timed out after %s", timeout)
 		}
-		<-done
-		return nil, fmt.Errorf("pr status probe timed out after %s", timeout)
 	}
 }
 
@@ -332,6 +346,14 @@ func prStatusPass(h *hub) {
 	for fleetName, f := range st.Fleets {
 		for _, inst := range f.Instances {
 			if inst.ContainerID == "" || inst.Status != fleet.StatusRunning {
+				continue
+			}
+			// A workspace dir is required to scope the probe: the backend's exec
+			// resolves it to the in-container workspace folder, which is where the
+			// script's `find` runs. Without it the script would run in the
+			// container's default cwd (often /) and scan the whole filesystem, so
+			// skip — the instance simply gets no auto-tag (graceful degrade).
+			if inst.WorkspaceDir == "" {
 				continue
 			}
 			items = append(items, item{fleetName, inst.Name, inst.WorkspaceDir, inst})

--- a/internal/server/pr_status.go
+++ b/internal/server/pr_status.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
@@ -250,19 +249,22 @@ func (h *hub) probePRStatus(b backend.Backend, workspaceDir string) (*fleetgrpc.
 // it overruns timeout. It drives the embedded raw *exec.Cmd directly (Start +
 // Wait) so it can interrupt a hung process — Output() offers no deadline.
 //
-// The probe is placed in its own process group so a timeout kills the WHOLE
-// tree: the backend's exec spawns helpers (devcontainer -> docker exec) that
-// inherit our stdout pipe, and killing only the direct child leaves those
-// holding the pipe's write end open, which wedges Wait until they exit on their
-// own. WaitDelay is a backstop that force-closes the pipes if a stray
-// descendant escapes the group.
+// On timeout it uses raw.Process.Kill() rather than a raw syscall.Kill on the
+// numeric pid: os.Process refuses to signal a pid it has already reaped
+// (returning ErrProcessDone under its internal lock), so it can never race
+// Wait() into signalling a REUSED pid. It signals only the direct child, but
+// that is sufficient here — WaitDelay handles the case where a helper the child
+// spawned (devcontainer -> docker exec) inherited our stdout pipe and would
+// otherwise keep it open: after the delay Go force-closes the pipe and Wait
+// returns, and the orphaned helper exits on its next write (EOF/SIGPIPE). This
+// keeps the fix self-contained, avoiding a context.Context thread through the
+// Backend.ExecCommand interface.
 func runProbeWithTimeout(cmd *backend.Cmd, timeout time.Duration) ([]byte, error) {
 	raw := cmd.Cmd
 	var buf bytes.Buffer
 	raw.Stdout = &buf
 	// Stderr stays nil -> /dev/null; the script already redirects gh's own
 	// diagnostics, and we only care about the JSON on stdout.
-	raw.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	raw.WaitDelay = 3 * time.Second
 	if err := raw.Start(); err != nil {
 		return nil, err
@@ -276,26 +278,11 @@ func runProbeWithTimeout(cmd *backend.Cmd, timeout time.Duration) ([]byte, error
 		}
 		return buf.Bytes(), nil
 	case <-time.After(timeout):
-		// Re-check done non-blockingly before signalling: the goroutine's Wait()
-		// may have reaped the process right at the deadline, and a reaped PID can
-		// be reused — group-killing it could then hit an unrelated process. While
-		// Wait() has NOT returned, the process is unreaped, so its PID/pgid can't
-		// have been reused and the group kill is safe.
-		select {
-		case err := <-done:
-			if err != nil {
-				return nil, err
-			}
-			return buf.Bytes(), nil
-		default:
-			if raw.Process != nil {
-				// Negative pid signals the whole process group (see above), so
-				// children that inherited our stdout pipe die too.
-				_ = syscall.Kill(-raw.Process.Pid, syscall.SIGKILL)
-			}
-			<-done
-			return nil, fmt.Errorf("pr status probe timed out after %s", timeout)
+		if raw.Process != nil {
+			_ = raw.Process.Kill()
 		}
+		<-done
+		return nil, fmt.Errorf("pr status probe timed out after %s", timeout)
 	}
 }
 

--- a/internal/server/pr_status.go
+++ b/internal/server/pr_status.go
@@ -208,7 +208,12 @@ func aggregatePRStatus(prs []ghPR) *fleetgrpc.PrStatus {
 // reads successive arrays regardless of their interleaving whitespace; malformed
 // trailing noise stops the scan without discarding what parsed cleanly.
 func parsePRProbeOutput(out string) *fleetgrpc.PrStatus {
-	if strings.Contains(out, prNoGHSentinel) || strings.Contains(out, prNoAuthSentinel) {
+	// Match the sentinels by PREFIX, not Contains: the script emits one as the
+	// sole output (before any JSON, then exits), while real output is a JSON
+	// array starting with '['. A prefix check can't be tripped by a sentinel
+	// string that happens to appear inside PR JSON (a branch name, check name…).
+	trimmed := strings.TrimSpace(out)
+	if strings.HasPrefix(trimmed, prNoGHSentinel) || strings.HasPrefix(trimmed, prNoAuthSentinel) {
 		return nil
 	}
 	var prs []ghPR
@@ -281,9 +286,14 @@ func runProbeWithTimeout(cmd *backend.Cmd, timeout time.Duration) ([]byte, error
 }
 
 // prStatusPoller fires the gh probe across running instances on the slow
-// prStatusInterval cadence, and immediately when a TUI first subscribes (the
-// runtime-wanted false->true edge) so the auto-tag appears without a long wait.
-// Like the other runtime pollers it does nothing while no TUI is connected.
+// prStatusInterval cadence, plus once on the runtime-wanted false->true edge so
+// the auto-tag appears shortly after a TUI first subscribes rather than after a
+// full interval. The edge is detected on the next gate tick (within
+// prStatusGatePoll) rather than via h.runtimeEdge, which is single-consumer
+// (owned by liveStatusPoller); a few seconds' latency on a status line that
+// refreshes every prStatusInterval is an acceptable trade for not reworking that
+// channel into a broadcast. Like the other runtime pollers it does nothing while
+// no TUI is connected.
 func prStatusPoller(ctx context.Context, h *hub) {
 	ticker := time.NewTicker(prStatusGatePoll)
 	defer ticker.Stop()

--- a/internal/server/pr_status.go
+++ b/internal/server/pr_status.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
@@ -243,12 +244,21 @@ func (h *hub) probePRStatus(b backend.Backend, workspaceDir string) (*fleetgrpc.
 // runProbeWithTimeout runs cmd to completion, capturing stdout, and kills it if
 // it overruns timeout. It drives the embedded raw *exec.Cmd directly (Start +
 // Wait) so it can interrupt a hung process — Output() offers no deadline.
+//
+// The probe is placed in its own process group so a timeout kills the WHOLE
+// tree: the backend's exec spawns helpers (devcontainer -> docker exec) that
+// inherit our stdout pipe, and killing only the direct child leaves those
+// holding the pipe's write end open, which wedges Wait until they exit on their
+// own. WaitDelay is a backstop that force-closes the pipes if a stray
+// descendant escapes the group.
 func runProbeWithTimeout(cmd *backend.Cmd, timeout time.Duration) ([]byte, error) {
 	raw := cmd.Cmd
 	var buf bytes.Buffer
 	raw.Stdout = &buf
 	// Stderr stays nil -> /dev/null; the script already redirects gh's own
 	// diagnostics, and we only care about the JSON on stdout.
+	raw.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	raw.WaitDelay = 3 * time.Second
 	if err := raw.Start(); err != nil {
 		return nil, err
 	}
@@ -262,7 +272,8 @@ func runProbeWithTimeout(cmd *backend.Cmd, timeout time.Duration) ([]byte, error
 		return buf.Bytes(), nil
 	case <-time.After(timeout):
 		if raw.Process != nil {
-			_ = raw.Process.Kill()
+			// Negative pid signals the whole process group (see above).
+			_ = syscall.Kill(-raw.Process.Pid, syscall.SIGKILL)
 		}
 		<-done
 		return nil, fmt.Errorf("pr status probe timed out after %s", timeout)

--- a/internal/server/pr_status.go
+++ b/internal/server/pr_status.go
@@ -1,0 +1,358 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// pr_status.go computes the per-instance "auto tag": the aggregated GitHub
+// pull-request state for an instance's workspace repo PLUS any nested subrepos.
+// It runs `gh` INSIDE the container (so it uses the instance's own gh auth) on a
+// slow cadence, parses the result, and pushes a PrStatus onto the runtime
+// sidecar. The TUI renders it in the tag slot when the instance has no user-set
+// tag. When gh is missing or unauthenticated inside the instance, the probe
+// degrades to "no auto-tag" (PrStatus nil), preserving today's behaviour.
+
+const (
+	// prStatusInterval is the run cadence for the gh probe. PR state changes on
+	// the order of minutes (CI runs), and each probe hits the GitHub API, so we
+	// keep this comfortably slow.
+	prStatusInterval = 45 * time.Second
+	// prStatusGatePoll is how often the poller checks the runtime-wanted gate so
+	// it can fire a probe promptly when a TUI first subscribes (rather than
+	// waiting a full prStatusInterval). The check itself is a cheap atomic load.
+	prStatusGatePoll = 5 * time.Second
+	// prProbeTimeout bounds a single instance's gh probe so a hung network call
+	// can't wedge the pass.
+	prProbeTimeout = 20 * time.Second
+	// prProbeMaxConcurrent caps how many container gh probes run at once.
+	prProbeMaxConcurrent = 4
+
+	prNoGHSentinel   = "FLEET_NO_GH"
+	prNoAuthSentinel = "FLEET_NO_AUTH"
+)
+
+// prProbeScript runs inside the container with the workspace folder as its cwd
+// (the backend's ExecCommand resolves that). For the workspace repo and every
+// nested subrepo it emits `gh pr list ... --json ...` — a JSON array of the open
+// PRs on that repo's current branch. The arrays are concatenated on stdout and
+// read back with a streaming json.Decoder, so their exact whitespace/formatting
+// doesn't matter. It prints a sentinel and exits 0 when gh is absent or not
+// logged in, so the server can distinguish "degrade quietly" from a transient
+// exec failure.
+const prProbeScript = `
+command -v gh >/dev/null 2>&1 || { printf '%s\n' "FLEET_NO_GH"; exit 0; }
+gh auth status >/dev/null 2>&1 || { printf '%s\n' "FLEET_NO_AUTH"; exit 0; }
+# Repo roots = the workspace repo plus any nested subrepos. Each match is a
+# ".git"; its parent dir is the repo. Bounded depth, skipping node_modules and
+# never descending into .git itself.
+find . -maxdepth 5 -name node_modules -prune -o -name .git -prune -print 2>/dev/null | while IFS= read -r gitpath; do
+  dir=$(dirname "$gitpath")
+  br=$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null) || continue
+  [ -z "$br" ] && continue
+  [ "$br" = "HEAD" ] && continue
+  ( cd "$dir" && gh pr list --state open --head "$br" \
+      --json number,state,mergeStateStatus,reviewDecision,statusCheckRollup 2>/dev/null )
+done
+`
+
+// ghPR mirrors the subset of `gh pr list --json` fields the auto-tag needs.
+type ghPR struct {
+	Number int    `json:"number"`
+	State  string `json:"state"`
+	// MergeStateStatus is GitHub's "ready to merge" verdict — CLEAN means the PR
+	// is mergeable (approved, required checks passed, no conflicts), which is the
+	// green signal. We use it over the plain `mergeable` field because that only
+	// reflects merge CONFLICTS and would show green while CI is still running.
+	MergeStateStatus  string    `json:"mergeStateStatus"` // CLEAN | BLOCKED | BEHIND | UNSTABLE | DIRTY | DRAFT | UNKNOWN | ...
+	ReviewDecision    string    `json:"reviewDecision"`   // APPROVED | CHANGES_REQUESTED | REVIEW_REQUIRED | ""
+	StatusCheckRollup []ghCheck `json:"statusCheckRollup"`
+}
+
+// ghCheck mirrors one element of statusCheckRollup. A CheckRun carries
+// status+conclusion; a StatusContext carries state — we classify from whichever
+// is present rather than relying on __typename.
+type ghCheck struct {
+	Status     string `json:"status"`     // CheckRun: QUEUED|IN_PROGRESS|COMPLETED|...
+	Conclusion string `json:"conclusion"` // CheckRun: SUCCESS|FAILURE|NEUTRAL|...
+	State      string `json:"state"`      // StatusContext: SUCCESS|PENDING|FAILURE|ERROR
+}
+
+type checkResult int
+
+const (
+	checkPending checkResult = iota
+	checkPass
+	checkFail
+)
+
+// classifyCheck reduces one rollup element to pass / pending / fail.
+func classifyCheck(c ghCheck) checkResult {
+	// StatusContext-style: a legacy commit-status with a State.
+	if c.State != "" {
+		switch strings.ToUpper(c.State) {
+		case "SUCCESS":
+			return checkPass
+		case "PENDING", "EXPECTED":
+			return checkPending
+		default: // FAILURE, ERROR
+			return checkFail
+		}
+	}
+	// CheckRun-style: status + conclusion.
+	switch strings.ToUpper(c.Status) {
+	case "COMPLETED":
+		switch strings.ToUpper(c.Conclusion) {
+		case "SUCCESS", "NEUTRAL", "SKIPPED":
+			return checkPass
+		case "": // completed without a conclusion yet — treat as still settling
+			return checkPending
+		default: // FAILURE, TIMED_OUT, CANCELLED, ACTION_REQUIRED, STARTUP_FAILURE, STALE
+			return checkFail
+		}
+	default: // QUEUED, IN_PROGRESS, PENDING, WAITING, REQUESTED, or unknown
+		return checkPending
+	}
+}
+
+// aggregatePRStatus folds the open PRs across an instance's repos into the
+// PrStatus the TUI renders. Returns nil when there are no open PRs (no auto-tag).
+func aggregatePRStatus(prs []ghPR) *fleetgrpc.PrStatus {
+	if len(prs) == 0 {
+		return nil
+	}
+
+	var passed, total int
+	anyFail, anyPending := false, false
+	anyChangesRequested, anyApproved := false, false
+	allClean := true
+
+	for _, pr := range prs {
+		for _, c := range pr.StatusCheckRollup {
+			total++
+			switch classifyCheck(c) {
+			case checkPass:
+				passed++
+			case checkFail:
+				anyFail = true
+			case checkPending:
+				anyPending = true
+			}
+		}
+		switch strings.ToUpper(pr.ReviewDecision) {
+		case "CHANGES_REQUESTED":
+			anyChangesRequested = true
+		case "APPROVED":
+			anyApproved = true
+		}
+		if strings.ToUpper(pr.MergeStateStatus) != "CLEAN" {
+			allClean = false
+		}
+	}
+
+	// PR indicator colour: red on any failure/changes-requested, else green
+	// when every PR is mergeable per GitHub (mergeStateStatus CLEAN), else yellow
+	// (open and in progress, no failures).
+	prSignal := fleetgrpc.PrSignal_PR_SIGNAL_YELLOW
+	switch {
+	case anyFail || anyChangesRequested:
+		prSignal = fleetgrpc.PrSignal_PR_SIGNAL_RED
+	case allClean:
+		prSignal = fleetgrpc.PrSignal_PR_SIGNAL_GREEN
+	}
+
+	// Review element: changes-requested wins over approved; neither => hidden.
+	review := fleetgrpc.PrReviewState_PR_REVIEW_STATE_UNSPECIFIED
+	switch {
+	case anyChangesRequested:
+		review = fleetgrpc.PrReviewState_PR_REVIEW_STATE_CHANGES_REQUESTED
+	case anyApproved:
+		review = fleetgrpc.PrReviewState_PR_REVIEW_STATE_APPROVED
+	}
+
+	// Checks colour: red on any failure, else yellow while any pending, else
+	// green (all passed).
+	checksSignal := fleetgrpc.PrSignal_PR_SIGNAL_GREEN
+	switch {
+	case anyFail:
+		checksSignal = fleetgrpc.PrSignal_PR_SIGNAL_RED
+	case anyPending:
+		checksSignal = fleetgrpc.PrSignal_PR_SIGNAL_YELLOW
+	}
+
+	return &fleetgrpc.PrStatus{
+		OpenCount:    int32(len(prs)),
+		PrSignal:     prSignal,
+		Review:       review,
+		ChecksPassed: int32(passed),
+		ChecksTotal:  int32(total),
+		ChecksSignal: checksSignal,
+	}
+}
+
+// parsePRProbeOutput turns the probe's stdout — one `gh pr list --json` array
+// per repo, concatenated — into a PrStatus. A nil result means "no auto-tag" (gh
+// unavailable, or no open PRs) and clears any prior status. The gh-missing /
+// no-auth sentinels and the empty case all map to nil. A streaming json.Decoder
+// reads successive arrays regardless of their interleaving whitespace; malformed
+// trailing noise stops the scan without discarding what parsed cleanly.
+func parsePRProbeOutput(out string) *fleetgrpc.PrStatus {
+	if strings.Contains(out, prNoGHSentinel) || strings.Contains(out, prNoAuthSentinel) {
+		return nil
+	}
+	var prs []ghPR
+	dec := json.NewDecoder(strings.NewReader(out))
+	for {
+		var batch []ghPR
+		if err := dec.Decode(&batch); err != nil {
+			break // io.EOF on clean exhaustion, or unexpected noise.
+		}
+		for _, p := range batch {
+			if strings.EqualFold(p.State, "OPEN") {
+				prs = append(prs, p)
+			}
+		}
+	}
+	return aggregatePRStatus(prs)
+}
+
+// probePRStatus runs the gh probe inside the instance and parses the result.
+// The bool is false only on a transient exec failure (timeout, container
+// briefly unavailable), in which case the caller keeps the prior status rather
+// than clearing it. A successful probe returns ok=true even when the PrStatus is
+// nil (gh absent / no PRs), which legitimately clears the auto-tag.
+func (h *hub) probePRStatus(b backend.Backend, workspaceDir string) (*fleetgrpc.PrStatus, bool) {
+	cmd := b.ExecCommandQuiet(workspaceDir, []string{"sh", "-c", prProbeScript})
+	out, err := runProbeWithTimeout(cmd, prProbeTimeout)
+	if err != nil {
+		return nil, false
+	}
+	return parsePRProbeOutput(string(out)), true
+}
+
+// runProbeWithTimeout runs cmd to completion, capturing stdout, and kills it if
+// it overruns timeout. It drives the embedded raw *exec.Cmd directly (Start +
+// Wait) so it can interrupt a hung process — Output() offers no deadline.
+func runProbeWithTimeout(cmd *backend.Cmd, timeout time.Duration) ([]byte, error) {
+	raw := cmd.Cmd
+	var buf bytes.Buffer
+	raw.Stdout = &buf
+	// Stderr stays nil -> /dev/null; the script already redirects gh's own
+	// diagnostics, and we only care about the JSON on stdout.
+	if err := raw.Start(); err != nil {
+		return nil, err
+	}
+	done := make(chan error, 1)
+	go func() { done <- raw.Wait() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	case <-time.After(timeout):
+		if raw.Process != nil {
+			_ = raw.Process.Kill()
+		}
+		<-done
+		return nil, fmt.Errorf("pr status probe timed out after %s", timeout)
+	}
+}
+
+// prStatusPoller fires the gh probe across running instances on the slow
+// prStatusInterval cadence, and immediately when a TUI first subscribes (the
+// runtime-wanted false->true edge) so the auto-tag appears without a long wait.
+// Like the other runtime pollers it does nothing while no TUI is connected.
+func prStatusPoller(ctx context.Context, h *hub) {
+	ticker := time.NewTicker(prStatusGatePoll)
+	defer ticker.Stop()
+	var lastRun time.Time
+	wasWanted := false
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if !h.runtimeWanted.Load() {
+				wasWanted = false
+				continue
+			}
+			edge := !wasWanted
+			wasWanted = true
+			due := lastRun.IsZero() || time.Since(lastRun) >= prStatusInterval
+			if edge || due {
+				prStatusPass(h)
+				lastRun = time.Now()
+			}
+		}
+	}
+}
+
+func prStatusPass(h *hub) {
+	st, err := state.Load()
+	if err != nil {
+		return
+	}
+	type item struct {
+		fleetName, instance, workspaceDir string
+		inst                              *fleet.Instance
+	}
+	var items []item
+	for fleetName, f := range st.Fleets {
+		for _, inst := range f.Instances {
+			if inst.ContainerID == "" || inst.Status != fleet.StatusRunning {
+				continue
+			}
+			items = append(items, item{fleetName, inst.Name, inst.WorkspaceDir, inst})
+		}
+	}
+	if len(items) == 0 {
+		return
+	}
+
+	type result struct {
+		fleetName, instance string
+		status              *fleetgrpc.PrStatus
+		ok                  bool
+	}
+	results := make([]result, len(items))
+	sem := make(chan struct{}, prProbeMaxConcurrent)
+	var wg sync.WaitGroup
+	for i, it := range items {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int, it item) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			b := h.backendFor(it.inst)
+			status, ok := h.probePRStatus(b, it.workspaceDir)
+			results[i] = result{it.fleetName, it.instance, status, ok}
+		}(i, it)
+	}
+	wg.Wait()
+
+	h.post(func(h *hub) {
+		ups := make([]runtimeUpdate, 0, len(results))
+		for _, r := range results {
+			if !r.ok {
+				// Transient probe failure: keep the prior PrStatus.
+				continue
+			}
+			status := r.status
+			ups = append(ups, runtimeUpdate{r.fleetName, r.instance, func(rt *fleetgrpc.InstanceRuntime) {
+				rt.PrStatus = status
+			}})
+		}
+		h.applyRuntime(ups)
+	})
+}

--- a/internal/server/pr_status_test.go
+++ b/internal/server/pr_status_test.go
@@ -1,10 +1,37 @@
 package server
 
 import (
+	"os/exec"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 )
+
+func TestRunProbeWithTimeout_CapturesOutput(t *testing.T) {
+	cmd := backend.NewCmd(exec.Command("sh", "-c", `printf 'hello\nworld\n'`), nil)
+	out, err := runProbeWithTimeout(cmd, 5*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "hello\nworld" {
+		t.Fatalf("output = %q, want \"hello\\nworld\"", got)
+	}
+}
+
+func TestRunProbeWithTimeout_KillsOnTimeout(t *testing.T) {
+	cmd := backend.NewCmd(exec.Command("sh", "-c", "sleep 30"), nil)
+	start := time.Now()
+	if _, err := runProbeWithTimeout(cmd, 150*time.Millisecond); err == nil {
+		t.Fatalf("expected a timeout error, got nil")
+	}
+	// The kill must happen promptly, not after the full sleep.
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("timeout took %v, expected it to fire near 150ms", elapsed)
+	}
+}
 
 func TestClassifyCheck(t *testing.T) {
 	tests := []struct {

--- a/internal/server/pr_status_test.go
+++ b/internal/server/pr_status_test.go
@@ -235,6 +235,20 @@ func TestParsePRProbeOutput_Sentinels(t *testing.T) {
 	}
 }
 
+func TestParsePRProbeOutput_SentinelStringInsideJSONIsNotDegrade(t *testing.T) {
+	// A check name (or branch, title, …) that coincidentally contains a sentinel
+	// string must NOT silently disable the probe — the real output is a JSON
+	// array, so only a leading sentinel counts as "degrade".
+	out := `[{"number":3,"state":"OPEN","mergeStateStatus":"UNSTABLE","reviewDecision":"","statusCheckRollup":[{"name":"FLEET_NO_GH-smoke","status":"COMPLETED","conclusion":"SUCCESS"}]}]`
+	got := parsePRProbeOutput(out)
+	if got == nil {
+		t.Fatalf("parsePRProbeOutput degraded to nil on a sentinel substring inside JSON")
+	}
+	if got.GetOpenCount() != 1 {
+		t.Errorf("OpenCount = %d, want 1", got.GetOpenCount())
+	}
+}
+
 func TestParsePRProbeOutput_ConcatenatedArrays(t *testing.T) {
 	// Two repos' `gh pr list --json` arrays concatenated: the workspace repo
 	// (one approved, all-green PR) and a subrepo (one failing-check PR). The

--- a/internal/server/pr_status_test.go
+++ b/internal/server/pr_status_test.go
@@ -1,0 +1,264 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+)
+
+func TestClassifyCheck(t *testing.T) {
+	tests := []struct {
+		name string
+		c    ghCheck
+		want checkResult
+	}{
+		{"checkrun success", ghCheck{Status: "COMPLETED", Conclusion: "SUCCESS"}, checkPass},
+		{"checkrun neutral", ghCheck{Status: "COMPLETED", Conclusion: "NEUTRAL"}, checkPass},
+		{"checkrun skipped", ghCheck{Status: "COMPLETED", Conclusion: "SKIPPED"}, checkPass},
+		{"checkrun failure", ghCheck{Status: "COMPLETED", Conclusion: "FAILURE"}, checkFail},
+		{"checkrun timed_out", ghCheck{Status: "COMPLETED", Conclusion: "TIMED_OUT"}, checkFail},
+		{"checkrun action_required", ghCheck{Status: "COMPLETED", Conclusion: "ACTION_REQUIRED"}, checkFail},
+		{"checkrun in_progress", ghCheck{Status: "IN_PROGRESS"}, checkPending},
+		{"checkrun queued", ghCheck{Status: "QUEUED"}, checkPending},
+		{"checkrun completed no conclusion", ghCheck{Status: "COMPLETED"}, checkPending},
+		{"statuscontext success", ghCheck{State: "SUCCESS"}, checkPass},
+		{"statuscontext pending", ghCheck{State: "PENDING"}, checkPending},
+		{"statuscontext expected", ghCheck{State: "EXPECTED"}, checkPending},
+		{"statuscontext failure", ghCheck{State: "FAILURE"}, checkFail},
+		{"statuscontext error", ghCheck{State: "ERROR"}, checkFail},
+		{"empty", ghCheck{}, checkPending},
+		{"lowercase success", ghCheck{Status: "completed", Conclusion: "success"}, checkPass},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyCheck(tt.c); got != tt.want {
+				t.Errorf("classifyCheck(%+v) = %d, want %d", tt.c, got, tt.want)
+			}
+		})
+	}
+}
+
+func passCheck() ghCheck { return ghCheck{Status: "COMPLETED", Conclusion: "SUCCESS"} }
+func failCheck() ghCheck { return ghCheck{Status: "COMPLETED", Conclusion: "FAILURE"} }
+func pendCheck() ghCheck { return ghCheck{Status: "IN_PROGRESS"} }
+
+func TestAggregatePRStatus_Empty(t *testing.T) {
+	if got := aggregatePRStatus(nil); got != nil {
+		t.Errorf("aggregatePRStatus(nil) = %+v, want nil", got)
+	}
+	if got := aggregatePRStatus([]ghPR{}); got != nil {
+		t.Errorf("aggregatePRStatus([]) = %+v, want nil", got)
+	}
+}
+
+func TestAggregatePRStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		prs  []ghPR
+
+		wantOpen     int32
+		wantPRSig    fleetgrpc.PrSignal
+		wantReview   fleetgrpc.PrReviewState
+		wantPassed   int32
+		wantTotal    int32
+		wantCheckSig fleetgrpc.PrSignal
+	}{
+		{
+			name: "single clean all-green approved",
+			prs: []ghPR{{
+				State: "OPEN", MergeStateStatus: "CLEAN", ReviewDecision: "APPROVED",
+				StatusCheckRollup: []ghCheck{passCheck(), passCheck(), passCheck()},
+			}},
+			wantOpen: 1, wantPRSig: fleetgrpc.PrSignal_PR_SIGNAL_GREEN,
+			wantReview: fleetgrpc.PrReviewState_PR_REVIEW_STATE_APPROVED,
+			wantPassed: 3, wantTotal: 3, wantCheckSig: fleetgrpc.PrSignal_PR_SIGNAL_GREEN,
+		},
+		{
+			name: "open with pending checks not yet clean -> yellow PR, yellow checks",
+			prs: []ghPR{{
+				State: "OPEN", MergeStateStatus: "BLOCKED", ReviewDecision: "REVIEW_REQUIRED",
+				StatusCheckRollup: []ghCheck{passCheck(), pendCheck()},
+			}},
+			// Not CLEAN (checks still running) => PR indicator yellow, not green.
+			wantOpen: 1, wantPRSig: fleetgrpc.PrSignal_PR_SIGNAL_YELLOW,
+			wantReview: fleetgrpc.PrReviewState_PR_REVIEW_STATE_UNSPECIFIED,
+			wantPassed: 1, wantTotal: 2, wantCheckSig: fleetgrpc.PrSignal_PR_SIGNAL_YELLOW,
+		},
+		{
+			name: "changes requested -> red PR + red review even if checks pass",
+			prs: []ghPR{{
+				State: "OPEN", MergeStateStatus: "BLOCKED", ReviewDecision: "CHANGES_REQUESTED",
+				StatusCheckRollup: []ghCheck{passCheck()},
+			}},
+			wantOpen: 1, wantPRSig: fleetgrpc.PrSignal_PR_SIGNAL_RED,
+			wantReview: fleetgrpc.PrReviewState_PR_REVIEW_STATE_CHANGES_REQUESTED,
+			wantPassed: 1, wantTotal: 1, wantCheckSig: fleetgrpc.PrSignal_PR_SIGNAL_GREEN,
+		},
+		{
+			name: "check failure -> red PR + red checks",
+			prs: []ghPR{{
+				State: "OPEN", MergeStateStatus: "UNSTABLE", ReviewDecision: "APPROVED",
+				StatusCheckRollup: []ghCheck{passCheck(), failCheck()},
+			}},
+			wantOpen: 1, wantPRSig: fleetgrpc.PrSignal_PR_SIGNAL_RED,
+			wantReview: fleetgrpc.PrReviewState_PR_REVIEW_STATE_APPROVED,
+			wantPassed: 1, wantTotal: 2, wantCheckSig: fleetgrpc.PrSignal_PR_SIGNAL_RED,
+		},
+		{
+			name: "conflicting (dirty) but no failures -> yellow PR",
+			prs: []ghPR{{
+				State: "OPEN", MergeStateStatus: "DIRTY", ReviewDecision: "",
+				StatusCheckRollup: []ghCheck{passCheck()},
+			}},
+			wantOpen: 1, wantPRSig: fleetgrpc.PrSignal_PR_SIGNAL_YELLOW,
+			wantReview: fleetgrpc.PrReviewState_PR_REVIEW_STATE_UNSPECIFIED,
+			wantPassed: 1, wantTotal: 1, wantCheckSig: fleetgrpc.PrSignal_PR_SIGNAL_GREEN,
+		},
+		{
+			name: "three PRs summed, one failing -> PRx3 red, checks summed red",
+			prs: []ghPR{
+				{State: "OPEN", MergeStateStatus: "CLEAN", ReviewDecision: "APPROVED",
+					StatusCheckRollup: []ghCheck{passCheck(), passCheck()}},
+				{State: "OPEN", MergeStateStatus: "CLEAN", ReviewDecision: "",
+					StatusCheckRollup: []ghCheck{passCheck()}},
+				{State: "OPEN", MergeStateStatus: "UNSTABLE", ReviewDecision: "",
+					StatusCheckRollup: []ghCheck{failCheck(), passCheck()}},
+			},
+			wantOpen: 3, wantPRSig: fleetgrpc.PrSignal_PR_SIGNAL_RED,
+			wantReview: fleetgrpc.PrReviewState_PR_REVIEW_STATE_APPROVED,
+			wantPassed: 4, wantTotal: 5, wantCheckSig: fleetgrpc.PrSignal_PR_SIGNAL_RED,
+		},
+		{
+			name: "two PRs both clean, one with a pending check -> green PR, yellow checks",
+			prs: []ghPR{
+				{State: "OPEN", MergeStateStatus: "CLEAN", ReviewDecision: "",
+					StatusCheckRollup: []ghCheck{passCheck()}},
+				{State: "OPEN", MergeStateStatus: "CLEAN", ReviewDecision: "",
+					StatusCheckRollup: []ghCheck{pendCheck()}},
+			},
+			// PR signal (all CLEAN) and checks signal (a pending check) are
+			// computed independently.
+			wantOpen: 2, wantPRSig: fleetgrpc.PrSignal_PR_SIGNAL_GREEN,
+			wantReview: fleetgrpc.PrReviewState_PR_REVIEW_STATE_UNSPECIFIED,
+			wantPassed: 1, wantTotal: 2, wantCheckSig: fleetgrpc.PrSignal_PR_SIGNAL_YELLOW,
+		},
+		{
+			name: "no checks at all -> green checks, total 0",
+			prs: []ghPR{{
+				State: "OPEN", MergeStateStatus: "CLEAN", ReviewDecision: "APPROVED",
+			}},
+			wantOpen: 1, wantPRSig: fleetgrpc.PrSignal_PR_SIGNAL_GREEN,
+			wantReview: fleetgrpc.PrReviewState_PR_REVIEW_STATE_APPROVED,
+			wantPassed: 0, wantTotal: 0, wantCheckSig: fleetgrpc.PrSignal_PR_SIGNAL_GREEN,
+		},
+		{
+			name: "changes requested wins over another PR's approval",
+			prs: []ghPR{
+				{State: "OPEN", MergeStateStatus: "CLEAN", ReviewDecision: "APPROVED",
+					StatusCheckRollup: []ghCheck{passCheck()}},
+				{State: "OPEN", MergeStateStatus: "BLOCKED", ReviewDecision: "CHANGES_REQUESTED",
+					StatusCheckRollup: []ghCheck{passCheck()}},
+			},
+			wantOpen: 2, wantPRSig: fleetgrpc.PrSignal_PR_SIGNAL_RED,
+			wantReview: fleetgrpc.PrReviewState_PR_REVIEW_STATE_CHANGES_REQUESTED,
+			wantPassed: 2, wantTotal: 2, wantCheckSig: fleetgrpc.PrSignal_PR_SIGNAL_GREEN,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := aggregatePRStatus(tt.prs)
+			if got == nil {
+				t.Fatalf("aggregatePRStatus returned nil")
+			}
+			if got.GetOpenCount() != tt.wantOpen {
+				t.Errorf("OpenCount = %d, want %d", got.GetOpenCount(), tt.wantOpen)
+			}
+			if got.GetPrSignal() != tt.wantPRSig {
+				t.Errorf("PrSignal = %v, want %v", got.GetPrSignal(), tt.wantPRSig)
+			}
+			if got.GetReview() != tt.wantReview {
+				t.Errorf("Review = %v, want %v", got.GetReview(), tt.wantReview)
+			}
+			if got.GetChecksPassed() != tt.wantPassed {
+				t.Errorf("ChecksPassed = %d, want %d", got.GetChecksPassed(), tt.wantPassed)
+			}
+			if got.GetChecksTotal() != tt.wantTotal {
+				t.Errorf("ChecksTotal = %d, want %d", got.GetChecksTotal(), tt.wantTotal)
+			}
+			if got.GetChecksSignal() != tt.wantCheckSig {
+				t.Errorf("ChecksSignal = %v, want %v", got.GetChecksSignal(), tt.wantCheckSig)
+			}
+		})
+	}
+}
+
+func TestParsePRProbeOutput_Sentinels(t *testing.T) {
+	if got := parsePRProbeOutput("FLEET_NO_GH\n"); got != nil {
+		t.Errorf("no-gh sentinel = %+v, want nil", got)
+	}
+	if got := parsePRProbeOutput("FLEET_NO_AUTH\n"); got != nil {
+		t.Errorf("no-auth sentinel = %+v, want nil", got)
+	}
+	if got := parsePRProbeOutput(""); got != nil {
+		t.Errorf("empty output = %+v, want nil", got)
+	}
+	if got := parsePRProbeOutput("\n  \n"); got != nil {
+		t.Errorf("blank output = %+v, want nil", got)
+	}
+}
+
+func TestParsePRProbeOutput_ConcatenatedArrays(t *testing.T) {
+	// Two repos' `gh pr list --json` arrays concatenated: the workspace repo
+	// (one approved, all-green PR) and a subrepo (one failing-check PR). The
+	// second array is pretty-printed to prove whitespace doesn't matter.
+	out := `[{"number":12,"state":"OPEN","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}]
+[
+  {
+    "number": 7,
+    "state": "OPEN",
+    "mergeStateStatus": "UNSTABLE",
+    "reviewDecision": "",
+    "statusCheckRollup": [
+      {"status": "COMPLETED", "conclusion": "FAILURE"},
+      {"state": "SUCCESS"}
+    ]
+  }
+]
+`
+	got := parsePRProbeOutput(out)
+	if got == nil {
+		t.Fatalf("parsePRProbeOutput returned nil")
+	}
+	if got.GetOpenCount() != 2 {
+		t.Errorf("OpenCount = %d, want 2", got.GetOpenCount())
+	}
+	if got.GetPrSignal() != fleetgrpc.PrSignal_PR_SIGNAL_RED {
+		t.Errorf("PrSignal = %v, want RED", got.GetPrSignal())
+	}
+	if got.GetChecksPassed() != 2 || got.GetChecksTotal() != 3 {
+		t.Errorf("checks = %d/%d, want 2/3", got.GetChecksPassed(), got.GetChecksTotal())
+	}
+	if got.GetChecksSignal() != fleetgrpc.PrSignal_PR_SIGNAL_RED {
+		t.Errorf("ChecksSignal = %v, want RED", got.GetChecksSignal())
+	}
+}
+
+func TestParsePRProbeOutput_EmptyArraysAndClosed(t *testing.T) {
+	// A repo with no PRs emits `[]`; a repo whose only PR is closed contributes
+	// nothing. Combined => no open PRs => nil.
+	out := "[]\n[{\"number\":1,\"state\":\"CLOSED\",\"mergeStateStatus\":\"CLEAN\",\"statusCheckRollup\":[]}]\n[]\n"
+	if got := parsePRProbeOutput(out); got != nil {
+		t.Errorf("parsePRProbeOutput = %+v, want nil (no open PRs)", got)
+	}
+
+	// Same but with one genuinely open PR mixed in.
+	out2 := "[]\n[{\"number\":2,\"state\":\"OPEN\",\"mergeStateStatus\":\"CLEAN\",\"reviewDecision\":\"APPROVED\",\"statusCheckRollup\":[{\"status\":\"COMPLETED\",\"conclusion\":\"SUCCESS\"}]}]\n"
+	got := parsePRProbeOutput(out2)
+	if got == nil {
+		t.Fatalf("parsePRProbeOutput returned nil, want one open PR")
+	}
+	if got.GetOpenCount() != 1 {
+		t.Errorf("OpenCount = %d, want 1", got.GetOpenCount())
+	}
+}

--- a/internal/server/runtime_poller.go
+++ b/internal/server/runtime_poller.go
@@ -86,6 +86,7 @@ func startRuntimePollers(ctx context.Context, h *hub) {
 	go liveStatusPoller(ctx, h)
 	go statsActivityPoller(ctx, h)
 	go sessionsPoller(ctx, h)
+	go prStatusPoller(ctx, h)
 }
 
 // runtimeUpdate is one instance's field mutation, applied on the hub loop.

--- a/internal/tui/auto_tag.go
+++ b/internal/tui/auto_tag.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// auto_tag.go renders the "auto tag": a glanceable PR/review/checks status line
+// the TUI shows in an instance's tag slot when the instance has no user-set tag.
+// The underlying data (fleetgrpc.PrStatus) is computed server-side by running
+// `gh` inside the instance (see internal/server/pr_status.go) and pushed over
+// the runtime sidecar; this file only formats it.
+
+// prSignalStyle maps a PrSignal colour to its lipgloss style.
+func prSignalStyle(sig fleetgrpc.PrSignal) lipgloss.Style {
+	switch sig {
+	case fleetgrpc.PrSignal_PR_SIGNAL_GREEN:
+		return prGreenStyle
+	case fleetgrpc.PrSignal_PR_SIGNAL_RED:
+		return prRedStyle
+	default:
+		return prYellowStyle
+	}
+}
+
+// instanceAutoTag renders the auto tag for an instance, or "" when there is
+// nothing to show — gh is unavailable inside the instance, no PR is open, or the
+// status hasn't been probed yet. The format is "[PR|PRxN] [Changes Requested |
+// Approved] [Checks x/x]", each element coloured and shown only when it applies.
+func (m *model) instanceAutoTag(fleetName, instance string) string {
+	ps := m.runtime[rtKey(fleetName, instance)].GetPrStatus()
+	if ps == nil || ps.GetOpenCount() == 0 {
+		return ""
+	}
+
+	parts := make([]string, 0, 3)
+
+	// PR indicator: "PR" for a single open PR, "PRxN" for N>1.
+	label := "PR"
+	if n := ps.GetOpenCount(); n > 1 {
+		label = fmt.Sprintf("PRx%d", n)
+	}
+	parts = append(parts, prSignalStyle(ps.GetPrSignal()).Render(label))
+
+	// Review indicator: only when a decision has landed.
+	switch ps.GetReview() {
+	case fleetgrpc.PrReviewState_PR_REVIEW_STATE_CHANGES_REQUESTED:
+		parts = append(parts, prRedStyle.Render("Changes Requested"))
+	case fleetgrpc.PrReviewState_PR_REVIEW_STATE_APPROVED:
+		parts = append(parts, prGreenStyle.Render("Approved"))
+	}
+
+	// Checks indicator: only when the PRs have any checks.
+	if ps.GetChecksTotal() > 0 {
+		checks := fmt.Sprintf("Checks %d/%d", ps.GetChecksPassed(), ps.GetChecksTotal())
+		parts = append(parts, prSignalStyle(ps.GetChecksSignal()).Render(checks))
+	}
+
+	return strings.Join(parts, "  ")
+}

--- a/internal/tui/auto_tag_test.go
+++ b/internal/tui/auto_tag_test.go
@@ -1,0 +1,189 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// autoTagModel builds a model with one instance and an optional PrStatus on the
+// runtime sidecar, mirroring tagTestModel but for the auto-tag path.
+func autoTagModel(fp *fleetPage, inst *fleet.Instance, expanded bool, ps *fleetgrpc.PrStatus) *model {
+	store := NewSessionStore()
+	if expanded {
+		store.SetExpanded(InstanceRef{Fleet: "alpha", Instance: inst.Name}, true)
+	}
+	runtime := map[string]*fleetgrpc.InstanceRuntime{}
+	if ps != nil {
+		runtime[rtKey("alpha", inst.Name)] = &fleetgrpc.InstanceRuntime{
+			Fleet: "alpha", Instance: inst.Name, PrStatus: ps,
+		}
+	}
+	return &model{
+		st: &state.State{
+			Fleets: map[string]*fleet.Fleet{
+				"alpha": {Name: "alpha", Instances: []*fleet.Instance{inst}},
+			},
+		},
+		sessionStore: store,
+		fleetPage:    fp,
+		runtime:      runtime,
+	}
+}
+
+func TestInstanceAutoTag_NoStatus(t *testing.T) {
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning}
+	m := autoTagModel(newFleetPage(), inst, true, nil)
+	if got := m.instanceAutoTag("alpha", "agent-1"); got != "" {
+		t.Fatalf("auto tag with no runtime = %q, want empty", got)
+	}
+	// Probed, but no open PRs.
+	m = autoTagModel(newFleetPage(), inst, true, &fleetgrpc.PrStatus{OpenCount: 0})
+	if got := m.instanceAutoTag("alpha", "agent-1"); got != "" {
+		t.Fatalf("auto tag with zero open PRs = %q, want empty", got)
+	}
+}
+
+func TestInstanceAutoTag_Format(t *testing.T) {
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning}
+	ps := &fleetgrpc.PrStatus{
+		OpenCount:    1,
+		PrSignal:     fleetgrpc.PrSignal_PR_SIGNAL_GREEN,
+		Review:       fleetgrpc.PrReviewState_PR_REVIEW_STATE_APPROVED,
+		ChecksPassed: 3,
+		ChecksTotal:  3,
+		ChecksSignal: fleetgrpc.PrSignal_PR_SIGNAL_GREEN,
+	}
+	m := autoTagModel(newFleetPage(), inst, true, ps)
+	got := m.instanceAutoTag("alpha", "agent-1")
+	for _, want := range []string{"PR", "Approved", "Checks 3/3"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("auto tag %q missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "PRx") {
+		t.Errorf("single PR should render \"PR\", not %q", got)
+	}
+}
+
+func TestInstanceAutoTag_MultiplePRsAndChangesRequested(t *testing.T) {
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning}
+	ps := &fleetgrpc.PrStatus{
+		OpenCount:    3,
+		PrSignal:     fleetgrpc.PrSignal_PR_SIGNAL_RED,
+		Review:       fleetgrpc.PrReviewState_PR_REVIEW_STATE_CHANGES_REQUESTED,
+		ChecksPassed: 4,
+		ChecksTotal:  6,
+		ChecksSignal: fleetgrpc.PrSignal_PR_SIGNAL_RED,
+	}
+	m := autoTagModel(newFleetPage(), inst, true, ps)
+	got := m.instanceAutoTag("alpha", "agent-1")
+	for _, want := range []string{"PRx3", "Changes Requested", "Checks 4/6"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("auto tag %q missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "Approved") {
+		t.Errorf("changes-requested tag should not contain Approved: %q", got)
+	}
+}
+
+func TestInstanceAutoTag_HidesReviewAndChecksWhenAbsent(t *testing.T) {
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning}
+	ps := &fleetgrpc.PrStatus{
+		OpenCount: 1,
+		PrSignal:  fleetgrpc.PrSignal_PR_SIGNAL_YELLOW,
+		Review:    fleetgrpc.PrReviewState_PR_REVIEW_STATE_UNSPECIFIED,
+		// No checks at all.
+		ChecksTotal: 0,
+	}
+	m := autoTagModel(newFleetPage(), inst, true, ps)
+	got := m.instanceAutoTag("alpha", "agent-1")
+	if !strings.Contains(got, "PR") {
+		t.Errorf("auto tag %q missing PR indicator", got)
+	}
+	if strings.Contains(got, "Approved") || strings.Contains(got, "Changes Requested") {
+		t.Errorf("review element should be hidden: %q", got)
+	}
+	if strings.Contains(got, "Checks") {
+		t.Errorf("checks element should be hidden when total is 0: %q", got)
+	}
+}
+
+func TestBuildRowsInsertsAutoTagRowWhenNoUserTag(t *testing.T) {
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning} // no user tag
+	ps := &fleetgrpc.PrStatus{OpenCount: 1, PrSignal: fleetgrpc.PrSignal_PR_SIGNAL_GREEN}
+	fp := newFleetPage()
+	m := autoTagModel(fp, inst, true, ps)
+
+	fp.buildRows(m)
+
+	found := false
+	for _, r := range fp.rows {
+		if r.kind == rowInstanceTag {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("auto-tag row not inserted: %#v", fp.rows)
+	}
+}
+
+func TestBuildRowsNoAutoTagRowWhenNoPRs(t *testing.T) {
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning}
+	fp := newFleetPage()
+	m := autoTagModel(fp, inst, true, nil) // no PrStatus at all
+
+	fp.buildRows(m)
+
+	for _, r := range fp.rows {
+		if r.kind == rowInstanceTag {
+			t.Fatalf("tag row present with no user tag and no PR status: %#v", fp.rows)
+		}
+	}
+}
+
+func TestViewFleetListRendersAutoTag(t *testing.T) {
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning}
+	ps := &fleetgrpc.PrStatus{
+		OpenCount:    2,
+		PrSignal:     fleetgrpc.PrSignal_PR_SIGNAL_YELLOW,
+		Review:       fleetgrpc.PrReviewState_PR_REVIEW_STATE_APPROVED,
+		ChecksPassed: 5,
+		ChecksTotal:  8,
+		ChecksSignal: fleetgrpc.PrSignal_PR_SIGNAL_YELLOW,
+	}
+	fp := newFleetPage()
+	m := autoTagModel(fp, inst, true, ps)
+	fp.buildRows(m)
+
+	view := fp.viewFleetList(m)
+	for _, want := range []string{"PRx2", "Approved", "Checks 5/8"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("view missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestUserTagTakesPrecedenceOverAutoTag(t *testing.T) {
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning, Tag: "refactor auth"}
+	ps := &fleetgrpc.PrStatus{
+		OpenCount:   1,
+		PrSignal:    fleetgrpc.PrSignal_PR_SIGNAL_GREEN,
+		ChecksTotal: 3, ChecksPassed: 3, ChecksSignal: fleetgrpc.PrSignal_PR_SIGNAL_GREEN,
+	}
+	fp := newFleetPage()
+	m := autoTagModel(fp, inst, true, ps)
+	fp.buildRows(m)
+
+	view := fp.viewFleetList(m)
+	if !strings.Contains(view, "# refactor auth") {
+		t.Fatalf("user tag not rendered:\n%s", view)
+	}
+	if strings.Contains(view, "Checks 3/3") {
+		t.Fatalf("auto tag rendered despite a user-set tag:\n%s", view)
+	}
+}

--- a/internal/tui/page_fleet_rows.go
+++ b/internal/tui/page_fleet_rows.go
@@ -39,7 +39,9 @@ func (fleetPage *fleetPage) buildRows(m *model) {
 				fleetPage.rows = append(fleetPage.rows, row{kind: rowInstance, fleetName: name, instance: instance})
 				ref := InstanceRef{Fleet: name, Instance: instance.Name}
 				if m.sessionStore.IsExpanded(ref) {
-					if instance.Tag != "" {
+					// The tag slot shows the user-set tag, or — when none is set —
+					// the computed "auto tag" (PR status), if there is one.
+					if instance.Tag != "" || m.instanceAutoTag(name, instance.Name) != "" {
 						fleetPage.rows = append(fleetPage.rows, row{kind: rowInstanceTag, fleetName: name, instance: instance})
 					}
 					liveGroups := make(map[string]bool)

--- a/internal/tui/page_fleet_view.go
+++ b/internal/tui/page_fleet_view.go
@@ -279,7 +279,14 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			listContent.WriteString(line)
 			listContent.WriteString("\n")
 		} else if r.kind == rowInstanceTag {
-			line := fmt.Sprintf("%s        %s", cursor, dimStyle.Render("# "+r.instance.Tag))
+			// User-set tag takes the slot; otherwise the auto tag (PR status).
+			var content string
+			if r.instance.Tag != "" {
+				content = dimStyle.Render("# " + r.instance.Tag)
+			} else {
+				content = m.instanceAutoTag(r.fleetName, r.instance.Name)
+			}
+			line := fmt.Sprintf("%s        %s", cursor, content)
 			if maxW := m.width - 4; maxW > 0 && lipgloss.Width(line) > maxW {
 				line = ansi.Truncate(line, maxW-1, "…")
 			}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -53,6 +53,17 @@ var (
 	statusCreatingStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("214"))
 
+	// Auto-tag (PR status) signal colours, reusing the running/creating/error
+	// palette: green = good, yellow = in-progress/neutral, red = needs attention.
+	prGreenStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("42"))
+
+	prYellowStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("214"))
+
+	prRedStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("196"))
+
 	// Agent tool indicator
 	agentWorkingStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("42")).


### PR DESCRIPTION
## Why

Instances support a user-set **tag** (`t` then type), but most of the time you
just want to know *what state the work is in* — is the PR up, did review pass,
are checks green? This adds an **auto tag**: when an instance has no user-set
tag, the tag slot instead shows a live, glanceable summary of its GitHub PR
state. A user-set tag always takes precedence, so nothing changes for tagged
instances.

## What

For an expanded instance with no user tag, the tag line renders:

```
[PR | PRxN]   [Changes Requested | Approved]   [Checks x/x]
```

Each element is dynamic and colour-coded; absent elements are omitted.

- **PR** — shown when a PR is open on the current branch of the workspace repo
  **or any nested subrepo**. `PRxN` when N>1 (counts summed across repos).
  Green when every PR is mergeable per GitHub (`mergeStateStatus == CLEAN`),
  red on any check failure or changes-requested, yellow otherwise (open, in
  progress).
- **Changes Requested / Approved** — red/green from the aggregate review
  decision; hidden until a decision lands.
- **Checks x/x** — passed/total summed across all open PRs. Green when all
  passed, red on any failure, yellow while any are pending.

### How it works

A new server-side poller (`internal/server/pr_status.go`) runs `gh pr list
--json …` **inside the instance** (so it uses the instance's own gh auth) on a
slow cadence (~45s, plus immediately when a TUI first subscribes), aggregates
the result, and pushes a new `PrStatus` message over the existing runtime
sidecar (`InstanceRuntime.pr_status`). The thin TUI just formats it
(`internal/tui/auto_tag.go`), mirroring how agent activity / stats already flow.

### Graceful degradation

If `gh` is missing or not logged in inside the instance, the probe emits a
sentinel and the auto tag is simply not shown — today's behaviour is preserved.
Transient probe failures keep the last known status rather than clearing it.

## Notes / scope

- The auto tag occupies the **same slot** as the manual tag (shown under an
  expanded instance), per "alternate display mode for tags". Always-visible
  (collapsed) display would be a larger UX change and is left as a follow-up.
- PRs are matched by each repo's **current branch** (`--head`), so the tag
  reflects *this instance's* work rather than every open PR in the repo.