### PR TITLE
feat/automation-tui-mode — automation mode: triggers that spin up agents (#188)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,9 +5,28 @@ on:
     branches: [main]
 
 jobs:
-  integration:
+  # The suite is sharded by test-number range across parallel runners so the
+  # SLOWEST shard — not the whole 80+-test suite — sets the wall-clock. Each
+  # shard runs integration/run.sh with FLEET_ITEST_RANGE; run.sh filters to the
+  # tests whose numeric filename prefix falls in [START, END). The open-ended
+  # "600-" shard catches any future high-numbered tests so none are dropped.
+  integration-shard:
+    name: integration ${{ matrix.range }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      # Run every shard to completion even if one fails — we want the full
+      # pass/fail picture across the suite, not a first-failure abort.
+      fail-fast: false
+      matrix:
+        range:
+          - "0-100"
+          - "100-200"
+          - "200-300"
+          - "300-400"
+          - "400-500"
+          - "500-600"
+          - "600-"
     steps:
       - uses: actions/checkout@v5
 
@@ -39,4 +58,23 @@ jobs:
       - name: Run integration tests
         env:
           FLEET_BIN: /usr/local/bin/fleet
+          FLEET_ITEST_RANGE: ${{ matrix.range }}
         run: ./integration/run.sh
+
+  # Single aggregate check: green only when every shard passed. Preserves one
+  # stable "integration" status name for branch protection / the review loop,
+  # independent of how many shards the matrix expands to.
+  integration:
+    name: integration
+    runs-on: ubuntu-latest
+    needs: [integration-shard]
+    if: ${{ always() }}
+    steps:
+      - name: Verify all shards passed
+        run: |
+          result="${{ needs.integration-shard.result }}"
+          echo "integration shard matrix result: ${result}"
+          if [ "${result}" != "success" ]; then
+            echo "::error::one or more integration shards failed (result=${result})"
+            exit 1
+          fi

--- a/fleetgrpc/domain.pb.go
+++ b/fleetgrpc/domain.pb.go
@@ -617,7 +617,6 @@ type Agent struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	Command       string                 `protobuf:"bytes,2,opt,name=command,proto3" json:"command,omitempty"`
-	TmuxMode      bool                   `protobuf:"varint,3,opt,name=tmux_mode,json=tmuxMode,proto3" json:"tmux_mode,omitempty"`
 	SystemPrompt  string                 `protobuf:"bytes,4,opt,name=system_prompt,json=systemPrompt,proto3" json:"system_prompt,omitempty"`
 	Backend       BackendType            `protobuf:"varint,5,opt,name=backend,proto3,enum=fleetgrpc.BackendType" json:"backend,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -666,13 +665,6 @@ func (x *Agent) GetCommand() string {
 		return x.Command
 	}
 	return ""
-}
-
-func (x *Agent) GetTmuxMode() bool {
-	if x != nil {
-		return x.TmuxMode
-	}
-	return false
 }
 
 func (x *Agent) GetSystemPrompt() string {
@@ -1076,13 +1068,12 @@ const file_domain_proto_rawDesc = "" +
 	"\fLayoutPreset\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
 	"\x06layout\x18\x02 \x01(\tR\x06layout\x12#\n" +
-	"\rpane_commands\x18\x03 \x03(\tR\fpaneCommands\"\xa9\x01\n" +
+	"\rpane_commands\x18\x03 \x03(\tR\fpaneCommands\"\x92\x01\n" +
 	"\x05Agent\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
-	"\acommand\x18\x02 \x01(\tR\acommand\x12\x1b\n" +
-	"\ttmux_mode\x18\x03 \x01(\bR\btmuxMode\x12#\n" +
+	"\acommand\x18\x02 \x01(\tR\acommand\x12#\n" +
 	"\rsystem_prompt\x18\x04 \x01(\tR\fsystemPrompt\x120\n" +
-	"\abackend\x18\x05 \x01(\x0e2\x16.fleetgrpc.BackendTypeR\abackend\"\x94\x02\n" +
+	"\abackend\x18\x05 \x01(\x0e2\x16.fleetgrpc.BackendTypeR\abackendJ\x04\b\x03\x10\x04\"\x94\x02\n" +
 	"\aTrigger\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x1f\n" +

--- a/fleetgrpc/domain.pb.go
+++ b/fleetgrpc/domain.pb.go
@@ -404,6 +404,15 @@ type FleetSettings struct {
 	// presets. Names are unique within the list (the server normalizes and
 	// rejects duplicates, like custom_mounts).
 	LayoutPresets []*LayoutPreset `protobuf:"bytes,11,rep,name=layout_presets,json=layoutPresets,proto3" json:"layout_presets,omitempty"`
+	// agents is the fleet's list of automation agent definitions (issue #188).
+	// repeated message; names unique within the list (server normalizes). An
+	// empty list (the default) means no agents.
+	Agents []*Agent `protobuf:"bytes,12,rep,name=agents,proto3" json:"agents,omitempty"`
+	// triggers is the fleet's list of automation trigger definitions (issue
+	// #188), each firing one or more agents (by name) on a schedule or webhook
+	// event. repeated message; names unique within the list (server normalizes
+	// against the agent set). An empty list (the default) means no triggers.
+	Triggers      []*Trigger `protobuf:"bytes,13,rep,name=triggers,proto3" json:"triggers,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -515,6 +524,20 @@ func (x *FleetSettings) GetLayoutPresets() []*LayoutPreset {
 	return nil
 }
 
+func (x *FleetSettings) GetAgents() []*Agent {
+	if x != nil {
+		return x.Agents
+	}
+	return nil
+}
+
+func (x *FleetSettings) GetTriggers() []*Trigger {
+	if x != nil {
+		return x.Triggers
+	}
+	return nil
+}
+
 // LayoutPreset mirrors internal/fleet.LayoutPreset — a saved pane-layout
 // template the user can apply when creating a new session (Tab in the
 // new-session dialog). It is captured FROM a live session group: layout is the
@@ -585,6 +608,209 @@ func (x *LayoutPreset) GetPaneCommands() []string {
 	return nil
 }
 
+// Agent mirrors internal/fleet.Agent — an automation worker definition (issue
+// #188). command may contain the ${PROMPT}/${SYS_PROMPT} placeholders. tmux_mode
+// is a plain bool whose user-facing default is ON (the new-agent dialog sets it
+// and it is always persisted explicitly). backend reuses Instance.backend's enum
+// (UNSPECIFIED -> devcontainer at normalization).
+type Agent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Command       string                 `protobuf:"bytes,2,opt,name=command,proto3" json:"command,omitempty"`
+	TmuxMode      bool                   `protobuf:"varint,3,opt,name=tmux_mode,json=tmuxMode,proto3" json:"tmux_mode,omitempty"`
+	SystemPrompt  string                 `protobuf:"bytes,4,opt,name=system_prompt,json=systemPrompt,proto3" json:"system_prompt,omitempty"`
+	Backend       BackendType            `protobuf:"varint,5,opt,name=backend,proto3,enum=fleetgrpc.BackendType" json:"backend,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Agent) Reset() {
+	*x = Agent{}
+	mi := &file_domain_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Agent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Agent) ProtoMessage() {}
+
+func (x *Agent) ProtoReflect() protoreflect.Message {
+	mi := &file_domain_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Agent.ProtoReflect.Descriptor instead.
+func (*Agent) Descriptor() ([]byte, []int) {
+	return file_domain_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *Agent) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Agent) GetCommand() string {
+	if x != nil {
+		return x.Command
+	}
+	return ""
+}
+
+func (x *Agent) GetTmuxMode() bool {
+	if x != nil {
+		return x.TmuxMode
+	}
+	return false
+}
+
+func (x *Agent) GetSystemPrompt() string {
+	if x != nil {
+		return x.SystemPrompt
+	}
+	return ""
+}
+
+func (x *Agent) GetBackend() BackendType {
+	if x != nil {
+		return x.Backend
+	}
+	return BackendType_BACKEND_TYPE_UNSPECIFIED
+}
+
+// Trigger mirrors internal/fleet.Trigger — an automation trigger (issue #188).
+// type is the string-valued TriggerType ("schedule" | "webhook"); filter_type is
+// the string-valued WebhookFilterType ("regex" | "jsonpath"). Schedule triggers
+// use cron; webhook triggers use webhook_name + filter_type + the matching
+// fields. agent_names references Agents by name. The string-valued enums match
+// the Go model's string types, so the wire mapping is a plain string copy.
+type Trigger struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Type          string                 `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	AgentNames    []string               `protobuf:"bytes,3,rep,name=agent_names,json=agentNames,proto3" json:"agent_names,omitempty"`
+	Prompt        string                 `protobuf:"bytes,4,opt,name=prompt,proto3" json:"prompt,omitempty"`
+	Cron          string                 `protobuf:"bytes,5,opt,name=cron,proto3" json:"cron,omitempty"`
+	WebhookName   string                 `protobuf:"bytes,6,opt,name=webhook_name,json=webhookName,proto3" json:"webhook_name,omitempty"`
+	FilterType    string                 `protobuf:"bytes,7,opt,name=filter_type,json=filterType,proto3" json:"filter_type,omitempty"`
+	Regex         string                 `protobuf:"bytes,8,opt,name=regex,proto3" json:"regex,omitempty"`
+	JsonPath      string                 `protobuf:"bytes,9,opt,name=json_path,json=jsonPath,proto3" json:"json_path,omitempty"`
+	JsonValue     string                 `protobuf:"bytes,10,opt,name=json_value,json=jsonValue,proto3" json:"json_value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Trigger) Reset() {
+	*x = Trigger{}
+	mi := &file_domain_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Trigger) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Trigger) ProtoMessage() {}
+
+func (x *Trigger) ProtoReflect() protoreflect.Message {
+	mi := &file_domain_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Trigger.ProtoReflect.Descriptor instead.
+func (*Trigger) Descriptor() ([]byte, []int) {
+	return file_domain_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *Trigger) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Trigger) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *Trigger) GetAgentNames() []string {
+	if x != nil {
+		return x.AgentNames
+	}
+	return nil
+}
+
+func (x *Trigger) GetPrompt() string {
+	if x != nil {
+		return x.Prompt
+	}
+	return ""
+}
+
+func (x *Trigger) GetCron() string {
+	if x != nil {
+		return x.Cron
+	}
+	return ""
+}
+
+func (x *Trigger) GetWebhookName() string {
+	if x != nil {
+		return x.WebhookName
+	}
+	return ""
+}
+
+func (x *Trigger) GetFilterType() string {
+	if x != nil {
+		return x.FilterType
+	}
+	return ""
+}
+
+func (x *Trigger) GetRegex() string {
+	if x != nil {
+		return x.Regex
+	}
+	return ""
+}
+
+func (x *Trigger) GetJsonPath() string {
+	if x != nil {
+		return x.JsonPath
+	}
+	return ""
+}
+
+func (x *Trigger) GetJsonValue() string {
+	if x != nil {
+		return x.JsonValue
+	}
+	return ""
+}
+
 // Fleet mirrors internal/fleet.Fleet. Settings is a NESTED message (not inlined)
 // so FleetSettings' tri-state presence stays self-contained; a nil Settings ==
 // zero settings. Instances ([]*Instance) -> repeated.
@@ -600,7 +826,7 @@ type Fleet struct {
 
 func (x *Fleet) Reset() {
 	*x = Fleet{}
-	mi := &file_domain_proto_msgTypes[3]
+	mi := &file_domain_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -612,7 +838,7 @@ func (x *Fleet) String() string {
 func (*Fleet) ProtoMessage() {}
 
 func (x *Fleet) ProtoReflect() protoreflect.Message {
-	mi := &file_domain_proto_msgTypes[3]
+	mi := &file_domain_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -625,7 +851,7 @@ func (x *Fleet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Fleet.ProtoReflect.Descriptor instead.
 func (*Fleet) Descriptor() ([]byte, []int) {
-	return file_domain_proto_rawDescGZIP(), []int{3}
+	return file_domain_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *Fleet) GetName() string {
@@ -674,7 +900,7 @@ type GroupLayout struct {
 
 func (x *GroupLayout) Reset() {
 	*x = GroupLayout{}
-	mi := &file_domain_proto_msgTypes[4]
+	mi := &file_domain_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -686,7 +912,7 @@ func (x *GroupLayout) String() string {
 func (*GroupLayout) ProtoMessage() {}
 
 func (x *GroupLayout) ProtoReflect() protoreflect.Message {
-	mi := &file_domain_proto_msgTypes[4]
+	mi := &file_domain_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -699,7 +925,7 @@ func (x *GroupLayout) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GroupLayout.ProtoReflect.Descriptor instead.
 func (*GroupLayout) Descriptor() ([]byte, []int) {
-	return file_domain_proto_rawDescGZIP(), []int{4}
+	return file_domain_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *GroupLayout) GetGroupId() string {
@@ -751,7 +977,7 @@ type State struct {
 
 func (x *State) Reset() {
 	*x = State{}
-	mi := &file_domain_proto_msgTypes[5]
+	mi := &file_domain_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -763,7 +989,7 @@ func (x *State) String() string {
 func (*State) ProtoMessage() {}
 
 func (x *State) ProtoReflect() protoreflect.Message {
-	mi := &file_domain_proto_msgTypes[5]
+	mi := &file_domain_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -776,7 +1002,7 @@ func (x *State) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use State.ProtoReflect.Descriptor instead.
 func (*State) Descriptor() ([]byte, []int) {
-	return file_domain_proto_rawDescGZIP(), []int{5}
+	return file_domain_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *State) GetFleets() map[string]*Fleet {
@@ -828,7 +1054,7 @@ const file_domain_proto_rawDesc = "" +
 	"\x06_errorB\x06\n" +
 	"\x04_tagB\b\n" +
 	"\x06_colorB\t\n" +
-	"\a_branchJ\x04\b\x0e\x10\x1f\"\xfa\x03\n" +
+	"\a_branchJ\x04\b\x0e\x10\x1f\"\xd4\x04\n" +
 	"\rFleetSettings\x12*\n" +
 	"\x11claude_code_mount\x18\x01 \x01(\bR\x0fclaudeCodeMount\x12\x1f\n" +
 	"\vcodex_mount\x18\x02 \x01(\bR\n" +
@@ -842,13 +1068,36 @@ const file_domain_proto_rawDesc = "" +
 	"\x12image_cache_server\x18\t \x01(\bR\x10imageCacheServer\x12!\n" +
 	"\fauggie_mount\x18\n" +
 	" \x01(\bR\vauggieMount\x12>\n" +
-	"\x0elayout_presets\x18\v \x03(\v2\x17.fleetgrpc.LayoutPresetR\rlayoutPresetsB\v\n" +
+	"\x0elayout_presets\x18\v \x03(\v2\x17.fleetgrpc.LayoutPresetR\rlayoutPresets\x12(\n" +
+	"\x06agents\x18\f \x03(\v2\x10.fleetgrpc.AgentR\x06agents\x12.\n" +
+	"\btriggers\x18\r \x03(\v2\x12.fleetgrpc.TriggerR\btriggersB\v\n" +
 	"\t_home_dirB\x16\n" +
 	"\x14_prefer_fleet_launch\"_\n" +
 	"\fLayoutPreset\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
 	"\x06layout\x18\x02 \x01(\tR\x06layout\x12#\n" +
-	"\rpane_commands\x18\x03 \x03(\tR\fpaneCommands\"\xa2\x01\n" +
+	"\rpane_commands\x18\x03 \x03(\tR\fpaneCommands\"\xa9\x01\n" +
+	"\x05Agent\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
+	"\acommand\x18\x02 \x01(\tR\acommand\x12\x1b\n" +
+	"\ttmux_mode\x18\x03 \x01(\bR\btmuxMode\x12#\n" +
+	"\rsystem_prompt\x18\x04 \x01(\tR\fsystemPrompt\x120\n" +
+	"\abackend\x18\x05 \x01(\x0e2\x16.fleetgrpc.BackendTypeR\abackend\"\x94\x02\n" +
+	"\aTrigger\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
+	"\x04type\x18\x02 \x01(\tR\x04type\x12\x1f\n" +
+	"\vagent_names\x18\x03 \x03(\tR\n" +
+	"agentNames\x12\x16\n" +
+	"\x06prompt\x18\x04 \x01(\tR\x06prompt\x12\x12\n" +
+	"\x04cron\x18\x05 \x01(\tR\x04cron\x12!\n" +
+	"\fwebhook_name\x18\x06 \x01(\tR\vwebhookName\x12\x1f\n" +
+	"\vfilter_type\x18\a \x01(\tR\n" +
+	"filterType\x12\x14\n" +
+	"\x05regex\x18\b \x01(\tR\x05regex\x12\x1b\n" +
+	"\tjson_path\x18\t \x01(\tR\bjsonPath\x12\x1d\n" +
+	"\n" +
+	"json_value\x18\n" +
+	" \x01(\tR\tjsonValue\"\xa2\x01\n" +
 	"\x05Fleet\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
 	"\x06remote\x18\x02 \x01(\tR\x06remote\x124\n" +
@@ -902,36 +1151,41 @@ func file_domain_proto_rawDescGZIP() []byte {
 }
 
 var file_domain_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_domain_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_domain_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_domain_proto_goTypes = []any{
 	(InstanceStatus)(0),           // 0: fleetgrpc.InstanceStatus
 	(BackendType)(0),              // 1: fleetgrpc.BackendType
 	(*Instance)(nil),              // 2: fleetgrpc.Instance
 	(*FleetSettings)(nil),         // 3: fleetgrpc.FleetSettings
 	(*LayoutPreset)(nil),          // 4: fleetgrpc.LayoutPreset
-	(*Fleet)(nil),                 // 5: fleetgrpc.Fleet
-	(*GroupLayout)(nil),           // 6: fleetgrpc.GroupLayout
-	(*State)(nil),                 // 7: fleetgrpc.State
-	nil,                           // 8: fleetgrpc.State.FleetsEntry
-	nil,                           // 9: fleetgrpc.State.GroupLayoutsEntry
-	(*timestamppb.Timestamp)(nil), // 10: google.protobuf.Timestamp
+	(*Agent)(nil),                 // 5: fleetgrpc.Agent
+	(*Trigger)(nil),               // 6: fleetgrpc.Trigger
+	(*Fleet)(nil),                 // 7: fleetgrpc.Fleet
+	(*GroupLayout)(nil),           // 8: fleetgrpc.GroupLayout
+	(*State)(nil),                 // 9: fleetgrpc.State
+	nil,                           // 10: fleetgrpc.State.FleetsEntry
+	nil,                           // 11: fleetgrpc.State.GroupLayoutsEntry
+	(*timestamppb.Timestamp)(nil), // 12: google.protobuf.Timestamp
 }
 var file_domain_proto_depIdxs = []int32{
-	10, // 0: fleetgrpc.Instance.created_at:type_name -> google.protobuf.Timestamp
+	12, // 0: fleetgrpc.Instance.created_at:type_name -> google.protobuf.Timestamp
 	0,  // 1: fleetgrpc.Instance.status:type_name -> fleetgrpc.InstanceStatus
 	1,  // 2: fleetgrpc.Instance.backend:type_name -> fleetgrpc.BackendType
 	4,  // 3: fleetgrpc.FleetSettings.layout_presets:type_name -> fleetgrpc.LayoutPreset
-	3,  // 4: fleetgrpc.Fleet.settings:type_name -> fleetgrpc.FleetSettings
-	2,  // 5: fleetgrpc.Fleet.instances:type_name -> fleetgrpc.Instance
-	8,  // 6: fleetgrpc.State.fleets:type_name -> fleetgrpc.State.FleetsEntry
-	9,  // 7: fleetgrpc.State.group_layouts:type_name -> fleetgrpc.State.GroupLayoutsEntry
-	5,  // 8: fleetgrpc.State.FleetsEntry.value:type_name -> fleetgrpc.Fleet
-	6,  // 9: fleetgrpc.State.GroupLayoutsEntry.value:type_name -> fleetgrpc.GroupLayout
-	10, // [10:10] is the sub-list for method output_type
-	10, // [10:10] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	5,  // 4: fleetgrpc.FleetSettings.agents:type_name -> fleetgrpc.Agent
+	6,  // 5: fleetgrpc.FleetSettings.triggers:type_name -> fleetgrpc.Trigger
+	1,  // 6: fleetgrpc.Agent.backend:type_name -> fleetgrpc.BackendType
+	3,  // 7: fleetgrpc.Fleet.settings:type_name -> fleetgrpc.FleetSettings
+	2,  // 8: fleetgrpc.Fleet.instances:type_name -> fleetgrpc.Instance
+	10, // 9: fleetgrpc.State.fleets:type_name -> fleetgrpc.State.FleetsEntry
+	11, // 10: fleetgrpc.State.group_layouts:type_name -> fleetgrpc.State.GroupLayoutsEntry
+	7,  // 11: fleetgrpc.State.FleetsEntry.value:type_name -> fleetgrpc.Fleet
+	8,  // 12: fleetgrpc.State.GroupLayoutsEntry.value:type_name -> fleetgrpc.GroupLayout
+	13, // [13:13] is the sub-list for method output_type
+	13, // [13:13] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_domain_proto_init() }
@@ -941,14 +1195,14 @@ func file_domain_proto_init() {
 	}
 	file_domain_proto_msgTypes[0].OneofWrappers = []any{}
 	file_domain_proto_msgTypes[1].OneofWrappers = []any{}
-	file_domain_proto_msgTypes[5].OneofWrappers = []any{}
+	file_domain_proto_msgTypes[7].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_domain_proto_rawDesc), len(file_domain_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   8,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/fleetgrpc/domain.proto
+++ b/fleetgrpc/domain.proto
@@ -184,6 +184,17 @@ message FleetSettings {
   // presets. Names are unique within the list (the server normalizes and
   // rejects duplicates, like custom_mounts).
   repeated LayoutPreset layout_presets = 11;
+
+  // agents is the fleet's list of automation agent definitions (issue #188).
+  // repeated message; names unique within the list (server normalizes). An
+  // empty list (the default) means no agents.
+  repeated Agent agents = 12;
+
+  // triggers is the fleet's list of automation trigger definitions (issue
+  // #188), each firing one or more agents (by name) on a schedule or webhook
+  // event. repeated message; names unique within the list (server normalizes
+  // against the agent set). An empty list (the default) means no triggers.
+  repeated Trigger triggers = 13;
 }
 
 // LayoutPreset mirrors internal/fleet.LayoutPreset — a saved pane-layout
@@ -200,6 +211,38 @@ message LayoutPreset {
   string name = 1;
   string layout = 2;
   repeated string pane_commands = 3;
+}
+
+// Agent mirrors internal/fleet.Agent — an automation worker definition (issue
+// #188). command may contain the ${PROMPT}/${SYS_PROMPT} placeholders. tmux_mode
+// is a plain bool whose user-facing default is ON (the new-agent dialog sets it
+// and it is always persisted explicitly). backend reuses Instance.backend's enum
+// (UNSPECIFIED -> devcontainer at normalization).
+message Agent {
+  string name = 1;
+  string command = 2;
+  bool tmux_mode = 3;
+  string system_prompt = 4;
+  BackendType backend = 5;
+}
+
+// Trigger mirrors internal/fleet.Trigger — an automation trigger (issue #188).
+// type is the string-valued TriggerType ("schedule" | "webhook"); filter_type is
+// the string-valued WebhookFilterType ("regex" | "jsonpath"). Schedule triggers
+// use cron; webhook triggers use webhook_name + filter_type + the matching
+// fields. agent_names references Agents by name. The string-valued enums match
+// the Go model's string types, so the wire mapping is a plain string copy.
+message Trigger {
+  string name = 1;
+  string type = 2;
+  repeated string agent_names = 3;
+  string prompt = 4;
+  string cron = 5;
+  string webhook_name = 6;
+  string filter_type = 7;
+  string regex = 8;
+  string json_path = 9;
+  string json_value = 10;
 }
 
 // Fleet mirrors internal/fleet.Fleet. Settings is a NESTED message (not inlined)

--- a/fleetgrpc/domain.proto
+++ b/fleetgrpc/domain.proto
@@ -221,9 +221,10 @@ message LayoutPreset {
 message Agent {
   string name = 1;
   string command = 2;
-  bool tmux_mode = 3;
   string system_prompt = 4;
   BackendType backend = 5;
+
+  reserved 3; // was tmux_mode (removed: agents always run in a tmux session)
 }
 
 // Trigger mirrors internal/fleet.Trigger — an automation trigger (issue #188).

--- a/integration/common.sh
+++ b/integration/common.sh
@@ -36,6 +36,13 @@ FIXTURE_AGENT_SRC="${INTEGRATION_DIR}/fixture-agent"
 # in-instance launcher has something to list / resolve.
 FIXTURE_LAUNCH_SRC="${INTEGRATION_DIR}/fixture-launch"
 
+# Alternate fixture whose postCreate installs a fake `claude` under
+# ~/.local/bin (on PATH only via .bashrc, mimicking the real install) that
+# records its args to /tmp/automation_agent_out. The automation scheduler test
+# opts into it via setup_automation_test to verify a fired trigger actually
+# launches the agent with the prompt.
+FIXTURE_AUTOMATION_SRC="${INTEGRATION_DIR}/fixture-automation"
+
 # Test scratch dir created fresh per test.
 TEST_SCRATCH_DIR="${TEST_SCRATCH_DIR:-/tmp/fleet-man-itest}"
 
@@ -210,6 +217,13 @@ setup_test() {
 # they need.
 setup_agent_test() {
   FIXTURE_SRC="${FIXTURE_AGENT_SRC}" setup_test
+}
+
+# setup_automation_test prepares a clean environment whose fixture installs a
+# fake `claude` (see FIXTURE_AUTOMATION_SRC) so the automation scheduler test can
+# verify an agent actually launches with its prompt.
+setup_automation_test() {
+  FIXTURE_SRC="${FIXTURE_AUTOMATION_SRC}" setup_test
 }
 
 # setup_launch_test prepares a clean environment whose fixture

--- a/integration/fixture-automation/.devcontainer/devcontainer.json
+++ b/integration/fixture-automation/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "fleet-man automation fixture",
+  "image": "mcr.microsoft.com/devcontainers/base:debian-12",
+  "postCreateCommand": "sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends tmux && mkdir -p $HOME/.local/bin && printf '#!/bin/sh\\necho AGENT_RAN $* > /tmp/automation_agent_out\\nexec sleep 600\\n' > $HOME/.local/bin/claude && chmod +x $HOME/.local/bin/claude && echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> $HOME/.bashrc"
+}

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -67,6 +67,29 @@ if [ "${#tests[@]}" -eq 0 ]; then
   exit 2
 fi
 
+# Optional sharding: FLEET_ITEST_RANGE="START-END" keeps only tests whose
+# numeric filename prefix N satisfies START <= N < END (END exclusive so
+# hundred-boundaries don't double-run). An empty END means no upper bound, so
+# the top shard ("600-") always catches new high-numbered tests instead of
+# silently dropping them. CI fans the suite across matrix machines by range so
+# the slowest shard — not the whole suite — sets the wall-clock. An empty result
+# is a legitimately empty shard (exits 0), distinct from the empty-glob fatal above.
+if [ -n "${FLEET_ITEST_RANGE:-}" ]; then
+  range_start="10#${FLEET_ITEST_RANGE%-*}"
+  range_end="${FLEET_ITEST_RANGE#*-}"
+  shard=()
+  for test_file in "${tests[@]}"; do
+    prefix=$(basename "${test_file}" | grep -oE '^[0-9]+' || true)
+    [ -n "${prefix}" ] || continue
+    n="$((10#${prefix}))"
+    [ "${n}" -ge "$((range_start))" ] || continue
+    [ -z "${range_end}" ] || [ "${n}" -lt "$((10#${range_end}))" ] || continue
+    shard+=("${test_file}")
+  done
+  tests=("${shard[@]}")
+  say "Shard ${FLEET_ITEST_RANGE}: running ${#tests[@]} test(s)"
+fi
+
 # Shared results file — tests append one row each via common.sh helpers.
 # run.sh does NOT judge results; it only aggregates this file at the end.
 FLEET_ITEST_RESULTS="$(mktemp)"

--- a/integration/tests/390_tui_automation_mode.sh
+++ b/integration/tests/390_tui_automation_mode.sh
@@ -49,8 +49,8 @@ tui_send_text "builder"
 sleep 0.2
 tui_send Enter         # commit the name
 sleep 0.2
-# Name -> Command -> Tmux -> Sys prompt -> Backend -> [ Save ]: five 'j'.
-for _ in 1 2 3 4 5; do tui_send j; sleep 0.15; done
+# Name -> Command -> Sys prompt -> Backend -> [ Save ]: four 'j'.
+for _ in 1 2 3 4; do tui_send j; sleep 0.15; done
 tui_send Enter         # save
 tui_wait_for "agents (1)" 10
 tui_assert_contains "builder" "saved agent row should be visible"

--- a/integration/tests/390_tui_automation_mode.sh
+++ b/integration/tests/390_tui_automation_mode.sh
@@ -40,7 +40,7 @@ info "opening the add-agent dialog"
 for _ in 1 2 3 4; do tui_send j; sleep 0.15; done
 tui_send Enter
 tui_wait_for "New agent" 5
-tui_assert_contains "Tmux:" "agent dialog should expose the tmux toggle"
+tui_assert_contains "Backend:" "agent dialog should expose the backend selector"
 
 info "typing an agent name and saving"
 tui_send Enter         # activate the Name field

--- a/integration/tests/390_tui_automation_mode.sh
+++ b/integration/tests/390_tui_automation_mode.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Description: TUI automation mode (issue #188) — 'm' toggles a fleet between its
+# instance view and its automation view (triggers + agents groups). Adding an
+# agent through the dialog persists it and shows it in the agents group, and 'm'
+# toggles back to the instance view.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+tui_spawn
+tui_wait_for "alpha" 15
+
+# ===========================================
+# Instance view shows the [automations] toggle button.
+# ===========================================
+tui_assert_contains "[automations]" "fleet header should offer the [automations] toggle"
+
+# ===========================================
+# 'm' switches the fleet to automation view: triggers + agents groups, the
+# "+ add" action rows, and the [instances] toggle.
+# ===========================================
+info "pressing 'm' to enter automation mode"
+tui_send m
+tui_wait_for "triggers" 5
+tui_assert_contains "agents" "agents group header should be visible"
+tui_assert_contains "+ add trigger" "add-trigger action row missing"
+tui_assert_contains "+ add agent" "add-agent action row missing"
+tui_assert_contains "[instances]" "automation view should offer the [instances] toggle"
+
+# ===========================================
+# Add an agent. From the fleet header the rows are: header, triggers,
+# + add trigger, agents, + add agent — four 'j' reach "+ add agent".
+# ===========================================
+info "opening the add-agent dialog"
+for _ in 1 2 3 4; do tui_send j; sleep 0.15; done
+tui_send Enter
+tui_wait_for "New agent" 5
+tui_assert_contains "Tmux:" "agent dialog should expose the tmux toggle"
+
+info "typing an agent name and saving"
+tui_send Enter         # activate the Name field
+sleep 0.2
+tui_send_text "builder"
+sleep 0.2
+tui_send Enter         # commit the name
+sleep 0.2
+# Name -> Command -> Tmux -> Sys prompt -> Backend -> [ Save ]: five 'j'.
+for _ in 1 2 3 4 5; do tui_send j; sleep 0.15; done
+tui_send Enter         # save
+tui_wait_for "agents (1)" 10
+tui_assert_contains "builder" "saved agent row should be visible"
+
+# ===========================================
+# 'm' toggles back to the instance view.
+# ===========================================
+info "pressing 'm' to return to the instance view"
+tui_send m
+tui_wait_for "[automations]" 5
+tui_assert_contains "alpha" "instance view should show the instance again"
+
+pass "TUI automation mode: toggle, add agent, toggle back"

--- a/integration/tests/391_automation_agent_runs.sh
+++ b/integration/tests/391_automation_agent_runs.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Description: end-to-end automation (issue #188) — a fired Schedule trigger
+# spawns an instance, launches the agent, and the agent actually RUNS with the
+# trigger's prompt. The fixture installs a fake `claude` under ~/.local/bin (on
+# PATH only via .bashrc, like the real install) that records its args to
+# /tmp/automation_agent_out; we assert the prompt reaches it. This is the real
+# proof the scheduler -> spawn -> launch chain works.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_automation_test
+
+MARKER="AUTOMATIONPROMPTMARKER42"
+
+# A cron matching the CURRENT minute fires once (next match is tomorrow), so the
+# daemon's immediate startup tick fires it without spamming a new instance every
+# minute. Guard the minute-rollover race: if we're near the end of a minute, wait
+# for the next one so the cron stays valid for ~a full minute.
+if [ "$(date +%S)" -gt 45 ]; then sleep 16; fi
+CRON="$(date +'%-M %-H') * * *"
+info "seeding automation: agent 'writer' + schedule trigger ('${CRON}') prompt='${MARKER}'"
+
+cat > "${HOME}/.fleet/state.json" <<EOF
+{
+  "fleets": {
+    "${FIXTURE_REPO_NAME}": {
+      "name": "${FIXTURE_REPO_NAME}",
+      "remote": "${FIXTURE_REPO_URL}",
+      "settings": {
+        "agents": [
+          {
+            "name": "writer",
+            "command": "claude --system-prompt '\${SYS_PROMPT}' '\${PROMPT}'",
+            "systemPrompt": "be-terse",
+            "backend": "devcontainer"
+          }
+        ],
+        "triggers": [
+          {
+            "name": "fire",
+            "type": "schedule",
+            "agentNames": ["writer"],
+            "cron": "${CRON}",
+            "prompt": "${MARKER}"
+          }
+        ]
+      },
+      "instances": []
+    }
+  }
+}
+EOF
+
+# Start the daemon (and its scheduler). The immediate startup tick fires the
+# due trigger, which creates the instance.
+info "starting the daemon + scheduler ('fleet ls')"
+"${FLEET_BIN}" ls "${FIXTURE_REPO_NAME}" >/dev/null 2>&1 || true
+
+# Wait for the scheduler to spawn the automation instance (name: writer-<HHMMSS>-<n>).
+info "waiting for the scheduler to spawn an instance"
+inst=""
+for _ in $(seq 1 40); do
+  inst=$(grep -oE 'writer-[0-9]+-[0-9]+' "${HOME}/.fleet/state.json" 2>/dev/null | head -1 || true)
+  [ -n "${inst}" ] && break
+  sleep 3
+done
+[ -n "${inst}" ] || fail "scheduler never spawned an automation instance"
+info "spawned instance: ${inst}"
+
+# Wait for the instance to provision + the agent to launch + write the marker.
+# This implicitly waits for the instance to reach 'running' ('fleet exec' fails
+# until then) and for launchAutomationCommand to have run the agent.
+info "waiting for the agent to launch and receive the prompt"
+out=""
+for _ in $(seq 1 80); do
+  out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/${inst}" -- cat /tmp/automation_agent_out 2>/dev/null || true)
+  [ -n "${out}" ] && break
+  sleep 3
+done
+
+printf 'agent output: %s\n' "${out}"
+assert_contains "${out}" "AGENT_RAN"  "fake claude was never executed (agent did not launch)"
+assert_contains "${out}" "${MARKER}"  "agent did not receive the trigger prompt"
+assert_contains "${out}" "be-terse"   "agent did not receive the system prompt"
+
+pass "automation: fired trigger spawned an instance and launched the agent with the prompt"

--- a/integration/tests/391_automation_agent_runs.sh
+++ b/integration/tests/391_automation_agent_runs.sh
@@ -1,24 +1,59 @@
 #!/usr/bin/env bash
 # Description: end-to-end automation (issue #188) — a fired Schedule trigger
-# spawns an instance, launches the agent, and the agent actually RUNS with the
-# trigger's prompt. The fixture installs a fake `claude` under ~/.local/bin (on
-# PATH only via .bashrc, like the real install) that records its args to
-# /tmp/automation_agent_out; we assert the prompt reaches it. This is the real
-# proof the scheduler -> spawn -> launch chain works.
+# spawns an instance, launches the agent (which RUNS with the trigger's prompt),
+# and then the idle instance is reaped. The fixture installs a fake `claude`
+# under ~/.local/bin (on PATH only via .bashrc, like the real install) that
+# records its args to /tmp/automation_agent_out then sleeps; we assert the prompt
+# reaches it AND that the idle agent's instance is torn down. This is the real
+# proof of the whole scheduler -> spawn -> launch -> reap lifecycle.
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
+# Kill our daemon on exit so its short idle-timeout env (set below) can't bleed
+# into a later test's scheduler. Mirrors 601/611.
+itest_cleanup() { pkill -f "${FLEET_BIN} server" >/dev/null 2>&1 || true; }
 itest_begin
+
+server_count() { pgrep -fc "${FLEET_BIN} server" 2>/dev/null || true; }
+
+# Shorten the scheduler's idle timeout + tick so the reap half of the lifecycle
+# verifies in ~a minute instead of the production 2m/30s. The daemon inherits
+# this env (spawn.go: cmd.Env = os.Environ()), so it must be exported BEFORE the
+# `fleet ls` below starts the daemon + scheduler. The idle clock only starts once
+# the agent launches (post-provision), so 60s leaves a wide margin to read the
+# agent's output before the instance is reaped, even on a slow runner.
+export FLEET_AUTOMATION_IDLE_TIMEOUT="60s"
+export FLEET_AUTOMATION_TICK_INTERVAL="5s"
 
 setup_automation_test
 
+# A daemon lingers across tests (teardown wipes ~/.fleet but never kills the
+# Setsid daemon). A prior test's daemon still has the PRODUCTION 2m idle timeout
+# and its own scheduler — left alive it would race ours (firing the trigger,
+# reaping on the wrong clock). Kill it so the `fleet ls` below cold-spawns
+# exactly one fresh daemon that inherits our short-timeout env.
+info "killing any lingering daemon so we cold-spawn one with our env"
+pkill -f "${FLEET_BIN} server" >/dev/null 2>&1 || true
+deadline=$(( $(date +%s) + $(_scale_timeout 5) ))
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  [ "$(server_count)" = "0" ] && break
+  sleep 0.2
+done
+
 MARKER="AUTOMATIONPROMPTMARKER42"
 
-# A cron matching the CURRENT minute fires once (next match is tomorrow), so the
-# daemon's immediate startup tick fires it without spamming a new instance every
-# minute. Guard the minute-rollover race: if we're near the end of a minute, wait
-# for the next one so the cron stays valid for ~a full minute.
-if [ "$(date +%S)" -gt 45 ]; then sleep 16; fi
+# A cron matching the CURRENT minute fires exactly once (its only match is this
+# minute of this hour; next is tomorrow), so the daemon's immediate startup tick
+# fires it without spawning a new instance every minute. The ONLY thing that fires
+# it is that startup tick evaluating the cron against the wall clock, so the daemon
+# must boot while we're still inside the seeded minute. Align to the top of a fresh
+# minute first (unless we're already near it) so there's ~a full minute of margin —
+# far more than the sub-second seed + daemon cold-spawn + first tick consumes, even
+# on a loaded runner. (Plain wall-clock alignment, not a scaled timeout budget.)
+# 10# forces base-10: date +%S is zero-padded ("08"/"09"), which arithmetic
+# context would otherwise read as invalid octal and abort under `set -e`.
+sec="10#$(date +%S)"
+if [ "$((sec))" -gt 5 ]; then sleep "$((60 - sec))"; fi
 CRON="$(date +'%-M %-H') * * *"
 info "seeding automation: agent 'writer' + schedule trigger ('${CRON}') prompt='${MARKER}'"
 
@@ -84,5 +119,24 @@ printf 'agent output: %s\n' "${out}"
 assert_contains "${out}" "AGENT_RAN"  "fake claude was never executed (agent did not launch)"
 assert_contains "${out}" "${MARKER}"  "agent did not receive the trigger prompt"
 assert_contains "${out}" "be-terse"   "agent did not receive the system prompt"
+info "agent ran with the prompt; now waiting for the idle reaper to tear it down"
 
-pass "automation: fired trigger spawned an instance and launched the agent with the prompt"
+# The fake claude `exec sleep 600`s, so the agent stays alive but produces no
+# screen output → the activity detector reports it idle (the Claude hook detector
+# sees no state file → StateWaiting; the screen-diff fallback sees a static pane →
+# StateWaiting), so after FLEET_AUTOMATION_IDLE_TIMEOUT the scheduler reaps it.
+# Poll state.json until the instance record disappears (the destroy job removed
+# the container + record). Budget = idle timeout + destroy time, generously. Match
+# the JSON-quoted name ("writer-...") so we key off the instance's `name` field
+# exactly, not a workspace-path substring that may linger.
+reaped=""
+for _ in $(seq 1 60); do
+  if ! grep -qF -- "\"${inst}\"" "${HOME}/.fleet/state.json" 2>/dev/null; then
+    reaped=1
+    break
+  fi
+  sleep 3
+done
+[ -n "${reaped}" ] || fail "idle automation instance was never reaped (still present after the idle timeout)"
+
+pass "automation: fired trigger ran the agent with the prompt, then reaped the idle instance"

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -121,6 +121,16 @@ type Backend interface {
 	// ("", false) on probe failure.
 	AgentToolProbe(containerID string) (string, bool)
 
+	// RunScript runs an arbitrary shell script directly inside the container as
+	// the session user, returning its combined output. Like
+	// ListSessions/CaptureAllSessions it execs straight against the container ID
+	// — no devcontainer Node CLI cold start and no workspace-folder resolution —
+	// which makes it the reliable path for non-interactive daemon-side container
+	// work (e.g. launching an automation agent's tmux session: a session created
+	// here lands under the same session user the poller reads, so it shows in the
+	// TUI). The error is non-nil when the exec itself fails.
+	RunScript(containerID, script string) (string, error)
+
 	// EditorURI returns a URI string that an editor (e.g. VS Code)
 	// can use to connect to this workspace. Returns ("", false) if
 	// editor integration is not supported by this backend.

--- a/internal/backend/coder/coder_backend.go
+++ b/internal/backend/coder/coder_backend.go
@@ -244,6 +244,16 @@ func (coderBackend *CoderBackend) ListSessions(containerID string) string {
 	return string(out)
 }
 
+// RunScript runs an arbitrary script directly inside the Coder workspace over a
+// single SSH round trip (coder ssh wraps everything after -- in a shell, so the
+// script is passed directly, as CaptureAllSessions does). Returns the combined
+// output and a non-nil error when the exec itself fails.
+func (coderBackend *CoderBackend) RunScript(containerID, script string) (string, error) {
+	target := coderBackend.resolveSSHTarget(containerID)
+	out, err := exec.Command("coder", sshArgs(target, []string{script})...).CombinedOutput()
+	return string(out), err
+}
+
 // AgentToolProbe detects which agent tool is running inside a Coder workspace.
 func (coderBackend *CoderBackend) AgentToolProbe(containerID string) (string, bool) {
 	// coder ssh wraps everything after -- in a shell invocation, so we

--- a/internal/backend/codespaces/codespaces_backend.go
+++ b/internal/backend/codespaces/codespaces_backend.go
@@ -269,6 +269,14 @@ func (codespacesBackend *CodespacesBackend) ListSessions(containerID string) str
 	return string(out)
 }
 
+// RunScript runs an arbitrary script directly inside the codespace over a single
+// SSH round trip (same path as CaptureAllSessions). Returns the combined output
+// and a non-nil error when the exec itself fails.
+func (codespacesBackend *CodespacesBackend) RunScript(containerID, script string) (string, error) {
+	out, err := codespacesBackend.sshCommand(containerID, []string{script}, false).CombinedOutput()
+	return string(out), err
+}
+
 // AgentToolProbe detects which agent tool is running inside a codespace.
 func (codespacesBackend *CodespacesBackend) AgentToolProbe(containerID string) (string, bool) {
 	cmd := codespacesBackend.sshCommand(containerID, []string{backend.ToolProbeScript}, false)

--- a/internal/backend/devcontainer/devcontainer_backend.go
+++ b/internal/backend/devcontainer/devcontainer_backend.go
@@ -534,6 +534,21 @@ func (devcontainerBackend *DevcontainerBackend) ListSessions(containerID string)
 	return string(out)
 }
 
+// RunScript runs an arbitrary script directly inside the container as the
+// container's non-root session user via `docker exec` — the same direct path
+// CaptureAllSessions/ListSessions use, bypassing the devcontainer Node CLI. A
+// tmux session created here lands under that user's socket, exactly where the
+// session poller (also -u that user) reads, so it surfaces in the TUI.
+func (devcontainerBackend *DevcontainerBackend) RunScript(containerID, script string) (string, error) {
+	args := []string{"exec"}
+	if user := devcontainerBackend.containerUser(containerID); user != "" {
+		args = append(args, "-u", user)
+	}
+	args = append(args, containerID, "sh", "-c", script)
+	out, err := exec.Command("docker", args...).CombinedOutput()
+	return string(out), err
+}
+
 // AgentToolProbe detects which agent tool is running inside a container.
 func (devcontainerBackend *DevcontainerBackend) AgentToolProbe(containerID string) (string, bool) {
 	args := []string{"exec"}

--- a/internal/fleet/automation.go
+++ b/internal/fleet/automation.go
@@ -15,11 +15,13 @@ import (
 // them.
 
 // DefaultAgentCommand is the initial command offered for a new automation
-// agent. ${SYS_PROMPT} and ${PROMPT} are substituted at trigger time; the user
-// need not use either placeholder. The trailing spaces leave the cursor past
-// the system-prompt flag so a user who prefers to append the prompt inline can
-// just keep typing.
-const DefaultAgentCommand = "claude --system-prompt '${SYS_PROMPT}'  "
+// agent. ${SYS_PROMPT} and ${PROMPT} are substituted at trigger time with a
+// fully shell-quoted value (see SubstituteAgentCommand), so the placeholders are
+// deliberately NOT wrapped in quotes here — adding your own quotes would
+// double-quote the value. The user need not use either placeholder. The trailing
+// spaces leave the cursor past the system-prompt flag so a user who prefers to
+// append the prompt inline can just keep typing.
+const DefaultAgentCommand = "claude --system-prompt ${SYS_PROMPT}  "
 
 // maxAutomationListLen bounds a fleet's trigger / agent lists so a corrupt or
 // hostile settings write cannot mint an absurd number of entries (mirrors the
@@ -281,28 +283,28 @@ func NormalizeTriggers(in []Trigger, agents []Agent) ([]Trigger, error) {
 }
 
 // SubstituteAgentCommand expands the ${PROMPT} and ${SYS_PROMPT} placeholders in
-// an agent command, replacing each with a SINGLE-QUOTE-ESCAPED value so the
-// substitution cannot break out of the surrounding quotes. The placeholders are
-// expected to be wrapped in single quotes, as the default command is:
+// an agent command, replacing each with a FULLY SHELL-QUOTED value: the
+// substituted text is wrapped in single quotes (with any embedded ' escaped), so
+// it becomes a single literal argument no matter how the placeholder was used in
+// the command. That makes it safe in every context — bare (the default uses a
+// bare ${SYS_PROMPT}) or already inside other syntax (e.g. `echo ${PROMPT}`) —
+// so a prompt containing shell metacharacters (or, once webhook delivery lands,
+// arbitrary external event text) cannot inject shell syntax. Because the value
+// is self-quoting, callers must NOT wrap the placeholder in their own quotes.
 //
-//	claude --system-prompt '${SYS_PROMPT}'
-//
-// Any single quote in a value is rewritten to '\” so a prompt containing a quote
-// (or, once webhook delivery lands, arbitrary external event text) stays a
-// literal argument instead of injecting shell syntax. Both placeholders expand
-// in a single pass, so a ${PROMPT} appearing inside the system-prompt text is not
-// re-expanded.
+// Both placeholders expand in a single pass, so a ${PROMPT} appearing inside the
+// substituted system-prompt text is not re-expanded.
 func SubstituteAgentCommand(command, prompt, systemPrompt string) string {
 	r := strings.NewReplacer(
-		"${SYS_PROMPT}", shellSingleQuoteEscape(systemPrompt),
-		"${PROMPT}", shellSingleQuoteEscape(prompt),
+		"${SYS_PROMPT}", shellQuote(systemPrompt),
+		"${PROMPT}", shellQuote(prompt),
 	)
 	return r.Replace(command)
 }
 
-// shellSingleQuoteEscape rewrites single quotes so a value is safe to embed
-// inside a single-quoted shell string: each ' becomes '\” (close the quote,
-// emit an escaped quote, reopen the quote).
-func shellSingleQuoteEscape(s string) string {
-	return strings.ReplaceAll(s, "'", `'\''`)
+// shellQuote wraps a value in single quotes so it is a single literal shell
+// argument, escaping any embedded single quote as the standard close-escape-reopen
+// sequence.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/internal/fleet/automation.go
+++ b/internal/fleet/automation.go
@@ -281,15 +281,28 @@ func NormalizeTriggers(in []Trigger, agents []Agent) ([]Trigger, error) {
 }
 
 // SubstituteAgentCommand expands the ${PROMPT} and ${SYS_PROMPT} placeholders in
-// an agent command. ${SYS_PROMPT} is expanded first and ${PROMPT} second; a
-// ${PROMPT} appearing inside the system prompt text is therefore NOT re-expanded
-// (the system prompt is substituted before the prompt pass runs, but the prompt
-// pass only scans the original command's ${PROMPT} occurrences... ) — to keep
-// that guarantee we expand in a single pass via a replacer.
+// an agent command, replacing each with a SINGLE-QUOTE-ESCAPED value so the
+// substitution cannot break out of the surrounding quotes. The placeholders are
+// expected to be wrapped in single quotes, as the default command is:
+//
+//	claude --system-prompt '${SYS_PROMPT}'
+//
+// Any single quote in a value is rewritten to '\” so a prompt containing a quote
+// (or, once webhook delivery lands, arbitrary external event text) stays a
+// literal argument instead of injecting shell syntax. Both placeholders expand
+// in a single pass, so a ${PROMPT} appearing inside the system-prompt text is not
+// re-expanded.
 func SubstituteAgentCommand(command, prompt, systemPrompt string) string {
 	r := strings.NewReplacer(
-		"${SYS_PROMPT}", systemPrompt,
-		"${PROMPT}", prompt,
+		"${SYS_PROMPT}", shellSingleQuoteEscape(systemPrompt),
+		"${PROMPT}", shellSingleQuoteEscape(prompt),
 	)
 	return r.Replace(command)
+}
+
+// shellSingleQuoteEscape rewrites single quotes so a value is safe to embed
+// inside a single-quoted shell string: each ' becomes '\” (close the quote,
+// emit an escaped quote, reopen the quote).
+func shellSingleQuoteEscape(s string) string {
+	return strings.ReplaceAll(s, "'", `'\''`)
 }

--- a/internal/fleet/automation.go
+++ b/internal/fleet/automation.go
@@ -1,0 +1,295 @@
+package fleet
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Automation (issue #188) lets a fleet define Triggers that spin up Agents.
+// Both lists are per-fleet config persisted inline on FleetSettings, validated
+// here (TUI validates for immediate UX feedback; the server validates
+// authoritatively in SetFleetSettings) and surfaced in the TUI's automation
+// view. An Agent describes HOW a worker is launched (command + env); a Trigger
+// describes WHEN, and names the Agent(s) it activates with the prompt to feed
+// them.
+
+// DefaultAgentCommand is the initial command offered for a new automation
+// agent. ${SYS_PROMPT} and ${PROMPT} are substituted at trigger time; the user
+// need not use either placeholder. The trailing spaces leave the cursor past
+// the system-prompt flag so a user who prefers to append the prompt inline can
+// just keep typing.
+const DefaultAgentCommand = "claude --system-prompt '${SYS_PROMPT}'  "
+
+// maxAutomationListLen bounds a fleet's trigger / agent lists so a corrupt or
+// hostile settings write cannot mint an absurd number of entries (mirrors the
+// bound on layout presets).
+const maxAutomationListLen = 128
+
+// TriggerType is the broad category of an automation trigger.
+type TriggerType string
+
+const (
+	// TriggerSchedule fires its agents on a cron schedule.
+	TriggerSchedule TriggerType = "schedule"
+	// TriggerWebhook fires its agents when a matching event arrives on the
+	// fleet gateway's webhook endpoint. (Delivering those events is out of
+	// scope for issue #188 — only the definition is modeled here.)
+	TriggerWebhook TriggerType = "webhook"
+)
+
+// WebhookFilterType selects how a webhook trigger decides whether an incoming
+// event should fire its agents.
+type WebhookFilterType string
+
+const (
+	// WebhookFilterRegex matches the raw event body against a regular
+	// expression.
+	WebhookFilterRegex WebhookFilterType = "regex"
+	// WebhookFilterJSONPath compares the value at a JSON path against an
+	// expected value.
+	WebhookFilterJSONPath WebhookFilterType = "jsonpath"
+)
+
+// Agent is an automation worker definition: the command to launch and the
+// environment to launch it in. Agents are spun up as ordinary fleet instances
+// (they appear in the fleet view like any other instance) — they are just
+// instances that a trigger created.
+type Agent struct {
+	// Name is the user-chosen label, unique within a fleet's agent list and
+	// referenced by triggers.
+	Name string `json:"name"`
+
+	// Command is the shell command that starts the agent. It may contain the
+	// ${PROMPT} and ${SYS_PROMPT} placeholders, substituted at trigger time
+	// with the trigger's prompt and this agent's SystemPrompt respectively.
+	// Empty falls back to DefaultAgentCommand at normalization time.
+	Command string `json:"command,omitempty"`
+
+	// TmuxMode runs Command in a fresh tmux session and sends the prompt via
+	// send-keys, so the user can open the session in the TUI and watch the
+	// agent work. Default ON (the new-agent dialog sets it). With TmuxMode on,
+	// the agent's instance is torn down after the agent goes inactive for
+	// longer than the automation idle timeout.
+	TmuxMode bool `json:"tmuxMode"`
+
+	// SystemPrompt steers the agent; it is injected into the ${SYS_PROMPT}
+	// placeholder of Command.
+	SystemPrompt string `json:"systemPrompt,omitempty"`
+
+	// Backend is the env backend the agent's instance is provisioned on, the
+	// same set offered when creating an instance. Empty falls back to
+	// BackendDevcontainer.
+	Backend BackendType `json:"backend,omitempty"`
+}
+
+// Trigger is an automation trigger: it activates one or more Agents with a
+// prompt when its condition (a schedule or a webhook event) is met.
+type Trigger struct {
+	// Name is the user-chosen label, unique within a fleet's trigger list.
+	Name string `json:"name"`
+
+	// Type is the trigger category (schedule or webhook). Fields below are
+	// interpreted per type (struct composition via a flat record).
+	Type TriggerType `json:"type"`
+
+	// AgentNames are the agents this trigger activates (each must name an Agent
+	// in the same fleet). At least one is required.
+	AgentNames []string `json:"agentNames,omitempty"`
+
+	// Prompt is fed to the activated agents (into ${PROMPT}).
+	Prompt string `json:"prompt,omitempty"`
+
+	// Cron is the schedule expression (TriggerSchedule only): a standard 5-field
+	// cron pattern.
+	Cron string `json:"cron,omitempty"`
+
+	// WebhookName is appended to the fleet gateway's webhook URL for this
+	// trigger (TriggerWebhook only).
+	WebhookName string `json:"webhookName,omitempty"`
+
+	// FilterType selects regex vs json-path filtering (TriggerWebhook only).
+	FilterType WebhookFilterType `json:"filterType,omitempty"`
+
+	// Regex filters incoming events when FilterType is regex: the event fires
+	// the agents when the expression matches.
+	Regex string `json:"regex,omitempty"`
+
+	// JSONPath selects the value compared against JSONValue when FilterType is
+	// json-path.
+	JSONPath string `json:"jsonPath,omitempty"`
+
+	// JSONValue is the value the JSONPath selection must equal to fire.
+	JSONValue string `json:"jsonValue,omitempty"`
+}
+
+// TmuxEnabled reports whether the agent runs in a tmux session. (Plain accessor
+// kept for symmetry with the rest of the model and to centralize the default.)
+func (a Agent) TmuxEnabled() bool { return a.TmuxMode }
+
+// NormalizeAgent validates a single agent and returns its canonical form: the
+// name is trimmed and must be non-empty, an empty command falls back to the
+// default, and the backend defaults to devcontainer and must be valid.
+func NormalizeAgent(a Agent) (Agent, error) {
+	a.Name = strings.TrimSpace(a.Name)
+	if a.Name == "" {
+		return Agent{}, fmt.Errorf("agent name is empty")
+	}
+	a.Command = strings.TrimSpace(a.Command)
+	if a.Command == "" {
+		a.Command = strings.TrimSpace(DefaultAgentCommand)
+	}
+	if a.Backend == "" {
+		a.Backend = BackendDevcontainer
+	}
+	if err := ValidateBackendType(a.Backend); err != nil {
+		return Agent{}, fmt.Errorf("agent %q: %w", a.Name, err)
+	}
+	return a, nil
+}
+
+// NormalizeAgents validates every agent and returns the normalized list (input
+// order preserved). A duplicate name (after trimming) is rejected — like layout
+// presets, two agents sharing a name are ambiguous, not redundant no-ops.
+func NormalizeAgents(in []Agent) ([]Agent, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	if len(in) > maxAutomationListLen {
+		return nil, fmt.Errorf("too many agents (%d, max %d)", len(in), maxAutomationListLen)
+	}
+	out := make([]Agent, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, raw := range in {
+		norm, err := NormalizeAgent(raw)
+		if err != nil {
+			return nil, err
+		}
+		if _, dup := seen[norm.Name]; dup {
+			return nil, fmt.Errorf("duplicate agent name %q", norm.Name)
+		}
+		seen[norm.Name] = struct{}{}
+		out = append(out, norm)
+	}
+	return out, nil
+}
+
+// NormalizeTrigger validates a single trigger against the set of known agent
+// names and returns its canonical form. Fields not relevant to the trigger's
+// type are cleared so the persisted record stays clean (e.g. a schedule trigger
+// never carries stale webhook fields).
+func NormalizeTrigger(t Trigger, agentNames map[string]struct{}) (Trigger, error) {
+	t.Name = strings.TrimSpace(t.Name)
+	if t.Name == "" {
+		return Trigger{}, fmt.Errorf("trigger name is empty")
+	}
+
+	// Validate + dedup the agent references.
+	if len(t.AgentNames) == 0 {
+		return Trigger{}, fmt.Errorf("trigger %q activates no agents", t.Name)
+	}
+	seenAgent := make(map[string]struct{}, len(t.AgentNames))
+	agents := make([]string, 0, len(t.AgentNames))
+	for _, name := range t.AgentNames {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, dup := seenAgent[name]; dup {
+			continue
+		}
+		if _, ok := agentNames[name]; !ok {
+			return Trigger{}, fmt.Errorf("trigger %q references unknown agent %q", t.Name, name)
+		}
+		seenAgent[name] = struct{}{}
+		agents = append(agents, name)
+	}
+	if len(agents) == 0 {
+		return Trigger{}, fmt.Errorf("trigger %q activates no agents", t.Name)
+	}
+	t.AgentNames = agents
+
+	switch t.Type {
+	case TriggerSchedule:
+		t.Cron = strings.TrimSpace(t.Cron)
+		if err := ValidateCron(t.Cron); err != nil {
+			return Trigger{}, fmt.Errorf("trigger %q: %w", t.Name, err)
+		}
+		// Clear webhook-only fields.
+		t.WebhookName, t.FilterType, t.Regex, t.JSONPath, t.JSONValue = "", "", "", "", ""
+	case TriggerWebhook:
+		t.WebhookName = strings.TrimSpace(t.WebhookName)
+		if t.WebhookName == "" {
+			return Trigger{}, fmt.Errorf("trigger %q: webhook name is empty", t.Name)
+		}
+		switch t.FilterType {
+		case WebhookFilterRegex:
+			t.Regex = strings.TrimSpace(t.Regex)
+			if t.Regex == "" {
+				return Trigger{}, fmt.Errorf("trigger %q: webhook regex is empty", t.Name)
+			}
+			if _, err := regexp.Compile(t.Regex); err != nil {
+				return Trigger{}, fmt.Errorf("trigger %q: invalid webhook regex: %w", t.Name, err)
+			}
+			t.JSONPath, t.JSONValue = "", ""
+		case WebhookFilterJSONPath:
+			t.JSONPath = strings.TrimSpace(t.JSONPath)
+			if t.JSONPath == "" {
+				return Trigger{}, fmt.Errorf("trigger %q: webhook json path is empty", t.Name)
+			}
+			t.JSONValue = strings.TrimSpace(t.JSONValue)
+			t.Regex = ""
+		default:
+			return Trigger{}, fmt.Errorf("trigger %q: invalid webhook filter type %q", t.Name, t.FilterType)
+		}
+		// Clear schedule-only fields.
+		t.Cron = ""
+	default:
+		return Trigger{}, fmt.Errorf("trigger %q: invalid type %q", t.Name, t.Type)
+	}
+	return t, nil
+}
+
+// NormalizeTriggers validates every trigger against the agents it may reference
+// and returns the normalized list (input order preserved). Duplicate trigger
+// names are rejected. agents is the fleet's (already-normalized) agent list.
+func NormalizeTriggers(in []Trigger, agents []Agent) ([]Trigger, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	if len(in) > maxAutomationListLen {
+		return nil, fmt.Errorf("too many triggers (%d, max %d)", len(in), maxAutomationListLen)
+	}
+	agentNames := make(map[string]struct{}, len(agents))
+	for _, a := range agents {
+		agentNames[a.Name] = struct{}{}
+	}
+	out := make([]Trigger, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, raw := range in {
+		norm, err := NormalizeTrigger(raw, agentNames)
+		if err != nil {
+			return nil, err
+		}
+		if _, dup := seen[norm.Name]; dup {
+			return nil, fmt.Errorf("duplicate trigger name %q", norm.Name)
+		}
+		seen[norm.Name] = struct{}{}
+		out = append(out, norm)
+	}
+	return out, nil
+}
+
+// SubstituteAgentCommand expands the ${PROMPT} and ${SYS_PROMPT} placeholders in
+// an agent command. ${SYS_PROMPT} is expanded first and ${PROMPT} second; a
+// ${PROMPT} appearing inside the system prompt text is therefore NOT re-expanded
+// (the system prompt is substituted before the prompt pass runs, but the prompt
+// pass only scans the original command's ${PROMPT} occurrences... ) — to keep
+// that guarantee we expand in a single pass via a replacer.
+func SubstituteAgentCommand(command, prompt, systemPrompt string) string {
+	r := strings.NewReplacer(
+		"${SYS_PROMPT}", systemPrompt,
+		"${PROMPT}", prompt,
+	)
+	return r.Replace(command)
+}

--- a/internal/fleet/automation.go
+++ b/internal/fleet/automation.go
@@ -15,13 +15,12 @@ import (
 // them.
 
 // DefaultAgentCommand is the initial command offered for a new automation
-// agent. ${SYS_PROMPT} and ${PROMPT} are substituted at trigger time with a
-// fully shell-quoted value (see SubstituteAgentCommand), so the placeholders are
-// deliberately NOT wrapped in quotes here — adding your own quotes would
-// double-quote the value. The user need not use either placeholder. The trailing
-// spaces leave the cursor past the system-prompt flag so a user who prefers to
-// append the prompt inline can just keep typing.
-const DefaultAgentCommand = "claude --system-prompt ${SYS_PROMPT}  "
+// agent. Passing the prompt as Claude's positional argument starts a live,
+// watchable Claude session that immediately works on the prompt — no separate
+// keystroke injection needed. ${SYS_PROMPT}/${PROMPT} are substituted at trigger
+// time (single-quote-escaped, see SubstituteAgentCommand), so the placeholders
+// are wrapped in single quotes here.
+const DefaultAgentCommand = "claude --system-prompt '${SYS_PROMPT}' '${PROMPT}'"
 
 // maxAutomationListLen bounds a fleet's trigger / agent lists so a corrupt or
 // hostile settings write cannot mint an absurd number of entries (mirrors the
@@ -62,18 +61,15 @@ type Agent struct {
 	// referenced by triggers.
 	Name string `json:"name"`
 
-	// Command is the shell command that starts the agent. It may contain the
-	// ${PROMPT} and ${SYS_PROMPT} placeholders, substituted at trigger time
-	// with the trigger's prompt and this agent's SystemPrompt respectively.
-	// Empty falls back to DefaultAgentCommand at normalization time.
+	// Command is the shell command that starts the agent, run in a fresh tmux
+	// session (so the user can open it in the TUI and watch the agent work). It
+	// may contain the ${PROMPT} and ${SYS_PROMPT} placeholders, substituted at
+	// trigger time with the trigger's prompt and this agent's SystemPrompt
+	// respectively — wrap them in single quotes (the default does). Empty falls
+	// back to DefaultAgentCommand at normalization time. The agent's instance is
+	// torn down after the agent goes inactive for longer than the automation idle
+	// timeout.
 	Command string `json:"command,omitempty"`
-
-	// TmuxMode runs Command in a fresh tmux session and sends the prompt via
-	// send-keys, so the user can open the session in the TUI and watch the
-	// agent work. Default ON (the new-agent dialog sets it). With TmuxMode on,
-	// the agent's instance is torn down after the agent goes inactive for
-	// longer than the automation idle timeout.
-	TmuxMode bool `json:"tmuxMode"`
 
 	// SystemPrompt steers the agent; it is injected into the ${SYS_PROMPT}
 	// placeholder of Command.
@@ -124,10 +120,6 @@ type Trigger struct {
 	// JSONValue is the value the JSONPath selection must equal to fire.
 	JSONValue string `json:"jsonValue,omitempty"`
 }
-
-// TmuxEnabled reports whether the agent runs in a tmux session. (Plain accessor
-// kept for symmetry with the rest of the model and to centralize the default.)
-func (a Agent) TmuxEnabled() bool { return a.TmuxMode }
 
 // NormalizeAgent validates a single agent and returns its canonical form: the
 // name is trimmed and must be non-empty, an empty command falls back to the
@@ -283,28 +275,27 @@ func NormalizeTriggers(in []Trigger, agents []Agent) ([]Trigger, error) {
 }
 
 // SubstituteAgentCommand expands the ${PROMPT} and ${SYS_PROMPT} placeholders in
-// an agent command, replacing each with a FULLY SHELL-QUOTED value: the
-// substituted text is wrapped in single quotes (with any embedded ' escaped), so
-// it becomes a single literal argument no matter how the placeholder was used in
-// the command. That makes it safe in every context — bare (the default uses a
-// bare ${SYS_PROMPT}) or already inside other syntax (e.g. `echo ${PROMPT}`) —
-// so a prompt containing shell metacharacters (or, once webhook delivery lands,
-// arbitrary external event text) cannot inject shell syntax. Because the value
-// is self-quoting, callers must NOT wrap the placeholder in their own quotes.
+// an agent command, replacing each with a SINGLE-QUOTE-ESCAPED value (any
+// embedded ' becomes the close-escape-reopen sequence) so it is safe inside the
+// single quotes the placeholders are expected to be wrapped in — as the default
+// command (`... '${SYS_PROMPT}' '${PROMPT}'`) is. A prompt containing a quote or
+// shell metacharacters therefore stays literal rather than injecting shell
+// syntax. Wrapping a placeholder in single quotes is the caller's responsibility
+// (the default does); an unquoted placeholder is not made safe.
 //
 // Both placeholders expand in a single pass, so a ${PROMPT} appearing inside the
 // substituted system-prompt text is not re-expanded.
 func SubstituteAgentCommand(command, prompt, systemPrompt string) string {
 	r := strings.NewReplacer(
-		"${SYS_PROMPT}", shellQuote(systemPrompt),
-		"${PROMPT}", shellQuote(prompt),
+		"${SYS_PROMPT}", shellSingleQuoteEscape(systemPrompt),
+		"${PROMPT}", shellSingleQuoteEscape(prompt),
 	)
 	return r.Replace(command)
 }
 
-// shellQuote wraps a value in single quotes so it is a single literal shell
-// argument, escaping any embedded single quote as the standard close-escape-reopen
-// sequence.
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+// shellSingleQuoteEscape rewrites single quotes so a value is safe inside a
+// single-quoted shell string: each ' becomes '\” (close the quote, emit an
+// escaped quote, reopen the quote).
+func shellSingleQuoteEscape(s string) string {
+	return strings.ReplaceAll(s, "'", `'\''`)
 }

--- a/internal/fleet/automation_test.go
+++ b/internal/fleet/automation_test.go
@@ -138,4 +138,12 @@ func TestSubstituteAgentCommand(t *testing.T) {
 	if got != want {
 		t.Errorf("re-expansion guard: got %q, want %q", got, want)
 	}
+
+	// A single quote in a value must be escaped so it can't break out of the
+	// surrounding single quotes.
+	got = SubstituteAgentCommand(`claude --system-prompt '${SYS_PROMPT}'`, "", "it's fine; rm -rf /")
+	want = `claude --system-prompt 'it'\''s fine; rm -rf /'`
+	if got != want {
+		t.Errorf("quote-escape: got %q, want %q", got, want)
+	}
 }

--- a/internal/fleet/automation_test.go
+++ b/internal/fleet/automation_test.go
@@ -1,0 +1,141 @@
+package fleet
+
+import "testing"
+
+func TestNormalizeAgentDefaults(t *testing.T) {
+	a, err := NormalizeAgent(Agent{Name: "  build  "})
+	if err != nil {
+		t.Fatalf("NormalizeAgent: %v", err)
+	}
+	if a.Name != "build" {
+		t.Errorf("name = %q, want %q", a.Name, "build")
+	}
+	if a.Command == "" {
+		t.Error("command was not defaulted")
+	}
+	if a.Backend != BackendDevcontainer {
+		t.Errorf("backend = %q, want %q", a.Backend, BackendDevcontainer)
+	}
+}
+
+func TestNormalizeAgentErrors(t *testing.T) {
+	if _, err := NormalizeAgent(Agent{Name: "   "}); err == nil {
+		t.Error("empty name: want error")
+	}
+	if _, err := NormalizeAgent(Agent{Name: "x", Backend: "nope"}); err == nil {
+		t.Error("invalid backend: want error")
+	}
+}
+
+func TestNormalizeAgentsDuplicate(t *testing.T) {
+	_, err := NormalizeAgents([]Agent{{Name: "a"}, {Name: "a"}})
+	if err == nil {
+		t.Error("duplicate agent name: want error")
+	}
+	out, err := NormalizeAgents([]Agent{{Name: "a"}, {Name: "b"}})
+	if err != nil {
+		t.Fatalf("NormalizeAgents: %v", err)
+	}
+	if len(out) != 2 || out[0].Name != "a" || out[1].Name != "b" {
+		t.Errorf("order not preserved: %+v", out)
+	}
+}
+
+func TestNormalizeTriggerSchedule(t *testing.T) {
+	agents := map[string]struct{}{"build": {}}
+	tr, err := NormalizeTrigger(Trigger{
+		Name:        "nightly",
+		Type:        TriggerSchedule,
+		AgentNames:  []string{"build"},
+		Cron:        "0 0 * * *",
+		WebhookName: "stale", // should be cleared
+		Regex:       "stale",
+	}, agents)
+	if err != nil {
+		t.Fatalf("NormalizeTrigger: %v", err)
+	}
+	if tr.WebhookName != "" || tr.Regex != "" {
+		t.Errorf("webhook fields not cleared: %+v", tr)
+	}
+}
+
+func TestNormalizeTriggerWebhook(t *testing.T) {
+	agents := map[string]struct{}{"build": {}}
+
+	// regex filter
+	tr, err := NormalizeTrigger(Trigger{
+		Name:        "wh",
+		Type:        TriggerWebhook,
+		AgentNames:  []string{"build"},
+		WebhookName: "deploy",
+		FilterType:  WebhookFilterRegex,
+		Regex:       "push",
+		Cron:        "0 0 * * *", // should be cleared
+	}, agents)
+	if err != nil {
+		t.Fatalf("regex webhook: %v", err)
+	}
+	if tr.Cron != "" {
+		t.Errorf("cron not cleared on webhook: %q", tr.Cron)
+	}
+
+	// jsonpath filter
+	if _, err := NormalizeTrigger(Trigger{
+		Name: "wh2", Type: TriggerWebhook, AgentNames: []string{"build"},
+		WebhookName: "deploy", FilterType: WebhookFilterJSONPath, JSONPath: "$.action", JSONValue: "opened",
+	}, agents); err != nil {
+		t.Fatalf("jsonpath webhook: %v", err)
+	}
+
+	// bad regex
+	if _, err := NormalizeTrigger(Trigger{
+		Name: "bad", Type: TriggerWebhook, AgentNames: []string{"build"},
+		WebhookName: "x", FilterType: WebhookFilterRegex, Regex: "(",
+	}, agents); err == nil {
+		t.Error("invalid regex: want error")
+	}
+}
+
+func TestNormalizeTriggerErrors(t *testing.T) {
+	agents := map[string]struct{}{"build": {}}
+	bad := []Trigger{
+		{Name: "", Type: TriggerSchedule, AgentNames: []string{"build"}, Cron: "* * * * *"},  // empty name
+		{Name: "x", Type: TriggerSchedule, AgentNames: nil, Cron: "* * * * *"},               // no agents
+		{Name: "x", Type: TriggerSchedule, AgentNames: []string{"ghost"}, Cron: "* * * * *"}, // unknown agent
+		{Name: "x", Type: TriggerSchedule, AgentNames: []string{"build"}, Cron: "nope"},      // bad cron
+		{Name: "x", Type: "bogus", AgentNames: []string{"build"}},                            // bad type
+		{Name: "x", Type: TriggerWebhook, AgentNames: []string{"build"}, WebhookName: ""},    // empty webhook name
+		{Name: "x", Type: TriggerWebhook, AgentNames: []string{"build"}, WebhookName: "w"},   // missing filter type
+	}
+	for i, tr := range bad {
+		if _, err := NormalizeTrigger(tr, agents); err == nil {
+			t.Errorf("case %d: want error, got nil for %+v", i, tr)
+		}
+	}
+}
+
+func TestNormalizeTriggersDuplicateAndRefs(t *testing.T) {
+	agents := []Agent{{Name: "build", Backend: BackendDevcontainer}}
+	_, err := NormalizeTriggers([]Trigger{
+		{Name: "a", Type: TriggerSchedule, AgentNames: []string{"build"}, Cron: "* * * * *"},
+		{Name: "a", Type: TriggerSchedule, AgentNames: []string{"build"}, Cron: "* * * * *"},
+	}, agents)
+	if err == nil {
+		t.Error("duplicate trigger name: want error")
+	}
+}
+
+func TestSubstituteAgentCommand(t *testing.T) {
+	got := SubstituteAgentCommand(`claude --system-prompt '${SYS_PROMPT}' '${PROMPT}'`, "do the thing", "be helpful")
+	want := `claude --system-prompt 'be helpful' 'do the thing'`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	// A ${PROMPT} that appears inside the system prompt text must not be
+	// re-expanded by the prompt pass.
+	got = SubstituteAgentCommand(`x ${SYS_PROMPT} ${PROMPT}`, "P", "contains ${PROMPT} literally")
+	want = `x contains ${PROMPT} literally P`
+	if got != want {
+		t.Errorf("re-expansion guard: got %q, want %q", got, want)
+	}
+}

--- a/internal/fleet/automation_test.go
+++ b/internal/fleet/automation_test.go
@@ -126,7 +126,9 @@ func TestNormalizeTriggersDuplicateAndRefs(t *testing.T) {
 }
 
 func TestSubstituteAgentCommand(t *testing.T) {
-	got := SubstituteAgentCommand(`claude --system-prompt '${SYS_PROMPT}' '${PROMPT}'`, "do the thing", "be helpful")
+	// Values are substituted FULLY shell-quoted, so placeholders are written
+	// bare (no surrounding quotes).
+	got := SubstituteAgentCommand(`claude --system-prompt ${SYS_PROMPT} ${PROMPT}`, "do the thing", "be helpful")
 	want := `claude --system-prompt 'be helpful' 'do the thing'`
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -134,16 +136,16 @@ func TestSubstituteAgentCommand(t *testing.T) {
 	// A ${PROMPT} that appears inside the system prompt text must not be
 	// re-expanded by the prompt pass.
 	got = SubstituteAgentCommand(`x ${SYS_PROMPT} ${PROMPT}`, "P", "contains ${PROMPT} literally")
-	want = `x contains ${PROMPT} literally P`
+	want = `x 'contains ${PROMPT} literally' 'P'`
 	if got != want {
 		t.Errorf("re-expansion guard: got %q, want %q", got, want)
 	}
 
-	// A single quote in a value must be escaped so it can't break out of the
-	// surrounding single quotes.
-	got = SubstituteAgentCommand(`claude --system-prompt '${SYS_PROMPT}'`, "", "it's fine; rm -rf /")
-	want = `claude --system-prompt 'it'\''s fine; rm -rf /'`
+	// A bare (unquoted) placeholder must still be safe: shell metacharacters in
+	// the value stay literal, never injecting a second command.
+	got = SubstituteAgentCommand(`echo ${PROMPT}`, "it's fine; rm -rf /", "")
+	want = `echo 'it'\''s fine; rm -rf /'`
 	if got != want {
-		t.Errorf("quote-escape: got %q, want %q", got, want)
+		t.Errorf("inject-guard: got %q, want %q", got, want)
 	}
 }

--- a/internal/fleet/automation_test.go
+++ b/internal/fleet/automation_test.go
@@ -126,26 +126,26 @@ func TestNormalizeTriggersDuplicateAndRefs(t *testing.T) {
 }
 
 func TestSubstituteAgentCommand(t *testing.T) {
-	// Values are substituted FULLY shell-quoted, so placeholders are written
-	// bare (no surrounding quotes).
-	got := SubstituteAgentCommand(`claude --system-prompt ${SYS_PROMPT} ${PROMPT}`, "do the thing", "be helpful")
+	// Values are single-quote-escaped; placeholders are wrapped in single quotes
+	// (as the default command is).
+	got := SubstituteAgentCommand(`claude --system-prompt '${SYS_PROMPT}' '${PROMPT}'`, "do the thing", "be helpful")
 	want := `claude --system-prompt 'be helpful' 'do the thing'`
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
 	// A ${PROMPT} that appears inside the system prompt text must not be
 	// re-expanded by the prompt pass.
-	got = SubstituteAgentCommand(`x ${SYS_PROMPT} ${PROMPT}`, "P", "contains ${PROMPT} literally")
-	want = `x 'contains ${PROMPT} literally' 'P'`
+	got = SubstituteAgentCommand(`x '${SYS_PROMPT}' '${PROMPT}'`, "P", "has ${PROMPT}")
+	want = `x 'has ${PROMPT}' 'P'`
 	if got != want {
 		t.Errorf("re-expansion guard: got %q, want %q", got, want)
 	}
 
-	// A bare (unquoted) placeholder must still be safe: shell metacharacters in
-	// the value stay literal, never injecting a second command.
-	got = SubstituteAgentCommand(`echo ${PROMPT}`, "it's fine; rm -rf /", "")
-	want = `echo 'it'\''s fine; rm -rf /'`
+	// A single quote in the value is escaped so it can't break out of the
+	// surrounding single quotes (and shell metacharacters stay literal).
+	got = SubstituteAgentCommand(`claude '${PROMPT}'`, "it's; rm -rf /", "")
+	want = `claude 'it'\''s; rm -rf /'`
 	if got != want {
-		t.Errorf("inject-guard: got %q, want %q", got, want)
+		t.Errorf("quote-escape: got %q, want %q", got, want)
 	}
 }

--- a/internal/fleet/cron.go
+++ b/internal/fleet/cron.go
@@ -63,7 +63,9 @@ func ParseCron(spec string) (CronSchedule, error) {
 	if err != nil {
 		return CronSchedule{}, fmt.Errorf("month field: %w", err)
 	}
-	dow, err := parseCronField(fields[4], 0, 6)
+	// Day-of-week accepts 0-7 (both 0 and 7 are Sunday); parseCronField folds 7
+	// into 0 after expansion so a range like 5-7 (Fri-Sun) parses correctly.
+	dow, err := parseCronField(fields[4], 0, 7)
 	if err != nil {
 		return CronSchedule{}, fmt.Errorf("day-of-week field: %w", err)
 	}
@@ -111,6 +113,15 @@ func parseCronField(field string, min, max int) (cronField, error) {
 	}
 	if len(vals) == 0 {
 		return cronField{}, fmt.Errorf("no values in field %q", field)
+	}
+	// Day-of-week (the only field parsed with max 7) treats 7 as Sunday: fold it
+	// into 0 AFTER range/list expansion, so "5-7" yields {5,6,0} rather than
+	// being rejected as a descending "5-0" range.
+	if max == 7 {
+		if vals[7] {
+			vals[0] = true
+		}
+		delete(vals, 7)
 	}
 	return cronField{vals: vals}, nil
 }
@@ -170,16 +181,14 @@ func parseCronPart(part string, min, max int, vals map[int]bool) error {
 	return nil
 }
 
-// cronAtoi parses a single field value, mapping day-of-week 7 to 0 (Sunday) and
-// enforcing the field's [min, max] bounds.
+// cronAtoi parses a single field value and enforces the field's [min, max]
+// bounds. Day-of-week's max is 7 (Sunday written as either 0 or 7); the 7→0
+// fold happens in parseCronField after expansion, not here, so ranges ending in
+// 7 keep their ascending order.
 func cronAtoi(s string, min, max int) (int, error) {
 	v, err := strconv.Atoi(strings.TrimSpace(s))
 	if err != nil {
 		return 0, fmt.Errorf("invalid number %q", s)
-	}
-	// Day-of-week Sunday may be written as 7; normalize to 0.
-	if min == 0 && max == 6 && v == 7 {
-		v = 0
 	}
 	if v < min || v > max {
 		return 0, fmt.Errorf("value %d out of range [%d-%d]", v, min, max)

--- a/internal/fleet/cron.go
+++ b/internal/fleet/cron.go
@@ -1,0 +1,188 @@
+package fleet
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// A minimal standard 5-field cron implementation (minute hour day-of-month
+// month day-of-week), used by Schedule automation triggers. Supporting just the
+// classic syntax — `*`, single values, `a-b` ranges, comma lists, and `*/s` /
+// `a-b/s` steps — keeps the dependency surface at zero (no third-party cron
+// library) while covering the expressions a user realistically types into a
+// schedule trigger. Evaluation is minute-granular: a schedule fires at most once
+// per matching wall-clock minute.
+
+// cronField is one parsed cron field: the set of integer values it matches. A
+// `*` field matches every value in the field's range and is tracked separately
+// so the day-of-month / day-of-week "or" rule (below) can tell a restricted
+// field from an unrestricted one.
+type cronField struct {
+	star bool
+	vals map[int]bool
+}
+
+func (f cronField) matches(v int) bool {
+	if f.star {
+		return true
+	}
+	return f.vals[v]
+}
+
+// CronSchedule is a parsed cron expression ready for repeated matching.
+type CronSchedule struct {
+	minute cronField
+	hour   cronField
+	dom    cronField
+	month  cronField
+	dow    cronField
+}
+
+// ParseCron parses a standard 5-field cron expression. Fields are separated by
+// runs of whitespace; an expression with any other field count is rejected.
+func ParseCron(spec string) (CronSchedule, error) {
+	fields := strings.Fields(spec)
+	if len(fields) != 5 {
+		return CronSchedule{}, fmt.Errorf("cron expression must have 5 fields (got %d): %q", len(fields), spec)
+	}
+	minute, err := parseCronField(fields[0], 0, 59)
+	if err != nil {
+		return CronSchedule{}, fmt.Errorf("minute field: %w", err)
+	}
+	hour, err := parseCronField(fields[1], 0, 23)
+	if err != nil {
+		return CronSchedule{}, fmt.Errorf("hour field: %w", err)
+	}
+	dom, err := parseCronField(fields[2], 1, 31)
+	if err != nil {
+		return CronSchedule{}, fmt.Errorf("day-of-month field: %w", err)
+	}
+	month, err := parseCronField(fields[3], 1, 12)
+	if err != nil {
+		return CronSchedule{}, fmt.Errorf("month field: %w", err)
+	}
+	dow, err := parseCronField(fields[4], 0, 6)
+	if err != nil {
+		return CronSchedule{}, fmt.Errorf("day-of-week field: %w", err)
+	}
+	return CronSchedule{minute: minute, hour: hour, dom: dom, month: month, dow: dow}, nil
+}
+
+// Matches reports whether t falls in a minute the schedule fires on. It follows
+// the classic Vixie-cron day rule: when BOTH day-of-month and day-of-week are
+// restricted (neither is `*`), the day matches if EITHER field matches;
+// otherwise both must match (a `*` field always matches).
+func (s CronSchedule) Matches(t time.Time) bool {
+	if !s.minute.matches(t.Minute()) || !s.hour.matches(t.Hour()) || !s.month.matches(int(t.Month())) {
+		return false
+	}
+	domMatch := s.dom.matches(t.Day())
+	dowMatch := s.dow.matches(int(t.Weekday()))
+	if !s.dom.star && !s.dow.star {
+		return domMatch || dowMatch
+	}
+	return domMatch && dowMatch
+}
+
+// ValidateCron returns an error if spec is not a parseable cron expression.
+func ValidateCron(spec string) error {
+	_, err := ParseCron(spec)
+	return err
+}
+
+// parseCronField parses one comma-separated cron field into the set of integers
+// it matches within [min, max]. day-of-week additionally accepts 7 as Sunday
+// (mapped to 0), matching common cron implementations.
+func parseCronField(field string, min, max int) (cronField, error) {
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return cronField{}, fmt.Errorf("empty field")
+	}
+	if field == "*" {
+		return cronField{star: true}, nil
+	}
+	vals := make(map[int]bool)
+	for _, part := range strings.Split(field, ",") {
+		if err := parseCronPart(strings.TrimSpace(part), min, max, vals); err != nil {
+			return cronField{}, err
+		}
+	}
+	if len(vals) == 0 {
+		return cronField{}, fmt.Errorf("no values in field %q", field)
+	}
+	return cronField{vals: vals}, nil
+}
+
+// parseCronPart parses a single comma-separated component — `*`, `a`, `a-b`,
+// `*/s`, `a/s`, or `a-b/s` — adding every matched value to vals.
+func parseCronPart(part string, min, max int, vals map[int]bool) error {
+	if part == "" {
+		return fmt.Errorf("empty list element")
+	}
+	rangeSpec := part
+	step := 1
+	if slash := strings.IndexByte(part, '/'); slash >= 0 {
+		rangeSpec = part[:slash]
+		stepStr := part[slash+1:]
+		s, err := strconv.Atoi(stepStr)
+		if err != nil || s <= 0 {
+			return fmt.Errorf("invalid step %q", stepStr)
+		}
+		step = s
+	}
+
+	low, high := min, max
+	switch {
+	case rangeSpec == "*":
+		// full range
+	case strings.IndexByte(rangeSpec, '-') >= 0:
+		bounds := strings.SplitN(rangeSpec, "-", 2)
+		l, err := cronAtoi(bounds[0], min, max)
+		if err != nil {
+			return err
+		}
+		h, err := cronAtoi(bounds[1], min, max)
+		if err != nil {
+			return err
+		}
+		if l > h {
+			return fmt.Errorf("range %q is descending", rangeSpec)
+		}
+		low, high = l, h
+	default:
+		v, err := cronAtoi(rangeSpec, min, max)
+		if err != nil {
+			return err
+		}
+		// A bare value with no slash matches exactly that value; with a slash
+		// (`a/s`) it means "from a to the field max, stepping by s".
+		low, high = v, v
+		if step != 1 {
+			high = max
+		}
+	}
+
+	for v := low; v <= high; v += step {
+		vals[v] = true
+	}
+	return nil
+}
+
+// cronAtoi parses a single field value, mapping day-of-week 7 to 0 (Sunday) and
+// enforcing the field's [min, max] bounds.
+func cronAtoi(s string, min, max int) (int, error) {
+	v, err := strconv.Atoi(strings.TrimSpace(s))
+	if err != nil {
+		return 0, fmt.Errorf("invalid number %q", s)
+	}
+	// Day-of-week Sunday may be written as 7; normalize to 0.
+	if min == 0 && max == 6 && v == 7 {
+		v = 0
+	}
+	if v < min || v > max {
+		return 0, fmt.Errorf("value %d out of range [%d-%d]", v, min, max)
+	}
+	return v, nil
+}

--- a/internal/fleet/cron_test.go
+++ b/internal/fleet/cron_test.go
@@ -1,0 +1,79 @@
+package fleet
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseCronInvalid(t *testing.T) {
+	cases := []string{
+		"",            // empty
+		"* * * *",     // 4 fields
+		"* * * * * *", // 6 fields
+		"60 * * * *",  // minute out of range
+		"* 24 * * *",  // hour out of range
+		"* * 0 * *",   // day-of-month out of range
+		"* * * 13 *",  // month out of range
+		"* * * * 8",   // day-of-week out of range
+		"*/0 * * * *", // zero step
+		"5-1 * * * *", // descending range
+		"a * * * *",   // non-numeric
+		"* * * * 1-",  // empty range bound
+	}
+	for _, c := range cases {
+		if err := ValidateCron(c); err == nil {
+			t.Errorf("ValidateCron(%q) = nil, want error", c)
+		}
+	}
+}
+
+func TestParseCronValid(t *testing.T) {
+	cases := []string{
+		"* * * * *",
+		"0 0 * * *",
+		"*/15 * * * *",
+		"0 9-17 * * 1-5",
+		"0,30 * * * *",
+		"5 4 1 1 *",
+		"0 0 * * 7", // Sunday as 7
+		"0-59/10 * * * *",
+	}
+	for _, c := range cases {
+		if err := ValidateCron(c); err != nil {
+			t.Errorf("ValidateCron(%q) = %v, want nil", c, err)
+		}
+	}
+}
+
+func TestCronMatches(t *testing.T) {
+	// 2026-06-20 is a Saturday (weekday 6); 2026-06-22 is a Monday (weekday 1).
+	mustMatch := func(spec string, ts time.Time, want bool) {
+		t.Helper()
+		s, err := ParseCron(spec)
+		if err != nil {
+			t.Fatalf("ParseCron(%q): %v", spec, err)
+		}
+		if got := s.Matches(ts); got != want {
+			t.Errorf("ParseCron(%q).Matches(%s) = %v, want %v", spec, ts.Format(time.RFC3339), got, want)
+		}
+	}
+
+	sat := time.Date(2026, 6, 20, 9, 30, 0, 0, time.UTC) // Saturday 09:30
+	mon := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)  // Monday 09:00
+
+	mustMatch("* * * * *", sat, true)
+	mustMatch("30 9 * * *", sat, true)
+	mustMatch("31 9 * * *", sat, false)
+	mustMatch("*/15 * * * *", sat, true)  // 30 is divisible by 15
+	mustMatch("*/20 * * * *", sat, false) // 30 not divisible by 20
+	mustMatch("0 9-17 * * 1-5", mon, true)
+	mustMatch("0 9-17 * * 1-5", sat, false) // Saturday excluded by dow
+	mustMatch("0 9 22 6 *", mon, true)      // day-of-month 22
+	mustMatch("0,30 * * * *", sat, true)
+	mustMatch("0 * * * *", sat, false)
+
+	// Vixie day rule: when BOTH dom and dow are restricted, match if EITHER.
+	mustMatch("0 9 20 * 1", mon, true)   // dow=Monday matches even though dom=20 != 22
+	mustMatch("30 9 20 * 1", sat, true)  // dom=20 matches even though dow != Monday
+	mustMatch("30 9 19 * 1", sat, false) // neither dom (19) nor dow (Monday) matches Saturday the 20th
+}

--- a/internal/fleet/cron_test.go
+++ b/internal/fleet/cron_test.go
@@ -35,7 +35,10 @@ func TestParseCronValid(t *testing.T) {
 		"0 9-17 * * 1-5",
 		"0,30 * * * *",
 		"5 4 1 1 *",
-		"0 0 * * 7", // Sunday as 7
+		"0 0 * * 7",   // Sunday as 7
+		"0 0 * * 5-7", // Fri-Sun range ending in 7
+		"0 0 * * 6-7", // Sat-Sun
+		"0 0 * * 0-7", // every day
 		"0-59/10 * * * *",
 	}
 	for _, c := range cases {
@@ -59,7 +62,14 @@ func TestCronMatches(t *testing.T) {
 	}
 
 	sat := time.Date(2026, 6, 20, 9, 30, 0, 0, time.UTC) // Saturday 09:30
+	sun := time.Date(2026, 6, 21, 0, 0, 0, 0, time.UTC)  // Sunday 00:00
 	mon := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)  // Monday 09:00
+
+	// Day-of-week range ending in 7 (Sunday) must match Fri/Sat/Sun, not be
+	// rejected as a descending range.
+	mustMatch("30 9 * * 5-7", sat, true) // Saturday is in 5-7 (Fri-Sun)
+	mustMatch("0 0 * * 5-7", sun, true)  // Sunday (7≡0) is in 5-7
+	mustMatch("0 9 * * 5-7", mon, false) // Monday is not
 
 	mustMatch("* * * * *", sat, true)
 	mustMatch("30 9 * * *", sat, true)

--- a/internal/fleet/fleet_settings.go
+++ b/internal/fleet/fleet_settings.go
@@ -114,6 +114,21 @@ type FleetSettings struct {
 	// means no presets.
 	LayoutPresets []LayoutPreset `json:"layoutPresets,omitempty"`
 
+	// Agents is the fleet's list of automation agent definitions (issue #188).
+	// An Agent describes how an automation worker is launched (command + tmux
+	// mode + system prompt + backend); Triggers reference agents by name. The
+	// list is validated/normalized (see NormalizeAgents) before persisting.
+	// Empty (the default) means no agents. Surfaced in the TUI's automation
+	// view.
+	Agents []Agent `json:"agents,omitempty"`
+
+	// Triggers is the fleet's list of automation trigger definitions (issue
+	// #188). A Trigger fires its referenced Agents (with a prompt) on a
+	// schedule or webhook event. Validated/normalized against Agents (see
+	// NormalizeTriggers) before persisting. Empty (the default) means no
+	// triggers.
+	Triggers []Trigger `json:"triggers,omitempty"`
+
 	// PreferFleetLaunch controls which page the built-in browser opens to
 	// when a workspace's devcontainer.json configures BOTH a
 	// customizations.fleet.browser.initialUrl AND a fleetLaunch block.

--- a/internal/server/automation_convert_test.go
+++ b/internal/server/automation_convert_test.go
@@ -17,15 +17,13 @@ func TestFleetSettingsAutomationRoundTrip(t *testing.T) {
 			{
 				Name:         "builder",
 				Command:      "claude --system-prompt '${SYS_PROMPT}' '${PROMPT}'",
-				TmuxMode:     true,
 				SystemPrompt: "be precise",
 				Backend:      fleet.BackendDevcontainer,
 			},
 			{
-				Name:     "noTmux",
-				Command:  "echo hi",
-				TmuxMode: false,
-				Backend:  fleet.BackendCoder,
+				Name:    "noTmux",
+				Command: "echo hi",
+				Backend: fleet.BackendCoder,
 			},
 		},
 		Triggers: []fleet.Trigger{

--- a/internal/server/automation_convert_test.go
+++ b/internal/server/automation_convert_test.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+)
+
+// TestFleetSettingsAutomationRoundTrip guards the agents/triggers wire mapping:
+// a settings value carrying automation agents + triggers must survive
+// legacy -> proto -> legacy unchanged, so a SetFleetSettings round-trip never
+// silently drops a field.
+func TestFleetSettingsAutomationRoundTrip(t *testing.T) {
+	in := fleet.FleetSettings{
+		Agents: []fleet.Agent{
+			{
+				Name:         "builder",
+				Command:      "claude --system-prompt '${SYS_PROMPT}' '${PROMPT}'",
+				TmuxMode:     true,
+				SystemPrompt: "be precise",
+				Backend:      fleet.BackendDevcontainer,
+			},
+			{
+				Name:     "noTmux",
+				Command:  "echo hi",
+				TmuxMode: false,
+				Backend:  fleet.BackendCoder,
+			},
+		},
+		Triggers: []fleet.Trigger{
+			{
+				Name:       "nightly",
+				Type:       fleet.TriggerSchedule,
+				AgentNames: []string{"builder"},
+				Prompt:     "rebuild the world",
+				Cron:       "0 0 * * *",
+			},
+			{
+				Name:        "on-push",
+				Type:        fleet.TriggerWebhook,
+				AgentNames:  []string{"builder", "noTmux"},
+				Prompt:      "react",
+				WebhookName: "push",
+				FilterType:  fleet.WebhookFilterJSONPath,
+				JSONPath:    "$.ref",
+				JSONValue:   "refs/heads/main",
+			},
+		},
+	}
+
+	out := protoFleetSettingsToLegacy(fleetSettingsToProto(in))
+
+	if !reflect.DeepEqual(in.Agents, out.Agents) {
+		t.Errorf("agents round-trip mismatch:\n in: %+v\nout: %+v", in.Agents, out.Agents)
+	}
+	if !reflect.DeepEqual(in.Triggers, out.Triggers) {
+		t.Errorf("triggers round-trip mismatch:\n in: %+v\nout: %+v", in.Triggers, out.Triggers)
+	}
+}

--- a/internal/server/convert.go
+++ b/internal/server/convert.go
@@ -79,7 +79,6 @@ func agentsToProto(in []fleet.Agent) []*fleetgrpc.Agent {
 		out = append(out, &fleetgrpc.Agent{
 			Name:         a.Name,
 			Command:      a.Command,
-			TmuxMode:     a.TmuxMode,
 			SystemPrompt: a.SystemPrompt,
 			Backend:      backendToProto(a.Backend),
 		})

--- a/internal/server/convert.go
+++ b/internal/server/convert.go
@@ -58,6 +58,8 @@ func fleetSettingsToProto(s fleet.FleetSettings) *fleetgrpc.FleetSettings {
 		DebCacheServer:   s.DebCacheServer,
 		ImageCacheServer: s.ImageCacheServer,
 		LayoutPresets:    layoutPresetsToProto(s.LayoutPresets),
+		Agents:           agentsToProto(s.Agents),
+		Triggers:         triggersToProto(s.Triggers),
 	}
 	if s.HomeDir != "" {
 		ps.HomeDir = strptr(s.HomeDir)
@@ -66,6 +68,45 @@ func fleetSettingsToProto(s fleet.FleetSettings) *fleetgrpc.FleetSettings {
 		ps.PreferFleetLaunch = boolptr(*s.PreferFleetLaunch)
 	}
 	return ps
+}
+
+func agentsToProto(in []fleet.Agent) []*fleetgrpc.Agent {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*fleetgrpc.Agent, 0, len(in))
+	for _, a := range in {
+		out = append(out, &fleetgrpc.Agent{
+			Name:         a.Name,
+			Command:      a.Command,
+			TmuxMode:     a.TmuxMode,
+			SystemPrompt: a.SystemPrompt,
+			Backend:      backendToProto(a.Backend),
+		})
+	}
+	return out
+}
+
+func triggersToProto(in []fleet.Trigger) []*fleetgrpc.Trigger {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*fleetgrpc.Trigger, 0, len(in))
+	for _, t := range in {
+		out = append(out, &fleetgrpc.Trigger{
+			Name:        t.Name,
+			Type:        string(t.Type),
+			AgentNames:  t.AgentNames,
+			Prompt:      t.Prompt,
+			Cron:        t.Cron,
+			WebhookName: t.WebhookName,
+			FilterType:  string(t.FilterType),
+			Regex:       t.Regex,
+			JsonPath:    t.JSONPath,
+			JsonValue:   t.JSONValue,
+		})
+	}
+	return out
 }
 
 func layoutPresetsToProto(in []fleet.LayoutPreset) []*fleetgrpc.LayoutPreset {

--- a/internal/server/copyinto_test.go
+++ b/internal/server/copyinto_test.go
@@ -110,11 +110,16 @@ func seedCopyIntoInstance(t *testing.T, ws string) {
 
 func sendCopyInto(t *testing.T, stream fleetgrpc.FleetService_CopyIntoClient, open *fleetgrpc.CopyIntoOpen, body string) (*fleetgrpc.CopyIntoReply, error) {
 	t.Helper()
-	if err := stream.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Open{Open: open}}); err != nil {
+	// gRPC client-streaming idiom: when the server rejects an early message and
+	// closes the stream, an in-flight Send returns io.EOF rather than the RPC
+	// status. Don't treat that EOF as the result — fall through to CloseAndRecv,
+	// which surfaces the real server status (e.g. NotFound). Bailing on the EOF
+	// here races the server's rejection and flakes (want NotFound, got EOF).
+	if err := stream.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Open{Open: open}}); err != nil && err != io.EOF {
 		return nil, err
 	}
 	if body != "" {
-		if err := stream.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Data{Data: []byte(body)}}); err != nil {
+		if err := stream.Send(&fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Data{Data: []byte(body)}}); err != nil && err != io.EOF {
 			return nil, err
 		}
 	}

--- a/internal/server/mutations.go
+++ b/internal/server/mutations.go
@@ -137,6 +137,19 @@ func (s *service) SetFleetSettings(_ context.Context, req *fleetgrpc.SetFleetSet
 		return nil, status.Errorf(codes.InvalidArgument, "invalid layout preset: %v", err)
 	}
 	settings.LayoutPresets = normalizedPresets
+	// Automation (issue #188): validate agents first so trigger validation can
+	// resolve the agent names each trigger references. Both are the server's
+	// trust boundary before the lists reach state.json.
+	normalizedAgents, err := fleet.NormalizeAgents(settings.Agents)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid automation agent: %v", err)
+	}
+	settings.Agents = normalizedAgents
+	normalizedTriggers, err := fleet.NormalizeTriggers(settings.Triggers, settings.Agents)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid automation trigger: %v", err)
+	}
+	settings.Triggers = normalizedTriggers
 
 	snapshot, err := s.mutate(func(st *state.State) error {
 		f, ok := st.Fleets[req.GetFleet()]
@@ -269,12 +282,57 @@ func protoFleetSettingsToLegacy(ps *fleetgrpc.FleetSettings) fleet.FleetSettings
 	s.DebCacheServer = ps.GetDebCacheServer()
 	s.ImageCacheServer = ps.GetImageCacheServer()
 	s.LayoutPresets = protoLayoutPresetsToLegacy(ps.GetLayoutPresets())
+	s.Agents = protoAgentsToLegacy(ps.GetAgents())
+	s.Triggers = protoTriggersToLegacy(ps.GetTriggers())
 	s.HomeDir = ps.GetHomeDir()
 	if ps.PreferFleetLaunch != nil {
 		v := ps.GetPreferFleetLaunch()
 		s.PreferFleetLaunch = &v
 	}
 	return s
+}
+
+// protoAgentsToLegacy maps the repeated proto Agent back to the legacy slice
+// (nil for an empty list, matching the `,omitempty` JSON tag).
+func protoAgentsToLegacy(in []*fleetgrpc.Agent) []fleet.Agent {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]fleet.Agent, 0, len(in))
+	for _, a := range in {
+		out = append(out, fleet.Agent{
+			Name:         a.GetName(),
+			Command:      a.GetCommand(),
+			TmuxMode:     a.GetTmuxMode(),
+			SystemPrompt: a.GetSystemPrompt(),
+			Backend:      fleet.BackendType(backendProtoToString(a.GetBackend())),
+		})
+	}
+	return out
+}
+
+// protoTriggersToLegacy maps the repeated proto Trigger back to the legacy
+// slice (nil for an empty list).
+func protoTriggersToLegacy(in []*fleetgrpc.Trigger) []fleet.Trigger {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]fleet.Trigger, 0, len(in))
+	for _, t := range in {
+		out = append(out, fleet.Trigger{
+			Name:        t.GetName(),
+			Type:        fleet.TriggerType(t.GetType()),
+			AgentNames:  t.GetAgentNames(),
+			Prompt:      t.GetPrompt(),
+			Cron:        t.GetCron(),
+			WebhookName: t.GetWebhookName(),
+			FilterType:  fleet.WebhookFilterType(t.GetFilterType()),
+			Regex:       t.GetRegex(),
+			JSONPath:    t.GetJsonPath(),
+			JSONValue:   t.GetJsonValue(),
+		})
+	}
+	return out
 }
 
 // protoLayoutPresetsToLegacy maps the repeated proto LayoutPreset back to the

--- a/internal/server/mutations.go
+++ b/internal/server/mutations.go
@@ -303,7 +303,6 @@ func protoAgentsToLegacy(in []*fleetgrpc.Agent) []fleet.Agent {
 		out = append(out, fleet.Agent{
 			Name:         a.GetName(),
 			Command:      a.GetCommand(),
-			TmuxMode:     a.GetTmuxMode(),
 			SystemPrompt: a.GetSystemPrompt(),
 			Backend:      fleet.BackendType(backendProtoToString(a.GetBackend())),
 		})

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -200,10 +200,18 @@ func (s *service) serviceWatched(ctx context.Context, sched *scheduler, st *stat
 			launchAutomationCommand(ctx, s, w, inst)
 			w.launched = true
 			w.lastActive = now
+			// Non-tmux agents are fire-and-forget: once launched there is no idle
+			// state to watch, so stop tracking them (otherwise the watch set would
+			// grow without bound).
+			if !w.tmux {
+				delete(sched.watched, k)
+			}
 			continue
 		}
 		if !w.tmux {
-			continue // non-tmux agents are fire-and-forget; never idle-reaped
+			// A non-tmux agent is dropped at launch above; never idle-reap one.
+			delete(sched.watched, k)
+			continue
 		}
 
 		activity, ok := automationActivity(s, w, inst, now)

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -102,13 +102,18 @@ func (s *service) runScheduler(ctx context.Context) {
 	}
 }
 
+// scheduleLoadState loads the persisted state for the scheduler. It is a seam so
+// tests can drive schedulerTick deterministically.
+var scheduleLoadState = state.Load
+
 // schedulerTick fires due triggers and services watched agents for one tick.
 func (s *service) schedulerTick(ctx context.Context, sched *scheduler, now time.Time) {
-	st, err := state.Load()
+	st, err := scheduleLoadState()
 	if err != nil {
 		flog.Warn("automation: load state failed", "err", err)
 		return
 	}
+	fired := false
 	for _, due := range dueSchedules(st.Fleets, now, sched.lastFired) {
 		for _, ag := range agentsForTrigger(st.Fleets[due.fleet], due.trigger) {
 			instName, err := createAutomationInstance(s, due.fleet, ag, now)
@@ -129,6 +134,17 @@ func (s *service) schedulerTick(ctx context.Context, sched *scheduler, now time.
 				detector:     agentdetect.NewTmuxPaneChangeDetector(),
 			}
 			sched.watched[w.key()] = w
+			fired = true
+		}
+	}
+	// createAutomationInstance writes the new StatusCreating record synchronously,
+	// but the snapshot loaded above predates it — so reload before servicing the
+	// watch set, otherwise findInstance can't see a just-created instance and the
+	// watch entry is dropped the same tick it was added (and the agent never
+	// launches).
+	if fired {
+		if reloaded, err := scheduleLoadState(); err == nil {
+			st = reloaded
 		}
 	}
 	s.serviceWatched(ctx, sched, st, now)

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -134,25 +134,37 @@ type scheduledFire struct {
 // except for the lastFired bookkeeping, so it is unit-tested directly.
 func dueSchedules(fleets map[string]*fleet.Fleet, now time.Time, lastFired map[string]time.Time) []scheduledFire {
 	minute := now.Truncate(time.Minute)
+	current := make(map[string]struct{})
 	var out []scheduledFire
 	for name, f := range fleets {
 		if f == nil {
 			continue
 		}
 		for _, t := range f.Settings.Triggers {
-			if t.Type != fleet.TriggerSchedule || t.Cron == "" {
+			if t.Type != fleet.TriggerSchedule {
+				continue
+			}
+			key := name + "\x00" + t.Name
+			current[key] = struct{}{}
+			if t.Cron == "" {
 				continue
 			}
 			sched, err := fleet.ParseCron(t.Cron)
 			if err != nil || !sched.Matches(now) {
 				continue
 			}
-			key := name + "\x00" + t.Name
 			if last, ok := lastFired[key]; ok && !last.Before(minute) {
 				continue // already fired this minute
 			}
 			lastFired[key] = minute
 			out = append(out, scheduledFire{fleet: name, trigger: t})
+		}
+	}
+	// Drop lastFired entries for triggers that no longer exist (deleted, renamed,
+	// or changed type) so the map can't grow without bound on a long-running daemon.
+	for k := range lastFired {
+		if _, ok := current[k]; !ok {
+			delete(lastFired, k)
 		}
 	}
 	return out

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -87,17 +87,19 @@ func newScheduler() *scheduler {
 	}
 }
 
-// runScheduler is the automation loop; it returns when ctx is cancelled.
+// runScheduler is the automation loop; it returns when ctx is cancelled. It
+// ticks once immediately so a trigger whose cron matches the current minute
+// fires promptly on daemon start instead of waiting up to a full interval.
 func (s *service) runScheduler(ctx context.Context) {
 	sched := newScheduler()
 	ticker := time.NewTicker(scheduleTickInterval)
 	defer ticker.Stop()
 	for {
+		s.schedulerTick(ctx, sched, time.Now())
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			s.schedulerTick(ctx, sched, time.Now())
 		}
 	}
 }
@@ -367,14 +369,26 @@ var createAutomationInstance = func(s *service, fleetName string, ag fleet.Agent
 var launchAutomationCommand = func(ctx context.Context, s *service, w *watchedAgent, inst *fleet.Instance) {
 	session := tui.ResolveSessionName(inst.Name, "agent")
 	command := fleet.SubstituteAgentCommand(w.command, w.prompt, w.systemPrompt)
-	script := dotfiles.TmuxEnsureInstalled +
-		fmt.Sprintf("tmux new-session -d -s %s %s", dotfiles.ShQuote(session), dotfiles.ShQuote(command))
+	script := buildAgentLaunchScript(session, command)
 	b := s.hub.backendFor(inst)
 	go func() {
 		if out, err := b.RunScript(inst.ContainerID, script); err != nil {
 			flog.Error("automation: launch agent failed", "instance", inst.Name, "err", err, "out", strings.TrimSpace(out))
 		}
 	}()
+}
+
+// buildAgentLaunchScript builds the in-container snippet that brings up the agent
+// in a fresh tmux session. The command runs via an INTERACTIVE bash (`bash -ic`):
+// tmux otherwise runs a new-session command through a bare `sh -c`, which doesn't
+// source ~/.bashrc, so an agent like Claude (installed under ~/.local/bin and
+// added to PATH only in .bashrc) isn't found and the session dies instantly. The
+// interactive shell sources .bashrc and has the agent on PATH — the same
+// environment the user's own session shell has.
+func buildAgentLaunchScript(sessionName, command string) string {
+	launch := "bash -ic " + dotfiles.ShQuote(command)
+	return dotfiles.TmuxEnsureInstalled +
+		fmt.Sprintf("tmux new-session -d -s %s %s", dotfiles.ShQuote(sessionName), dotfiles.ShQuote(launch))
 }
 
 // automationActivity reports a watched agent's current activity, choosing the

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -23,11 +23,14 @@ import (
 //
 //  1. fires due Schedule triggers, spawning a normal fleet instance per
 //     referenced agent (they appear in the TUI like any other instance);
-//  2. once that instance is running, launches the agent's command — in a tmux
-//     session (default) so the user can open it in the TUI, with the trigger
-//     prompt + agent system prompt substituted into ${PROMPT}/${SYS_PROMPT};
-//  3. reaps tmux-mode agents that go idle for longer than the idle timeout,
-//     detected with the same screen-diff mechanism the TUI shows.
+//  2. once that instance is running, launches the agent's command in a fresh
+//     tmux session (so the user can open it in the TUI), with the trigger prompt
+//     + agent system prompt substituted into ${PROMPT}/${SYS_PROMPT} — the prompt
+//     rides the command itself (e.g. `claude ... '${PROMPT}'`), so no keystroke
+//     injection is needed;
+//  3. reaps agents that go idle for longer than the idle timeout, using the same
+//     agent-state detector factory the rest of the app uses (Claude/Auggie hooks,
+//     screen-diff fallback).
 //
 // Webhook triggers are modeled but not delivered here — wiring the gateway
 // endpoint is explicitly out of scope for issue #188.
@@ -41,16 +44,9 @@ var (
 	// services watched agents. ~30s comfortably samples every minute-granular
 	// cron minute at least once while staying cheap.
 	scheduleTickInterval = 30 * time.Second
-	// automationIdleTimeout is how long a tmux-mode agent may stay inactive
-	// before its instance is torn down (issue #188: "inactive for more than 2
-	// minutes").
+	// automationIdleTimeout is how long an agent may stay inactive before its
+	// instance is torn down (issue #188: "inactive for more than 2 minutes").
 	automationIdleTimeout = 2 * time.Minute
-	// automationPromptMaxWait caps how long the launch waits for a tmux-mode
-	// agent's TUI to finish booting (its pane to stop changing) before typing the
-	// prompt. A fixed delay drops the prompt when the agent (e.g. Claude Code,
-	// especially with MCP servers) is slow to come up, so the launch polls for
-	// readiness and only falls back to this cap if the pane never settles.
-	automationPromptMaxWait = 30 * time.Second
 )
 
 // maxAutomationProbeConcurrency bounds how many agent activity probes run at
@@ -66,11 +62,14 @@ type watchedAgent struct {
 	command      string
 	prompt       string
 	systemPrompt string
-	tmux         bool
 	spawnedAt    time.Time
 	lastActive   time.Time
 	launched     bool
-	detector     *agentdetect.TmuxPaneChangeDetector
+	// detector + detectorTool are the per-agent activity detector, chosen by the
+	// shared agentdetect factory from the probed tool (Claude/Auggie hooks, or the
+	// screen-diff fallback). Lazily created/replaced in automationActivity.
+	detector     agentdetect.Detector
+	detectorTool state.AgentTool
 }
 
 func (w *watchedAgent) key() string { return w.fleet + "/" + w.instance }
@@ -129,10 +128,8 @@ func (s *service) schedulerTick(ctx context.Context, sched *scheduler, now time.
 				command:      ag.Command,
 				prompt:       due.trigger.Prompt,
 				systemPrompt: ag.SystemPrompt,
-				tmux:         ag.TmuxMode,
 				spawnedAt:    now,
 				lastActive:   now,
-				detector:     agentdetect.NewTmuxPaneChangeDetector(),
 			}
 			sched.watched[w.key()] = w
 			fired = true
@@ -253,17 +250,6 @@ func (s *service) serviceWatched(ctx context.Context, sched *scheduler, st *stat
 			launchAutomationCommand(ctx, s, w, inst)
 			w.launched = true
 			w.lastActive = now
-			// Non-tmux agents are fire-and-forget: once launched there is no idle
-			// state to watch, so stop tracking them (otherwise the watch set would
-			// grow without bound).
-			if !w.tmux {
-				delete(sched.watched, k)
-			}
-			continue
-		}
-		if !w.tmux {
-			// A non-tmux agent is dropped at launch above; never idle-reap one.
-			delete(sched.watched, k)
 			continue
 		}
 		checks = append(checks, pendingCheck{key: k, w: w, inst: inst})
@@ -366,98 +352,53 @@ var createAutomationInstance = func(s *service, fleetName string, ag fleet.Agent
 	return instName, nil
 }
 
-// launchAutomationCommand runs the agent's command inside its (running)
-// instance: a detached tmux session the user can open in the TUI (tmux mode), or
-// a detached background process (non-tmux).
+// launchAutomationCommand starts the agent's command in a fresh tmux session
+// inside its (running) instance, so it's viewable in the TUI. Both ${SYS_PROMPT}
+// and ${PROMPT} are substituted into the command (the default passes the prompt
+// as the agent's positional argument), so the command itself brings up a live
+// agent already working on the prompt — no keystroke injection, no readiness
+// polling.
 //
-// In tmux mode the prompt is delivered the way issue #188 specifies — "the
-// PROMPT will be sent via tmux send keys": the agent command (with ${SYS_PROMPT}
-// substituted) starts the agent, then the trigger prompt is typed into it as a
-// SEPARATE send-keys line. That is what makes the default command —
-// `claude --system-prompt '${SYS_PROMPT}'`, which has no ${PROMPT} — actually do
-// work: the prompt is typed into the running agent rather than relying on a
-// ${PROMPT} placeholder the default doesn't contain. If the command DOES embed
-// ${PROMPT} the prompt is substituted there instead and not re-sent.
-//
-// The tmux script runs in a goroutine because it sleeps (giving the agent's REPL
-// a moment to start before the prompt is typed) and must not stall the tick.
+// `tmux new-session -d -s X <cmd>` runs <cmd> as the session's process (tmux
+// hands it to sh -c). It execs straight against the container (RunScript) as the
+// session user — NOT the devcontainer Node CLI path, which from the daemon
+// silently produced no tmux server. Runs off the tick because TmuxEnsureInstalled
+// may apt-install tmux on first use.
 var launchAutomationCommand = func(ctx context.Context, s *service, w *watchedAgent, inst *fleet.Instance) {
-	// Exec straight against the container (RunScript), NOT the devcontainer Node
-	// CLI path (ExecCommand/runContainerShell): from the daemon's scheduler the
-	// Node CLI path silently produced no tmux server, whereas RunScript runs as
-	// the same session user the poller reads, so the agent's session reliably
-	// comes up and shows in the TUI.
-	b := s.hub.backendFor(inst)
-	if w.tmux {
-		session := tui.ResolveSessionName(inst.Name, "agent")
-		cmdHasPrompt := strings.Contains(w.command, "${PROMPT}")
-		command := fleet.SubstituteAgentCommand(w.command, w.prompt, w.systemPrompt)
-		script := buildTmuxLaunchScript(session, command, w.prompt, !cmdHasPrompt)
-		// The script sleeps to await REPL readiness before typing the prompt, so
-		// run it off the tick.
-		go func() {
-			if out, err := b.RunScript(inst.ContainerID, script); err != nil {
-				flog.Error("automation: launch tmux agent failed", "instance", inst.Name, "err", err, "out", strings.TrimSpace(out))
-			}
-		}()
-		return
-	}
-	// Non-tmux: run detached so the launch never blocks. There is no interactive
-	// session to type into, so a non-tmux agent must use the ${PROMPT} placeholder
-	// in its command to receive the prompt.
+	session := tui.ResolveSessionName(inst.Name, "agent")
 	command := fleet.SubstituteAgentCommand(w.command, w.prompt, w.systemPrompt)
-	detached := fmt.Sprintf(`nohup sh -lc %s >/tmp/fleet-automation.log 2>&1 &`, dotfiles.ShQuote(command))
-	if out, err := b.RunScript(inst.ContainerID, detached); err != nil {
-		flog.Error("automation: launch command failed", "instance", inst.Name, "err", err, "out", strings.TrimSpace(out))
-	}
+	script := dotfiles.TmuxEnsureInstalled +
+		fmt.Sprintf("tmux new-session -d -s %s %s", dotfiles.ShQuote(session), dotfiles.ShQuote(command))
+	b := s.hub.backendFor(inst)
+	go func() {
+		if out, err := b.RunScript(inst.ContainerID, script); err != nil {
+			flog.Error("automation: launch agent failed", "instance", inst.Name, "err", err, "out", strings.TrimSpace(out))
+		}
+	}()
 }
 
-// buildTmuxLaunchScript builds the in-container shell snippet that starts a
-// tmux-mode agent: ensure tmux, create the (detached) session, type the agent
-// command, then — when sendPrompt is set — wait for the agent's REPL to come up
-// and type the prompt into it. Text is sent with `send-keys -l` (literal) so a
-// prompt that happens to contain tmux key names ("Enter", "C-c", ...) is typed
-// verbatim, with a separate bare `Enter` to submit each line.
-func buildTmuxLaunchScript(sessionName, agentCommand, prompt string, sendPrompt bool) string {
-	sess := dotfiles.ShQuote(sessionName)
-	var b strings.Builder
-	b.WriteString(dotfiles.TmuxEnsureInstalled)
-	fmt.Fprintf(&b, "tmux new-session -d -s %s\n", sess)
-	fmt.Fprintf(&b, "tmux send-keys -t %s -l -- %s\n", sess, dotfiles.ShQuote(agentCommand))
-	fmt.Fprintf(&b, "tmux send-keys -t %s Enter\n", sess)
-	if sendPrompt && prompt != "" {
-		// Wait for the agent's TUI to settle (boot finished, idle waiting for
-		// input) before typing the prompt: poll the pane until its captured text
-		// is unchanged for two consecutive seconds, capped at
-		// automationPromptMaxWait. capture-pane -p returns text only (no cursor),
-		// so a blinking cursor doesn't defeat the "stable" check. A fixed delay
-		// drops the prompt when a slow agent like Claude Code isn't ready yet.
-		fmt.Fprintf(&b, "__fp=''; __fs=0; __fi=0\n")
-		fmt.Fprintf(&b, "while [ \"$__fi\" -lt %d ]; do\n", int(automationPromptMaxWait.Seconds()))
-		fmt.Fprintf(&b, "sleep 1; __fi=$((__fi+1))\n")
-		fmt.Fprintf(&b, "__fc=$(tmux capture-pane -t %s -p 2>/dev/null)\n", sess)
-		fmt.Fprintf(&b, "if [ -n \"$__fc\" ] && [ \"$__fc\" = \"$__fp\" ]; then __fs=$((__fs+1)); [ \"$__fs\" -ge 2 ] && break; else __fs=0; fi\n")
-		fmt.Fprintf(&b, "__fp=$__fc\n")
-		fmt.Fprintf(&b, "done\n")
-		// Type the prompt, then submit with a separate Enter after a short gap so
-		// the agent registers the text before the newline submits it.
-		fmt.Fprintf(&b, "tmux send-keys -t %s -l -- %s\n", sess, dotfiles.ShQuote(prompt))
-		fmt.Fprintf(&b, "sleep 1\n")
-		fmt.Fprintf(&b, "tmux send-keys -t %s Enter\n", sess)
-	}
-	return b.String()
-}
-
-// automationActivity reports a watched agent's current activity by diffing its
-// tmux screen (the same mechanism the TUI shows). The bool is false on a
-// transient capture failure, telling the caller to leave the agent untouched.
+// automationActivity reports a watched agent's current activity, choosing the
+// detector via the shared agentdetect factory from the probed tool — so Claude /
+// Auggie use their lifecycle hooks and other tools fall back to screen-diff,
+// identical to the live TUI path and improvable in one place. The bool is false
+// on a transient capture failure, telling the caller to leave the agent
+// untouched.
 var automationActivity = func(s *service, w *watchedAgent, inst *fleet.Instance, now time.Time) (agentdetect.State, bool) {
 	if inst.ContainerID == "" {
 		return agentdetect.StateNotRunning, false
 	}
-	caps := s.hub.backendFor(inst).CaptureAllSessions(inst.ContainerID)
+	b := s.hub.backendFor(inst)
+	caps := b.CaptureAllSessions(inst.ContainerID)
 	if !caps.OK {
 		return agentdetect.StateNotRunning, false
+	}
+	tool := state.AgentTool("")
+	if t, ok := b.AgentToolProbe(inst.ContainerID); ok {
+		tool = state.AgentTool(t)
+	}
+	if w.detector == nil || w.detectorTool != tool {
+		w.detector = agentdetect.NewDetector(tool)
+		w.detectorTool = tool
 	}
 	return w.detector.Detect(caps, now), true
 }

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -42,12 +43,31 @@ import (
 var (
 	// scheduleTickInterval is how often the loop samples cron triggers and
 	// services watched agents. ~30s comfortably samples every minute-granular
-	// cron minute at least once while staying cheap.
-	scheduleTickInterval = 30 * time.Second
+	// cron minute at least once while staying cheap. Overridable via
+	// FLEET_AUTOMATION_TICK_INTERVAL (a Go duration) so the integration test can
+	// drive the spawn→launch→reap lifecycle in seconds instead of minutes.
+	scheduleTickInterval = envDurationDefault("FLEET_AUTOMATION_TICK_INTERVAL", 30*time.Second)
 	// automationIdleTimeout is how long an agent may stay inactive before its
 	// instance is torn down (issue #188: "inactive for more than 2 minutes").
-	automationIdleTimeout = 2 * time.Minute
+	// Overridable via FLEET_AUTOMATION_IDLE_TIMEOUT (a Go duration) for the same
+	// reason — production keeps the 2m default.
+	automationIdleTimeout = envDurationDefault("FLEET_AUTOMATION_IDLE_TIMEOUT", 2*time.Minute)
 )
+
+// envDurationDefault returns the Go duration parsed from the named env var, or
+// def when it is unset, blank, or unparseable (a non-positive value is also
+// rejected). These knobs exist only so the integration test can shorten the
+// scheduler's cadence and idle timeout to verify the full lifecycle quickly;
+// the daemon inherits the spawning client's environment (spawn.go), so setting
+// them before `fleet ls` reaches the scheduler.
+func envDurationDefault(name string, def time.Duration) time.Duration {
+	if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return def
+}
 
 // maxAutomationProbeConcurrency bounds how many agent activity probes run at
 // once per tick, so a large watch set fans out without spawning an unbounded

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -45,6 +46,11 @@ var (
 	// minutes").
 	automationIdleTimeout = 2 * time.Minute
 )
+
+// maxAutomationProbeConcurrency bounds how many agent activity probes run at
+// once per tick, so a large watch set fans out without spawning an unbounded
+// number of concurrent container execs.
+const maxAutomationProbeConcurrency = 8
 
 // watchedAgent tracks one automation-spawned instance from creation through
 // launch to idle reaping.
@@ -189,8 +195,21 @@ func agentsForTrigger(f *fleet.Fleet, t fleet.Trigger) []fleet.Agent {
 }
 
 // serviceWatched advances every tracked agent: launch its command once running,
-// reap it once idle (tmux mode only), and drop it once gone.
+// reap it once idle (tmux mode only), and drop it once gone. The per-agent
+// activity probe is a potentially slow exec, so the probes run concurrently
+// (bounded) — a large watch set can't stall the scheduler tick. All map
+// mutations and reap decisions stay on this single goroutine; only the probes
+// fan out, and each touches just its own detector + instance (and the
+// mutex-guarded backendFor), so they are race-free.
 func (s *service) serviceWatched(ctx context.Context, sched *scheduler, st *state.State, now time.Time) {
+	// Phase 1 (sequential): lifecycle. Drop gone/failed, launch on running, drop
+	// fire-and-forget agents. Collect the launched tmux agents needing a probe.
+	type pendingCheck struct {
+		key  string
+		w    *watchedAgent
+		inst *fleet.Instance
+	}
+	var checks []pendingCheck
 	for k, w := range sched.watched {
 		inst := findInstance(st, w.fleet, w.instance)
 		if inst == nil {
@@ -225,19 +244,43 @@ func (s *service) serviceWatched(ctx context.Context, sched *scheduler, st *stat
 			delete(sched.watched, k)
 			continue
 		}
+		checks = append(checks, pendingCheck{key: k, w: w, inst: inst})
+	}
 
-		activity, ok := automationActivity(s, w, inst, now)
-		if !ok {
+	// Phase 2 (concurrent, bounded): probe each agent's activity.
+	type probeResult struct {
+		state agentdetect.State
+		ok    bool
+	}
+	results := make([]probeResult, len(checks))
+	sem := make(chan struct{}, maxAutomationProbeConcurrency)
+	var wg sync.WaitGroup
+	for i := range checks {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			activity, ok := automationActivity(s, checks[i].w, checks[i].inst, now)
+			results[i] = probeResult{state: activity, ok: ok}
+		}(i)
+	}
+	wg.Wait()
+
+	// Phase 3 (sequential): apply activity + reap idle agents.
+	for i, c := range checks {
+		r := results[i]
+		if !r.ok {
 			continue // transient capture failure — don't reset activity or reap
 		}
-		if activity == agentdetect.StateWorking {
-			w.lastActive = now
+		if r.state == agentdetect.StateWorking {
+			c.w.lastActive = now
 			continue
 		}
-		if now.Sub(w.lastActive) >= automationIdleTimeout {
-			flog.Info("automation: reaping idle agent", "fleet", w.fleet, "instance", w.instance, "idle", now.Sub(w.lastActive).Round(time.Second).String())
-			reapAutomationInstance(s, w.fleet, w.instance)
-			delete(sched.watched, k)
+		if now.Sub(c.w.lastActive) >= automationIdleTimeout {
+			flog.Info("automation: reaping idle agent", "fleet", c.w.fleet, "instance", c.w.instance, "idle", now.Sub(c.w.lastActive).Round(time.Second).String())
+			reapAutomationInstance(s, c.w.fleet, c.w.instance)
+			delete(sched.watched, c.key)
 		}
 	}
 }

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -365,24 +365,32 @@ var createAutomationInstance = func(s *service, fleetName string, ag fleet.Agent
 // The tmux script runs in a goroutine because it sleeps (giving the agent's REPL
 // a moment to start before the prompt is typed) and must not stall the tick.
 var launchAutomationCommand = func(ctx context.Context, s *service, w *watchedAgent, inst *fleet.Instance) {
+	// Exec straight against the container (RunScript), NOT the devcontainer Node
+	// CLI path (ExecCommand/runContainerShell): from the daemon's scheduler the
+	// Node CLI path silently produced no tmux server, whereas RunScript runs as
+	// the same session user the poller reads, so the agent's session reliably
+	// comes up and shows in the TUI.
+	b := s.hub.backendFor(inst)
 	if w.tmux {
 		session := tui.ResolveSessionName(inst.Name, "agent")
 		cmdHasPrompt := strings.Contains(w.command, "${PROMPT}")
 		command := fleet.SubstituteAgentCommand(w.command, w.prompt, w.systemPrompt)
 		script := buildTmuxLaunchScript(session, command, w.prompt, !cmdHasPrompt)
+		// The script sleeps to await REPL readiness before typing the prompt, so
+		// run it off the tick.
 		go func() {
-			if out, err := runContainerShell(ctx, inst, script); err != nil {
+			if out, err := b.RunScript(inst.ContainerID, script); err != nil {
 				flog.Error("automation: launch tmux agent failed", "instance", inst.Name, "err", err, "out", strings.TrimSpace(out))
 			}
 		}()
 		return
 	}
-	// Non-tmux: run detached so the scheduler tick never blocks on the agent.
-	// There is no interactive session to type into, so a non-tmux agent must use
-	// the ${PROMPT} placeholder in its command to receive the prompt.
+	// Non-tmux: run detached so the launch never blocks. There is no interactive
+	// session to type into, so a non-tmux agent must use the ${PROMPT} placeholder
+	// in its command to receive the prompt.
 	command := fleet.SubstituteAgentCommand(w.command, w.prompt, w.systemPrompt)
 	detached := fmt.Sprintf(`nohup sh -lc %s >/tmp/fleet-automation.log 2>&1 &`, dotfiles.ShQuote(command))
-	if out, err := runContainerShell(ctx, inst, detached); err != nil {
+	if out, err := b.RunScript(inst.ContainerID, detached); err != nil {
 		flog.Error("automation: launch command failed", "instance", inst.Name, "err", err, "out", strings.TrimSpace(out))
 	}
 }

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -45,6 +45,11 @@ var (
 	// before its instance is torn down (issue #188: "inactive for more than 2
 	// minutes").
 	automationIdleTimeout = 2 * time.Minute
+	// automationPromptDelay is how long to wait after starting a tmux-mode
+	// agent before typing the prompt into it, giving the agent's REPL time to
+	// come up so the keystrokes are not dropped. Best-effort (a fixed delay is
+	// imperfect, but agents like Claude Code start within a few seconds).
+	automationPromptDelay = 5 * time.Second
 )
 
 // maxAutomationProbeConcurrency bounds how many agent activity probes run at
@@ -346,28 +351,61 @@ var createAutomationInstance = func(s *service, fleetName string, ag fleet.Agent
 
 // launchAutomationCommand runs the agent's command inside its (running)
 // instance: a detached tmux session the user can open in the TUI (tmux mode), or
-// a detached background process (non-tmux). ${PROMPT}/${SYS_PROMPT} are
-// substituted first.
+// a detached background process (non-tmux).
+//
+// In tmux mode the prompt is delivered the way issue #188 specifies — "the
+// PROMPT will be sent via tmux send keys": the agent command (with ${SYS_PROMPT}
+// substituted) starts the agent, then the trigger prompt is typed into it as a
+// SEPARATE send-keys line. That is what makes the default command —
+// `claude --system-prompt '${SYS_PROMPT}'`, which has no ${PROMPT} — actually do
+// work: the prompt is typed into the running agent rather than relying on a
+// ${PROMPT} placeholder the default doesn't contain. If the command DOES embed
+// ${PROMPT} the prompt is substituted there instead and not re-sent.
+//
+// The tmux script runs in a goroutine because it sleeps (giving the agent's REPL
+// a moment to start before the prompt is typed) and must not stall the tick.
 var launchAutomationCommand = func(ctx context.Context, s *service, w *watchedAgent, inst *fleet.Instance) {
-	command := fleet.SubstituteAgentCommand(w.command, w.prompt, w.systemPrompt)
 	if w.tmux {
 		session := tui.ResolveSessionName(inst.Name, "agent")
-		spawn := dotfiles.TmuxEnsureInstalled + fmt.Sprintf(`tmux new-session -d -s %s`, dotfiles.ShQuote(session))
-		if out, err := runContainerShell(ctx, inst, spawn); err != nil {
-			flog.Error("automation: spawn session failed", "instance", inst.Name, "err", err, "out", strings.TrimSpace(out))
-			return
-		}
-		send := fmt.Sprintf(`tmux send-keys -t %s %s Enter`, dotfiles.ShQuote(session), dotfiles.ShQuote(command))
-		if out, err := runContainerShell(ctx, inst, send); err != nil {
-			flog.Error("automation: send command failed", "instance", inst.Name, "err", err, "out", strings.TrimSpace(out))
-		}
+		cmdHasPrompt := strings.Contains(w.command, "${PROMPT}")
+		command := fleet.SubstituteAgentCommand(w.command, w.prompt, w.systemPrompt)
+		script := buildTmuxLaunchScript(session, command, w.prompt, !cmdHasPrompt)
+		go func() {
+			if out, err := runContainerShell(ctx, inst, script); err != nil {
+				flog.Error("automation: launch tmux agent failed", "instance", inst.Name, "err", err, "out", strings.TrimSpace(out))
+			}
+		}()
 		return
 	}
 	// Non-tmux: run detached so the scheduler tick never blocks on the agent.
+	// There is no interactive session to type into, so a non-tmux agent must use
+	// the ${PROMPT} placeholder in its command to receive the prompt.
+	command := fleet.SubstituteAgentCommand(w.command, w.prompt, w.systemPrompt)
 	detached := fmt.Sprintf(`nohup sh -lc %s >/tmp/fleet-automation.log 2>&1 &`, dotfiles.ShQuote(command))
 	if out, err := runContainerShell(ctx, inst, detached); err != nil {
 		flog.Error("automation: launch command failed", "instance", inst.Name, "err", err, "out", strings.TrimSpace(out))
 	}
+}
+
+// buildTmuxLaunchScript builds the in-container shell snippet that starts a
+// tmux-mode agent: ensure tmux, create the (detached) session, type the agent
+// command, then — when sendPrompt is set — wait for the agent's REPL to come up
+// and type the prompt into it. Text is sent with `send-keys -l` (literal) so a
+// prompt that happens to contain tmux key names ("Enter", "C-c", ...) is typed
+// verbatim, with a separate bare `Enter` to submit each line.
+func buildTmuxLaunchScript(sessionName, agentCommand, prompt string, sendPrompt bool) string {
+	sess := dotfiles.ShQuote(sessionName)
+	var b strings.Builder
+	b.WriteString(dotfiles.TmuxEnsureInstalled)
+	fmt.Fprintf(&b, "tmux new-session -d -s %s\n", sess)
+	fmt.Fprintf(&b, "tmux send-keys -t %s -l -- %s\n", sess, dotfiles.ShQuote(agentCommand))
+	fmt.Fprintf(&b, "tmux send-keys -t %s Enter\n", sess)
+	if sendPrompt && prompt != "" {
+		fmt.Fprintf(&b, "sleep %d\n", int(automationPromptDelay.Seconds()))
+		fmt.Fprintf(&b, "tmux send-keys -t %s -l -- %s\n", sess, dotfiles.ShQuote(prompt))
+		fmt.Fprintf(&b, "tmux send-keys -t %s Enter\n", sess)
+	}
+	return b.String()
 }
 
 // automationActivity reports a watched agent's current activity by diffing its

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -45,11 +45,12 @@ var (
 	// before its instance is torn down (issue #188: "inactive for more than 2
 	// minutes").
 	automationIdleTimeout = 2 * time.Minute
-	// automationPromptDelay is how long to wait after starting a tmux-mode
-	// agent before typing the prompt into it, giving the agent's REPL time to
-	// come up so the keystrokes are not dropped. Best-effort (a fixed delay is
-	// imperfect, but agents like Claude Code start within a few seconds).
-	automationPromptDelay = 5 * time.Second
+	// automationPromptMaxWait caps how long the launch waits for a tmux-mode
+	// agent's TUI to finish booting (its pane to stop changing) before typing the
+	// prompt. A fixed delay drops the prompt when the agent (e.g. Claude Code,
+	// especially with MCP servers) is slow to come up, so the launch polls for
+	// readiness and only falls back to this cap if the pane never settles.
+	automationPromptMaxWait = 30 * time.Second
 )
 
 // maxAutomationProbeConcurrency bounds how many agent activity probes run at
@@ -425,8 +426,23 @@ func buildTmuxLaunchScript(sessionName, agentCommand, prompt string, sendPrompt 
 	fmt.Fprintf(&b, "tmux send-keys -t %s -l -- %s\n", sess, dotfiles.ShQuote(agentCommand))
 	fmt.Fprintf(&b, "tmux send-keys -t %s Enter\n", sess)
 	if sendPrompt && prompt != "" {
-		fmt.Fprintf(&b, "sleep %d\n", int(automationPromptDelay.Seconds()))
+		// Wait for the agent's TUI to settle (boot finished, idle waiting for
+		// input) before typing the prompt: poll the pane until its captured text
+		// is unchanged for two consecutive seconds, capped at
+		// automationPromptMaxWait. capture-pane -p returns text only (no cursor),
+		// so a blinking cursor doesn't defeat the "stable" check. A fixed delay
+		// drops the prompt when a slow agent like Claude Code isn't ready yet.
+		fmt.Fprintf(&b, "__fp=''; __fs=0; __fi=0\n")
+		fmt.Fprintf(&b, "while [ \"$__fi\" -lt %d ]; do\n", int(automationPromptMaxWait.Seconds()))
+		fmt.Fprintf(&b, "sleep 1; __fi=$((__fi+1))\n")
+		fmt.Fprintf(&b, "__fc=$(tmux capture-pane -t %s -p 2>/dev/null)\n", sess)
+		fmt.Fprintf(&b, "if [ -n \"$__fc\" ] && [ \"$__fc\" = \"$__fp\" ]; then __fs=$((__fs+1)); [ \"$__fs\" -ge 2 ] && break; else __fs=0; fi\n")
+		fmt.Fprintf(&b, "__fp=$__fc\n")
+		fmt.Fprintf(&b, "done\n")
+		// Type the prompt, then submit with a separate Enter after a short gap so
+		// the agent registers the text before the newline submits it.
 		fmt.Fprintf(&b, "tmux send-keys -t %s -l -- %s\n", sess, dotfiles.ShQuote(prompt))
+		fmt.Fprintf(&b, "sleep 1\n")
 		fmt.Fprintf(&b, "tmux send-keys -t %s Enter\n", sess)
 	}
 	return b.String()

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -1,0 +1,333 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/agentdetect"
+	"github.com/BenjaminBenetti/fleet-man/internal/dotfiles"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+	"github.com/BenjaminBenetti/fleet-man/internal/tui"
+)
+
+// schedule.go is the server-side automation scheduler (issue #188). It runs as
+// an unconditional background loop (cron triggers must fire even when no TUI is
+// connected — that is the whole point of automation) and:
+//
+//  1. fires due Schedule triggers, spawning a normal fleet instance per
+//     referenced agent (they appear in the TUI like any other instance);
+//  2. once that instance is running, launches the agent's command — in a tmux
+//     session (default) so the user can open it in the TUI, with the trigger
+//     prompt + agent system prompt substituted into ${PROMPT}/${SYS_PROMPT};
+//  3. reaps tmux-mode agents that go idle for longer than the idle timeout,
+//     detected with the same screen-diff mechanism the TUI shows.
+//
+// Webhook triggers are modeled but not delivered here — wiring the gateway
+// endpoint is explicitly out of scope for issue #188.
+//
+// The loop is single-goroutine: scheduler's maps are only ever touched from the
+// tick, so they need no locking. The live operations (instance create, command
+// launch, activity capture, reap) are package-var seams so tests drive the
+// lifecycle deterministically without containers.
+var (
+	// scheduleTickInterval is how often the loop samples cron triggers and
+	// services watched agents. ~30s comfortably samples every minute-granular
+	// cron minute at least once while staying cheap.
+	scheduleTickInterval = 30 * time.Second
+	// automationIdleTimeout is how long a tmux-mode agent may stay inactive
+	// before its instance is torn down (issue #188: "inactive for more than 2
+	// minutes").
+	automationIdleTimeout = 2 * time.Minute
+)
+
+// watchedAgent tracks one automation-spawned instance from creation through
+// launch to idle reaping.
+type watchedAgent struct {
+	fleet        string
+	instance     string
+	command      string
+	prompt       string
+	systemPrompt string
+	tmux         bool
+	spawnedAt    time.Time
+	lastActive   time.Time
+	launched     bool
+	detector     *agentdetect.TmuxPaneChangeDetector
+}
+
+func (w *watchedAgent) key() string { return w.fleet + "/" + w.instance }
+
+// scheduler holds the loop's per-process state (single-goroutine, no locks).
+type scheduler struct {
+	lastFired map[string]time.Time     // "fleet\x00trigger" -> minute it last fired
+	watched   map[string]*watchedAgent // "fleet/instance" -> tracked agent
+}
+
+func newScheduler() *scheduler {
+	return &scheduler{
+		lastFired: make(map[string]time.Time),
+		watched:   make(map[string]*watchedAgent),
+	}
+}
+
+// runScheduler is the automation loop; it returns when ctx is cancelled.
+func (s *service) runScheduler(ctx context.Context) {
+	sched := newScheduler()
+	ticker := time.NewTicker(scheduleTickInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.schedulerTick(ctx, sched, time.Now())
+		}
+	}
+}
+
+// schedulerTick fires due triggers and services watched agents for one tick.
+func (s *service) schedulerTick(ctx context.Context, sched *scheduler, now time.Time) {
+	st, err := state.Load()
+	if err != nil {
+		flog.Warn("automation: load state failed", "err", err)
+		return
+	}
+	for _, due := range dueSchedules(st.Fleets, now, sched.lastFired) {
+		for _, ag := range agentsForTrigger(st.Fleets[due.fleet], due.trigger) {
+			instName, err := createAutomationInstance(s, due.fleet, ag, now)
+			if err != nil {
+				flog.Warn("automation: create instance failed", "fleet", due.fleet, "agent", ag.Name, "err", err)
+				continue
+			}
+			flog.Info("automation: trigger fired", "fleet", due.fleet, "trigger", due.trigger.Name, "agent", ag.Name, "instance", instName)
+			w := &watchedAgent{
+				fleet:        due.fleet,
+				instance:     instName,
+				command:      ag.Command,
+				prompt:       due.trigger.Prompt,
+				systemPrompt: ag.SystemPrompt,
+				tmux:         ag.TmuxMode,
+				spawnedAt:    now,
+				lastActive:   now,
+				detector:     agentdetect.NewTmuxPaneChangeDetector(),
+			}
+			sched.watched[w.key()] = w
+		}
+	}
+	s.serviceWatched(ctx, sched, st, now)
+}
+
+// scheduledFire is one trigger that should fire now.
+type scheduledFire struct {
+	fleet   string
+	trigger fleet.Trigger
+}
+
+// dueSchedules returns the schedule triggers whose cron matches now and that
+// have not already fired this minute, recording the fire in lastFired. Pure
+// except for the lastFired bookkeeping, so it is unit-tested directly.
+func dueSchedules(fleets map[string]*fleet.Fleet, now time.Time, lastFired map[string]time.Time) []scheduledFire {
+	minute := now.Truncate(time.Minute)
+	var out []scheduledFire
+	for name, f := range fleets {
+		if f == nil {
+			continue
+		}
+		for _, t := range f.Settings.Triggers {
+			if t.Type != fleet.TriggerSchedule || t.Cron == "" {
+				continue
+			}
+			sched, err := fleet.ParseCron(t.Cron)
+			if err != nil || !sched.Matches(now) {
+				continue
+			}
+			key := name + "\x00" + t.Name
+			if last, ok := lastFired[key]; ok && !last.Before(minute) {
+				continue // already fired this minute
+			}
+			lastFired[key] = minute
+			out = append(out, scheduledFire{fleet: name, trigger: t})
+		}
+	}
+	return out
+}
+
+// agentsForTrigger resolves a trigger's agent names to the fleet's Agent records
+// (in reference order, skipping any that no longer exist).
+func agentsForTrigger(f *fleet.Fleet, t fleet.Trigger) []fleet.Agent {
+	if f == nil {
+		return nil
+	}
+	var out []fleet.Agent
+	for _, name := range t.AgentNames {
+		for _, a := range f.Settings.Agents {
+			if a.Name == name {
+				out = append(out, a)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// serviceWatched advances every tracked agent: launch its command once running,
+// reap it once idle (tmux mode only), and drop it once gone.
+func (s *service) serviceWatched(ctx context.Context, sched *scheduler, st *state.State, now time.Time) {
+	for k, w := range sched.watched {
+		inst := findInstance(st, w.fleet, w.instance)
+		if inst == nil {
+			delete(sched.watched, k) // instance gone (reaped / destroyed)
+			continue
+		}
+		switch inst.Status {
+		case fleet.StatusFailed:
+			// Provisioning failed; stop tracking and leave the record for the user.
+			delete(sched.watched, k)
+			continue
+		case fleet.StatusRunning:
+			// fall through
+		default:
+			continue // still creating / transitional
+		}
+
+		if !w.launched {
+			launchAutomationCommand(ctx, s, w, inst)
+			w.launched = true
+			w.lastActive = now
+			continue
+		}
+		if !w.tmux {
+			continue // non-tmux agents are fire-and-forget; never idle-reaped
+		}
+
+		activity, ok := automationActivity(s, w, inst, now)
+		if !ok {
+			continue // transient capture failure — don't reset activity or reap
+		}
+		if activity == agentdetect.StateWorking {
+			w.lastActive = now
+			continue
+		}
+		if now.Sub(w.lastActive) >= automationIdleTimeout {
+			flog.Info("automation: reaping idle agent", "fleet", w.fleet, "instance", w.instance, "idle", now.Sub(w.lastActive).Round(time.Second).String())
+			reapAutomationInstance(s, w.fleet, w.instance)
+			delete(sched.watched, k)
+		}
+	}
+}
+
+func findInstance(st *state.State, fleetName, instanceName string) *fleet.Instance {
+	f, ok := st.Fleets[fleetName]
+	if !ok {
+		return nil
+	}
+	inst, err := f.GetInstance(instanceName)
+	if err != nil {
+		return nil
+	}
+	return inst
+}
+
+// automationSeq makes automation instance names unique within a second.
+var automationSeq int64
+
+// automationInstanceName builds a unique, valid instance name for an agent run.
+func automationInstanceName(agentName string, now time.Time) string {
+	base := sanitizeAutomationName(agentName)
+	if base == "" {
+		base = "agent"
+	}
+	return fmt.Sprintf("%s-%s-%d", base, now.Format("150405"), atomic.AddInt64(&automationSeq, 1))
+}
+
+// sanitizeAutomationName lowercases and reduces a name to [a-z0-9-] so it embeds
+// cleanly in container names / workspace paths.
+func sanitizeAutomationName(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if len(out) > 24 {
+		out = strings.Trim(out[:24], "-")
+	}
+	return out
+}
+
+// --- Live operation seams (overridden in tests) ----------------------------
+
+// createAutomationInstance spawns a new instance for an agent run and returns
+// its name. It reuses the same job path as the CreateInstance RPC.
+var createAutomationInstance = func(s *service, fleetName string, ag fleet.Agent, now time.Time) (string, error) {
+	instName := automationInstanceName(ag.Name, now)
+	if _, err := s.startCreateInstanceJob(&fleetgrpc.CreateInstanceRequest{
+		Fleet:    fleetName,
+		Instance: instName,
+		Backend:  backendToProto(ag.Backend),
+	}); err != nil {
+		return "", err
+	}
+	return instName, nil
+}
+
+// launchAutomationCommand runs the agent's command inside its (running)
+// instance: a detached tmux session the user can open in the TUI (tmux mode), or
+// a detached background process (non-tmux). ${PROMPT}/${SYS_PROMPT} are
+// substituted first.
+var launchAutomationCommand = func(ctx context.Context, s *service, w *watchedAgent, inst *fleet.Instance) {
+	command := fleet.SubstituteAgentCommand(w.command, w.prompt, w.systemPrompt)
+	if w.tmux {
+		session := tui.ResolveSessionName(inst.Name, "agent")
+		spawn := dotfiles.TmuxEnsureInstalled + fmt.Sprintf(`tmux new-session -d -s %s`, dotfiles.ShQuote(session))
+		if out, err := runContainerShell(ctx, inst, spawn); err != nil {
+			flog.Error("automation: spawn session failed", "instance", inst.Name, "err", err, "out", strings.TrimSpace(out))
+			return
+		}
+		send := fmt.Sprintf(`tmux send-keys -t %s %s Enter`, dotfiles.ShQuote(session), dotfiles.ShQuote(command))
+		if out, err := runContainerShell(ctx, inst, send); err != nil {
+			flog.Error("automation: send command failed", "instance", inst.Name, "err", err, "out", strings.TrimSpace(out))
+		}
+		return
+	}
+	// Non-tmux: run detached so the scheduler tick never blocks on the agent.
+	detached := fmt.Sprintf(`nohup sh -lc %s >/tmp/fleet-automation.log 2>&1 &`, dotfiles.ShQuote(command))
+	if out, err := runContainerShell(ctx, inst, detached); err != nil {
+		flog.Error("automation: launch command failed", "instance", inst.Name, "err", err, "out", strings.TrimSpace(out))
+	}
+}
+
+// automationActivity reports a watched agent's current activity by diffing its
+// tmux screen (the same mechanism the TUI shows). The bool is false on a
+// transient capture failure, telling the caller to leave the agent untouched.
+var automationActivity = func(s *service, w *watchedAgent, inst *fleet.Instance, now time.Time) (agentdetect.State, bool) {
+	if inst.ContainerID == "" {
+		return agentdetect.StateNotRunning, false
+	}
+	caps := s.hub.backendFor(inst).CaptureAllSessions(inst.ContainerID)
+	if !caps.OK {
+		return agentdetect.StateNotRunning, false
+	}
+	return w.detector.Detect(caps, now), true
+}
+
+// reapAutomationInstance tears down an idle automation instance (container +
+// record) via the same destroy job the CLI/TUI use.
+var reapAutomationInstance = func(s *service, fleetName, instanceName string) {
+	if _, err := s.startDestroyInstanceJob(&fleetgrpc.DestroyInstanceRequest{
+		Fleet:    fleetName,
+		Instance: &instanceName,
+	}); err != nil {
+		flog.Error("automation: reap failed", "fleet", fleetName, "instance", instanceName, "err", err)
+	}
+}

--- a/internal/server/schedule_test.go
+++ b/internal/server/schedule_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -293,6 +294,35 @@ func TestServiceWatchedConcurrentProbesReapAll(t *testing.T) {
 	}
 	if len(sched.watched) != 0 {
 		t.Fatalf("watch set should be drained, still has %d", len(sched.watched))
+	}
+}
+
+func TestEnvDurationDefault(t *testing.T) {
+	const name = "FLEET_TEST_DURATION_KNOB"
+	def := 2 * time.Minute
+	cases := []struct {
+		val  string
+		set  bool
+		want time.Duration
+	}{
+		{set: false, want: def},             // unset → default
+		{val: "", set: true, want: def},     // blank → default
+		{val: "  ", set: true, want: def},   // whitespace → default
+		{val: "nope", set: true, want: def}, // unparseable → default
+		{val: "0s", set: true, want: def},   // non-positive → default
+		{val: "-5s", set: true, want: def},  // negative → default
+		{val: "20s", set: true, want: 20 * time.Second},
+		{val: "1m30s", set: true, want: 90 * time.Second},
+	}
+	for _, c := range cases {
+		if c.set {
+			t.Setenv(name, c.val)
+		} else {
+			os.Unsetenv(name)
+		}
+		if got := envDurationDefault(name, def); got != c.want {
+			t.Fatalf("envDurationDefault(%q set=%v) = %v, want %v", c.val, c.set, got, c.want)
+		}
 	}
 }
 

--- a/internal/server/schedule_test.go
+++ b/internal/server/schedule_test.go
@@ -230,6 +230,36 @@ func TestServiceWatchedNonTmuxDroppedAfterLaunch(t *testing.T) {
 	}
 }
 
+func TestBuildTmuxLaunchScript(t *testing.T) {
+	// Default-style command (no ${PROMPT}): the prompt must be typed in as a
+	// SEPARATE send-keys line after the agent starts — otherwise the agent never
+	// gets prompted and no work begins (the reported bug).
+	script := buildTmuxLaunchScript("alpha~agent", "claude --system-prompt 'be terse'", "do the task", true)
+	for _, want := range []string{
+		"tmux new-session -d -s 'alpha~agent'",
+		"send-keys -t 'alpha~agent' -l -- 'claude --system-prompt '\\''be terse'\\'''",
+		"sleep 5",
+		"send-keys -t 'alpha~agent' -l -- 'do the task'",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("launch script missing %q\n%s", want, script)
+		}
+	}
+	// Two literal sends (agent command + prompt), each followed by a bare Enter.
+	if n := strings.Count(script, "-l --"); n != 2 {
+		t.Fatalf("expected 2 literal send-keys (command + prompt), got %d:\n%s", n, script)
+	}
+	if n := strings.Count(script, "Enter\n"); n != 2 {
+		t.Fatalf("expected 2 Enter submits, got %d:\n%s", n, script)
+	}
+
+	// When the command already embeds ${PROMPT}, the prompt is NOT re-sent.
+	noResend := buildTmuxLaunchScript("alpha~agent", "claude -p 'do the task'", "do the task", false)
+	if strings.Contains(noResend, "sleep") || strings.Count(noResend, "-l --") != 1 {
+		t.Fatalf("prompt must not be sent separately when the command embeds it:\n%s", noResend)
+	}
+}
+
 func TestServiceWatchedConcurrentProbesReapAll(t *testing.T) {
 	rec := stubAutomationSeams(t)
 	rec.activity = func(time.Time) (agentdetect.State, bool) { return agentdetect.StateWaiting, true }

--- a/internal/server/schedule_test.go
+++ b/internal/server/schedule_test.go
@@ -1,0 +1,202 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/agentdetect"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+func scheduleFleet(triggers []fleet.Trigger, agents []fleet.Agent) map[string]*fleet.Fleet {
+	return map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Settings: fleet.FleetSettings{Triggers: triggers, Agents: agents}},
+	}
+}
+
+func TestDueSchedulesFiresOncePerMinute(t *testing.T) {
+	// 2026-06-22 is a Monday at 09:00.
+	now := time.Date(2026, 6, 22, 9, 0, 30, 0, time.UTC)
+	fleets := scheduleFleet([]fleet.Trigger{
+		{Name: "match", Type: fleet.TriggerSchedule, AgentNames: []string{"a"}, Cron: "0 9 * * 1"},
+		{Name: "nomatch", Type: fleet.TriggerSchedule, AgentNames: []string{"a"}, Cron: "0 10 * * 1"},
+		{Name: "webhook", Type: fleet.TriggerWebhook, AgentNames: []string{"a"}, WebhookName: "x"},
+		{Name: "badcron", Type: fleet.TriggerSchedule, AgentNames: []string{"a"}, Cron: "not cron"},
+	}, []fleet.Agent{{Name: "a"}})
+
+	lastFired := map[string]time.Time{}
+	due := dueSchedules(fleets, now, lastFired)
+	if len(due) != 1 || due[0].trigger.Name != "match" {
+		t.Fatalf("want only 'match' to fire, got %+v", due)
+	}
+
+	// Same minute again: no re-fire.
+	if again := dueSchedules(fleets, now.Add(20*time.Second), lastFired); len(again) != 0 {
+		t.Fatalf("trigger re-fired within the same minute: %+v", again)
+	}
+
+	// Next matching week: fires again.
+	next := now.AddDate(0, 0, 7)
+	if again := dueSchedules(fleets, next, lastFired); len(again) != 1 {
+		t.Fatalf("trigger should fire on the next matching minute: %+v", again)
+	}
+}
+
+func TestAgentsForTrigger(t *testing.T) {
+	f := &fleet.Fleet{Settings: fleet.FleetSettings{Agents: []fleet.Agent{{Name: "a"}, {Name: "b"}}}}
+	got := agentsForTrigger(f, fleet.Trigger{AgentNames: []string{"b", "ghost", "a"}})
+	if len(got) != 2 || got[0].Name != "b" || got[1].Name != "a" {
+		t.Fatalf("agentsForTrigger = %+v", got)
+	}
+}
+
+func TestAutomationInstanceName(t *testing.T) {
+	now := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
+	n1 := automationInstanceName("My Builder!", now)
+	n2 := automationInstanceName("My Builder!", now)
+	if n1 == n2 {
+		t.Fatalf("names should be unique: %q == %q", n1, n2)
+	}
+	for _, n := range []string{n1, n2} {
+		if err := fleet.ValidateInstanceName(n); err != nil {
+			t.Fatalf("invalid instance name %q: %v", n, err)
+		}
+		if !strings.HasPrefix(n, "my-builder-") {
+			t.Fatalf("sanitized name unexpected: %q", n)
+		}
+	}
+}
+
+// stubAutomationSeams overrides the live operation seams for the duration of a
+// test, returning a restore function and recorders.
+type seamRecorder struct {
+	launched []string
+	reaped   []string
+	activity func(now time.Time) (agentdetect.State, bool)
+}
+
+func stubAutomationSeams(t *testing.T) *seamRecorder {
+	t.Helper()
+	rec := &seamRecorder{activity: func(time.Time) (agentdetect.State, bool) { return agentdetect.StateWaiting, true }}
+
+	origLaunch := launchAutomationCommand
+	origActivity := automationActivity
+	origReap := reapAutomationInstance
+	launchAutomationCommand = func(_ context.Context, _ *service, w *watchedAgent, _ *fleet.Instance) {
+		rec.launched = append(rec.launched, w.instance)
+	}
+	automationActivity = func(_ *service, _ *watchedAgent, _ *fleet.Instance, now time.Time) (agentdetect.State, bool) {
+		return rec.activity(now)
+	}
+	reapAutomationInstance = func(_ *service, _, instanceName string) {
+		rec.reaped = append(rec.reaped, instanceName)
+	}
+	t.Cleanup(func() {
+		launchAutomationCommand = origLaunch
+		automationActivity = origActivity
+		reapAutomationInstance = origReap
+	})
+	return rec
+}
+
+func watchedState(status fleet.InstanceStatus) *state.State {
+	return &state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Instances: []*fleet.Instance{
+			{Name: "agent-1", Status: status, ContainerID: "c1"},
+		}},
+	}}
+}
+
+func newWatchedScheduler(now time.Time, tmux bool) *scheduler {
+	sched := newScheduler()
+	sched.watched["alpha/agent-1"] = &watchedAgent{
+		fleet: "alpha", instance: "agent-1", tmux: tmux,
+		spawnedAt: now, lastActive: now,
+		detector: agentdetect.NewTmuxPaneChangeDetector(),
+	}
+	return sched
+}
+
+func TestServiceWatchedLaunchesWhenRunning(t *testing.T) {
+	rec := stubAutomationSeams(t)
+	s := &service{}
+	now := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
+	sched := newWatchedScheduler(now, true)
+
+	// Still creating → no launch.
+	s.serviceWatched(context.Background(), sched, watchedState(fleet.StatusCreating), now)
+	if len(rec.launched) != 0 {
+		t.Fatalf("should not launch before running: %v", rec.launched)
+	}
+
+	// Running → launch once, mark launched.
+	s.serviceWatched(context.Background(), sched, watchedState(fleet.StatusRunning), now)
+	if len(rec.launched) != 1 || rec.launched[0] != "agent-1" {
+		t.Fatalf("expected one launch, got %v", rec.launched)
+	}
+	if !sched.watched["alpha/agent-1"].launched {
+		t.Fatal("watched agent should be marked launched")
+	}
+}
+
+func TestServiceWatchedReapsIdle(t *testing.T) {
+	rec := stubAutomationSeams(t)
+	s := &service{}
+	t0 := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
+	sched := newWatchedScheduler(t0, true)
+	sched.watched["alpha/agent-1"].launched = true
+	st := watchedState(fleet.StatusRunning)
+
+	// Working keeps it alive and resets the idle clock.
+	rec.activity = func(time.Time) (agentdetect.State, bool) { return agentdetect.StateWorking, true }
+	s.serviceWatched(context.Background(), sched, st, t0.Add(time.Minute))
+	if len(rec.reaped) != 0 {
+		t.Fatalf("working agent must not be reaped: %v", rec.reaped)
+	}
+
+	// Idle but within the timeout → not reaped.
+	rec.activity = func(time.Time) (agentdetect.State, bool) { return agentdetect.StateWaiting, true }
+	s.serviceWatched(context.Background(), sched, st, t0.Add(2*time.Minute))
+	if len(rec.reaped) != 0 {
+		t.Fatalf("agent reaped too early: %v", rec.reaped)
+	}
+
+	// Idle past the timeout (measured from the last Working at t0+1m) → reaped.
+	s.serviceWatched(context.Background(), sched, st, t0.Add(time.Minute+automationIdleTimeout))
+	if len(rec.reaped) != 1 || rec.reaped[0] != "agent-1" {
+		t.Fatalf("expected reap, got %v", rec.reaped)
+	}
+	if _, still := sched.watched["alpha/agent-1"]; still {
+		t.Fatal("reaped agent should be dropped from the watch set")
+	}
+}
+
+func TestServiceWatchedNonTmuxNotReaped(t *testing.T) {
+	rec := stubAutomationSeams(t)
+	rec.activity = func(time.Time) (agentdetect.State, bool) { return agentdetect.StateWaiting, true }
+	s := &service{}
+	t0 := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
+	sched := newWatchedScheduler(t0, false) // non-tmux
+	sched.watched["alpha/agent-1"].launched = true
+
+	s.serviceWatched(context.Background(), sched, watchedState(fleet.StatusRunning), t0.Add(time.Hour))
+	if len(rec.reaped) != 0 {
+		t.Fatalf("non-tmux agents must never be idle-reaped: %v", rec.reaped)
+	}
+}
+
+func TestServiceWatchedDropsGoneInstance(t *testing.T) {
+	stubAutomationSeams(t)
+	s := &service{}
+	now := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
+	sched := newWatchedScheduler(now, true)
+
+	// Instance not present in state (destroyed) → dropped from the watch set.
+	s.serviceWatched(context.Background(), sched, &state.State{Fleets: map[string]*fleet.Fleet{"alpha": {Name: "alpha"}}}, now)
+	if _, still := sched.watched["alpha/agent-1"]; still {
+		t.Fatal("vanished instance should be dropped from the watch set")
+	}
+}

--- a/internal/server/schedule_test.go
+++ b/internal/server/schedule_test.go
@@ -132,12 +132,11 @@ func watchedState(status fleet.InstanceStatus) *state.State {
 	}}
 }
 
-func newWatchedScheduler(now time.Time, tmux bool) *scheduler {
+func newWatchedScheduler(now time.Time) *scheduler {
 	sched := newScheduler()
 	sched.watched["alpha/agent-1"] = &watchedAgent{
-		fleet: "alpha", instance: "agent-1", tmux: tmux,
+		fleet: "alpha", instance: "agent-1",
 		spawnedAt: now, lastActive: now,
-		detector: agentdetect.NewTmuxPaneChangeDetector(),
 	}
 	return sched
 }
@@ -146,7 +145,7 @@ func TestServiceWatchedLaunchesWhenRunning(t *testing.T) {
 	rec := stubAutomationSeams(t)
 	s := &service{}
 	now := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
-	sched := newWatchedScheduler(now, true)
+	sched := newWatchedScheduler(now)
 
 	// Still creating → no launch.
 	s.serviceWatched(context.Background(), sched, watchedState(fleet.StatusCreating), now)
@@ -168,7 +167,7 @@ func TestServiceWatchedReapsIdle(t *testing.T) {
 	rec := stubAutomationSeams(t)
 	s := &service{}
 	t0 := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
-	sched := newWatchedScheduler(t0, true)
+	sched := newWatchedScheduler(t0)
 	sched.watched["alpha/agent-1"].launched = true
 	st := watchedState(fleet.StatusRunning)
 
@@ -196,40 +195,6 @@ func TestServiceWatchedReapsIdle(t *testing.T) {
 	}
 }
 
-func TestServiceWatchedNonTmuxNotReaped(t *testing.T) {
-	rec := stubAutomationSeams(t)
-	rec.activity = func(time.Time) (agentdetect.State, bool) { return agentdetect.StateWaiting, true }
-	s := &service{}
-	t0 := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
-	sched := newWatchedScheduler(t0, false) // non-tmux
-	sched.watched["alpha/agent-1"].launched = true
-
-	s.serviceWatched(context.Background(), sched, watchedState(fleet.StatusRunning), t0.Add(time.Hour))
-	if len(rec.reaped) != 0 {
-		t.Fatalf("non-tmux agents must never be idle-reaped: %v", rec.reaped)
-	}
-}
-
-func TestServiceWatchedNonTmuxDroppedAfterLaunch(t *testing.T) {
-	rec := stubAutomationSeams(t)
-	s := &service{}
-	now := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
-	sched := newWatchedScheduler(now, false) // non-tmux, not yet launched
-
-	// First running tick: launch once, then drop from the watch set (fire-and-
-	// forget) so it can't accumulate or be idle-reaped.
-	s.serviceWatched(context.Background(), sched, watchedState(fleet.StatusRunning), now)
-	if len(rec.launched) != 1 {
-		t.Fatalf("expected one launch, got %v", rec.launched)
-	}
-	if _, still := sched.watched["alpha/agent-1"]; still {
-		t.Fatal("non-tmux agent should be dropped from the watch set after launch")
-	}
-	if len(rec.reaped) != 0 {
-		t.Fatalf("non-tmux agent must not be reaped: %v", rec.reaped)
-	}
-}
-
 func TestSchedulerTickKeepsWatchAfterFiring(t *testing.T) {
 	// Regression: schedulerTick used the pre-fire state snapshot for
 	// serviceWatched, so the just-created instance wasn't visible and the watch
@@ -238,7 +203,7 @@ func TestSchedulerTickKeepsWatchAfterFiring(t *testing.T) {
 
 	st := &state.State{Fleets: map[string]*fleet.Fleet{
 		"alpha": {Name: "alpha", Remote: "file:///x", Settings: fleet.FleetSettings{
-			Agents:   []fleet.Agent{{Name: "echoer", TmuxMode: true, Backend: fleet.BackendDevcontainer}},
+			Agents:   []fleet.Agent{{Name: "echoer", Backend: fleet.BackendDevcontainer}},
 			Triggers: []fleet.Trigger{{Name: "t", Type: fleet.TriggerSchedule, AgentNames: []string{"echoer"}, Cron: "* * * * *", Prompt: "hi"}},
 		}},
 	}}
@@ -277,45 +242,14 @@ func TestSchedulerTickKeepsWatchAfterFiring(t *testing.T) {
 	}
 }
 
-func TestBuildTmuxLaunchScript(t *testing.T) {
-	// Default-style command (no ${PROMPT}): the prompt must be typed in as a
-	// SEPARATE send-keys line after the agent starts — otherwise the agent never
-	// gets prompted and no work begins (the reported bug).
-	script := buildTmuxLaunchScript("alpha~agent", "claude --system-prompt 'be terse'", "do the task", true)
-	for _, want := range []string{
-		"tmux new-session -d -s 'alpha~agent'",
-		"send-keys -t 'alpha~agent' -l -- 'claude --system-prompt '\\''be terse'\\'''",
-		"capture-pane -t 'alpha~agent' -p", // readiness poll, not a fixed delay
-		"send-keys -t 'alpha~agent' -l -- 'do the task'",
-	} {
-		if !strings.Contains(script, want) {
-			t.Fatalf("launch script missing %q\n%s", want, script)
-		}
-	}
-	// Two literal sends (agent command + prompt), each followed by a bare Enter.
-	if n := strings.Count(script, "-l --"); n != 2 {
-		t.Fatalf("expected 2 literal send-keys (command + prompt), got %d:\n%s", n, script)
-	}
-	if n := strings.Count(script, "Enter\n"); n != 2 {
-		t.Fatalf("expected 2 Enter submits, got %d:\n%s", n, script)
-	}
-
-	// When the command already embeds ${PROMPT}, the prompt is NOT re-sent (no
-	// readiness poll, no separate prompt send).
-	noResend := buildTmuxLaunchScript("alpha~agent", "claude -p 'do the task'", "do the task", false)
-	if strings.Contains(noResend, "capture-pane") || strings.Count(noResend, "-l --") != 1 {
-		t.Fatalf("prompt must not be sent separately when the command embeds it:\n%s", noResend)
-	}
-}
-
 func TestServiceWatchedConcurrentProbesReapAll(t *testing.T) {
 	rec := stubAutomationSeams(t)
 	rec.activity = func(time.Time) (agentdetect.State, bool) { return agentdetect.StateWaiting, true }
 	s := &service{}
 	t0 := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
 
-	// Several idle tmux agents probed concurrently must all reap, with the watch
-	// set fully drained (no double-count / drop under the fan-out).
+	// Several idle agents probed concurrently must all reap, with the watch set
+	// fully drained (no double-count / drop under the fan-out).
 	const n = 5
 	sched := newScheduler()
 	insts := make([]*fleet.Instance, 0, n)
@@ -323,9 +257,8 @@ func TestServiceWatchedConcurrentProbesReapAll(t *testing.T) {
 		name := automationInstanceName("agent", t0.Add(time.Duration(i)*time.Second))
 		insts = append(insts, &fleet.Instance{Name: name, Status: fleet.StatusRunning, ContainerID: "c"})
 		sched.watched["alpha/"+name] = &watchedAgent{
-			fleet: "alpha", instance: name, tmux: true, launched: true,
+			fleet: "alpha", instance: name, launched: true,
 			spawnedAt: t0, lastActive: t0,
-			detector: agentdetect.NewTmuxPaneChangeDetector(),
 		}
 	}
 	st := &state.State{Fleets: map[string]*fleet.Fleet{"alpha": {Name: "alpha", Instances: insts}}}
@@ -343,7 +276,7 @@ func TestServiceWatchedDropsGoneInstance(t *testing.T) {
 	stubAutomationSeams(t)
 	s := &service{}
 	now := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
-	sched := newWatchedScheduler(now, true)
+	sched := newWatchedScheduler(now)
 
 	// Instance not present in state (destroyed) → dropped from the watch set.
 	s.serviceWatched(context.Background(), sched, &state.State{Fleets: map[string]*fleet.Fleet{"alpha": {Name: "alpha"}}}, now)

--- a/internal/server/schedule_test.go
+++ b/internal/server/schedule_test.go
@@ -188,6 +188,26 @@ func TestServiceWatchedNonTmuxNotReaped(t *testing.T) {
 	}
 }
 
+func TestServiceWatchedNonTmuxDroppedAfterLaunch(t *testing.T) {
+	rec := stubAutomationSeams(t)
+	s := &service{}
+	now := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
+	sched := newWatchedScheduler(now, false) // non-tmux, not yet launched
+
+	// First running tick: launch once, then drop from the watch set (fire-and-
+	// forget) so it can't accumulate or be idle-reaped.
+	s.serviceWatched(context.Background(), sched, watchedState(fleet.StatusRunning), now)
+	if len(rec.launched) != 1 {
+		t.Fatalf("expected one launch, got %v", rec.launched)
+	}
+	if _, still := sched.watched["alpha/agent-1"]; still {
+		t.Fatal("non-tmux agent should be dropped from the watch set after launch")
+	}
+	if len(rec.reaped) != 0 {
+		t.Fatalf("non-tmux agent must not be reaped: %v", rec.reaped)
+	}
+}
+
 func TestServiceWatchedDropsGoneInstance(t *testing.T) {
 	stubAutomationSeams(t)
 	s := &service{}

--- a/internal/server/schedule_test.go
+++ b/internal/server/schedule_test.go
@@ -285,7 +285,7 @@ func TestBuildTmuxLaunchScript(t *testing.T) {
 	for _, want := range []string{
 		"tmux new-session -d -s 'alpha~agent'",
 		"send-keys -t 'alpha~agent' -l -- 'claude --system-prompt '\\''be terse'\\'''",
-		"sleep 5",
+		"capture-pane -t 'alpha~agent' -p", // readiness poll, not a fixed delay
 		"send-keys -t 'alpha~agent' -l -- 'do the task'",
 	} {
 		if !strings.Contains(script, want) {
@@ -300,9 +300,10 @@ func TestBuildTmuxLaunchScript(t *testing.T) {
 		t.Fatalf("expected 2 Enter submits, got %d:\n%s", n, script)
 	}
 
-	// When the command already embeds ${PROMPT}, the prompt is NOT re-sent.
+	// When the command already embeds ${PROMPT}, the prompt is NOT re-sent (no
+	// readiness poll, no separate prompt send).
 	noResend := buildTmuxLaunchScript("alpha~agent", "claude -p 'do the task'", "do the task", false)
-	if strings.Contains(noResend, "sleep") || strings.Count(noResend, "-l --") != 1 {
+	if strings.Contains(noResend, "capture-pane") || strings.Count(noResend, "-l --") != 1 {
 		t.Fatalf("prompt must not be sent separately when the command embeds it:\n%s", noResend)
 	}
 }

--- a/internal/server/schedule_test.go
+++ b/internal/server/schedule_test.go
@@ -230,6 +230,53 @@ func TestServiceWatchedNonTmuxDroppedAfterLaunch(t *testing.T) {
 	}
 }
 
+func TestSchedulerTickKeepsWatchAfterFiring(t *testing.T) {
+	// Regression: schedulerTick used the pre-fire state snapshot for
+	// serviceWatched, so the just-created instance wasn't visible and the watch
+	// entry was deleted the same tick — the agent never launched.
+	rec := stubAutomationSeams(t)
+
+	st := &state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Remote: "file:///x", Settings: fleet.FleetSettings{
+			Agents:   []fleet.Agent{{Name: "echoer", TmuxMode: true, Backend: fleet.BackendDevcontainer}},
+			Triggers: []fleet.Trigger{{Name: "t", Type: fleet.TriggerSchedule, AgentNames: []string{"echoer"}, Cron: "* * * * *", Prompt: "hi"}},
+		}},
+	}}
+
+	origLoad := scheduleLoadState
+	scheduleLoadState = func() (*state.State, error) { return st, nil }
+	origCreate := createAutomationInstance
+	// Mimic startCreateInstanceJob: synchronously add a StatusCreating record.
+	createAutomationInstance = func(_ *service, fleetName string, _ fleet.Agent, _ time.Time) (string, error) {
+		st.Fleets[fleetName].Instances = append(st.Fleets[fleetName].Instances,
+			&fleet.Instance{Name: "echoer-inst", Status: fleet.StatusCreating, ContainerID: "c1"})
+		return "echoer-inst", nil
+	}
+	t.Cleanup(func() { scheduleLoadState = origLoad; createAutomationInstance = origCreate })
+
+	s := &service{}
+	sched := newScheduler()
+	now := time.Date(2026, 6, 22, 9, 0, 30, 0, time.UTC)
+
+	// Tick 1: fires + creates the (Creating) instance. The watch entry must
+	// survive — not be deleted by serviceWatched running on stale state.
+	s.schedulerTick(context.Background(), sched, now)
+	w, ok := sched.watched["alpha/echoer-inst"]
+	if !ok {
+		t.Fatal("watch entry must survive the firing tick")
+	}
+	if w.launched || len(rec.launched) != 0 {
+		t.Fatal("agent must not launch while the instance is still Creating")
+	}
+
+	// Tick 2 (same minute → no re-fire): instance now Running → agent launches.
+	st.Fleets["alpha"].Instances[0].Status = fleet.StatusRunning
+	s.schedulerTick(context.Background(), sched, now.Add(10*time.Second))
+	if len(rec.launched) != 1 || rec.launched[0] != "echoer-inst" {
+		t.Fatalf("agent should launch once the instance is running, got %v", rec.launched)
+	}
+}
+
 func TestBuildTmuxLaunchScript(t *testing.T) {
 	// Default-style command (no ${PROMPT}): the prompt must be typed in as a
 	// SEPARATE send-keys line after the agent starts — otherwise the agent never

--- a/internal/server/schedule_test.go
+++ b/internal/server/schedule_test.go
@@ -242,6 +242,30 @@ func TestSchedulerTickKeepsWatchAfterFiring(t *testing.T) {
 	}
 }
 
+func TestBuildAgentLaunchScript(t *testing.T) {
+	// The substituted command (prompt already inside it) must run via an
+	// interactive bash so ~/.bashrc is sourced and the agent (e.g. ~/.local/bin/
+	// claude) is found — a bare tmux `sh -c` does not source it and the session
+	// dies instantly.
+	cmd := fleet.SubstituteAgentCommand(fleet.DefaultAgentCommand, "do it", "be terse")
+	script := buildAgentLaunchScript("inst~agent", cmd)
+	for _, want := range []string{
+		"tmux new-session -d -s 'inst~agent'",
+		"bash -ic ",
+		// Both prompts are carried by the command (single-quote-escaped); no
+		// send-keys.
+		"be terse",
+		"do it",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("launch script missing %q\n%s", want, script)
+		}
+	}
+	if strings.Contains(script, "send-keys") {
+		t.Fatalf("launch should not use send-keys anymore:\n%s", script)
+	}
+}
+
 func TestServiceWatchedConcurrentProbesReapAll(t *testing.T) {
 	rec := stubAutomationSeams(t)
 	rec.activity = func(time.Time) (agentdetect.State, bool) { return agentdetect.StateWaiting, true }

--- a/internal/server/schedule_test.go
+++ b/internal/server/schedule_test.go
@@ -230,6 +230,37 @@ func TestServiceWatchedNonTmuxDroppedAfterLaunch(t *testing.T) {
 	}
 }
 
+func TestServiceWatchedConcurrentProbesReapAll(t *testing.T) {
+	rec := stubAutomationSeams(t)
+	rec.activity = func(time.Time) (agentdetect.State, bool) { return agentdetect.StateWaiting, true }
+	s := &service{}
+	t0 := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
+
+	// Several idle tmux agents probed concurrently must all reap, with the watch
+	// set fully drained (no double-count / drop under the fan-out).
+	const n = 5
+	sched := newScheduler()
+	insts := make([]*fleet.Instance, 0, n)
+	for i := 0; i < n; i++ {
+		name := automationInstanceName("agent", t0.Add(time.Duration(i)*time.Second))
+		insts = append(insts, &fleet.Instance{Name: name, Status: fleet.StatusRunning, ContainerID: "c"})
+		sched.watched["alpha/"+name] = &watchedAgent{
+			fleet: "alpha", instance: name, tmux: true, launched: true,
+			spawnedAt: t0, lastActive: t0,
+			detector: agentdetect.NewTmuxPaneChangeDetector(),
+		}
+	}
+	st := &state.State{Fleets: map[string]*fleet.Fleet{"alpha": {Name: "alpha", Instances: insts}}}
+
+	s.serviceWatched(context.Background(), sched, st, t0.Add(automationIdleTimeout))
+	if len(rec.reaped) != n {
+		t.Fatalf("expected %d reaps, got %d (%v)", n, len(rec.reaped), rec.reaped)
+	}
+	if len(sched.watched) != 0 {
+		t.Fatalf("watch set should be drained, still has %d", len(sched.watched))
+	}
+}
+
 func TestServiceWatchedDropsGoneInstance(t *testing.T) {
 	stubAutomationSeams(t)
 	s := &service{}

--- a/internal/server/schedule_test.go
+++ b/internal/server/schedule_test.go
@@ -45,6 +45,28 @@ func TestDueSchedulesFiresOncePerMinute(t *testing.T) {
 	}
 }
 
+func TestDueSchedulesPrunesStaleLastFired(t *testing.T) {
+	now := time.Date(2026, 6, 22, 9, 0, 30, 0, time.UTC) // Monday 09:00
+	fleets := scheduleFleet([]fleet.Trigger{
+		{Name: "match", Type: fleet.TriggerSchedule, AgentNames: []string{"a"}, Cron: "0 9 * * 1"},
+	}, []fleet.Agent{{Name: "a"}})
+
+	lastFired := map[string]time.Time{}
+	dueSchedules(fleets, now, lastFired)
+	if _, ok := lastFired["alpha\x00match"]; !ok {
+		t.Fatal("expected lastFired entry for the fired trigger")
+	}
+	// A stale entry (trigger that no longer exists) plus the live one.
+	lastFired["alpha\x00deleted"] = now
+	dueSchedules(fleets, now.Add(time.Minute), lastFired)
+	if _, ok := lastFired["alpha\x00deleted"]; ok {
+		t.Fatal("stale lastFired entry should have been pruned")
+	}
+	if _, ok := lastFired["alpha\x00match"]; !ok {
+		t.Fatal("live trigger's lastFired entry must be kept")
+	}
+}
+
 func TestAgentsForTrigger(t *testing.T) {
 	f := &fleet.Fleet{Settings: fleet.FleetSettings{Agents: []fleet.Agent{{Name: "a"}, {Name: "b"}}}}
 	got := agentsForTrigger(f, fleet.Trigger{AgentNames: []string{"b", "ghost", "a"}})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -80,6 +80,10 @@ func Serve(ctx context.Context) error {
 	// runtime subscriber, so they stay idle until a TUI connects with
 	// subscribe_runtime — no backend traffic for plain `fleet ls`.
 	startRuntimePollers(hubCtx, svc.hub)
+	// Automation scheduler (issue #188): fires Schedule triggers and reaps idle
+	// agents. Runs unconditionally — cron triggers must fire even when no TUI is
+	// connected — and stops on shutdown via hubCtx.
+	go svc.runScheduler(hubCtx)
 
 	// Control-socket listeners: the server owns every running instance's control
 	// socket and turns received browser.open envelopes (from an in-container

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -686,6 +686,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						page.armadaSel.focused = false
 						page.tagSelected = true
 						hit = true
+					case page.rows[idx].kind == rowFleetHeader &&
+						page.rows[idx].toggleX1 > page.rows[idx].toggleX0 &&
+						mouseMsg.X >= page.rows[idx].toggleX0 && mouseMsg.X < page.rows[idx].toggleX1:
+						// Clicking the [automations]/[instances] button on a fleet
+						// header toggles that fleet's automation mode (issue #188),
+						// synthesizing the same `m` the keyboard path uses — rather
+						// than collapsing the fleet like a click elsewhere on the row.
+						page.cursor = idx
+						page.armadaSel.focused = false
+						page.tagSelected = false
+						synthesizedKey = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}}
+						hit = true
 					case page.rows[idx].selectable():
 						page.cursor = idx
 						// Clicking a row takes focus off the Armada selector, so

--- a/internal/tui/automation_test.go
+++ b/internal/tui/automation_test.go
@@ -63,9 +63,6 @@ func TestAddAgentThenTrigger(t *testing.T) {
 
 	// Add an agent via the dialog state + save path.
 	fp.openAddAgentDialog(m, "alpha")
-	if !fp.agentDlg.tmuxMode {
-		t.Fatal("new agent should default to tmux mode ON")
-	}
 	if fp.agentDlg.command == "" {
 		t.Fatal("new agent command should default to a non-empty value")
 	}
@@ -210,7 +207,7 @@ func TestHeaderToggleButtonMouseClick(t *testing.T) {
 func TestAutomationViewRenders(t *testing.T) {
 	m, fp := newAutomationModel(t)
 	f := m.st.Fleets["alpha"]
-	f.Settings.Agents = []fleet.Agent{{Name: "builder", TmuxMode: true, Backend: fleet.BackendDevcontainer}}
+	f.Settings.Agents = []fleet.Agent{{Name: "builder", Backend: fleet.BackendDevcontainer}}
 	f.Settings.Triggers = []fleet.Trigger{{Name: "nightly", Type: fleet.TriggerSchedule, AgentNames: []string{"builder"}, Cron: "0 0 * * *"}}
 	fp.toggleAutomationMode(m, "alpha")
 

--- a/internal/tui/automation_test.go
+++ b/internal/tui/automation_test.go
@@ -1,0 +1,209 @@
+package tui
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// newAutomationModel builds a one-fleet model ("alpha", no instances) with rows
+// built and the server-persist stubbed so dialog saves stay in-process.
+func newAutomationModel(t *testing.T) (*model, *fleetPage) {
+	t.Helper()
+	orig := setFleetSettingsRemote
+	setFleetSettingsRemote = func(string, fleet.FleetSettings) error { return nil }
+	t.Cleanup(func() { setFleetSettingsRemote = orig })
+
+	fp := newFleetPage()
+	m := &model{
+		st: &state.State{
+			Fleets: map[string]*fleet.Fleet{
+				"alpha": {Name: "alpha"},
+			},
+		},
+		sessionStore: NewSessionStore(),
+		fleetPage:    fp,
+		width:        120,
+		height:       50,
+	}
+	fp.buildRows(m)
+	return m, fp
+}
+
+func TestAutomationToggleBuildsGroups(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	fp.toggleAutomationMode(m, "alpha")
+
+	if !fp.automationMode["alpha"] {
+		t.Fatal("automation mode should be on for alpha")
+	}
+	kinds := rowKinds(fp)
+	for _, want := range []rowKind{rowAutomationTriggers, rowNewTrigger, rowAutomationAgents, rowNewAgent} {
+		if !slices.Contains(kinds, want) {
+			t.Fatalf("automation rows missing %v, got %v", want, kinds)
+		}
+	}
+	// Instance-view rows must be gone.
+	if slices.Contains(kinds, rowInstance) {
+		t.Fatalf("instance rows should be hidden in automation mode: %v", kinds)
+	}
+	// Toggling back restores the instance view.
+	fp.toggleAutomationMode(m, "alpha")
+	if fp.automationMode["alpha"] {
+		t.Fatal("automation mode should be off after second toggle")
+	}
+}
+
+func TestAddAgentThenTrigger(t *testing.T) {
+	m, fp := newAutomationModel(t)
+
+	// Add an agent via the dialog state + save path.
+	fp.openAddAgentDialog(m, "alpha")
+	if !fp.agentDlg.tmuxMode {
+		t.Fatal("new agent should default to tmux mode ON")
+	}
+	if fp.agentDlg.command == "" {
+		t.Fatal("new agent command should default to a non-empty value")
+	}
+	fp.agentDlg.name = "builder"
+	fp.saveAutomationAgent(m)
+
+	agents := m.st.Fleets["alpha"].Settings.Agents
+	if len(agents) != 1 || agents[0].Name != "builder" {
+		t.Fatalf("agent not saved: %+v", agents)
+	}
+	if fp.mode != viewNormal {
+		t.Fatalf("dialog should close after save, mode=%v", fp.mode)
+	}
+
+	// Add a schedule trigger referencing the agent.
+	fp.openAddTriggerDialog(m, "alpha")
+	st := &fp.triggerDlg
+	if !st.agentSel["builder"] {
+		t.Fatal("single agent should be pre-selected")
+	}
+	st.name = "nightly"
+	st.cron = "0 0 * * *"
+	fp.saveAutomationTrigger(m)
+
+	triggers := m.st.Fleets["alpha"].Settings.Triggers
+	if len(triggers) != 1 || triggers[0].Name != "nightly" {
+		t.Fatalf("trigger not saved: %+v", triggers)
+	}
+	if got := triggers[0].AgentNames; len(got) != 1 || got[0] != "builder" {
+		t.Fatalf("trigger agent refs = %v, want [builder]", got)
+	}
+}
+
+func TestSaveTriggerRejectsBadCron(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	m.st.Fleets["alpha"].Settings.Agents = []fleet.Agent{{Name: "a", Backend: fleet.BackendDevcontainer}}
+
+	fp.openAddTriggerDialog(m, "alpha")
+	st := &fp.triggerDlg
+	st.name = "bad"
+	st.agentSel["a"] = true
+	st.cron = "not a cron"
+	fp.saveAutomationTrigger(m)
+
+	if st.errMsg == "" {
+		t.Fatal("expected an error message for an invalid cron")
+	}
+	if len(m.st.Fleets["alpha"].Settings.Triggers) != 0 {
+		t.Fatal("invalid trigger must not be persisted")
+	}
+	if fp.mode != viewAutomationTrigger {
+		t.Fatal("dialog should stay open on validation error")
+	}
+}
+
+func TestVisibleTriggerRowsByType(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	m.st.Fleets["alpha"].Settings.Agents = []fleet.Agent{{Name: "a", Backend: fleet.BackendDevcontainer}}
+	fp.openAddTriggerDialog(m, "alpha")
+	st := &fp.triggerDlg
+
+	st.triggerType = fleet.TriggerSchedule
+	rows := fp.visibleTriggerRows(m)
+	if !slices.Contains(rows, trigRowCron) || slices.Contains(rows, trigRowWebhookName) {
+		t.Fatalf("schedule rows wrong: %v", rows)
+	}
+
+	st.triggerType = fleet.TriggerWebhook
+	st.filterType = fleet.WebhookFilterRegex
+	rows = fp.visibleTriggerRows(m)
+	if !slices.Contains(rows, trigRowRegex) || slices.Contains(rows, trigRowCron) || slices.Contains(rows, trigRowJSONPath) {
+		t.Fatalf("webhook+regex rows wrong: %v", rows)
+	}
+
+	st.filterType = fleet.WebhookFilterJSONPath
+	rows = fp.visibleTriggerRows(m)
+	if !slices.Contains(rows, trigRowJSONPath) || !slices.Contains(rows, trigRowJSONValue) || slices.Contains(rows, trigRowRegex) {
+		t.Fatalf("webhook+jsonpath rows wrong: %v", rows)
+	}
+}
+
+func TestDeleteAgentBlockedWhenReferenced(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	f := m.st.Fleets["alpha"]
+	f.Settings.Agents = []fleet.Agent{{Name: "a", Backend: fleet.BackendDevcontainer}}
+	f.Settings.Triggers = []fleet.Trigger{{Name: "t", Type: fleet.TriggerSchedule, AgentNames: []string{"a"}, Cron: "* * * * *"}}
+
+	fp.deleteAgent(m, "alpha", 0)
+	if len(f.Settings.Agents) != 1 {
+		t.Fatal("referenced agent should not be deletable")
+	}
+
+	// Removing the trigger first frees the agent for deletion.
+	fp.deleteTrigger(m, "alpha", 0)
+	fp.deleteAgent(m, "alpha", 0)
+	if len(f.Settings.Agents) != 0 {
+		t.Fatalf("agent should be deletable once unreferenced: %+v", f.Settings.Agents)
+	}
+}
+
+func TestAutomationViewRenders(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	f := m.st.Fleets["alpha"]
+	f.Settings.Agents = []fleet.Agent{{Name: "builder", TmuxMode: true, Backend: fleet.BackendDevcontainer}}
+	f.Settings.Triggers = []fleet.Trigger{{Name: "nightly", Type: fleet.TriggerSchedule, AgentNames: []string{"builder"}, Cron: "0 0 * * *"}}
+	fp.toggleAutomationMode(m, "alpha")
+
+	out := fp.viewFleetList(m)
+	for _, want := range []string{"[instances]", "triggers", "agents", "nightly", "builder", "+ add trigger", "+ add agent"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("automation view missing %q\n%s", want, out)
+		}
+	}
+
+	// The trigger and agent dialogs must render without panicking.
+	fp.openAddTriggerDialog(m, "alpha")
+	if d := fp.renderAutomationTriggerDialog(m); !strings.Contains(d, "New trigger") {
+		t.Fatalf("trigger dialog render: %q", d)
+	}
+	fp.openAddAgentDialog(m, "alpha")
+	if d := fp.renderAutomationAgentDialog(m); !strings.Contains(d, "New agent") {
+		t.Fatalf("agent dialog render: %q", d)
+	}
+}
+
+func TestRenameAgentUpdatesTriggerRefs(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	f := m.st.Fleets["alpha"]
+	f.Settings.Agents = []fleet.Agent{{Name: "old", Backend: fleet.BackendDevcontainer}}
+	f.Settings.Triggers = []fleet.Trigger{{Name: "t", Type: fleet.TriggerSchedule, AgentNames: []string{"old"}, Cron: "* * * * *"}}
+
+	fp.openEditAgentDialog(m, "alpha", 0)
+	fp.agentDlg.name = "renamed"
+	fp.saveAutomationAgent(m)
+
+	if f.Settings.Agents[0].Name != "renamed" {
+		t.Fatalf("agent not renamed: %+v", f.Settings.Agents)
+	}
+	if got := f.Settings.Triggers[0].AgentNames; len(got) != 1 || got[0] != "renamed" {
+		t.Fatalf("trigger ref not updated on rename: %v", got)
+	}
+}

--- a/internal/tui/automation_test.go
+++ b/internal/tui/automation_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // newAutomationModel builds a one-fleet model ("alpha", no instances) with rows
@@ -162,6 +163,47 @@ func TestDeleteAgentBlockedWhenReferenced(t *testing.T) {
 	fp.deleteAgent(m, "alpha", 0)
 	if len(f.Settings.Agents) != 0 {
 		t.Fatalf("agent should be deletable once unreferenced: %+v", f.Settings.Agents)
+	}
+}
+
+func TestHeaderToggleButtonMouseClick(t *testing.T) {
+	mp, fp := newAutomationModel(t)
+	m := *mp
+	m.currentPage = fp
+
+	// Render once so the fleet header's toggle-button span + listRowY are recorded.
+	fp.viewFleetList(&m)
+	if fp.rows[0].kind != rowFleetHeader || fp.rows[0].toggleX1 <= fp.rows[0].toggleX0 {
+		t.Fatalf("toggle button span not recorded on the fleet header: %+v", fp.rows[0])
+	}
+
+	// A click inside the [automations] button toggles the fleet into automation mode.
+	click := tea.MouseMsg{
+		Action: tea.MouseActionPress,
+		Button: tea.MouseButtonLeft,
+		X:      fp.rows[0].toggleX0,
+		Y:      fp.listRowY,
+	}
+	next, _ := m.Update(click)
+	if !next.(model).fleetPage.automationMode["alpha"] {
+		t.Fatal("clicking the [automations] button should toggle automation mode on")
+	}
+
+	// A click elsewhere on the header (before the button) must NOT toggle — it
+	// collapses the fleet like a normal header click.
+	mp2, fp2 := newAutomationModel(t)
+	m2 := *mp2
+	m2.currentPage = fp2
+	fp2.viewFleetList(&m2)
+	miss := tea.MouseMsg{
+		Action: tea.MouseActionPress,
+		Button: tea.MouseButtonLeft,
+		X:      listContentXOffset, // the cursor column, far left of the button
+		Y:      fp2.listRowY,
+	}
+	next2, _ := m2.Update(miss)
+	if next2.(model).fleetPage.automationMode["alpha"] {
+		t.Fatal("a click outside the button span must not toggle automation mode")
 	}
 }
 

--- a/internal/tui/automation_view.go
+++ b/internal/tui/automation_view.go
@@ -137,9 +137,6 @@ func triggerSummary(t fleet.Trigger) string {
 func agentSummary(f *fleet.Fleet, a fleet.Agent) string {
 	n := triggerCountForAgent(f, a.Name)
 	parts := []string{backendTypeLabel(a.Backend)}
-	if a.TmuxMode {
-		parts = append(parts, "tmux")
-	}
 	suffix := "s"
 	if n == 1 {
 		suffix = ""

--- a/internal/tui/automation_view.go
+++ b/internal/tui/automation_view.go
@@ -1,0 +1,257 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// automation_view.go renders a fleet's in-page automation view (issue #188) and
+// holds the shared helpers the trigger/agent dialogs build on: list accessors,
+// the persist-to-server path, and item deletion. The two modal editors live in
+// dialog_automation_trigger.go and dialog_automation_agent.go.
+
+// newAutomationInput builds the single reusable text input the automation
+// dialogs drive (one active field at a time: its value is loaded on edit and
+// written back on commit, so one input covers every text field).
+func newAutomationInput() textinput.Model {
+	ti := textinput.New()
+	ti.CharLimit = 1024
+	ti.Width = 52
+	return ti
+}
+
+// isAutomationRow reports whether a row kind belongs to the automation view.
+func isAutomationRow(kind rowKind) bool {
+	switch kind {
+	case rowAutomationTriggers, rowAutomationAgents, rowTrigger, rowAgent, rowNewTrigger, rowNewAgent:
+		return true
+	}
+	return false
+}
+
+// triggerAt / agentAt safely fetch the automation item a row points at.
+func triggerAt(f *fleet.Fleet, idx int) *fleet.Trigger {
+	if f == nil || idx < 0 || idx >= len(f.Settings.Triggers) {
+		return nil
+	}
+	return &f.Settings.Triggers[idx]
+}
+
+func agentAt(f *fleet.Fleet, idx int) *fleet.Agent {
+	if f == nil || idx < 0 || idx >= len(f.Settings.Agents) {
+		return nil
+	}
+	return &f.Settings.Agents[idx]
+}
+
+// renderAutomationRow renders one automation-view row (group header, item, or
+// "+ add" action). The caller handles trailing newline + width truncation.
+func (fleetPage *fleetPage) renderAutomationRow(m *model, r row, cursor string, isSelected bool) string {
+	f := m.st.Fleets[r.fleetName]
+	switch r.kind {
+	case rowAutomationTriggers, rowAutomationAgents:
+		isTriggers := r.kind == rowAutomationTriggers
+		label, n, collapsed := "agents", 0, fleetPage.agentsCollapsed(r.fleetName)
+		if isTriggers {
+			label, collapsed = "triggers", fleetPage.triggersCollapsed(r.fleetName)
+			if f != nil {
+				n = len(f.Settings.Triggers)
+			}
+		} else if f != nil {
+			n = len(f.Settings.Agents)
+		}
+		arrow := "▼ "
+		if collapsed {
+			arrow = "▶ "
+		}
+		style := fleetExpandedStyle
+		if isSelected {
+			style = selectedStyle
+		}
+		return fmt.Sprintf("%s    %s%s", cursor, style.Render(arrow+label), dimStyle.Render(fmt.Sprintf(" (%d)", n)))
+
+	case rowTrigger:
+		t := triggerAt(f, r.autoIdx)
+		if t == nil {
+			return fmt.Sprintf("%s        %s", cursor, dimStyle.Render("(missing trigger)"))
+		}
+		style := sessionStyle
+		if isSelected {
+			style = selectedStyle
+		}
+		return fmt.Sprintf("%s        %s%s", cursor, style.Render(t.Name), dimStyle.Render("  "+triggerSummary(*t)))
+
+	case rowAgent:
+		a := agentAt(f, r.autoIdx)
+		if a == nil {
+			return fmt.Sprintf("%s        %s", cursor, dimStyle.Render("(missing agent)"))
+		}
+		style := sessionStyle
+		if isSelected {
+			style = selectedStyle
+		}
+		return fmt.Sprintf("%s        %s%s", cursor, style.Render(a.Name), dimStyle.Render("  "+agentSummary(f, *a)))
+
+	case rowNewTrigger:
+		return renderAutomationAction(cursor, "+ add trigger", isSelected)
+	case rowNewAgent:
+		return renderAutomationAction(cursor, "+ add agent", isSelected)
+	}
+	return ""
+}
+
+func renderAutomationAction(cursor, label string, isSelected bool) string {
+	style := newSessionStyle
+	if isSelected {
+		style = selectedStyle
+	}
+	return fmt.Sprintf("%s        %s", cursor, style.Render(label))
+}
+
+// triggerSummary is the dim one-line description shown beside a trigger's name.
+func triggerSummary(t fleet.Trigger) string {
+	var detail string
+	switch t.Type {
+	case fleet.TriggerSchedule:
+		detail = "⏱ " + t.Cron
+		if t.Cron == "" {
+			detail = "⏱ (no schedule)"
+		}
+	case fleet.TriggerWebhook:
+		detail = "⇄ webhook:" + t.WebhookName
+	default:
+		detail = string(t.Type)
+	}
+	if len(t.AgentNames) > 0 {
+		detail += "  →  " + strings.Join(t.AgentNames, ", ")
+	}
+	return detail
+}
+
+// agentSummary is the dim description shown beside an agent's name, including
+// how many triggers reference it (the issue's "<- x" indicator).
+func agentSummary(f *fleet.Fleet, a fleet.Agent) string {
+	n := triggerCountForAgent(f, a.Name)
+	parts := []string{backendTypeLabel(a.Backend)}
+	if a.TmuxMode {
+		parts = append(parts, "tmux")
+	}
+	suffix := "s"
+	if n == 1 {
+		suffix = ""
+	}
+	parts = append(parts, fmt.Sprintf("← %d trigger%s", n, suffix))
+	return strings.Join(parts, " · ")
+}
+
+func triggerCountForAgent(f *fleet.Fleet, name string) int {
+	if f == nil {
+		return 0
+	}
+	n := 0
+	for _, t := range f.Settings.Triggers {
+		for _, an := range t.AgentNames {
+			if an == name {
+				n++
+				break
+			}
+		}
+	}
+	return n
+}
+
+// persistAutomationSettings optimistically applies newSettings to the in-memory
+// fleet and pushes them to the server, reverting on failure (the server is the
+// trust boundary — it may reject a bad cron, duplicate name, etc.).
+func (fleetPage *fleetPage) persistAutomationSettings(m *model, fleetName string, newSettings fleet.FleetSettings) error {
+	f, ok := m.st.Fleets[fleetName]
+	if !ok {
+		return fmt.Errorf("fleet %s not found", fleetName)
+	}
+	prev := f.Settings
+	f.Settings = newSettings
+	if err := setFleetSettingsRemote(fleetName, newSettings); err != nil {
+		f.Settings = prev
+		return err
+	}
+	fleetPage.buildRows(m)
+	return nil
+}
+
+// deleteTrigger removes the trigger at idx and persists.
+func (fleetPage *fleetPage) deleteTrigger(m *model, fleetName string, idx int) tea.Cmd {
+	f, ok := m.st.Fleets[fleetName]
+	if !ok || idx < 0 || idx >= len(f.Settings.Triggers) {
+		return nil
+	}
+	name := f.Settings.Triggers[idx].Name
+	newSettings := f.Settings
+	newSettings.Triggers = removeTriggerAt(f.Settings.Triggers, idx)
+	if err := fleetPage.persistAutomationSettings(m, fleetName, newSettings); err != nil {
+		m.message = fmt.Sprintf("Delete failed: %v", err)
+		return nil
+	}
+	m.message = fmt.Sprintf("Deleted trigger %q", name)
+	return nil
+}
+
+// deleteAgent removes the agent at idx and persists. An agent still referenced
+// by a trigger is not deleted — the user is told to detach it first, so a delete
+// can never orphan a trigger (which the server would then reject wholesale).
+func (fleetPage *fleetPage) deleteAgent(m *model, fleetName string, idx int) tea.Cmd {
+	f, ok := m.st.Fleets[fleetName]
+	if !ok || idx < 0 || idx >= len(f.Settings.Agents) {
+		return nil
+	}
+	name := f.Settings.Agents[idx].Name
+	for _, t := range f.Settings.Triggers {
+		for _, an := range t.AgentNames {
+			if an == name {
+				m.message = fmt.Sprintf("Agent %q is used by trigger %q — remove it there first", name, t.Name)
+				return nil
+			}
+		}
+	}
+	newSettings := f.Settings
+	newSettings.Agents = removeAgentAt(f.Settings.Agents, idx)
+	if err := fleetPage.persistAutomationSettings(m, fleetName, newSettings); err != nil {
+		m.message = fmt.Sprintf("Delete failed: %v", err)
+		return nil
+	}
+	m.message = fmt.Sprintf("Deleted agent %q", name)
+	return nil
+}
+
+// removeTriggerAt / removeAgentAt return a NEW slice with the element at idx
+// removed (never mutating the original, so persist's revert restores it).
+func removeTriggerAt(in []fleet.Trigger, idx int) []fleet.Trigger {
+	out := make([]fleet.Trigger, 0, len(in)-1)
+	out = append(out, in[:idx]...)
+	out = append(out, in[idx+1:]...)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func removeAgentAt(in []fleet.Agent, idx int) []fleet.Agent {
+	out := make([]fleet.Agent, 0, len(in)-1)
+	out = append(out, in[:idx]...)
+	out = append(out, in[idx+1:]...)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// fleetAgents returns the named fleet's automation agents (nil if none).
+func fleetAgents(m *model, fleetName string) []fleet.Agent {
+	if f, ok := m.st.Fleets[fleetName]; ok {
+		return f.Settings.Agents
+	}
+	return nil
+}

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -442,7 +442,6 @@ func agentsToProto(in []fleet.Agent) []*fleetgrpc.Agent {
 		out = append(out, &fleetgrpc.Agent{
 			Name:         a.Name,
 			Command:      a.Command,
-			TmuxMode:     a.TmuxMode,
 			SystemPrompt: a.SystemPrompt,
 			Backend:      backendStringToProto(string(a.Backend)),
 		})
@@ -459,7 +458,6 @@ func protoAgentsToLegacy(in []*fleetgrpc.Agent) []fleet.Agent {
 		out = append(out, fleet.Agent{
 			Name:         a.GetName(),
 			Command:      a.GetCommand(),
-			TmuxMode:     a.GetTmuxMode(),
 			SystemPrompt: a.GetSystemPrompt(),
 			Backend:      fleet.BackendType(backendProtoToString(a.GetBackend())),
 		})

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -405,6 +405,8 @@ func fleetSettingsToProto(s fleet.FleetSettings) *fleetgrpc.FleetSettings {
 		DebCacheServer:   s.DebCacheServer,
 		ImageCacheServer: s.ImageCacheServer,
 		LayoutPresets:    layoutPresetsToProto(s.LayoutPresets),
+		Agents:           agentsToProto(s.Agents),
+		Triggers:         triggersToProto(s.Triggers),
 	}
 	if s.HomeDir != "" {
 		ps.HomeDir = &s.HomeDir
@@ -426,6 +428,84 @@ func layoutPresetsToProto(in []fleet.LayoutPreset) []*fleetgrpc.LayoutPreset {
 			Name:         p.Name,
 			Layout:       p.Layout,
 			PaneCommands: p.PaneCommands,
+		})
+	}
+	return out
+}
+
+func agentsToProto(in []fleet.Agent) []*fleetgrpc.Agent {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*fleetgrpc.Agent, 0, len(in))
+	for _, a := range in {
+		out = append(out, &fleetgrpc.Agent{
+			Name:         a.Name,
+			Command:      a.Command,
+			TmuxMode:     a.TmuxMode,
+			SystemPrompt: a.SystemPrompt,
+			Backend:      backendStringToProto(string(a.Backend)),
+		})
+	}
+	return out
+}
+
+func protoAgentsToLegacy(in []*fleetgrpc.Agent) []fleet.Agent {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]fleet.Agent, 0, len(in))
+	for _, a := range in {
+		out = append(out, fleet.Agent{
+			Name:         a.GetName(),
+			Command:      a.GetCommand(),
+			TmuxMode:     a.GetTmuxMode(),
+			SystemPrompt: a.GetSystemPrompt(),
+			Backend:      fleet.BackendType(backendProtoToString(a.GetBackend())),
+		})
+	}
+	return out
+}
+
+func triggersToProto(in []fleet.Trigger) []*fleetgrpc.Trigger {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*fleetgrpc.Trigger, 0, len(in))
+	for _, t := range in {
+		out = append(out, &fleetgrpc.Trigger{
+			Name:        t.Name,
+			Type:        string(t.Type),
+			AgentNames:  t.AgentNames,
+			Prompt:      t.Prompt,
+			Cron:        t.Cron,
+			WebhookName: t.WebhookName,
+			FilterType:  string(t.FilterType),
+			Regex:       t.Regex,
+			JsonPath:    t.JSONPath,
+			JsonValue:   t.JSONValue,
+		})
+	}
+	return out
+}
+
+func protoTriggersToLegacy(in []*fleetgrpc.Trigger) []fleet.Trigger {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]fleet.Trigger, 0, len(in))
+	for _, t := range in {
+		out = append(out, fleet.Trigger{
+			Name:        t.GetName(),
+			Type:        fleet.TriggerType(t.GetType()),
+			AgentNames:  t.GetAgentNames(),
+			Prompt:      t.GetPrompt(),
+			Cron:        t.GetCron(),
+			WebhookName: t.GetWebhookName(),
+			FilterType:  fleet.WebhookFilterType(t.GetFilterType()),
+			Regex:       t.GetRegex(),
+			JSONPath:    t.GetJsonPath(),
+			JSONValue:   t.GetJsonValue(),
 		})
 	}
 	return out
@@ -621,6 +701,8 @@ func protoFleetToLegacy(pf *fleetgrpc.Fleet) *fleet.Fleet {
 			DebCacheServer:   ps.GetDebCacheServer(),
 			ImageCacheServer: ps.GetImageCacheServer(),
 			LayoutPresets:    protoLayoutPresetsToLegacy(ps.GetLayoutPresets()),
+			Agents:           protoAgentsToLegacy(ps.GetAgents()),
+			Triggers:         protoTriggersToLegacy(ps.GetTriggers()),
 			HomeDir:          ps.GetHomeDir(),
 		}
 		if ps.PreferFleetLaunch != nil {

--- a/internal/tui/dialog_automation_agent.go
+++ b/internal/tui/dialog_automation_agent.go
@@ -11,13 +11,13 @@ import (
 
 // dialog_automation_agent.go is the add/edit-agent modal (issue #188). An agent
 // defines how an automation worker is launched: a command (with ${PROMPT}/
-// ${SYS_PROMPT} placeholders), tmux mode, a system prompt, and an env backend.
+// ${SYS_PROMPT} placeholders), a system prompt, and an env backend. The command
+// always runs in a tmux session so the user can open it in the TUI and watch.
 
 // agentRow identifies a focusable field in the agent dialog.
 const (
 	agentRowName = iota
 	agentRowCommand
-	agentRowTmux
 	agentRowSystemPrompt
 	agentRowBackend
 	agentRowSave
@@ -36,7 +36,6 @@ type automationAgentState struct {
 
 	name         string
 	command      string
-	tmuxMode     bool
 	systemPrompt string
 	backend      fleet.BackendType
 	errMsg       string
@@ -44,8 +43,8 @@ type automationAgentState struct {
 
 // openAddAgentDialog opens the agent editor for a new agent. The command field
 // defaults to the most recently defined agent's command (the issue's "remember
-// the last value" behavior), falling back to fleet.DefaultAgentCommand; tmux
-// mode defaults ON; backend defaults to the user's default backend.
+// the last value" behavior), falling back to fleet.DefaultAgentCommand; backend
+// defaults to the user's default backend.
 func (fleetPage *fleetPage) openAddAgentDialog(m *model, fleetName string) tea.Cmd {
 	command := fleet.DefaultAgentCommand
 	if agents := fleetAgents(m, fleetName); len(agents) > 0 {
@@ -60,7 +59,6 @@ func (fleetPage *fleetPage) openAddAgentDialog(m *model, fleetName string) tea.C
 		editIdx:   -1,
 		input:     fleetPage.agentDlg.input,
 		command:   command,
-		tmuxMode:  true,
 		backend:   backend,
 	}
 	fleetPage.mode = viewAutomationAgent
@@ -87,7 +85,6 @@ func (fleetPage *fleetPage) openEditAgentDialog(m *model, fleetName string, idx 
 		input:        fleetPage.agentDlg.input,
 		name:         a.Name,
 		command:      a.Command,
-		tmuxMode:     a.TmuxMode,
 		systemPrompt: a.SystemPrompt,
 		backend:      backend,
 	}
@@ -128,25 +125,15 @@ func (fleetPage *fleetPage) updateAutomationAgent(m *model, msg tea.Msg) tea.Cmd
 	case "down", "j", "tab":
 		st.row = (st.row + 1) % agentRowCount
 		return nil
-	case "enter":
-		return fleetPage.agentRowEnter(m)
-	case " ":
-		if st.row == agentRowTmux {
-			st.tmuxMode = !st.tmuxMode
-			return nil
-		}
+	case "enter", " ":
 		return fleetPage.agentRowEnter(m)
 	case "left", "h":
-		if st.row == agentRowTmux {
-			st.tmuxMode = !st.tmuxMode
-		} else if st.row == agentRowBackend {
+		if st.row == agentRowBackend {
 			st.backend = nextBackendType(st.backend, -1, allBackendTypes)
 		}
 		return nil
 	case "right", "l":
-		if st.row == agentRowTmux {
-			st.tmuxMode = !st.tmuxMode
-		} else if st.row == agentRowBackend {
+		if st.row == agentRowBackend {
 			st.backend = nextBackendType(st.backend, 1, allBackendTypes)
 		}
 		return nil
@@ -170,8 +157,6 @@ func (fleetPage *fleetPage) agentRowEnter(m *model) tea.Cmd {
 	switch st.row {
 	case agentRowName, agentRowCommand, agentRowSystemPrompt:
 		return fleetPage.activateAgentField()
-	case agentRowTmux:
-		st.tmuxMode = !st.tmuxMode
 	case agentRowBackend:
 		st.backend = nextBackendType(st.backend, 1, allBackendTypes)
 	case agentRowSave:
@@ -233,7 +218,6 @@ func (fleetPage *fleetPage) saveAutomationAgent(m *model) tea.Cmd {
 	candidate := fleet.Agent{
 		Name:         st.name,
 		Command:      st.command,
-		TmuxMode:     st.tmuxMode,
 		SystemPrompt: st.systemPrompt,
 		Backend:      st.backend,
 	}
@@ -325,16 +309,10 @@ func (fleetPage *fleetPage) renderAutomationAgentDialog(m *model) string {
 		return value
 	}
 
-	tmux := "[ ] off"
-	if st.tmuxMode {
-		tmux = "[x] on"
-	}
-
 	var body strings.Builder
 	fmt.Fprintf(&body, "%s\n\n", dialogTitle.Render(title))
 	fmt.Fprintf(&body, "%s%s %s\n", marker(agentRowName), dialogLabel.Render("Name:    "), field(agentRowName, st.name, "agent-name"))
 	fmt.Fprintf(&body, "%s%s %s\n", marker(agentRowCommand), dialogLabel.Render("Command: "), field(agentRowCommand, st.command, fleet.DefaultAgentCommand))
-	fmt.Fprintf(&body, "%s%s %s\n", marker(agentRowTmux), dialogLabel.Render("Tmux:    "), tmux)
 	fmt.Fprintf(&body, "%s%s %s\n", marker(agentRowSystemPrompt), dialogLabel.Render("Sys prompt:"), field(agentRowSystemPrompt, st.systemPrompt, "(optional, injected into ${SYS_PROMPT})"))
 	fmt.Fprintf(&body, "%s%s [ %s ]\n", marker(agentRowBackend), dialogLabel.Render("Backend: "), backendTypeLabel(st.backend))
 	fmt.Fprintf(&body, "%s%s\n", marker(agentRowSave), saveButtonLabel(st.row == agentRowSave))

--- a/internal/tui/dialog_automation_agent.go
+++ b/internal/tui/dialog_automation_agent.go
@@ -1,0 +1,367 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// dialog_automation_agent.go is the add/edit-agent modal (issue #188). An agent
+// defines how an automation worker is launched: a command (with ${PROMPT}/
+// ${SYS_PROMPT} placeholders), tmux mode, a system prompt, and an env backend.
+
+// agentRow identifies a focusable field in the agent dialog.
+const (
+	agentRowName = iota
+	agentRowCommand
+	agentRowTmux
+	agentRowSystemPrompt
+	agentRowBackend
+	agentRowSave
+	agentRowCount
+)
+
+// automationAgentState holds the add/edit-agent form (issue #188). The target
+// fleet + index live here (not in dlg) so the automation dialogs never collide
+// with the instance dialogs' shared scratch.
+type automationAgentState struct {
+	fleetName   string
+	editIdx     int // -1 == creating a new agent
+	row         int
+	fieldActive bool
+	input       textinput.Model
+
+	name         string
+	command      string
+	tmuxMode     bool
+	systemPrompt string
+	backend      fleet.BackendType
+	errMsg       string
+}
+
+// openAddAgentDialog opens the agent editor for a new agent. The command field
+// defaults to the most recently defined agent's command (the issue's "remember
+// the last value" behavior), falling back to fleet.DefaultAgentCommand; tmux
+// mode defaults ON; backend defaults to the user's default backend.
+func (fleetPage *fleetPage) openAddAgentDialog(m *model, fleetName string) tea.Cmd {
+	command := fleet.DefaultAgentCommand
+	if agents := fleetAgents(m, fleetName); len(agents) > 0 {
+		command = agents[len(agents)-1].Command
+	}
+	backend := fleet.BackendDevcontainer
+	if m.config != nil && m.config.DefaultBackend != "" {
+		backend = fleet.BackendType(m.config.DefaultBackend)
+	}
+	fleetPage.agentDlg = automationAgentState{
+		fleetName: fleetName,
+		editIdx:   -1,
+		input:     fleetPage.agentDlg.input,
+		command:   command,
+		tmuxMode:  true,
+		backend:   backend,
+	}
+	fleetPage.mode = viewAutomationAgent
+	return nil
+}
+
+// openEditAgentDialog opens the agent editor for an existing agent.
+func (fleetPage *fleetPage) openEditAgentDialog(m *model, fleetName string, idx int) tea.Cmd {
+	f, ok := m.st.Fleets[fleetName]
+	if !ok {
+		return nil
+	}
+	a := agentAt(f, idx)
+	if a == nil {
+		return nil
+	}
+	backend := a.Backend
+	if backend == "" {
+		backend = fleet.BackendDevcontainer
+	}
+	fleetPage.agentDlg = automationAgentState{
+		fleetName:    fleetName,
+		editIdx:      idx,
+		input:        fleetPage.agentDlg.input,
+		name:         a.Name,
+		command:      a.Command,
+		tmuxMode:     a.TmuxMode,
+		systemPrompt: a.SystemPrompt,
+		backend:      backend,
+	}
+	fleetPage.mode = viewAutomationAgent
+	return nil
+}
+
+func (fleetPage *fleetPage) updateAutomationAgent(m *model, msg tea.Msg) tea.Cmd {
+	st := &fleetPage.agentDlg
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return nil
+	}
+
+	if st.fieldActive {
+		switch key.String() {
+		case "enter":
+			fleetPage.commitAgentField()
+			return nil
+		case "esc":
+			st.fieldActive = false
+			st.input.Blur()
+			return nil
+		case "ctrl+c":
+			return fleetPage.cancelAutomationAgent(m)
+		}
+		var cmd tea.Cmd
+		st.input, cmd = st.input.Update(msg)
+		return cmd
+	}
+
+	switch key.String() {
+	case "q", "esc", "ctrl+c":
+		return fleetPage.cancelAutomationAgent(m)
+	case "up", "k", "shift+tab":
+		st.row = (st.row - 1 + agentRowCount) % agentRowCount
+		return nil
+	case "down", "j", "tab":
+		st.row = (st.row + 1) % agentRowCount
+		return nil
+	case "enter":
+		return fleetPage.agentRowEnter(m)
+	case " ":
+		if st.row == agentRowTmux {
+			st.tmuxMode = !st.tmuxMode
+			return nil
+		}
+		return fleetPage.agentRowEnter(m)
+	case "left", "h":
+		if st.row == agentRowTmux {
+			st.tmuxMode = !st.tmuxMode
+		} else if st.row == agentRowBackend {
+			st.backend = nextBackendType(st.backend, -1, allBackendTypes)
+		}
+		return nil
+	case "right", "l":
+		if st.row == agentRowTmux {
+			st.tmuxMode = !st.tmuxMode
+		} else if st.row == agentRowBackend {
+			st.backend = nextBackendType(st.backend, 1, allBackendTypes)
+		}
+		return nil
+	}
+
+	if isDialogTextKey(key) && agentRowIsText(st.row) {
+		blink := fleetPage.activateAgentField()
+		var cmd tea.Cmd
+		st.input, cmd = st.input.Update(msg)
+		return tea.Batch(blink, cmd)
+	}
+	return nil
+}
+
+func agentRowIsText(row int) bool {
+	return row == agentRowName || row == agentRowCommand || row == agentRowSystemPrompt
+}
+
+func (fleetPage *fleetPage) agentRowEnter(m *model) tea.Cmd {
+	st := &fleetPage.agentDlg
+	switch st.row {
+	case agentRowName, agentRowCommand, agentRowSystemPrompt:
+		return fleetPage.activateAgentField()
+	case agentRowTmux:
+		st.tmuxMode = !st.tmuxMode
+	case agentRowBackend:
+		st.backend = nextBackendType(st.backend, 1, allBackendTypes)
+	case agentRowSave:
+		return fleetPage.saveAutomationAgent(m)
+	}
+	return nil
+}
+
+func (fleetPage *fleetPage) activateAgentField() tea.Cmd {
+	st := &fleetPage.agentDlg
+	st.fieldActive = true
+	st.input.SetValue(fleetPage.agentFieldValue())
+	st.input.CursorEnd()
+	st.input.Focus()
+	return st.input.Cursor.BlinkCmd()
+}
+
+func (fleetPage *fleetPage) agentFieldValue() string {
+	st := &fleetPage.agentDlg
+	switch st.row {
+	case agentRowName:
+		return st.name
+	case agentRowCommand:
+		return st.command
+	case agentRowSystemPrompt:
+		return st.systemPrompt
+	}
+	return ""
+}
+
+func (fleetPage *fleetPage) commitAgentField() {
+	st := &fleetPage.agentDlg
+	v := st.input.Value()
+	switch st.row {
+	case agentRowName:
+		st.name = v
+	case agentRowCommand:
+		st.command = v
+	case agentRowSystemPrompt:
+		st.systemPrompt = v
+	}
+	st.fieldActive = false
+	st.input.Blur()
+}
+
+func (fleetPage *fleetPage) cancelAutomationAgent(m *model) tea.Cmd {
+	fleetPage.agentDlg.fieldActive = false
+	fleetPage.agentDlg.input.Blur()
+	fleetPage.mode = viewNormal
+	m.message = "Cancelled"
+	return nil
+}
+
+func (fleetPage *fleetPage) saveAutomationAgent(m *model) tea.Cmd {
+	st := &fleetPage.agentDlg
+	if st.fieldActive {
+		fleetPage.commitAgentField()
+	}
+	candidate := fleet.Agent{
+		Name:         st.name,
+		Command:      st.command,
+		TmuxMode:     st.tmuxMode,
+		SystemPrompt: st.systemPrompt,
+		Backend:      st.backend,
+	}
+	norm, err := fleet.NormalizeAgent(candidate)
+	if err != nil {
+		st.errMsg = err.Error()
+		return nil
+	}
+
+	f, ok := m.st.Fleets[st.fleetName]
+	if !ok {
+		return fleetPage.cancelAutomationAgent(m)
+	}
+	// Reject a duplicate name (against every other agent).
+	for i, a := range f.Settings.Agents {
+		if i != st.editIdx && a.Name == norm.Name {
+			st.errMsg = fmt.Sprintf("agent %q already exists", norm.Name)
+			return nil
+		}
+	}
+
+	newSettings := f.Settings
+	newAgents := append([]fleet.Agent(nil), f.Settings.Agents...)
+	if st.editIdx >= 0 && st.editIdx < len(newAgents) {
+		oldName := newAgents[st.editIdx].Name
+		newAgents[st.editIdx] = norm
+		// A rename must follow through to every trigger referencing the old
+		// name, or the server rejects the settings (unknown agent reference).
+		if oldName != norm.Name {
+			newSettings.Triggers = renameAgentInTriggers(f.Settings.Triggers, oldName, norm.Name)
+		}
+	} else {
+		newAgents = append(newAgents, norm)
+	}
+	newSettings.Agents = newAgents
+
+	if err := fleetPage.persistAutomationSettings(m, st.fleetName, newSettings); err != nil {
+		st.errMsg = err.Error()
+		return nil
+	}
+	fleetPage.mode = viewNormal
+	m.message = fmt.Sprintf("Saved agent %q", norm.Name)
+	return nil
+}
+
+// renameAgentInTriggers returns a deep copy of triggers with every reference to
+// oldName rewritten to newName (deep copy so the optimistic-revert in persist
+// never sees a mutated original).
+func renameAgentInTriggers(triggers []fleet.Trigger, oldName, newName string) []fleet.Trigger {
+	if len(triggers) == 0 {
+		return nil
+	}
+	out := make([]fleet.Trigger, len(triggers))
+	for i, t := range triggers {
+		t.AgentNames = append([]string(nil), t.AgentNames...)
+		for j, an := range t.AgentNames {
+			if an == oldName {
+				t.AgentNames[j] = newName
+			}
+		}
+		out[i] = t
+	}
+	return out
+}
+
+func (fleetPage *fleetPage) renderAutomationAgentDialog(m *model) string {
+	st := &fleetPage.agentDlg
+	var b strings.Builder
+	b.WriteString("\n")
+
+	title := "New agent"
+	if st.editIdx >= 0 {
+		title = "Edit agent"
+	}
+
+	marker := func(r int) string {
+		if st.row == r {
+			return cursorStyle.Render("> ")
+		}
+		return "  "
+	}
+	field := func(r int, value, placeholder string) string {
+		if st.fieldActive && st.row == r {
+			return st.input.View()
+		}
+		if value == "" {
+			return dimStyle.Render(placeholder)
+		}
+		return value
+	}
+
+	tmux := "[ ] off"
+	if st.tmuxMode {
+		tmux = "[x] on"
+	}
+
+	var body strings.Builder
+	fmt.Fprintf(&body, "%s\n\n", dialogTitle.Render(title))
+	fmt.Fprintf(&body, "%s%s %s\n", marker(agentRowName), dialogLabel.Render("Name:    "), field(agentRowName, st.name, "agent-name"))
+	fmt.Fprintf(&body, "%s%s %s\n", marker(agentRowCommand), dialogLabel.Render("Command: "), field(agentRowCommand, st.command, fleet.DefaultAgentCommand))
+	fmt.Fprintf(&body, "%s%s %s\n", marker(agentRowTmux), dialogLabel.Render("Tmux:    "), tmux)
+	fmt.Fprintf(&body, "%s%s %s\n", marker(agentRowSystemPrompt), dialogLabel.Render("Sys prompt:"), field(agentRowSystemPrompt, st.systemPrompt, "(optional, injected into ${SYS_PROMPT})"))
+	fmt.Fprintf(&body, "%s%s [ %s ]\n", marker(agentRowBackend), dialogLabel.Render("Backend: "), backendTypeLabel(st.backend))
+	fmt.Fprintf(&body, "%s%s\n", marker(agentRowSave), saveButtonLabel(st.row == agentRowSave))
+
+	if st.errMsg != "" {
+		fmt.Fprintf(&body, "\n%s\n", errorStyle.Render(st.errMsg))
+	}
+	body.WriteString("\n")
+	body.WriteString(dialogHint.Render(automationHint(st.fieldActive)))
+
+	b.WriteString(dialogBox.Render(body.String()))
+	b.WriteString("\n")
+	return b.String()
+}
+
+// saveButtonLabel renders the dialogs' shared "[ Save ]" action.
+func saveButtonLabel(selected bool) string {
+	if selected {
+		return selectedStyle.Render("[ Save ]")
+	}
+	return dimStyle.Render("[ Save ]")
+}
+
+// automationHint is the footer hint shared by the automation dialogs.
+func automationHint(fieldActive bool) string {
+	if fieldActive {
+		return "[enter] Done editing  [ctrl+c] Cancel"
+	}
+	return "[j/k] Move  [enter] Edit/Toggle  [h/l] Cycle  [q/esc] Cancel"
+}

--- a/internal/tui/dialog_automation_trigger.go
+++ b/internal/tui/dialog_automation_trigger.go
@@ -468,8 +468,8 @@ func (fleetPage *fleetPage) renderAutomationTriggerDialog(m *model) string {
 		fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowWebhookName), dialogLabel.Render("Webhook:"), field(trigRowWebhookName, st.webhookName, "name (appended to gateway URL)"))
 		fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowFilterType), dialogLabel.Render("Filter: "), selectorLabel(filterTypeLabel(st.filterType)))
 		if st.filterType == fleet.WebhookFilterJSONPath {
-			fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowJSONPath), dialogLabel.Render("JSON path:"), field(trigRowJSONPath, st.jsonPath, "$.action"))
-			fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowJSONValue), dialogLabel.Render("JSON value:"), field(trigRowJSONValue, st.jsonValue, "opened"))
+			fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowJSONPath), dialogLabel.Render("JSON path:"), field(trigRowJSONPath, st.jsonPath, "e.g. $.action (required)"))
+			fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowJSONValue), dialogLabel.Render("JSON value:"), field(trigRowJSONValue, st.jsonValue, "e.g. opened"))
 		} else {
 			fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowRegex), dialogLabel.Render("Regex:  "), field(trigRowRegex, st.regex, "event body must match"))
 		}

--- a/internal/tui/dialog_automation_trigger.go
+++ b/internal/tui/dialog_automation_trigger.go
@@ -183,11 +183,8 @@ func (fleetPage *fleetPage) updateAutomationTrigger(m *model, msg tea.Msg) tea.C
 		return fleetPage.triggerRowEnter(m)
 	case " ":
 		return fleetPage.triggerRowToggle(m)
-	case "left", "h":
-		fleetPage.triggerRowCycle(-1)
-		return nil
-	case "right", "l":
-		fleetPage.triggerRowCycle(1)
+	case "left", "h", "right", "l":
+		fleetPage.triggerRowCycle()
 		return nil
 	}
 
@@ -245,15 +242,15 @@ func (fleetPage *fleetPage) triggerRowToggle(m *model) tea.Cmd {
 	return fleetPage.triggerRowEnter(m)
 }
 
-func (fleetPage *fleetPage) triggerRowCycle(direction int) {
+// triggerRowCycle handles h/l on a selector row. Both selectors are two-valued,
+// so direction is immaterial — left and right just flip to the other option.
+func (fleetPage *fleetPage) triggerRowCycle() {
 	st := &fleetPage.triggerDlg
 	switch st.row {
 	case trigRowType:
 		fleetPage.cycleTriggerType()
 	case trigRowFilterType:
 		fleetPage.cycleFilterType()
-	case trigRowSave:
-		_ = direction // selectors only; nothing else cycles
 	}
 }
 

--- a/internal/tui/dialog_automation_trigger.go
+++ b/internal/tui/dialog_automation_trigger.go
@@ -1,0 +1,520 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// dialog_automation_trigger.go is the add/edit-trigger modal (issue #188). A
+// trigger fires one or more of the fleet's agents (with a prompt) when its
+// condition is met. The fields shown depend on the trigger type (schedule vs
+// webhook) and, for webhooks, on the filter type (regex vs json-path) — the
+// visible-row list (visibleTriggerRows) recomputes on every change so navigation
+// only ever lands on a field that currently applies.
+
+// Trigger dialog field ids. Agent toggle rows use trigRowAgentBase+i so the
+// fixed fields and the variable-length agent list never collide.
+const (
+	trigRowName = iota
+	trigRowType
+	trigRowPrompt
+	trigRowCron
+	trigRowWebhookName
+	trigRowFilterType
+	trigRowRegex
+	trigRowJSONPath
+	trigRowJSONValue
+	trigRowSave
+)
+
+const trigRowAgentBase = 1000
+
+// automationTriggerState holds the add/edit-trigger form (issue #188).
+type automationTriggerState struct {
+	fleetName   string
+	editIdx     int // -1 == creating a new trigger
+	row         int
+	fieldActive bool
+	input       textinput.Model
+
+	name        string
+	triggerType fleet.TriggerType
+	agentSel    map[string]bool // agent name -> activated by this trigger
+	prompt      string
+	cron        string
+	webhookName string
+	filterType  fleet.WebhookFilterType
+	regex       string
+	jsonPath    string
+	jsonValue   string
+	errMsg      string
+}
+
+func (fleetPage *fleetPage) openAddTriggerDialog(m *model, fleetName string) tea.Cmd {
+	fleetPage.triggerDlg = automationTriggerState{
+		fleetName:   fleetName,
+		editIdx:     -1,
+		input:       fleetPage.triggerDlg.input,
+		triggerType: fleet.TriggerSchedule,
+		filterType:  fleet.WebhookFilterRegex,
+		agentSel:    map[string]bool{},
+	}
+	// Convenience: pre-select the only agent when there is exactly one.
+	if agents := fleetAgents(m, fleetName); len(agents) == 1 {
+		fleetPage.triggerDlg.agentSel[agents[0].Name] = true
+	}
+	fleetPage.mode = viewAutomationTrigger
+	return nil
+}
+
+func (fleetPage *fleetPage) openEditTriggerDialog(m *model, fleetName string, idx int) tea.Cmd {
+	f, ok := m.st.Fleets[fleetName]
+	if !ok {
+		return nil
+	}
+	t := triggerAt(f, idx)
+	if t == nil {
+		return nil
+	}
+	sel := map[string]bool{}
+	for _, name := range t.AgentNames {
+		sel[name] = true
+	}
+	filterType := t.FilterType
+	if filterType == "" {
+		filterType = fleet.WebhookFilterRegex
+	}
+	triggerType := t.Type
+	if triggerType == "" {
+		triggerType = fleet.TriggerSchedule
+	}
+	fleetPage.triggerDlg = automationTriggerState{
+		fleetName:   fleetName,
+		editIdx:     idx,
+		input:       fleetPage.triggerDlg.input,
+		name:        t.Name,
+		triggerType: triggerType,
+		agentSel:    sel,
+		prompt:      t.Prompt,
+		cron:        t.Cron,
+		webhookName: t.WebhookName,
+		filterType:  filterType,
+		regex:       t.Regex,
+		jsonPath:    t.JSONPath,
+		jsonValue:   t.JSONValue,
+	}
+	fleetPage.mode = viewAutomationTrigger
+	return nil
+}
+
+// visibleTriggerRows is the ordered list of currently-applicable field ids.
+func (fleetPage *fleetPage) visibleTriggerRows(m *model) []int {
+	st := &fleetPage.triggerDlg
+	rows := []int{trigRowName, trigRowType}
+	for i := range fleetAgents(m, st.fleetName) {
+		rows = append(rows, trigRowAgentBase+i)
+	}
+	rows = append(rows, trigRowPrompt)
+	if st.triggerType == fleet.TriggerWebhook {
+		rows = append(rows, trigRowWebhookName, trigRowFilterType)
+		if st.filterType == fleet.WebhookFilterJSONPath {
+			rows = append(rows, trigRowJSONPath, trigRowJSONValue)
+		} else {
+			rows = append(rows, trigRowRegex)
+		}
+	} else {
+		rows = append(rows, trigRowCron)
+	}
+	return append(rows, trigRowSave)
+}
+
+func (fleetPage *fleetPage) moveTriggerRow(m *model, delta int) {
+	st := &fleetPage.triggerDlg
+	rows := fleetPage.visibleTriggerRows(m)
+	idx := 0
+	for i, r := range rows {
+		if r == st.row {
+			idx = i
+			break
+		}
+	}
+	idx = (idx + delta + len(rows)) % len(rows)
+	st.row = rows[idx]
+}
+
+func (fleetPage *fleetPage) updateAutomationTrigger(m *model, msg tea.Msg) tea.Cmd {
+	st := &fleetPage.triggerDlg
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return nil
+	}
+
+	if st.fieldActive {
+		switch key.String() {
+		case "enter":
+			fleetPage.commitTriggerField()
+			return nil
+		case "esc":
+			st.fieldActive = false
+			st.input.Blur()
+			return nil
+		case "ctrl+c":
+			return fleetPage.cancelAutomationTrigger(m)
+		}
+		var cmd tea.Cmd
+		st.input, cmd = st.input.Update(msg)
+		return cmd
+	}
+
+	switch key.String() {
+	case "q", "esc", "ctrl+c":
+		return fleetPage.cancelAutomationTrigger(m)
+	case "up", "k", "shift+tab":
+		fleetPage.moveTriggerRow(m, -1)
+		return nil
+	case "down", "j", "tab":
+		fleetPage.moveTriggerRow(m, 1)
+		return nil
+	case "enter":
+		return fleetPage.triggerRowEnter(m)
+	case " ":
+		return fleetPage.triggerRowToggle(m)
+	case "left", "h":
+		fleetPage.triggerRowCycle(-1)
+		return nil
+	case "right", "l":
+		fleetPage.triggerRowCycle(1)
+		return nil
+	}
+
+	if isDialogTextKey(key) && isTriggerTextRow(st.row) {
+		blink := fleetPage.activateTriggerField()
+		var cmd tea.Cmd
+		st.input, cmd = st.input.Update(msg)
+		return tea.Batch(blink, cmd)
+	}
+	return nil
+}
+
+func isTriggerTextRow(row int) bool {
+	switch row {
+	case trigRowName, trigRowPrompt, trigRowCron, trigRowWebhookName, trigRowRegex, trigRowJSONPath, trigRowJSONValue:
+		return true
+	}
+	return false
+}
+
+// triggerRowEnter performs the row's primary action: edit a text field, cycle a
+// selector, toggle an agent, or save.
+func (fleetPage *fleetPage) triggerRowEnter(m *model) tea.Cmd {
+	st := &fleetPage.triggerDlg
+	switch {
+	case isTriggerTextRow(st.row):
+		return fleetPage.activateTriggerField()
+	case st.row == trigRowType:
+		fleetPage.cycleTriggerType()
+	case st.row == trigRowFilterType:
+		fleetPage.cycleFilterType()
+	case st.row >= trigRowAgentBase:
+		fleetPage.toggleTriggerAgent(m)
+	case st.row == trigRowSave:
+		return fleetPage.saveAutomationTrigger(m)
+	}
+	return nil
+}
+
+// triggerRowToggle is space: toggle an agent or cycle a selector; otherwise it
+// falls back to the row's enter action (so space activates text fields too).
+func (fleetPage *fleetPage) triggerRowToggle(m *model) tea.Cmd {
+	st := &fleetPage.triggerDlg
+	switch {
+	case st.row >= trigRowAgentBase:
+		fleetPage.toggleTriggerAgent(m)
+		return nil
+	case st.row == trigRowType:
+		fleetPage.cycleTriggerType()
+		return nil
+	case st.row == trigRowFilterType:
+		fleetPage.cycleFilterType()
+		return nil
+	}
+	return fleetPage.triggerRowEnter(m)
+}
+
+func (fleetPage *fleetPage) triggerRowCycle(direction int) {
+	st := &fleetPage.triggerDlg
+	switch st.row {
+	case trigRowType:
+		fleetPage.cycleTriggerType()
+	case trigRowFilterType:
+		fleetPage.cycleFilterType()
+	case trigRowSave:
+		_ = direction // selectors only; nothing else cycles
+	}
+}
+
+func (fleetPage *fleetPage) cycleTriggerType() {
+	st := &fleetPage.triggerDlg
+	if st.triggerType == fleet.TriggerSchedule {
+		st.triggerType = fleet.TriggerWebhook
+	} else {
+		st.triggerType = fleet.TriggerSchedule
+	}
+	// The applicable rows changed; park the cursor back on the type selector.
+	st.row = trigRowType
+}
+
+func (fleetPage *fleetPage) cycleFilterType() {
+	st := &fleetPage.triggerDlg
+	if st.filterType == fleet.WebhookFilterRegex {
+		st.filterType = fleet.WebhookFilterJSONPath
+	} else {
+		st.filterType = fleet.WebhookFilterRegex
+	}
+	st.row = trigRowFilterType
+}
+
+func (fleetPage *fleetPage) toggleTriggerAgent(m *model) {
+	st := &fleetPage.triggerDlg
+	agents := fleetAgents(m, st.fleetName)
+	idx := st.row - trigRowAgentBase
+	if idx < 0 || idx >= len(agents) {
+		return
+	}
+	name := agents[idx].Name
+	if st.agentSel == nil {
+		st.agentSel = map[string]bool{}
+	}
+	st.agentSel[name] = !st.agentSel[name]
+}
+
+func (fleetPage *fleetPage) activateTriggerField() tea.Cmd {
+	st := &fleetPage.triggerDlg
+	st.fieldActive = true
+	st.input.SetValue(fleetPage.triggerFieldValue())
+	st.input.CursorEnd()
+	st.input.Focus()
+	return st.input.Cursor.BlinkCmd()
+}
+
+func (fleetPage *fleetPage) triggerFieldValue() string {
+	st := &fleetPage.triggerDlg
+	switch st.row {
+	case trigRowName:
+		return st.name
+	case trigRowPrompt:
+		return st.prompt
+	case trigRowCron:
+		return st.cron
+	case trigRowWebhookName:
+		return st.webhookName
+	case trigRowRegex:
+		return st.regex
+	case trigRowJSONPath:
+		return st.jsonPath
+	case trigRowJSONValue:
+		return st.jsonValue
+	}
+	return ""
+}
+
+func (fleetPage *fleetPage) commitTriggerField() {
+	st := &fleetPage.triggerDlg
+	v := st.input.Value()
+	switch st.row {
+	case trigRowName:
+		st.name = v
+	case trigRowPrompt:
+		st.prompt = v
+	case trigRowCron:
+		st.cron = v
+	case trigRowWebhookName:
+		st.webhookName = v
+	case trigRowRegex:
+		st.regex = v
+	case trigRowJSONPath:
+		st.jsonPath = v
+	case trigRowJSONValue:
+		st.jsonValue = v
+	}
+	st.fieldActive = false
+	st.input.Blur()
+}
+
+func (fleetPage *fleetPage) cancelAutomationTrigger(m *model) tea.Cmd {
+	fleetPage.triggerDlg.fieldActive = false
+	fleetPage.triggerDlg.input.Blur()
+	fleetPage.mode = viewNormal
+	m.message = "Cancelled"
+	return nil
+}
+
+func (fleetPage *fleetPage) saveAutomationTrigger(m *model) tea.Cmd {
+	st := &fleetPage.triggerDlg
+	if st.fieldActive {
+		fleetPage.commitTriggerField()
+	}
+
+	f, ok := m.st.Fleets[st.fleetName]
+	if !ok {
+		return fleetPage.cancelAutomationTrigger(m)
+	}
+
+	// Collect selected agents in the fleet's agent order (stable output).
+	var selected []string
+	for _, a := range f.Settings.Agents {
+		if st.agentSel[a.Name] {
+			selected = append(selected, a.Name)
+		}
+	}
+
+	candidate := fleet.Trigger{
+		Name:        st.name,
+		Type:        st.triggerType,
+		AgentNames:  selected,
+		Prompt:      st.prompt,
+		Cron:        st.cron,
+		WebhookName: st.webhookName,
+		FilterType:  st.filterType,
+		Regex:       st.regex,
+		JSONPath:    st.jsonPath,
+		JSONValue:   st.jsonValue,
+	}
+
+	agentNames := make(map[string]struct{}, len(f.Settings.Agents))
+	for _, a := range f.Settings.Agents {
+		agentNames[a.Name] = struct{}{}
+	}
+	norm, err := fleet.NormalizeTrigger(candidate, agentNames)
+	if err != nil {
+		st.errMsg = err.Error()
+		return nil
+	}
+	for i, t := range f.Settings.Triggers {
+		if i != st.editIdx && t.Name == norm.Name {
+			st.errMsg = fmt.Sprintf("trigger %q already exists", norm.Name)
+			return nil
+		}
+	}
+
+	newSettings := f.Settings
+	newTriggers := append([]fleet.Trigger(nil), f.Settings.Triggers...)
+	if st.editIdx >= 0 && st.editIdx < len(newTriggers) {
+		newTriggers[st.editIdx] = norm
+	} else {
+		newTriggers = append(newTriggers, norm)
+	}
+	newSettings.Triggers = newTriggers
+
+	if err := fleetPage.persistAutomationSettings(m, st.fleetName, newSettings); err != nil {
+		st.errMsg = err.Error()
+		return nil
+	}
+	fleetPage.mode = viewNormal
+	m.message = fmt.Sprintf("Saved trigger %q", norm.Name)
+	return nil
+}
+
+func (fleetPage *fleetPage) renderAutomationTriggerDialog(m *model) string {
+	st := &fleetPage.triggerDlg
+	agents := fleetAgents(m, st.fleetName)
+
+	var b strings.Builder
+	b.WriteString("\n")
+	title := "New trigger"
+	if st.editIdx >= 0 {
+		title = "Edit trigger"
+	}
+
+	marker := func(r int) string {
+		if st.row == r {
+			return cursorStyle.Render("> ")
+		}
+		return "  "
+	}
+	field := func(r int, value, placeholder string) string {
+		if st.fieldActive && st.row == r {
+			return st.input.View()
+		}
+		if value == "" {
+			return dimStyle.Render(placeholder)
+		}
+		return value
+	}
+
+	var body strings.Builder
+	fmt.Fprintf(&body, "%s\n\n", dialogTitle.Render(title))
+	fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowName), dialogLabel.Render("Name:   "), field(trigRowName, st.name, "trigger-name"))
+	fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowType), dialogLabel.Render("Type:   "), selectorLabel(triggerTypeLabel(st.triggerType)))
+
+	// Agents multi-select.
+	body.WriteString(dialogLabel.Render("Agents: "))
+	body.WriteString("\n")
+	if len(agents) == 0 {
+		body.WriteString("    " + dimStyle.Render("(no agents — add an agent first)") + "\n")
+	}
+	for i, a := range agents {
+		box := "[ ]"
+		if st.agentSel[a.Name] {
+			box = "[x]"
+		}
+		fmt.Fprintf(&body, "%s    %s %s\n", marker(trigRowAgentBase+i), box, a.Name)
+	}
+
+	fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowPrompt), dialogLabel.Render("Prompt: "), field(trigRowPrompt, st.prompt, "(fed to the agent via ${PROMPT})"))
+
+	if st.triggerType == fleet.TriggerWebhook {
+		fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowWebhookName), dialogLabel.Render("Webhook:"), field(trigRowWebhookName, st.webhookName, "name (appended to gateway URL)"))
+		fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowFilterType), dialogLabel.Render("Filter: "), selectorLabel(filterTypeLabel(st.filterType)))
+		if st.filterType == fleet.WebhookFilterJSONPath {
+			fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowJSONPath), dialogLabel.Render("JSON path:"), field(trigRowJSONPath, st.jsonPath, "$.action"))
+			fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowJSONValue), dialogLabel.Render("JSON value:"), field(trigRowJSONValue, st.jsonValue, "opened"))
+		} else {
+			fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowRegex), dialogLabel.Render("Regex:  "), field(trigRowRegex, st.regex, "event body must match"))
+		}
+	} else {
+		fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowCron), dialogLabel.Render("Cron:   "), field(trigRowCron, st.cron, "0 9 * * 1-5"))
+	}
+
+	fmt.Fprintf(&body, "%s%s\n", marker(trigRowSave), saveButtonLabel(st.row == trigRowSave))
+
+	if st.errMsg != "" {
+		fmt.Fprintf(&body, "\n%s\n", errorStyle.Render(st.errMsg))
+	}
+	body.WriteString("\n")
+	body.WriteString(dialogHint.Render(automationTriggerHint(st.fieldActive, st.row)))
+
+	b.WriteString(dialogBox.Render(body.String()))
+	b.WriteString("\n")
+	return b.String()
+}
+
+func selectorLabel(text string) string { return fmt.Sprintf("[ %s ]", text) }
+
+func triggerTypeLabel(t fleet.TriggerType) string {
+	if t == fleet.TriggerWebhook {
+		return "Webhook"
+	}
+	return "Schedule"
+}
+
+func filterTypeLabel(f fleet.WebhookFilterType) string {
+	if f == fleet.WebhookFilterJSONPath {
+		return "json-path"
+	}
+	return "regex"
+}
+
+func automationTriggerHint(fieldActive bool, row int) string {
+	if fieldActive {
+		return "[enter] Done editing  [ctrl+c] Cancel"
+	}
+	if row >= trigRowAgentBase {
+		return "[j/k] Move  [space] Toggle agent  [enter] Edit/Cycle  [q/esc] Cancel"
+	}
+	return "[j/k] Move  [enter] Edit/Toggle  [h/l] Cycle  [q/esc] Cancel"
+}

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -63,6 +63,17 @@ type fleetPage struct {
 	listRowY int
 
 	armadaSel armadaSelectState // Armada selector widget (border label + dropdown)
+
+	// automationMode[fleet] is true when that fleet renders its automation view
+	// (collapsible triggers + agents groups) instead of its instance list
+	// (issue #188). Toggled with 'm'; persists across route changes like the
+	// rest of fleetPage.
+	automationMode map[string]bool
+	// autoCollapsed holds the collapse state of the per-fleet automation groups,
+	// keyed "trig:<fleet>" / "agent:<fleet>"; an absent key == expanded.
+	autoCollapsed map[string]bool
+	triggerDlg    automationTriggerState // add/edit-trigger dialog
+	agentDlg      automationAgentState   // add/edit-agent dialog
 }
 
 // newFleetPage creates a new fleet page with default state.
@@ -92,6 +103,10 @@ func newFleetPage() *fleetPage {
 		customMountInput: customMountInput,
 		listRowY:         -1,
 		armadaSel:        armadaSelectState{y: -1},
+		automationMode:   make(map[string]bool),
+		autoCollapsed:    make(map[string]bool),
+		triggerDlg:       automationTriggerState{input: newAutomationInput()},
+		agentDlg:         automationAgentState{input: newAutomationInput()},
 	}
 }
 
@@ -198,6 +213,10 @@ func (fleetPage *fleetPage) Update(m *model, msg tea.Msg) tea.Cmd {
 		return fleetPage.updateArmadaSelect(m, msg)
 	case viewCreateSession:
 		return fleetPage.updateCreateSession(m, msg)
+	case viewAutomationTrigger:
+		return fleetPage.updateAutomationTrigger(m, msg)
+	case viewAutomationAgent:
+		return fleetPage.updateAutomationAgent(m, msg)
 	case viewLayoutPreset:
 		return fleetPage.updateLayoutPreset(m, msg)
 	case viewRenameSession:

--- a/internal/tui/page_fleet_keys.go
+++ b/internal/tui/page_fleet_keys.go
@@ -138,7 +138,9 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 						m.refreshSessionsFromRuntime(ref)
 						fleetPage.buildRows(m)
 					}
-				case rowSession, rowNewSession, rowSettings, rowLeaveFocus:
+				case rowSession, rowNewSession, rowSettings, rowLeaveFocus,
+					rowAutomationTriggers, rowAutomationAgents, rowTrigger, rowAgent,
+					rowNewTrigger, rowNewAgent:
 					return fleetPage.handleEnter(m)
 				}
 			}
@@ -201,6 +203,15 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 		case "d":
 			r := fleetPage.currentRow()
 			if r == nil || r.kind == rowSettings || r.kind == rowLeaveFocus || r.kind == rowNewSession {
+				break
+			}
+			if r.kind == rowTrigger {
+				return fleetPage.deleteTrigger(m, r.fleetName, r.autoIdx)
+			}
+			if r.kind == rowAgent {
+				return fleetPage.deleteAgent(m, r.fleetName, r.autoIdx)
+			}
+			if r.kind == rowAutomationTriggers || r.kind == rowAutomationAgents || r.kind == rowNewTrigger || r.kind == rowNewAgent {
 				break
 			}
 			if r.kind == rowSession {
@@ -294,8 +305,17 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			return fleetPage.handleEnter(m)
 
 		case "e":
-			if r := fleetPage.currentRow(); r != nil && r.kind == rowFleetHeader {
-				return fleetPage.openEditFleetDialog(m)
+			if r := fleetPage.currentRow(); r != nil {
+				switch r.kind {
+				case rowFleetHeader:
+					return fleetPage.openEditFleetDialog(m)
+				case rowTrigger:
+					return fleetPage.openEditTriggerDialog(m, r.fleetName, r.autoIdx)
+				case rowAgent:
+					return fleetPage.openEditAgentDialog(m, r.fleetName, r.autoIdx)
+				case rowAutomationTriggers, rowAutomationAgents, rowNewTrigger, rowNewAgent:
+					return nil
+				}
 			}
 			return fleetPage.openEditInstanceDialog(m)
 
@@ -460,6 +480,16 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			}
 			fleetPage.enterFocus(m, name)
 
+		case "m":
+			// Toggle the fleet between its instance view and its automation view
+			// (triggers + agents). Works from any row belonging to a fleet.
+			name := fleetPage.currentFleetName()
+			if name == "" {
+				m.message = "Select a fleet to toggle automation"
+				break
+			}
+			fleetPage.toggleAutomationMode(m, name)
+
 		case "p":
 			_, instance := fleetPage.selectedInstance(m)
 			if instance == nil {
@@ -515,6 +545,26 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 		name := r.fleetName
 		fleetPage.collapsed[name] = !fleetPage.collapsed[name]
 		fleetPage.buildRows(m)
+
+	case rowAutomationTriggers:
+		fleetPage.autoCollapsed["trig:"+r.fleetName] = !fleetPage.autoCollapsed["trig:"+r.fleetName]
+		fleetPage.buildRows(m)
+
+	case rowAutomationAgents:
+		fleetPage.autoCollapsed["agent:"+r.fleetName] = !fleetPage.autoCollapsed["agent:"+r.fleetName]
+		fleetPage.buildRows(m)
+
+	case rowTrigger:
+		return fleetPage.openEditTriggerDialog(m, r.fleetName, r.autoIdx)
+
+	case rowNewTrigger:
+		return fleetPage.openAddTriggerDialog(m, r.fleetName)
+
+	case rowAgent:
+		return fleetPage.openEditAgentDialog(m, r.fleetName, r.autoIdx)
+
+	case rowNewAgent:
+		return fleetPage.openAddAgentDialog(m, r.fleetName)
 
 	case rowNewSession:
 		return fleetPage.openCreateSessionDialog(m, r.fleetName, r.instance)
@@ -657,9 +707,28 @@ func (fleetPage *fleetPage) contextualHelpKeysBase(m *model) []string {
 
 	switch r.kind {
 	case rowFleetHeader:
+		toggle := "m: automations"
+		if fleetPage.automationMode[r.fleetName] {
+			toggle = "m: instances"
+		}
 		return withArmadaHint([]string{
-			"j/k: navigate", "space/enter: expand/collapse", "e: edit fleet",
+			"j/k: navigate", "space/enter: expand/collapse", toggle, "e: edit fleet",
 			"a: add instance", "n: new fleet", "d: delete fleet", "r: refresh", "q: quit",
+		})
+
+	case rowAutomationTriggers, rowAutomationAgents:
+		return withArmadaHint([]string{
+			"j/k: navigate", "space/enter: expand/collapse", "m: instances", "q: quit",
+		})
+
+	case rowTrigger, rowAgent:
+		return withArmadaHint([]string{
+			"j/k: navigate", "enter/e: edit", "d: delete", "m: instances", "q: quit",
+		})
+
+	case rowNewTrigger, rowNewAgent:
+		return withArmadaHint([]string{
+			"j/k: navigate", "enter: add", "m: instances", "q: quit",
 		})
 
 	case rowInstance:

--- a/internal/tui/page_fleet_rows.go
+++ b/internal/tui/page_fleet_rows.go
@@ -34,6 +34,10 @@ func (fleetPage *fleetPage) buildRows(m *model) {
 		}
 		f := m.st.Fleets[name]
 		fleetPage.rows = append(fleetPage.rows, row{kind: rowFleetHeader, fleetName: name})
+		if !fleetPage.collapsed[name] && fleetPage.automationMode[name] {
+			fleetPage.appendAutomationRows(name, f)
+			continue
+		}
 		if !fleetPage.collapsed[name] {
 			for _, instance := range f.Instances {
 				fleetPage.rows = append(fleetPage.rows, row{kind: rowInstance, fleetName: name, instance: instance})
@@ -159,6 +163,48 @@ func (fleetPage *fleetPage) appendSavedGroupRows(fleetName string, instance *fle
 			groupSize:   savedGroupPaneCount(group),
 		})
 	}
+}
+
+// appendAutomationRows emits a fleet's automation view: a collapsible triggers
+// group and a collapsible agents group, each with its items and a trailing
+// "+ add" action row. Mirrors the instance/session row structure so navigation,
+// cursor nudging, and rendering reuse the same machinery.
+func (fleetPage *fleetPage) appendAutomationRows(name string, f *fleet.Fleet) {
+	fleetPage.rows = append(fleetPage.rows, row{kind: rowAutomationTriggers, fleetName: name})
+	if !fleetPage.triggersCollapsed(name) {
+		for i := range f.Settings.Triggers {
+			fleetPage.rows = append(fleetPage.rows, row{kind: rowTrigger, fleetName: name, autoIdx: i})
+		}
+		fleetPage.rows = append(fleetPage.rows, row{kind: rowNewTrigger, fleetName: name})
+	}
+	fleetPage.rows = append(fleetPage.rows, row{kind: rowAutomationAgents, fleetName: name})
+	if !fleetPage.agentsCollapsed(name) {
+		for i := range f.Settings.Agents {
+			fleetPage.rows = append(fleetPage.rows, row{kind: rowAgent, fleetName: name, autoIdx: i})
+		}
+		fleetPage.rows = append(fleetPage.rows, row{kind: rowNewAgent, fleetName: name})
+	}
+}
+
+func (fleetPage *fleetPage) triggersCollapsed(fleet string) bool {
+	return fleetPage.autoCollapsed["trig:"+fleet]
+}
+
+func (fleetPage *fleetPage) agentsCollapsed(fleet string) bool {
+	return fleetPage.autoCollapsed["agent:"+fleet]
+}
+
+// toggleAutomationMode flips the named fleet between its instance view and its
+// automation view, parking the cursor on the fleet header so the toggle target
+// stays in sight.
+func (fleetPage *fleetPage) toggleAutomationMode(m *model, name string) {
+	if name == "" {
+		return
+	}
+	fleetPage.automationMode[name] = !fleetPage.automationMode[name]
+	fleetPage.tagSelected = false
+	fleetPage.buildRows(m)
+	fleetPage.cursorToFleetHeader(name)
 }
 
 func (fleetPage *fleetPage) savedGroupsForInstance(instanceName string) []savedGroup {

--- a/internal/tui/page_fleet_view.go
+++ b/internal/tui/page_fleet_view.go
@@ -165,11 +165,19 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 				style = fleetCollapsedStyle
 			}
 
-			count := 0
-			if f, ok := m.st.Fleets[r.fleetName]; ok {
-				count = len(f.Instances)
+			// The fleet header carries a mode-toggle "button" (issue #188): the
+			// instance view shows the instance count plus an [automations] switch;
+			// the automation view shows an [instances] switch. 'm' toggles it.
+			var suffix string
+			if fleetPage.automationMode[r.fleetName] {
+				suffix = dimStyle.Render(" [instances]")
+			} else {
+				count := 0
+				if f, ok := m.st.Fleets[r.fleetName]; ok {
+					count = len(f.Instances)
+				}
+				suffix = dimStyle.Render(fmt.Sprintf(" (%d) [automations]", count))
 			}
-			suffix := dimStyle.Render(fmt.Sprintf(" (%d)", count))
 
 			if isSelected {
 				listContent.WriteString(fmt.Sprintf("%s%s%s",
@@ -354,6 +362,13 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			}
 			listContent.WriteString(line)
 			listContent.WriteString("\n")
+		} else if isAutomationRow(r.kind) {
+			line := fleetPage.renderAutomationRow(m, r, cursor, isSelected)
+			if maxW := m.width - 4; maxW > 0 && lipgloss.Width(line) > maxW {
+				line = ansi.Truncate(line, maxW-1, "…")
+			}
+			listContent.WriteString(line)
+			listContent.WriteString("\n")
 		} else {
 			label := "settings"
 			if r.kind == rowLeaveFocus {
@@ -460,6 +475,10 @@ func (fleetPage *fleetPage) viewActiveDialog(m *model) string {
 		return fleetPage.renderCodespacesLimitDialog(m)
 	case viewCreateSession:
 		return fleetPage.renderCreateSessionDialog(m)
+	case viewAutomationTrigger:
+		return fleetPage.renderAutomationTriggerDialog(m)
+	case viewAutomationAgent:
+		return fleetPage.renderAutomationAgentDialog(m)
 	case viewCloneInstance:
 		return fleetPage.renderCloneInstanceDialog(m)
 	case viewRenameSession:

--- a/internal/tui/page_fleet_view.go
+++ b/internal/tui/page_fleet_view.go
@@ -167,17 +167,28 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 
 			// The fleet header carries a mode-toggle "button" (issue #188): the
 			// instance view shows the instance count plus an [automations] switch;
-			// the automation view shows an [instances] switch. 'm' toggles it.
-			var suffix string
+			// the automation view shows an [instances] switch. 'm' (or a click on
+			// the button — see app.go) toggles it. We record the button's absolute
+			// column span here so the click handler can hit-test it.
+			var suffix, toggleText string
+			// Columns before the suffix: cursor(2) + arrow(2) + name width.
+			labelStart := listContentXOffset + 4 + lipgloss.Width(r.fleetName)
 			if fleetPage.automationMode[r.fleetName] {
-				suffix = dimStyle.Render(" [instances]")
+				toggleText = "[instances]"
+				suffix = dimStyle.Render(" " + toggleText)
+				labelStart += 1 // a single leading space precedes the label
 			} else {
 				count := 0
 				if f, ok := m.st.Fleets[r.fleetName]; ok {
 					count = len(f.Instances)
 				}
-				suffix = dimStyle.Render(fmt.Sprintf(" (%d) [automations]", count))
+				countPart := fmt.Sprintf(" (%d) ", count)
+				toggleText = "[automations]"
+				suffix = dimStyle.Render(countPart + toggleText)
+				labelStart += lipgloss.Width(countPart)
 			}
+			fleetPage.rows[i].toggleX0 = labelStart
+			fleetPage.rows[i].toggleX1 = labelStart + lipgloss.Width(toggleText)
 
 			if isSelected {
 				listContent.WriteString(fmt.Sprintf("%s%s%s",

--- a/internal/tui/rows.go
+++ b/internal/tui/rows.go
@@ -40,6 +40,13 @@ type row struct {
 	// autoIdx indexes the fleet's Settings.Triggers (rowTrigger) or
 	// Settings.Agents (rowAgent) — the automation item this row renders/edits.
 	autoIdx int
+	// toggleX0/toggleX1 record the absolute terminal column span of the
+	// [automations]/[instances] mode-toggle button on a rowFleetHeader (set
+	// during View). A left click landing in [toggleX0, toggleX1) toggles the
+	// fleet's automation mode instead of collapsing it. toggleX1 == toggleX0
+	// means "no button here".
+	toggleX0 int
+	toggleX1 int
 	// prStatusInline marks the first child row of an expanded instance that has
 	// no user tag, telling the renderer to show the instance's PR-status auto tag
 	// at the status column on this row (a "second status line"). See buildRows.

--- a/internal/tui/rows.go
+++ b/internal/tui/rows.go
@@ -19,6 +19,14 @@ const (
 	rowNewSession
 	rowSettings
 	rowLeaveFocus
+	// Automation-view rows (issue #188). A fleet in automation mode renders two
+	// collapsible groups — triggers and agents — in place of its instances.
+	rowAutomationTriggers // triggers group header
+	rowAutomationAgents   // agents group header
+	rowTrigger            // a trigger child (autoIdx indexes Settings.Triggers)
+	rowAgent              // an agent child (autoIdx indexes Settings.Agents)
+	rowNewTrigger         // "+ add trigger" action row
+	rowNewAgent           // "+ add agent" action row
 )
 
 // row represents a single navigable row in the TUI.
@@ -29,6 +37,9 @@ type row struct {
 	sessionName string // set when kind == rowSession or rowNewSession
 	groupID     string // set for grouped session rows
 	groupSize   int    // number of sessions in the group (for display)
+	// autoIdx indexes the fleet's Settings.Triggers (rowTrigger) or
+	// Settings.Agents (rowAgent) — the automation item this row renders/edits.
+	autoIdx int
 	// prStatusInline marks the first child row of an expanded instance that has
 	// no user tag, telling the renderer to show the instance's PR-status auto tag
 	// at the status column on this row (a "second status line"). See buildRows.

--- a/internal/tui/view_mode.go
+++ b/internal/tui/view_mode.go
@@ -33,4 +33,6 @@ const (
 	viewChooseBrowserLaunch
 	viewArmadaSelect
 	viewChoosePR
+	viewAutomationTrigger
+	viewAutomationAgent
 )


### PR DESCRIPTION
## Summary

Implements the **automation TUI mode** from #188. Each fleet can now be toggled (`m`, or the `[automations]`/`[instances]` button on the fleet header) between its normal **instance view** and a new **automation view** showing two collapsible groups — **triggers** and **agents** — that the user authors in place.

**Model + persistence.** New per-fleet `Agent` and `Trigger` types on `FleetSettings`, persisted inline in `state.json` and synced over gRPC exactly like layout presets (new proto `Agent`/`Trigger` messages, matching legacy↔proto converters on both the server and TUI sides, authoritative `NormalizeAgents`/`NormalizeTriggers` validation in `SetFleetSettings`).
- **Agent**: command (with `${PROMPT}`/`${SYS_PROMPT}` placeholders), tmux mode (default ON), system prompt, env backend.
- **Trigger**: type (Schedule | Webhook), the agent(s) it activates, a prompt, and type-dependent fields — a cron pattern for Schedule, or a webhook name + regex / json-path filter for Webhook.
- Cron matching is a small dependency-free 5-field implementation (`*`, ranges, lists, steps, the Vixie day-of-month/day-of-week rule).

**TUI.** A `buildRows` branch renders the two groups (reusing the existing row/cursor/collapse machinery); an agent shows how many triggers reference it (the issue's "← x"). Two modal editors handle add/edit, persisting through the existing optimistic `SetFleetSettings` path. Renaming an agent rewrites its trigger references; a referenced agent can't be deleted (so a trigger is never orphaned).

**Scheduler (fleetd).** An unconditional background loop fires due Schedule triggers — spawning a normal instance per agent via the same `CreateInstance` job path the RPC uses — then, once the instance is running, launches the agent command in a detached tmux session (so it's openable in the TUI) with the prompts substituted in. Tmux-mode agents that stay inactive past 2 minutes are torn down, detected with the same tmux screen-diff the TUI shows (so it works with no TUI attached). The live operations are package-var seams, so the lifecycle is unit-tested deterministically without containers.

## Scope notes
- **Webhook delivery is out of scope** per the ticket — webhook triggers are fully modeled, validated, persisted, and editable, but the fleet-gateway receiver endpoint is left to a follow-up.
- The agent command's "remember the last value" is implemented by defaulting a new agent's command to the most recently defined agent's command in that fleet (falling back to the built-in `claude --system-prompt '${SYS_PROMPT}'` default).

## Tests
- Unit: cron parse/match, agent/trigger normalization, a legacy→proto→legacy wire round-trip, TUI mode toggle + dialogs (add/edit/delete, validation, rename ref-update, render), and the scheduler (cron due-selection + per-minute dedup, launch-on-running, idle reap, non-tmux never reaped).
- Integration: `390_tui_automation_mode.sh` drives the real binary — toggle into automation mode, add an agent end-to-end, confirm it persists, toggle back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)