### PR TITLE
feat/automation-cli-mcp — fleet agent/trigger CLI commands + MCP tools (#189)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ fleet up agent-1 --repo git@github.com:org/my-project.git
 
 # Reference an existing fleet from anywhere
 fleet up my-project/agent-3
+
+# Configure automation: agents (workers) and triggers (what fires them)
+fleet agent create my-project nightly-builder --system-prompt "Build and report"
+fleet trigger create my-project nightly --agent nightly-builder --cron "0 0 * * *" --prompt "Run the nightly build"
+fleet agent list my-project
+fleet trigger list my-project
 ```
 
 ## TUI Keybindings
@@ -180,8 +186,12 @@ An MCP client config (`mcp.json`) can then reference them directly:
 Tools mirror the non-interactive CLI: `fleet_list`, `fleet_status`,
 `fleet_version`, `fleet_logs`, `fleet_up`, `fleet_start`, `fleet_stop`,
 `fleet_down`, `fleet_destroy_fleet`, `fleet_clone`, `fleet_rebuild`, `fleet_exec`,
-and the tmux session tools `fleet_session_spawn` / `fleet_session_exec` /
-`fleet_session_read` / `fleet_session_list`.
+the tmux session tools `fleet_session_spawn` / `fleet_session_exec` /
+`fleet_session_read` / `fleet_session_list`, and the automation CRUD tools
+`fleet_automation_list`, `fleet_agent_create` / `fleet_agent_update` /
+`fleet_agent_delete`, and `fleet_trigger_create` / `fleet_trigger_update` /
+`fleet_trigger_delete` (mirroring the `fleet agent` and `fleet trigger` CLI
+commands).
 Interactive, open-ended commands (`fleet shell`, log following) are intentionally
 not exposed.
 

--- a/integration/tests/392_automation_cli.sh
+++ b/integration/tests/392_automation_cli.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Description: fleet agent / fleet trigger CLI CRUD (issue #189) — create, list,
+# edit (rename), and delete automation agents and triggers through a real
+# daemon, asserting the changes round-trip to state.json, that a rename rewrites
+# trigger references, that a referenced agent can't be deleted, and that the
+# read-modify-write preserves unrelated fleet settings.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+# Kill our daemon on exit so its in-memory state (our seeded fleet + triggers)
+# can't bleed into a later test. Mirrors 391/611.
+itest_cleanup() { pkill -f "${FLEET_BIN} server" >/dev/null 2>&1 || true; }
+itest_begin
+
+server_count() { pgrep -fc "${FLEET_BIN} server" 2>/dev/null || true; }
+
+setup_test
+
+# A daemon lingers across tests (teardown wipes ~/.fleet but never kills the
+# Setsid daemon), and the socket is HOME-scoped and shared. Kill any lingering
+# one so the first CLI call below cold-spawns a fresh daemon that loads the
+# state.json we seed.
+info "killing any lingering daemon so we cold-spawn one with our seeded state"
+pkill -f "${FLEET_BIN} server" >/dev/null 2>&1 || true
+deadline=$(( $(date +%s) + $(_scale_timeout 5) ))
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  [ "$(server_count)" = "0" ] && break
+  sleep 0.2
+done
+
+FLEET="${FIXTURE_REPO_NAME}"
+# Seed a bare fleet carrying a non-default setting (claudeCodeMount=true) so we
+# can prove the automation writes preserve unrelated settings. claudeCodeMount
+# is omitempty, so if a write ever clobbered it to false the key would vanish
+# entirely — its continued presence is the proof.
+seed_fleet_settings "${FLEET}" true false /home/node
+
+# --- agents: create + list ---
+info "creating an agent"
+out=$("${FLEET_BIN}" agent create "${FLEET}" builder --backend devcontainer --system-prompt "be terse" 2>&1) \
+  || fail "agent create failed: ${out}"
+assert_contains "${out}" "Created agent" "agent create did not confirm"
+
+out=$("${FLEET_BIN}" agent list "${FLEET}" 2>&1) || fail "agent list failed: ${out}"
+assert_contains "${out}" "builder" "agent list missing the new agent"
+assert_contains "${out}" "devcontainer" "agent list missing the backend"
+
+state=$(cat "${HOME}/.fleet/state.json")
+assert_contains "${state}" "builder" "agent not persisted to state.json"
+assert_contains "${state}" "claudeCodeMount" "automation write clobbered claudeCodeMount"
+
+# --- triggers: create + list ---
+# A cron that won't match during CI (midnight, Jan 1) so the scheduler never
+# spawns a real instance while this CLI test runs.
+info "creating a trigger"
+out=$("${FLEET_BIN}" trigger create "${FLEET}" nightly --agent builder --cron "0 0 1 1 *" --prompt "go" 2>&1) \
+  || fail "trigger create failed: ${out}"
+assert_contains "${out}" "Created trigger" "trigger create did not confirm"
+
+out=$("${FLEET_BIN}" trigger list "${FLEET}" 2>&1) || fail "trigger list failed: ${out}"
+assert_contains "${out}" "nightly" "trigger list missing the new trigger"
+assert_contains "${out}" "builder" "trigger list missing the agent reference"
+
+# The agent list's TRIGGERS column now reports the reference count for builder.
+# Columns are NAME BACKEND TRIGGERS COMMAND, so match builder's row with a 1.
+out=$("${FLEET_BIN}" agent list "${FLEET}" 2>&1) || fail "agent list (after trigger) failed: ${out}"
+printf '%s' "${out}" | grep -qE 'builder[[:space:]]+devcontainer[[:space:]]+1' \
+  || fail "agent list TRIGGERS column should show 1 for builder: ${out}"
+
+# --- delete guard: a referenced agent can't be deleted ---
+info "verifying a referenced agent cannot be deleted"
+if "${FLEET_BIN}" agent delete "${FLEET}" builder >/dev/null 2>&1; then
+  fail "deleting a referenced agent should have failed"
+fi
+assert_contains "$(cat "${HOME}/.fleet/state.json")" "builder" "agent wrongly removed despite the reference guard"
+
+# --- edit: rename rewrites trigger refs ---
+info "renaming the agent (trigger references must follow)"
+out=$("${FLEET_BIN}" agent edit "${FLEET}" builder --rename builder2 2>&1) || fail "agent edit failed: ${out}"
+assert_contains "$(cat "${HOME}/.fleet/state.json")" "builder2" "rename not persisted"
+out=$("${FLEET_BIN}" trigger list "${FLEET}" 2>&1)
+assert_contains "${out}" "builder2" "trigger reference not rewritten on rename"
+
+# --- trigger edit (changed-only) ---
+"${FLEET_BIN}" trigger edit "${FLEET}" nightly --prompt "updated" >/dev/null 2>&1 \
+  || fail "trigger edit failed"
+
+# --- delete: trigger first, then the now-unreferenced agent ---
+info "deleting the trigger, then the now-free agent"
+"${FLEET_BIN}" trigger delete "${FLEET}" nightly >/dev/null 2>&1 || fail "trigger delete failed"
+"${FLEET_BIN}" agent delete "${FLEET}" builder2 >/dev/null 2>&1 || fail "agent delete (after detach) failed"
+
+state=$(cat "${HOME}/.fleet/state.json")
+assert_not_contains "${state}" "builder2" "agent still present after delete"
+assert_not_contains "${state}" "nightly" "trigger still present after delete"
+# The fleet and its unrelated settings survive the automation deletes.
+assert_contains "${state}" "claudeCodeMount" "fleet settings lost after automation deletes"
+
+pass "fleet agent/trigger CLI: create, list, edit/rename, reference guard, and delete all work"

--- a/internal/admiralskill/SKILL.md
+++ b/internal/admiralskill/SKILL.md
@@ -131,6 +131,31 @@ short name with these tools (they all resolve it the same way);
 To put an agent to work, spawn a session, exec the agent's launch command with
 the task as its prompt, then read the session to see what it's doing or asking.
 
+**Configure automations.** A fleet can run unattended: **agents** are worker
+definitions (a launch command with `${PROMPT}`/`${SYS_PROMPT}` placeholders, a
+system prompt, an env backend) and **triggers** fire one or more agents — on a
+cron **schedule** or a gateway **webhook** event — each firing spins up a fresh
+instance that runs the agent. These tools let you set that up for the user.
+
+- `fleet_automation_list {fleet}` returns the fleet's `{agents, triggers}`.
+  Read it first before an update — updates are field-merges, so you send only
+  what changes.
+- `fleet_agent_create {fleet, name, command?, system_prompt?, backend?}` and
+  `fleet_agent_update {fleet, name, new_name?, command?, system_prompt?,
+  backend?}` (omit a field to keep it; `new_name` renames and rewrites the
+  triggers that reference it). `fleet_agent_delete {fleet, name}` refuses while
+  a trigger still references the agent — detach it first.
+- `fleet_trigger_create {fleet, name, type, agents[], prompt?, ...}` where
+  `type` is `schedule` (needs `cron`) or `webhook` (needs `webhook_name` +
+  `filter_type` `regex`/`jsonpath` and the matching `regex` or
+  `json_path`+`json_value`); `agents` names the agents it fires (each must
+  exist). `fleet_trigger_update` merges fields like the agent one;
+  `fleet_trigger_delete {fleet, name}` removes it.
+
+Every write returns the fleet's resulting `{agents, triggers}`. Names are
+unique per fleet; an invalid cron, an unknown agent reference, or a duplicate
+name comes back as a tool error.
+
 ## Behaviors worth knowing
 
 - An instance must be `running` to exec into it or use its sessions;
@@ -182,4 +207,13 @@ SESSIONS  (interact with an agent / long-lived process in an instance)
   fleet_session_exec {fleet, instance, session, command: "shell string"}
   fleet_session_read {fleet, instance, session, scrollback?}   # 0 screen, N last N, <0 all
   fleet_session_list {fleet, instance}
+
+AUTOMATION  (unattended agents fired by triggers; every write returns {agents, triggers})
+  fleet_automation_list {fleet}                                # read agents + triggers
+  fleet_agent_create {fleet, name, command?, system_prompt?, backend?}
+  fleet_agent_update {fleet, name, new_name?, command?, system_prompt?, backend?}   # omit a field to keep it
+  fleet_agent_delete {fleet, name}                             # fails if a trigger references it
+  fleet_trigger_create {fleet, name, type, agents:[...], prompt?, cron? | webhook_name?+filter_type?+regex?|json_path?+json_value?}
+  fleet_trigger_update {fleet, name, new_name?, type?, agents?, ...}                 # omit a field to keep it
+  fleet_trigger_delete {fleet, name}
 ```

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"fmt"
+	"slices"
+	"text/tabwriter"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/spf13/cobra"
+)
+
+// agent.go is the `fleet agent` command tree (issue #189): CRUD over a fleet's
+// automation agents. An agent defines how an automation worker is launched (a
+// command with ${PROMPT}/${SYS_PROMPT} placeholders, a system prompt, and an
+// env backend); triggers reference agents by name to fire them. The shared
+// read-modify-write plumbing lives in automation.go.
+
+// newAgentCmd builds the `fleet agent` command group.
+func newAgentCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "agent",
+		Short: "Manage a fleet's automation agents",
+	}
+	cmd.AddCommand(
+		newAgentListCmd(),
+		newAgentCreateCmd(),
+		newAgentEditCmd(),
+		newAgentDeleteCmd(),
+	)
+	return cmd
+}
+
+func newAgentListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list <fleet>",
+		Aliases: []string{"ls"},
+		Short:   "List a fleet's automation agents",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			settings, err := loadAutomation(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "NAME\tBACKEND\tTRIGGERS\tCOMMAND")
+			for _, a := range settings.Agents {
+				fmt.Fprintf(w, "%s\t%s\t%d\t%s\n", a.Name, a.Backend, triggersUsing(settings.Triggers, a.Name), a.Command)
+			}
+			return w.Flush()
+		},
+	}
+}
+
+func newAgentCreateCmd() *cobra.Command {
+	var command, systemPrompt, backend string
+	cmd := &cobra.Command{
+		Use:   "create <fleet> <name>",
+		Short: "Create an automation agent",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fleetName, name := args[0], args[1]
+			err := mutateAutomation(cmd.Context(), fleetName, func(s fleet.FleetSettings) (fleet.FleetSettings, error) {
+				return fleet.AddAgent(s, fleet.Agent{
+					Name:         name,
+					Command:      command,
+					SystemPrompt: systemPrompt,
+					Backend:      fleet.BackendType(backend),
+				})
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Created agent %q in fleet %q\n", name, fleetName)
+			return nil
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&command, "command", "", "launch command (${PROMPT}/${SYS_PROMPT} substituted; default: "+fleet.DefaultAgentCommand+")")
+	f.StringVar(&systemPrompt, "system-prompt", "", "system prompt injected into ${SYS_PROMPT}")
+	f.StringVar(&backend, "backend", string(fleet.BackendDevcontainer), "env backend: devcontainer, coder, or codespaces")
+	return cmd
+}
+
+func newAgentEditCmd() *cobra.Command {
+	var command, systemPrompt, backend, rename string
+	cmd := &cobra.Command{
+		Use:   "edit <fleet> <name>",
+		Short: "Edit an automation agent (only the flags you pass change)",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fleetName, name := args[0], args[1]
+			flags := cmd.Flags()
+			err := mutateAutomation(cmd.Context(), fleetName, func(s fleet.FleetSettings) (fleet.FleetSettings, error) {
+				a, ok := fleet.FindAgent(s.Agents, name)
+				if !ok {
+					return s, fmt.Errorf("agent %q not found", name)
+				}
+				if flags.Changed("rename") {
+					a.Name = rename
+				}
+				if flags.Changed("command") {
+					a.Command = command
+				}
+				if flags.Changed("system-prompt") {
+					a.SystemPrompt = systemPrompt
+				}
+				if flags.Changed("backend") {
+					a.Backend = fleet.BackendType(backend)
+				}
+				return fleet.UpdateAgent(s, name, a)
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Updated agent %q in fleet %q\n", name, fleetName)
+			return nil
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&rename, "rename", "", "new name (also rewrites triggers that reference this agent)")
+	f.StringVar(&command, "command", "", "launch command (${PROMPT}/${SYS_PROMPT} substituted)")
+	f.StringVar(&systemPrompt, "system-prompt", "", "system prompt injected into ${SYS_PROMPT}")
+	f.StringVar(&backend, "backend", "", "env backend: devcontainer, coder, or codespaces")
+	return cmd
+}
+
+func newAgentDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "delete <fleet> <name>",
+		Aliases: []string{"rm"},
+		Short:   "Delete an automation agent (must not be referenced by a trigger)",
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fleetName, name := args[0], args[1]
+			err := mutateAutomation(cmd.Context(), fleetName, func(s fleet.FleetSettings) (fleet.FleetSettings, error) {
+				return fleet.DeleteAgent(s, name)
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted agent %q in fleet %q\n", name, fleetName)
+			return nil
+		},
+	}
+}
+
+// triggersUsing counts the triggers that reference the named agent.
+func triggersUsing(triggers []fleet.Trigger, agentName string) int {
+	n := 0
+	for _, t := range triggers {
+		if slices.Contains(t.AgentNames, agentName) {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -1,0 +1,189 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+)
+
+// stubMutate replaces the mutateAutomation seam with one that runs the command's
+// mutation against seed (in memory) and records the fleet name + result, so the
+// command + mutation logic is exercised without a server. The captured result
+// pointer is updated on success.
+func stubMutate(t *testing.T, seed fleet.FleetSettings) (gotFleet *string, result *fleet.FleetSettings) {
+	t.Helper()
+	gotFleet = new(string)
+	result = new(fleet.FleetSettings)
+	orig := mutateAutomation
+	t.Cleanup(func() { mutateAutomation = orig })
+	mutateAutomation = func(_ context.Context, fleetName string, fn func(fleet.FleetSettings) (fleet.FleetSettings, error)) error {
+		*gotFleet = fleetName
+		out, err := fn(seed)
+		if err != nil {
+			return err
+		}
+		*result = out
+		return nil
+	}
+	return gotFleet, result
+}
+
+func runCLI(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := NewRootCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+func TestAgentCreate(t *testing.T) {
+	gotFleet, result := stubMutate(t, fleet.FleetSettings{})
+
+	out, err := runCLI(t, "agent", "create", "alpha", "builder", "--backend", "coder", "--system-prompt", "be terse")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if *gotFleet != "alpha" {
+		t.Errorf("fleet = %q, want alpha", *gotFleet)
+	}
+	if len(result.Agents) != 1 {
+		t.Fatalf("want 1 agent, got %+v", result.Agents)
+	}
+	a := result.Agents[0]
+	if a.Name != "builder" || a.Backend != fleet.BackendCoder || a.SystemPrompt != "be terse" {
+		t.Errorf("agent = %+v", a)
+	}
+	// An unspecified command normalizes to the default.
+	if a.Command != strings.TrimSpace(fleet.DefaultAgentCommand) {
+		t.Errorf("command = %q, want default", a.Command)
+	}
+	if !strings.Contains(out, "Created agent") {
+		t.Errorf("output = %q", out)
+	}
+}
+
+func TestAgentCreateDuplicateFails(t *testing.T) {
+	stubMutate(t, fleet.FleetSettings{Agents: []fleet.Agent{{Name: "builder", Backend: fleet.BackendDevcontainer}}})
+	if _, err := runCLI(t, "agent", "create", "alpha", "builder"); err == nil {
+		t.Fatal("want duplicate-name error")
+	}
+}
+
+func TestAgentEditChangedOnly(t *testing.T) {
+	seed := fleet.FleetSettings{Agents: []fleet.Agent{
+		{Name: "a", Backend: fleet.BackendDevcontainer, Command: "orig", SystemPrompt: "keep me"},
+	}}
+	_, result := stubMutate(t, seed)
+
+	if _, err := runCLI(t, "agent", "edit", "alpha", "a", "--command", "new"); err != nil {
+		t.Fatalf("edit: %v", err)
+	}
+	a := result.Agents[0]
+	if a.Command != "new" {
+		t.Errorf("command = %q, want new", a.Command)
+	}
+	if a.SystemPrompt != "keep me" {
+		t.Errorf("system prompt = %q, want unchanged", a.SystemPrompt)
+	}
+}
+
+func TestAgentEditBackend(t *testing.T) {
+	seed := fleet.FleetSettings{Agents: []fleet.Agent{
+		{Name: "a", Backend: fleet.BackendDevcontainer, Command: "claude", SystemPrompt: "keep me"},
+	}}
+	_, result := stubMutate(t, seed)
+
+	if _, err := runCLI(t, "agent", "edit", "alpha", "a", "--backend", "coder"); err != nil {
+		t.Fatalf("edit backend: %v", err)
+	}
+	a := result.Agents[0]
+	if a.Backend != fleet.BackendCoder {
+		t.Errorf("backend = %q, want coder", a.Backend)
+	}
+	// Other fields are untouched (only-passed-flags-change).
+	if a.Command != "claude" || a.SystemPrompt != "keep me" {
+		t.Errorf("unrelated fields changed: %+v", a)
+	}
+}
+
+func TestAgentEditRenameRewritesTriggers(t *testing.T) {
+	seed := fleet.FleetSettings{
+		Agents:   []fleet.Agent{{Name: "old", Backend: fleet.BackendDevcontainer}},
+		Triggers: []fleet.Trigger{{Name: "t", Type: fleet.TriggerSchedule, AgentNames: []string{"old"}, Cron: "* * * * *"}},
+	}
+	_, result := stubMutate(t, seed)
+
+	if _, err := runCLI(t, "agent", "edit", "alpha", "old", "--rename", "new"); err != nil {
+		t.Fatalf("edit rename: %v", err)
+	}
+	if result.Agents[0].Name != "new" {
+		t.Errorf("agent not renamed: %+v", result.Agents)
+	}
+	if got := result.Triggers[0].AgentNames; len(got) != 1 || got[0] != "new" {
+		t.Errorf("trigger ref not rewritten: %v", got)
+	}
+}
+
+func TestAgentDelete(t *testing.T) {
+	seed := fleet.FleetSettings{Agents: []fleet.Agent{
+		{Name: "a", Backend: fleet.BackendDevcontainer},
+		{Name: "b", Backend: fleet.BackendDevcontainer},
+	}}
+	_, result := stubMutate(t, seed)
+
+	if _, err := runCLI(t, "agent", "rm", "alpha", "a"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if len(result.Agents) != 1 || result.Agents[0].Name != "b" {
+		t.Errorf("want [b] left, got %+v", result.Agents)
+	}
+}
+
+func TestAgentDeleteReferencedFails(t *testing.T) {
+	stubMutate(t, fleet.FleetSettings{
+		Agents:   []fleet.Agent{{Name: "a", Backend: fleet.BackendDevcontainer}},
+		Triggers: []fleet.Trigger{{Name: "t", Type: fleet.TriggerSchedule, AgentNames: []string{"a"}, Cron: "* * * * *"}},
+	})
+	if _, err := runCLI(t, "agent", "delete", "alpha", "a"); err == nil {
+		t.Fatal("want referenced-agent error")
+	}
+}
+
+func TestAgentList(t *testing.T) {
+	orig := loadAutomation
+	t.Cleanup(func() { loadAutomation = orig })
+	loadAutomation = func(_ context.Context, fleetName string) (fleet.FleetSettings, error) {
+		return fleet.FleetSettings{
+			Agents:   []fleet.Agent{{Name: "builder", Backend: fleet.BackendDevcontainer, Command: "claude"}},
+			Triggers: []fleet.Trigger{{Name: "nightly", Type: fleet.TriggerSchedule, AgentNames: []string{"builder"}, Cron: "0 0 * * *"}},
+		}, nil
+	}
+
+	out, err := runCLI(t, "agent", "list", "alpha")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	for _, want := range []string{"NAME", "BACKEND", "TRIGGERS", "builder", "devcontainer", "claude"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("list output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestAgentAliases(t *testing.T) {
+	cmds := map[string]string{}
+	for _, c := range newAgentCmd().Commands() {
+		for _, a := range c.Aliases {
+			cmds[a] = c.Name()
+		}
+	}
+	if cmds["ls"] != "list" || cmds["rm"] != "delete" {
+		t.Errorf("agent aliases = %v, want ls->list, rm->delete", cmds)
+	}
+}

--- a/internal/cli/automation.go
+++ b/internal/cli/automation.go
@@ -1,0 +1,191 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetclient"
+)
+
+// automation.go is the shared plumbing for the `fleet agent` and `fleet trigger`
+// command trees (issue #189): programmatic CRUD over a fleet's automation
+// agents and triggers (the same config the TUI's automation view edits).
+//
+// There is no per-item RPC — automation lives inline on FleetSettings, which
+// SetFleetSettings replaces wholesale. So every write is read-modify-write:
+// fetch the fleet's current settings, apply one change to the agent/trigger
+// lists (via the shared fleet.* mutators, which own the invariants — unique
+// names, rename-rewrites-references, no-orphan deletes), and send the full
+// settings back. The other settings fields ride along untouched on the proto
+// object we read, so a write here never disturbs mounts, presets, or the rest.
+//
+// loadAutomation / mutateAutomation are package vars so the command tests can
+// stub the server round-trip and exercise the command + mutation logic in
+// memory.
+
+// loadAutomation fetches the named fleet's automation lists as domain types.
+var loadAutomation = func(ctx context.Context, fleetName string) (fleet.FleetSettings, error) {
+	conn, err := fleetclient.Dial(ctx)
+	if err != nil {
+		return fleet.FleetSettings{}, err
+	}
+	defer conn.Close()
+	reply, err := conn.Service().GetState(ctx, &fleetgrpc.GetStateRequest{})
+	if err != nil {
+		return fleet.FleetSettings{}, err
+	}
+	pf := reply.GetState().GetFleets()[fleetName]
+	if pf == nil {
+		return fleet.FleetSettings{}, fmt.Errorf("fleet %q not found", fleetName)
+	}
+	ps := pf.GetSettings()
+	return fleet.FleetSettings{
+		Agents:   protoAgentsToFleet(ps.GetAgents()),
+		Triggers: protoTriggersToFleet(ps.GetTriggers()),
+	}, nil
+}
+
+// mutateAutomation reads the named fleet's settings, applies fn to its
+// (domain) agent/trigger lists, and writes the result back — preserving every
+// other settings field. fn returns the modified settings (the shared fleet.*
+// mutators do exactly this) or an error that aborts the write.
+var mutateAutomation = func(ctx context.Context, fleetName string, fn func(fleet.FleetSettings) (fleet.FleetSettings, error)) error {
+	conn, err := fleetclient.Dial(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	svc := conn.Service()
+
+	reply, err := svc.GetState(ctx, &fleetgrpc.GetStateRequest{})
+	if err != nil {
+		return err
+	}
+	pf := reply.GetState().GetFleets()[fleetName]
+	if pf == nil {
+		return fmt.Errorf("fleet %q not found", fleetName)
+	}
+	// Keep the live proto settings as the carrier so all the fields this command
+	// doesn't touch (mounts, presets, home dir, ...) survive the wholesale write.
+	ps := pf.GetSettings()
+	if ps == nil {
+		ps = &fleetgrpc.FleetSettings{}
+	}
+
+	settings := fleet.FleetSettings{
+		Agents:   protoAgentsToFleet(ps.GetAgents()),
+		Triggers: protoTriggersToFleet(ps.GetTriggers()),
+	}
+	settings, err = fn(settings)
+	if err != nil {
+		return err
+	}
+	ps.Agents = fleetAgentsToProto(settings.Agents)
+	ps.Triggers = fleetTriggersToProto(settings.Triggers)
+
+	if _, err := svc.SetFleetSettings(ctx, &fleetgrpc.SetFleetSettingsRequest{Fleet: fleetName, Settings: ps}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// --- proto <-> domain converters (agents/triggers only) ---
+//
+// These mirror the server-side converters (internal/server/convert.go) and the
+// TUI's (internal/tui/client.go). The duplication is the depguard boundary's
+// price: client code cannot import the server, so each side maps the shared
+// proto wire types to its own domain view.
+
+func protoAgentsToFleet(in []*fleetgrpc.Agent) []fleet.Agent {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]fleet.Agent, 0, len(in))
+	for _, a := range in {
+		out = append(out, fleet.Agent{
+			Name:         a.GetName(),
+			Command:      a.GetCommand(),
+			SystemPrompt: a.GetSystemPrompt(),
+			Backend:      fleet.BackendType(backendProtoToString(a.GetBackend())),
+		})
+	}
+	return out
+}
+
+func fleetAgentsToProto(in []fleet.Agent) []*fleetgrpc.Agent {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*fleetgrpc.Agent, 0, len(in))
+	for _, a := range in {
+		out = append(out, &fleetgrpc.Agent{
+			Name:         a.Name,
+			Command:      a.Command,
+			SystemPrompt: a.SystemPrompt,
+			Backend:      backendTypeToProto(a.Backend),
+		})
+	}
+	return out
+}
+
+func protoTriggersToFleet(in []*fleetgrpc.Trigger) []fleet.Trigger {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]fleet.Trigger, 0, len(in))
+	for _, t := range in {
+		out = append(out, fleet.Trigger{
+			Name:        t.GetName(),
+			Type:        fleet.TriggerType(t.GetType()),
+			AgentNames:  t.GetAgentNames(),
+			Prompt:      t.GetPrompt(),
+			Cron:        t.GetCron(),
+			WebhookName: t.GetWebhookName(),
+			FilterType:  fleet.WebhookFilterType(t.GetFilterType()),
+			Regex:       t.GetRegex(),
+			JSONPath:    t.GetJsonPath(),
+			JSONValue:   t.GetJsonValue(),
+		})
+	}
+	return out
+}
+
+func fleetTriggersToProto(in []fleet.Trigger) []*fleetgrpc.Trigger {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*fleetgrpc.Trigger, 0, len(in))
+	for _, t := range in {
+		out = append(out, &fleetgrpc.Trigger{
+			Name:        t.Name,
+			Type:        string(t.Type),
+			AgentNames:  t.AgentNames,
+			Prompt:      t.Prompt,
+			Cron:        t.Cron,
+			WebhookName: t.WebhookName,
+			FilterType:  string(t.FilterType),
+			Regex:       t.Regex,
+			JsonPath:    t.JSONPath,
+			JsonValue:   t.JSONValue,
+		})
+	}
+	return out
+}
+
+// backendProtoToString maps the backend enum to the legacy string ("" for
+// UNSPECIFIED, which NormalizeAgent then defaults to devcontainer). The reverse,
+// backendTypeToProto, lives in jobs.go.
+func backendProtoToString(b fleetgrpc.BackendType) string {
+	switch b {
+	case fleetgrpc.BackendType_BACKEND_TYPE_DEVCONTAINER:
+		return string(fleet.BackendDevcontainer)
+	case fleetgrpc.BackendType_BACKEND_TYPE_CODER:
+		return string(fleet.BackendCoder)
+	case fleetgrpc.BackendType_BACKEND_TYPE_CODESPACES:
+		return string(fleet.BackendCodespaces)
+	default:
+		return ""
+	}
+}

--- a/internal/cli/automation_test.go
+++ b/internal/cli/automation_test.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+)
+
+// TestAutomationConvertersRoundTrip locks in that the CLI's proto<->domain
+// agent/trigger converters are lossless: a write reads the current proto
+// settings, converts to domain, mutates, and converts back, so any field that
+// doesn't survive the round trip would be silently dropped.
+func TestAutomationConvertersRoundTrip(t *testing.T) {
+	agents := []fleet.Agent{
+		{Name: "a", Command: "claude '${PROMPT}'", SystemPrompt: "be terse", Backend: fleet.BackendCoder},
+		{Name: "b", Command: "run", Backend: fleet.BackendDevcontainer},
+	}
+	if got := protoAgentsToFleet(fleetAgentsToProto(agents)); !reflect.DeepEqual(got, agents) {
+		t.Fatalf("agent round trip:\n got %+v\nwant %+v", got, agents)
+	}
+
+	triggers := []fleet.Trigger{
+		{Name: "nightly", Type: fleet.TriggerSchedule, AgentNames: []string{"a", "b"}, Prompt: "go", Cron: "0 0 * * *"},
+		{Name: "hook", Type: fleet.TriggerWebhook, AgentNames: []string{"a"}, WebhookName: "ci", FilterType: fleet.WebhookFilterJSONPath, JSONPath: "$.action", JSONValue: "opened"},
+	}
+	if got := protoTriggersToFleet(fleetTriggersToProto(triggers)); !reflect.DeepEqual(got, triggers) {
+		t.Fatalf("trigger round trip:\n got %+v\nwant %+v", got, triggers)
+	}
+}
+
+func TestAutomationConvertersEmpty(t *testing.T) {
+	if protoAgentsToFleet(nil) != nil || fleetAgentsToProto(nil) != nil {
+		t.Error("empty agent lists should map to nil both ways")
+	}
+	if protoTriggersToFleet(nil) != nil || fleetTriggersToProto(nil) != nil {
+		t.Error("empty trigger lists should map to nil both ways")
+	}
+}
+
+func TestBackendProtoToString(t *testing.T) {
+	// Every backend value survives string -> proto -> string.
+	for _, b := range []fleet.BackendType{fleet.BackendDevcontainer, fleet.BackendCoder, fleet.BackendCodespaces} {
+		if got := backendProtoToString(backendTypeToProto(b)); got != string(b) {
+			t.Errorf("%q round trip: got %q", b, got)
+		}
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -57,6 +57,8 @@ func NewRootCmd() *cobra.Command {
 		newVersionCmd(),
 		newServerCmd(),
 		newGatewayCmd(),
+		newAgentCmd(),
+		newTriggerCmd(),
 	)
 
 	return root

--- a/internal/cli/trigger.go
+++ b/internal/cli/trigger.go
@@ -1,0 +1,193 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/spf13/cobra"
+)
+
+// trigger.go is the `fleet trigger` command tree (issue #189): CRUD over a
+// fleet's automation triggers. A trigger fires one or more of the fleet's
+// agents (with a prompt) when its condition is met — a cron schedule or a
+// gateway webhook event. The shared read-modify-write plumbing lives in
+// automation.go; the type-specific field validation lives in fleet.Normalize-
+// Trigger (which AddTrigger/UpdateTrigger apply).
+
+// newTriggerCmd builds the `fleet trigger` command group.
+func newTriggerCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "trigger",
+		Short: "Manage a fleet's automation triggers",
+	}
+	cmd.AddCommand(
+		newTriggerListCmd(),
+		newTriggerCreateCmd(),
+		newTriggerEditCmd(),
+		newTriggerDeleteCmd(),
+	)
+	return cmd
+}
+
+func newTriggerListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list <fleet>",
+		Aliases: []string{"ls"},
+		Short:   "List a fleet's automation triggers",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			settings, err := loadAutomation(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "NAME\tTYPE\tAGENTS\tDETAIL")
+			for _, t := range settings.Triggers {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", t.Name, t.Type, strings.Join(t.AgentNames, ","), triggerDetail(t))
+			}
+			return w.Flush()
+		},
+	}
+}
+
+// triggerFlags are the per-field flags shared by create and edit.
+type triggerFlags struct {
+	triggerType string
+	agents      []string
+	prompt      string
+	cron        string
+	webhookName string
+	filterType  string
+	regex       string
+	jsonPath    string
+	jsonValue   string
+}
+
+func (tf *triggerFlags) bind(cmd *cobra.Command, typeDefault, filterDefault string) {
+	f := cmd.Flags()
+	f.StringVar(&tf.triggerType, "type", typeDefault, "trigger type: schedule or webhook")
+	f.StringArrayVar(&tf.agents, "agent", nil, "agent to activate (repeatable; at least one required)")
+	f.StringVar(&tf.prompt, "prompt", "", "prompt fed to the agents via ${PROMPT}")
+	f.StringVar(&tf.cron, "cron", "", "schedule: 5-field cron expression (schedule type)")
+	f.StringVar(&tf.webhookName, "webhook-name", "", "webhook: name appended to the gateway URL (webhook type)")
+	f.StringVar(&tf.filterType, "filter-type", filterDefault, "webhook: filter type, regex or jsonpath (webhook type)")
+	f.StringVar(&tf.regex, "regex", "", "webhook: regex the event body must match (regex filter)")
+	f.StringVar(&tf.jsonPath, "json-path", "", "webhook: JSON path to compare (jsonpath filter)")
+	f.StringVar(&tf.jsonValue, "json-value", "", "webhook: value the JSON path must equal (jsonpath filter)")
+}
+
+// apply writes the flag values onto t. When onlyChanged is true (edit), a field
+// is written only if its flag was explicitly set, so unspecified fields keep
+// their stored value.
+func (tf *triggerFlags) apply(cmd *cobra.Command, t *fleet.Trigger, onlyChanged bool) {
+	flags := cmd.Flags()
+	set := func(name string, write func()) {
+		if !onlyChanged || flags.Changed(name) {
+			write()
+		}
+	}
+	set("type", func() { t.Type = fleet.TriggerType(tf.triggerType) })
+	set("agent", func() { t.AgentNames = tf.agents })
+	set("prompt", func() { t.Prompt = tf.prompt })
+	set("cron", func() { t.Cron = tf.cron })
+	set("webhook-name", func() { t.WebhookName = tf.webhookName })
+	set("filter-type", func() { t.FilterType = fleet.WebhookFilterType(tf.filterType) })
+	set("regex", func() { t.Regex = tf.regex })
+	set("json-path", func() { t.JSONPath = tf.jsonPath })
+	set("json-value", func() { t.JSONValue = tf.jsonValue })
+}
+
+func newTriggerCreateCmd() *cobra.Command {
+	var tf triggerFlags
+	cmd := &cobra.Command{
+		Use:   "create <fleet> <name>",
+		Short: "Create an automation trigger",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fleetName, name := args[0], args[1]
+			err := mutateAutomation(cmd.Context(), fleetName, func(s fleet.FleetSettings) (fleet.FleetSettings, error) {
+				t := fleet.Trigger{Name: name}
+				tf.apply(cmd, &t, false)
+				return fleet.AddTrigger(s, t)
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Created trigger %q in fleet %q\n", name, fleetName)
+			return nil
+		},
+	}
+	tf.bind(cmd, string(fleet.TriggerSchedule), string(fleet.WebhookFilterRegex))
+	return cmd
+}
+
+func newTriggerEditCmd() *cobra.Command {
+	var tf triggerFlags
+	var rename string
+	cmd := &cobra.Command{
+		Use:   "edit <fleet> <name>",
+		Short: "Edit an automation trigger (only the flags you pass change)",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fleetName, name := args[0], args[1]
+			err := mutateAutomation(cmd.Context(), fleetName, func(s fleet.FleetSettings) (fleet.FleetSettings, error) {
+				t, ok := fleet.FindTrigger(s.Triggers, name)
+				if !ok {
+					return s, fmt.Errorf("trigger %q not found", name)
+				}
+				if cmd.Flags().Changed("rename") {
+					t.Name = rename
+				}
+				tf.apply(cmd, &t, true)
+				return fleet.UpdateTrigger(s, name, t)
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Updated trigger %q in fleet %q\n", name, fleetName)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&rename, "rename", "", "new name")
+	tf.bind(cmd, string(fleet.TriggerSchedule), string(fleet.WebhookFilterRegex))
+	return cmd
+}
+
+func newTriggerDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "delete <fleet> <name>",
+		Aliases: []string{"rm"},
+		Short:   "Delete an automation trigger",
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fleetName, name := args[0], args[1]
+			err := mutateAutomation(cmd.Context(), fleetName, func(s fleet.FleetSettings) (fleet.FleetSettings, error) {
+				return fleet.DeleteTrigger(s, name)
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted trigger %q in fleet %q\n", name, fleetName)
+			return nil
+		},
+	}
+}
+
+// triggerDetail is the one-line schedule/webhook summary shown by `list`.
+func triggerDetail(t fleet.Trigger) string {
+	switch t.Type {
+	case fleet.TriggerSchedule:
+		return "cron: " + t.Cron
+	case fleet.TriggerWebhook:
+		switch t.FilterType {
+		case fleet.WebhookFilterJSONPath:
+			return fmt.Sprintf("webhook:%s jsonpath %s=%s", t.WebhookName, t.JSONPath, t.JSONValue)
+		default:
+			return fmt.Sprintf("webhook:%s regex %s", t.WebhookName, t.Regex)
+		}
+	default:
+		return string(t.Type)
+	}
+}

--- a/internal/cli/trigger_test.go
+++ b/internal/cli/trigger_test.go
@@ -1,0 +1,200 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+)
+
+func TestTriggerCreateSchedule(t *testing.T) {
+	seed := fleet.FleetSettings{Agents: []fleet.Agent{{Name: "builder", Backend: fleet.BackendDevcontainer}}}
+	gotFleet, result := stubMutate(t, seed)
+
+	out, err := runCLI(t, "trigger", "create", "alpha", "nightly", "--agent", "builder", "--cron", "0 0 * * *", "--prompt", "go")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if *gotFleet != "alpha" {
+		t.Errorf("fleet = %q", *gotFleet)
+	}
+	if len(result.Triggers) != 1 {
+		t.Fatalf("want 1 trigger, got %+v", result.Triggers)
+	}
+	tr := result.Triggers[0]
+	if tr.Name != "nightly" || tr.Type != fleet.TriggerSchedule || tr.Cron != "0 0 * * *" {
+		t.Errorf("trigger = %+v", tr)
+	}
+	if len(tr.AgentNames) != 1 || tr.AgentNames[0] != "builder" {
+		t.Errorf("agents = %v", tr.AgentNames)
+	}
+	if !strings.Contains(out, "Created trigger") {
+		t.Errorf("output = %q", out)
+	}
+}
+
+func TestTriggerCreateWebhook(t *testing.T) {
+	seed := fleet.FleetSettings{Agents: []fleet.Agent{{Name: "a", Backend: fleet.BackendDevcontainer}}}
+	_, result := stubMutate(t, seed)
+
+	_, err := runCLI(t, "trigger", "create", "alpha", "hook",
+		"--type", "webhook", "--agent", "a",
+		"--webhook-name", "ci", "--filter-type", "jsonpath",
+		"--json-path", "$.action", "--json-value", "opened")
+	if err != nil {
+		t.Fatalf("create webhook: %v", err)
+	}
+	tr := result.Triggers[0]
+	if tr.Type != fleet.TriggerWebhook || tr.WebhookName != "ci" || tr.JSONPath != "$.action" || tr.JSONValue != "opened" {
+		t.Errorf("webhook trigger = %+v", tr)
+	}
+	// Cron is a schedule-only field; a webhook trigger must not carry one.
+	if tr.Cron != "" {
+		t.Errorf("webhook trigger carries cron %q", tr.Cron)
+	}
+}
+
+func TestTriggerCreateRequiresAgent(t *testing.T) {
+	stubMutate(t, fleet.FleetSettings{Agents: []fleet.Agent{{Name: "a", Backend: fleet.BackendDevcontainer}}})
+	// No --agent: NormalizeTrigger rejects a trigger that activates no agents.
+	if _, err := runCLI(t, "trigger", "create", "alpha", "t", "--cron", "* * * * *"); err == nil {
+		t.Fatal("want error for a trigger with no agents")
+	}
+}
+
+func TestTriggerCreateUnknownAgentFails(t *testing.T) {
+	stubMutate(t, fleet.FleetSettings{Agents: []fleet.Agent{{Name: "a", Backend: fleet.BackendDevcontainer}}})
+	if _, err := runCLI(t, "trigger", "create", "alpha", "t", "--agent", "ghost", "--cron", "* * * * *"); err == nil {
+		t.Fatal("want unknown-agent error")
+	}
+}
+
+func TestTriggerEditChangedOnly(t *testing.T) {
+	seed := fleet.FleetSettings{
+		Agents:   []fleet.Agent{{Name: "a", Backend: fleet.BackendDevcontainer}},
+		Triggers: []fleet.Trigger{{Name: "t", Type: fleet.TriggerSchedule, AgentNames: []string{"a"}, Prompt: "keep", Cron: "0 0 * * *"}},
+	}
+	_, result := stubMutate(t, seed)
+
+	if _, err := runCLI(t, "trigger", "edit", "alpha", "t", "--cron", "5 4 * * *"); err != nil {
+		t.Fatalf("edit: %v", err)
+	}
+	tr := result.Triggers[0]
+	if tr.Cron != "5 4 * * *" {
+		t.Errorf("cron = %q, want updated", tr.Cron)
+	}
+	if tr.Prompt != "keep" {
+		t.Errorf("prompt = %q, want unchanged", tr.Prompt)
+	}
+	if len(tr.AgentNames) != 1 || tr.AgentNames[0] != "a" {
+		t.Errorf("agents changed unexpectedly: %v", tr.AgentNames)
+	}
+}
+
+func TestTriggerEditReplaceAgents(t *testing.T) {
+	seed := fleet.FleetSettings{
+		Agents: []fleet.Agent{
+			{Name: "a", Backend: fleet.BackendDevcontainer},
+			{Name: "b", Backend: fleet.BackendDevcontainer},
+		},
+		Triggers: []fleet.Trigger{{Name: "t", Type: fleet.TriggerSchedule, AgentNames: []string{"a"}, Cron: "* * * * *"}},
+	}
+	_, result := stubMutate(t, seed)
+
+	if _, err := runCLI(t, "trigger", "edit", "alpha", "t", "--agent", "a", "--agent", "b"); err != nil {
+		t.Fatalf("edit agents: %v", err)
+	}
+	if got := result.Triggers[0].AgentNames; len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("agents = %v, want [a b]", got)
+	}
+}
+
+func TestTriggerEditTypeChange(t *testing.T) {
+	seed := fleet.FleetSettings{
+		Agents:   []fleet.Agent{{Name: "a", Backend: fleet.BackendDevcontainer}},
+		Triggers: []fleet.Trigger{{Name: "t", Type: fleet.TriggerSchedule, AgentNames: []string{"a"}, Cron: "0 0 * * *"}},
+	}
+	_, result := stubMutate(t, seed)
+
+	// Convert the schedule trigger to a webhook: the webhook fields are set and
+	// the schedule-only cron is cleared by normalization.
+	_, err := runCLI(t, "trigger", "edit", "alpha", "t",
+		"--type", "webhook", "--webhook-name", "ci",
+		"--filter-type", "jsonpath", "--json-path", "$.action", "--json-value", "opened")
+	if err != nil {
+		t.Fatalf("edit type change: %v", err)
+	}
+	tr := result.Triggers[0]
+	if tr.Type != fleet.TriggerWebhook || tr.WebhookName != "ci" || tr.JSONPath != "$.action" || tr.JSONValue != "opened" {
+		t.Errorf("webhook fields wrong after type change: %+v", tr)
+	}
+	if tr.Cron != "" {
+		t.Errorf("schedule-only cron should be cleared after switch to webhook: %q", tr.Cron)
+	}
+}
+
+func TestTriggerEditRename(t *testing.T) {
+	seed := fleet.FleetSettings{
+		Agents:   []fleet.Agent{{Name: "a", Backend: fleet.BackendDevcontainer}},
+		Triggers: []fleet.Trigger{{Name: "old", Type: fleet.TriggerSchedule, AgentNames: []string{"a"}, Cron: "* * * * *"}},
+	}
+	_, result := stubMutate(t, seed)
+
+	if _, err := runCLI(t, "trigger", "edit", "alpha", "old", "--rename", "new"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if result.Triggers[0].Name != "new" {
+		t.Errorf("trigger not renamed: %+v", result.Triggers)
+	}
+}
+
+func TestTriggerDelete(t *testing.T) {
+	seed := fleet.FleetSettings{
+		Agents:   []fleet.Agent{{Name: "a", Backend: fleet.BackendDevcontainer}},
+		Triggers: []fleet.Trigger{{Name: "t", Type: fleet.TriggerSchedule, AgentNames: []string{"a"}, Cron: "* * * * *"}},
+	}
+	_, result := stubMutate(t, seed)
+
+	if _, err := runCLI(t, "trigger", "delete", "alpha", "t"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if len(result.Triggers) != 0 {
+		t.Errorf("trigger not deleted: %+v", result.Triggers)
+	}
+}
+
+func TestTriggerList(t *testing.T) {
+	orig := loadAutomation
+	t.Cleanup(func() { loadAutomation = orig })
+	loadAutomation = func(_ context.Context, _ string) (fleet.FleetSettings, error) {
+		return fleet.FleetSettings{
+			Triggers: []fleet.Trigger{
+				{Name: "nightly", Type: fleet.TriggerSchedule, AgentNames: []string{"builder"}, Cron: "0 0 * * *"},
+				{Name: "hook", Type: fleet.TriggerWebhook, AgentNames: []string{"a", "b"}, WebhookName: "ci", FilterType: fleet.WebhookFilterRegex, Regex: "push"},
+			},
+		}, nil
+	}
+
+	out, err := runCLI(t, "trigger", "ls", "alpha")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	for _, want := range []string{"NAME", "TYPE", "AGENTS", "nightly", "0 0 * * *", "hook", "webhook:ci", "a,b"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("list output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestTriggerAliases(t *testing.T) {
+	cmds := map[string]string{}
+	for _, c := range newTriggerCmd().Commands() {
+		for _, a := range c.Aliases {
+			cmds[a] = c.Name()
+		}
+	}
+	if cmds["ls"] != "list" || cmds["rm"] != "delete" {
+		t.Errorf("trigger aliases = %v, want ls->list, rm->delete", cmds)
+	}
+}

--- a/internal/fleet/automation_mutate.go
+++ b/internal/fleet/automation_mutate.go
@@ -1,0 +1,220 @@
+package fleet
+
+import (
+	"fmt"
+	"slices"
+)
+
+// automation_mutate.go holds the per-fleet add/edit/delete operations for
+// automation Agents and Triggers (issue #189). They are the single home for the
+// non-trivial invariants the three editors (TUI, CLI, MCP) all need:
+//
+//   - a name is unique within its list (a duplicate is ambiguous, not a no-op);
+//   - renaming an agent rewrites every trigger that references it, so the
+//     settings never carry a dangling agent reference;
+//   - an agent still referenced by a trigger cannot be deleted (that would
+//     orphan the trigger, which the server rejects wholesale).
+//
+// Every function takes and returns a FleetSettings by value and never mutates
+// the input's Agents/Triggers slices (it builds fresh ones), so a caller that
+// applies the result optimistically can revert by restoring the original
+// settings. The item is normalized (NormalizeAgent / NormalizeTrigger) before
+// it lands in the list, so these give the same client-side validation the
+// server re-applies authoritatively in SetFleetSettings.
+
+// FindAgent returns the agent named name (and true) from agents, or a zero
+// Agent and false. The match is on the trimmed-and-normalized name space:
+// names are compared verbatim, as they are stored already trimmed.
+func FindAgent(agents []Agent, name string) (Agent, bool) {
+	if i := indexOfAgent(agents, name); i >= 0 {
+		return agents[i], true
+	}
+	return Agent{}, false
+}
+
+// FindTrigger returns the trigger named name (and true), or a zero Trigger and
+// false.
+func FindTrigger(triggers []Trigger, name string) (Trigger, bool) {
+	if i := indexOfTrigger(triggers, name); i >= 0 {
+		return triggers[i], true
+	}
+	return Trigger{}, false
+}
+
+// AddAgent appends a (normalized) agent to s, rejecting a name already in use.
+func AddAgent(s FleetSettings, a Agent) (FleetSettings, error) {
+	norm, err := NormalizeAgent(a)
+	if err != nil {
+		return s, err
+	}
+	if indexOfAgent(s.Agents, norm.Name) >= 0 {
+		return s, fmt.Errorf("agent %q already exists", norm.Name)
+	}
+	s.Agents = append(append([]Agent(nil), s.Agents...), norm)
+	return s, nil
+}
+
+// UpdateAgent replaces the agent named name with updated (normalized). When the
+// name changes, every trigger referencing the old name is rewritten so no
+// trigger is left dangling. It errors if name is absent or the new name
+// collides with a different agent.
+func UpdateAgent(s FleetSettings, name string, updated Agent) (FleetSettings, error) {
+	idx := indexOfAgent(s.Agents, name)
+	if idx < 0 {
+		return s, fmt.Errorf("agent %q not found", name)
+	}
+	norm, err := NormalizeAgent(updated)
+	if err != nil {
+		return s, err
+	}
+	for i, a := range s.Agents {
+		if i != idx && a.Name == norm.Name {
+			return s, fmt.Errorf("agent %q already exists", norm.Name)
+		}
+	}
+	newAgents := append([]Agent(nil), s.Agents...)
+	oldName := newAgents[idx].Name
+	newAgents[idx] = norm
+	s.Agents = newAgents
+	if oldName != norm.Name {
+		s.Triggers = renameAgentInTriggers(s.Triggers, oldName, norm.Name)
+	}
+	return s, nil
+}
+
+// DeleteAgent removes the agent named name. It errors if the agent is absent or
+// is still referenced by a trigger (deleting it would orphan that trigger).
+func DeleteAgent(s FleetSettings, name string) (FleetSettings, error) {
+	idx := indexOfAgent(s.Agents, name)
+	if idx < 0 {
+		return s, fmt.Errorf("agent %q not found", name)
+	}
+	for _, t := range s.Triggers {
+		if slices.Contains(t.AgentNames, name) {
+			return s, fmt.Errorf("agent %q is referenced by trigger %q; remove it from that trigger first", name, t.Name)
+		}
+	}
+	s.Agents = removeAgentAt(s.Agents, idx)
+	return s, nil
+}
+
+// AddTrigger appends a (normalized) trigger to s, rejecting a name already in
+// use. The trigger is validated against s.Agents (every referenced agent must
+// exist).
+func AddTrigger(s FleetSettings, t Trigger) (FleetSettings, error) {
+	norm, err := NormalizeTrigger(t, agentNameSet(s.Agents))
+	if err != nil {
+		return s, err
+	}
+	if indexOfTrigger(s.Triggers, norm.Name) >= 0 {
+		return s, fmt.Errorf("trigger %q already exists", norm.Name)
+	}
+	s.Triggers = append(append([]Trigger(nil), s.Triggers...), norm)
+	return s, nil
+}
+
+// UpdateTrigger replaces the trigger named name with updated (normalized
+// against s.Agents). It errors if name is absent or the new name collides with
+// a different trigger.
+func UpdateTrigger(s FleetSettings, name string, updated Trigger) (FleetSettings, error) {
+	idx := indexOfTrigger(s.Triggers, name)
+	if idx < 0 {
+		return s, fmt.Errorf("trigger %q not found", name)
+	}
+	norm, err := NormalizeTrigger(updated, agentNameSet(s.Agents))
+	if err != nil {
+		return s, err
+	}
+	for i, t := range s.Triggers {
+		if i != idx && t.Name == norm.Name {
+			return s, fmt.Errorf("trigger %q already exists", norm.Name)
+		}
+	}
+	newTriggers := append([]Trigger(nil), s.Triggers...)
+	newTriggers[idx] = norm
+	s.Triggers = newTriggers
+	return s, nil
+}
+
+// DeleteTrigger removes the trigger named name, erroring if it is absent. A
+// trigger has no dependents, so there is no reference guard.
+func DeleteTrigger(s FleetSettings, name string) (FleetSettings, error) {
+	idx := indexOfTrigger(s.Triggers, name)
+	if idx < 0 {
+		return s, fmt.Errorf("trigger %q not found", name)
+	}
+	s.Triggers = removeTriggerAt(s.Triggers, idx)
+	return s, nil
+}
+
+// indexOfAgent / indexOfTrigger return the slice index of the named item, or -1.
+func indexOfAgent(agents []Agent, name string) int {
+	for i, a := range agents {
+		if a.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func indexOfTrigger(triggers []Trigger, name string) int {
+	for i, t := range triggers {
+		if t.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// agentNameSet is the lookup NormalizeTrigger consumes to resolve a trigger's
+// agent references.
+func agentNameSet(agents []Agent) map[string]struct{} {
+	set := make(map[string]struct{}, len(agents))
+	for _, a := range agents {
+		set[a.Name] = struct{}{}
+	}
+	return set
+}
+
+// renameAgentInTriggers returns a deep copy of triggers with every reference to
+// oldName rewritten to newName (deep copy so an optimistic-revert never sees a
+// mutated original).
+func renameAgentInTriggers(triggers []Trigger, oldName, newName string) []Trigger {
+	if len(triggers) == 0 {
+		return nil
+	}
+	out := make([]Trigger, len(triggers))
+	for i, t := range triggers {
+		t.AgentNames = append([]string(nil), t.AgentNames...)
+		for j, an := range t.AgentNames {
+			if an == oldName {
+				t.AgentNames[j] = newName
+			}
+		}
+		out[i] = t
+	}
+	return out
+}
+
+// removeAgentAt / removeTriggerAt return a NEW slice with the element at idx
+// removed (never mutating the original), nil when the result is empty so the
+// persisted JSON stays clean (matching the `,omitempty` list tags).
+func removeAgentAt(in []Agent, idx int) []Agent {
+	out := make([]Agent, 0, len(in)-1)
+	out = append(out, in[:idx]...)
+	out = append(out, in[idx+1:]...)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func removeTriggerAt(in []Trigger, idx int) []Trigger {
+	out := make([]Trigger, 0, len(in)-1)
+	out = append(out, in[:idx]...)
+	out = append(out, in[idx+1:]...)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/fleet/automation_mutate_test.go
+++ b/internal/fleet/automation_mutate_test.go
@@ -1,0 +1,282 @@
+package fleet
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// settingsWith builds a FleetSettings carrying just the automation lists (the
+// only fields the mutation helpers touch).
+func settingsWith(agents []Agent, triggers []Trigger) FleetSettings {
+	return FleetSettings{Agents: agents, Triggers: triggers}
+}
+
+func TestAddAgent(t *testing.T) {
+	s, err := AddAgent(FleetSettings{}, Agent{Name: "  builder  "})
+	if err != nil {
+		t.Fatalf("AddAgent: %v", err)
+	}
+	if len(s.Agents) != 1 {
+		t.Fatalf("want 1 agent, got %d", len(s.Agents))
+	}
+	a := s.Agents[0]
+	if a.Name != "builder" {
+		t.Errorf("name = %q, want trimmed %q", a.Name, "builder")
+	}
+	// An empty command normalizes to the default; backend defaults to devcontainer.
+	if a.Command != strings.TrimSpace(DefaultAgentCommand) {
+		t.Errorf("command = %q, want default", a.Command)
+	}
+	if a.Backend != BackendDevcontainer {
+		t.Errorf("backend = %q, want devcontainer", a.Backend)
+	}
+}
+
+func TestAddAgentRejectsDuplicate(t *testing.T) {
+	s := settingsWith([]Agent{{Name: "a", Backend: BackendDevcontainer}}, nil)
+	if _, err := AddAgent(s, Agent{Name: "a"}); err == nil {
+		t.Fatal("want duplicate-name error")
+	}
+}
+
+func TestAddAgentRejectsEmptyName(t *testing.T) {
+	if _, err := AddAgent(FleetSettings{}, Agent{Name: "   "}); err == nil {
+		t.Fatal("want empty-name error")
+	}
+}
+
+func TestAddAgentDoesNotMutateInput(t *testing.T) {
+	orig := []Agent{{Name: "a", Backend: BackendDevcontainer}}
+	s := settingsWith(orig, nil)
+	if _, err := AddAgent(s, Agent{Name: "b"}); err != nil {
+		t.Fatalf("AddAgent: %v", err)
+	}
+	if len(orig) != 1 {
+		t.Fatalf("input slice was mutated: len=%d", len(orig))
+	}
+}
+
+func TestUpdateAgentRenameRewritesTriggerRefs(t *testing.T) {
+	s := settingsWith(
+		[]Agent{{Name: "old", Backend: BackendDevcontainer}},
+		[]Trigger{{Name: "t", Type: TriggerSchedule, AgentNames: []string{"old"}, Cron: "* * * * *"}},
+	)
+	out, err := UpdateAgent(s, "old", Agent{Name: "new", Backend: BackendDevcontainer})
+	if err != nil {
+		t.Fatalf("UpdateAgent: %v", err)
+	}
+	if out.Agents[0].Name != "new" {
+		t.Errorf("agent not renamed: %+v", out.Agents)
+	}
+	if got := out.Triggers[0].AgentNames; len(got) != 1 || got[0] != "new" {
+		t.Errorf("trigger ref not rewritten on rename: %v", got)
+	}
+	// The original settings must be untouched (optimistic-revert safety).
+	if s.Agents[0].Name != "old" || s.Triggers[0].AgentNames[0] != "old" {
+		t.Errorf("UpdateAgent mutated its input: %+v / %+v", s.Agents, s.Triggers)
+	}
+}
+
+func TestUpdateAgentRenameRewritesAllTriggers(t *testing.T) {
+	s := settingsWith(
+		[]Agent{{Name: "old", Backend: BackendDevcontainer}},
+		[]Trigger{
+			{Name: "t1", Type: TriggerSchedule, AgentNames: []string{"old"}, Cron: "* * * * *"},
+			{Name: "t2", Type: TriggerSchedule, AgentNames: []string{"old"}, Cron: "0 0 * * *"},
+			{Name: "t3", Type: TriggerWebhook, AgentNames: []string{"old"}, WebhookName: "ci", FilterType: WebhookFilterRegex, Regex: "push"},
+		},
+	)
+	out, err := UpdateAgent(s, "old", Agent{Name: "new", Backend: BackendDevcontainer})
+	if err != nil {
+		t.Fatalf("UpdateAgent: %v", err)
+	}
+	for i, tr := range out.Triggers {
+		if !slices.Equal(tr.AgentNames, []string{"new"}) {
+			t.Errorf("trigger %d (%q) ref not rewritten: %v", i, tr.Name, tr.AgentNames)
+		}
+	}
+}
+
+func TestUpdateAgentMissing(t *testing.T) {
+	if _, err := UpdateAgent(FleetSettings{}, "ghost", Agent{Name: "ghost"}); err == nil {
+		t.Fatal("want not-found error")
+	}
+}
+
+func TestUpdateAgentRenameCollision(t *testing.T) {
+	s := settingsWith([]Agent{
+		{Name: "a", Backend: BackendDevcontainer},
+		{Name: "b", Backend: BackendDevcontainer},
+	}, nil)
+	// Renaming "a" to "b" collides with the existing "b".
+	if _, err := UpdateAgent(s, "a", Agent{Name: "b", Backend: BackendDevcontainer}); err == nil {
+		t.Fatal("want collision error")
+	}
+}
+
+func TestUpdateAgentInPlaceNoRename(t *testing.T) {
+	s := settingsWith(
+		[]Agent{{Name: "a", Backend: BackendDevcontainer, Command: "old"}},
+		[]Trigger{{Name: "t", Type: TriggerSchedule, AgentNames: []string{"a"}, Cron: "* * * * *"}},
+	)
+	out, err := UpdateAgent(s, "a", Agent{Name: "a", Backend: BackendCoder, Command: "new"})
+	if err != nil {
+		t.Fatalf("UpdateAgent: %v", err)
+	}
+	if out.Agents[0].Command != "new" || out.Agents[0].Backend != BackendCoder {
+		t.Errorf("fields not updated: %+v", out.Agents[0])
+	}
+	// No rename, so the trigger reference is unchanged and still valid.
+	if got := out.Triggers[0].AgentNames; len(got) != 1 || got[0] != "a" {
+		t.Errorf("trigger ref changed unexpectedly: %v", got)
+	}
+}
+
+func TestDeleteAgentBlockedWhenReferenced(t *testing.T) {
+	s := settingsWith(
+		[]Agent{{Name: "a", Backend: BackendDevcontainer}},
+		[]Trigger{{Name: "t", Type: TriggerSchedule, AgentNames: []string{"a"}, Cron: "* * * * *"}},
+	)
+	if _, err := DeleteAgent(s, "a"); err == nil {
+		t.Fatal("want referenced-agent error")
+	} else if !strings.Contains(err.Error(), "trigger \"t\"") {
+		t.Errorf("error should name the referencing trigger: %v", err)
+	}
+}
+
+func TestDeleteAgentUnreferenced(t *testing.T) {
+	s := settingsWith([]Agent{
+		{Name: "a", Backend: BackendDevcontainer},
+		{Name: "b", Backend: BackendDevcontainer},
+	}, nil)
+	out, err := DeleteAgent(s, "a")
+	if err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
+	}
+	if len(out.Agents) != 1 || out.Agents[0].Name != "b" {
+		t.Errorf("want [b] left, got %+v", out.Agents)
+	}
+	if len(s.Agents) != 2 {
+		t.Errorf("DeleteAgent mutated its input: %+v", s.Agents)
+	}
+}
+
+func TestDeleteAgentMissing(t *testing.T) {
+	if _, err := DeleteAgent(FleetSettings{}, "ghost"); err == nil {
+		t.Fatal("want not-found error")
+	}
+}
+
+func TestAddTrigger(t *testing.T) {
+	s := settingsWith([]Agent{{Name: "a", Backend: BackendDevcontainer}}, nil)
+	out, err := AddTrigger(s, Trigger{Name: "nightly", Type: TriggerSchedule, AgentNames: []string{"a"}, Cron: "0 0 * * *"})
+	if err != nil {
+		t.Fatalf("AddTrigger: %v", err)
+	}
+	if len(out.Triggers) != 1 || out.Triggers[0].Name != "nightly" {
+		t.Fatalf("trigger not added: %+v", out.Triggers)
+	}
+}
+
+func TestAddTriggerUnknownAgent(t *testing.T) {
+	s := settingsWith([]Agent{{Name: "a", Backend: BackendDevcontainer}}, nil)
+	if _, err := AddTrigger(s, Trigger{Name: "t", Type: TriggerSchedule, AgentNames: []string{"ghost"}, Cron: "* * * * *"}); err == nil {
+		t.Fatal("want unknown-agent error")
+	}
+}
+
+func TestAddTriggerBadCron(t *testing.T) {
+	s := settingsWith([]Agent{{Name: "a", Backend: BackendDevcontainer}}, nil)
+	if _, err := AddTrigger(s, Trigger{Name: "t", Type: TriggerSchedule, AgentNames: []string{"a"}, Cron: "nope"}); err == nil {
+		t.Fatal("want invalid-cron error")
+	}
+}
+
+func TestAddTriggerRejectsDuplicate(t *testing.T) {
+	s := settingsWith(
+		[]Agent{{Name: "a", Backend: BackendDevcontainer}},
+		[]Trigger{{Name: "t", Type: TriggerSchedule, AgentNames: []string{"a"}, Cron: "* * * * *"}},
+	)
+	if _, err := AddTrigger(s, Trigger{Name: "t", Type: TriggerSchedule, AgentNames: []string{"a"}, Cron: "* * * * *"}); err == nil {
+		t.Fatal("want duplicate-name error")
+	}
+}
+
+func TestAddTriggerWebhookClearsScheduleFields(t *testing.T) {
+	s := settingsWith([]Agent{{Name: "a", Backend: BackendDevcontainer}}, nil)
+	out, err := AddTrigger(s, Trigger{
+		Name: "hook", Type: TriggerWebhook, AgentNames: []string{"a"},
+		WebhookName: "ci", FilterType: WebhookFilterRegex, Regex: "push",
+		Cron: "0 0 * * *", // should be cleared for a webhook trigger
+	})
+	if err != nil {
+		t.Fatalf("AddTrigger webhook: %v", err)
+	}
+	if out.Triggers[0].Cron != "" {
+		t.Errorf("schedule-only Cron should be cleared on a webhook trigger: %q", out.Triggers[0].Cron)
+	}
+}
+
+func TestUpdateTriggerMissing(t *testing.T) {
+	s := settingsWith([]Agent{{Name: "a", Backend: BackendDevcontainer}}, nil)
+	if _, err := UpdateTrigger(s, "ghost", Trigger{Name: "ghost", Type: TriggerSchedule, AgentNames: []string{"a"}, Cron: "* * * * *"}); err == nil {
+		t.Fatal("want not-found error")
+	}
+}
+
+func TestUpdateTriggerRenameCollision(t *testing.T) {
+	s := settingsWith(
+		[]Agent{{Name: "a", Backend: BackendDevcontainer}},
+		[]Trigger{
+			{Name: "t1", Type: TriggerSchedule, AgentNames: []string{"a"}, Cron: "* * * * *"},
+			{Name: "t2", Type: TriggerSchedule, AgentNames: []string{"a"}, Cron: "* * * * *"},
+		},
+	)
+	if _, err := UpdateTrigger(s, "t1", Trigger{Name: "t2", Type: TriggerSchedule, AgentNames: []string{"a"}, Cron: "* * * * *"}); err == nil {
+		t.Fatal("want collision error")
+	}
+}
+
+func TestDeleteTrigger(t *testing.T) {
+	s := settingsWith(
+		[]Agent{{Name: "a", Backend: BackendDevcontainer}},
+		[]Trigger{{Name: "t", Type: TriggerSchedule, AgentNames: []string{"a"}, Cron: "* * * * *"}},
+	)
+	out, err := DeleteTrigger(s, "t")
+	if err != nil {
+		t.Fatalf("DeleteTrigger: %v", err)
+	}
+	if len(out.Triggers) != 0 {
+		t.Errorf("trigger not deleted: %+v", out.Triggers)
+	}
+	// Deleting a trigger frees its agent for deletion.
+	if _, err := DeleteAgent(out, "a"); err != nil {
+		t.Errorf("agent should be deletable once unreferenced: %v", err)
+	}
+}
+
+func TestDeleteTriggerMissing(t *testing.T) {
+	if _, err := DeleteTrigger(FleetSettings{}, "ghost"); err == nil {
+		t.Fatal("want not-found error")
+	}
+}
+
+func TestFindAgentAndTrigger(t *testing.T) {
+	s := settingsWith(
+		[]Agent{{Name: "a", Backend: BackendDevcontainer, Command: "cmd"}},
+		[]Trigger{{Name: "t", Type: TriggerSchedule, AgentNames: []string{"a"}, Cron: "* * * * *"}},
+	)
+	if a, ok := FindAgent(s.Agents, "a"); !ok || a.Command != "cmd" {
+		t.Errorf("FindAgent: ok=%v a=%+v", ok, a)
+	}
+	if _, ok := FindAgent(s.Agents, "ghost"); ok {
+		t.Error("FindAgent should miss an unknown name")
+	}
+	if tr, ok := FindTrigger(s.Triggers, "t"); !ok || !slices.Equal(tr.AgentNames, []string{"a"}) {
+		t.Errorf("FindTrigger: ok=%v t=%+v", ok, tr)
+	}
+	if _, ok := FindTrigger(s.Triggers, "ghost"); ok {
+		t.Error("FindTrigger should miss an unknown name")
+	}
+}

--- a/internal/server/mcp_automation.go
+++ b/internal/server/mcp_automation.go
@@ -1,0 +1,341 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// mcp_automation.go adds the automation CRUD tools (issue #189): create / read /
+// update / delete for a fleet's automation agents and triggers — the same
+// config the TUI's automation view and the `fleet agent` / `fleet trigger` CLI
+// edit. They let the fleet admiral set up automations programmatically.
+//
+// Automation lives inline on FleetSettings, which SetFleetSettings replaces
+// wholesale, so every write is read-modify-write through mutateAutomation:
+// fetch the fleet's full settings, apply one change via the shared fleet.*
+// mutators (which own the invariants — unique names, rename-rewrites-references,
+// no-orphan deletes — and re-validate, matching what SetFleetSettings enforces
+// authoritatively), and write the full settings back. Every write returns the
+// fleet's resulting automation config so the caller sees the new state.
+
+// --- output shapes ---
+
+// mcpAgent / mcpTrigger are the JSON-friendly views of an automation agent /
+// trigger.
+type mcpAgent struct {
+	Name         string `json:"name"`
+	Command      string `json:"command,omitempty"`
+	SystemPrompt string `json:"system_prompt,omitempty"`
+	Backend      string `json:"backend,omitempty"`
+}
+
+type mcpTrigger struct {
+	Name        string   `json:"name"`
+	Type        string   `json:"type"`
+	Agents      []string `json:"agents"`
+	Prompt      string   `json:"prompt,omitempty"`
+	Cron        string   `json:"cron,omitempty"`
+	WebhookName string   `json:"webhook_name,omitempty"`
+	FilterType  string   `json:"filter_type,omitempty"`
+	Regex       string   `json:"regex,omitempty"`
+	JSONPath    string   `json:"json_path,omitempty"`
+	JSONValue   string   `json:"json_value,omitempty"`
+}
+
+// AutomationOutput is a fleet's full automation config, returned by the read
+// tool and by every write tool (so the caller sees the result of its change).
+type AutomationOutput struct {
+	Agents   []mcpAgent   `json:"agents"`
+	Triggers []mcpTrigger `json:"triggers"`
+}
+
+func toMCPAutomation(s fleet.FleetSettings) AutomationOutput {
+	out := AutomationOutput{Agents: []mcpAgent{}, Triggers: []mcpTrigger{}}
+	for _, a := range s.Agents {
+		out.Agents = append(out.Agents, mcpAgent{
+			Name:         a.Name,
+			Command:      a.Command,
+			SystemPrompt: a.SystemPrompt,
+			Backend:      string(a.Backend),
+		})
+	}
+	for _, t := range s.Triggers {
+		out.Triggers = append(out.Triggers, mcpTrigger{
+			Name:        t.Name,
+			Type:        string(t.Type),
+			Agents:      t.AgentNames,
+			Prompt:      t.Prompt,
+			Cron:        t.Cron,
+			WebhookName: t.WebhookName,
+			FilterType:  string(t.FilterType),
+			Regex:       t.Regex,
+			JSONPath:    t.JSONPath,
+			JSONValue:   t.JSONValue,
+		})
+	}
+	return out
+}
+
+// --- shared read-modify-write ---
+
+// automationSettings reads the named fleet's full settings (NotFound if the
+// fleet is unknown).
+func (s *service) automationSettings(ctx context.Context, fleetName string) (fleet.FleetSettings, error) {
+	reply, err := s.GetState(ctx, &fleetgrpc.GetStateRequest{})
+	if err != nil {
+		return fleet.FleetSettings{}, mcpErr(err)
+	}
+	pf := reply.GetState().GetFleets()[fleetName]
+	if pf == nil {
+		return fleet.FleetSettings{}, fmt.Errorf("fleet %q not found", fleetName)
+	}
+	return protoFleetSettingsToLegacy(pf.GetSettings()), nil
+}
+
+// mutateAutomation reads the fleet's full settings, applies fn to them, and
+// writes the result back — preserving every settings field fn doesn't touch.
+// It returns the settings as persisted.
+func (s *service) mutateAutomation(ctx context.Context, fleetName string, fn func(fleet.FleetSettings) (fleet.FleetSettings, error)) (fleet.FleetSettings, error) {
+	settings, err := s.automationSettings(ctx, fleetName)
+	if err != nil {
+		return fleet.FleetSettings{}, err
+	}
+	settings, err = fn(settings)
+	if err != nil {
+		return fleet.FleetSettings{}, err
+	}
+	if _, err := s.SetFleetSettings(ctx, &fleetgrpc.SetFleetSettingsRequest{Fleet: fleetName, Settings: fleetSettingsToProto(settings)}); err != nil {
+		return fleet.FleetSettings{}, mcpErr(err)
+	}
+	return settings, nil
+}
+
+// --- read ---
+
+type FleetAutomationListInput struct {
+	Fleet string `json:"fleet" jsonschema:"fleet name"`
+}
+
+func (s *service) mcpAutomationList(ctx context.Context, _ *mcp.CallToolRequest, in FleetAutomationListInput) (*mcp.CallToolResult, AutomationOutput, error) {
+	if in.Fleet == "" {
+		return nil, AutomationOutput{}, errors.New("fleet is required")
+	}
+	settings, err := s.automationSettings(ctx, in.Fleet)
+	if err != nil {
+		return nil, AutomationOutput{}, err
+	}
+	return nil, toMCPAutomation(settings), nil
+}
+
+// --- agents ---
+
+type FleetAgentCreateInput struct {
+	Fleet        string `json:"fleet" jsonschema:"fleet name"`
+	Name         string `json:"name" jsonschema:"agent name, unique within the fleet"`
+	Command      string `json:"command,omitempty" jsonschema:"launch command; ${PROMPT} and ${SYS_PROMPT} are substituted when a trigger fires it. Defaults to a live claude session command if omitted"`
+	SystemPrompt string `json:"system_prompt,omitempty" jsonschema:"system prompt injected into the command's ${SYS_PROMPT}"`
+	Backend      string `json:"backend,omitempty" jsonschema:"env backend the agent's instance runs on: devcontainer (default), coder, or codespaces"`
+}
+
+func (s *service) mcpAgentCreate(ctx context.Context, _ *mcp.CallToolRequest, in FleetAgentCreateInput) (*mcp.CallToolResult, AutomationOutput, error) {
+	if in.Fleet == "" || in.Name == "" {
+		return nil, AutomationOutput{}, errors.New("fleet and name are required")
+	}
+	settings, err := s.mutateAutomation(ctx, in.Fleet, func(st fleet.FleetSettings) (fleet.FleetSettings, error) {
+		return fleet.AddAgent(st, fleet.Agent{
+			Name:         in.Name,
+			Command:      in.Command,
+			SystemPrompt: in.SystemPrompt,
+			Backend:      fleet.BackendType(in.Backend),
+		})
+	})
+	if err != nil {
+		return nil, AutomationOutput{}, err
+	}
+	return nil, toMCPAutomation(settings), nil
+}
+
+type FleetAgentUpdateInput struct {
+	Fleet        string `json:"fleet" jsonschema:"fleet name"`
+	Name         string `json:"name" jsonschema:"name of the agent to update"`
+	NewName      string `json:"new_name,omitempty" jsonschema:"rename the agent (also rewrites triggers that reference it); omit to keep the name"`
+	Command      string `json:"command,omitempty" jsonschema:"new launch command; omit to keep the current one"`
+	SystemPrompt string `json:"system_prompt,omitempty" jsonschema:"new system prompt; omit to keep the current one"`
+	Backend      string `json:"backend,omitempty" jsonschema:"new backend (devcontainer, coder, codespaces); omit to keep the current one"`
+}
+
+func (s *service) mcpAgentUpdate(ctx context.Context, _ *mcp.CallToolRequest, in FleetAgentUpdateInput) (*mcp.CallToolResult, AutomationOutput, error) {
+	if in.Fleet == "" || in.Name == "" {
+		return nil, AutomationOutput{}, errors.New("fleet and name are required")
+	}
+	settings, err := s.mutateAutomation(ctx, in.Fleet, func(st fleet.FleetSettings) (fleet.FleetSettings, error) {
+		a, ok := fleet.FindAgent(st.Agents, in.Name)
+		if !ok {
+			return st, fmt.Errorf("agent %q not found", in.Name)
+		}
+		// Empty means "keep current" — JSON value-typed fields can't tell an
+		// omitted field from an explicit empty one, so an update is a merge.
+		if in.NewName != "" {
+			a.Name = in.NewName
+		}
+		if in.Command != "" {
+			a.Command = in.Command
+		}
+		if in.SystemPrompt != "" {
+			a.SystemPrompt = in.SystemPrompt
+		}
+		if in.Backend != "" {
+			a.Backend = fleet.BackendType(in.Backend)
+		}
+		return fleet.UpdateAgent(st, in.Name, a)
+	})
+	if err != nil {
+		return nil, AutomationOutput{}, err
+	}
+	return nil, toMCPAutomation(settings), nil
+}
+
+// FleetAutomationItemInput identifies one automation item (agent or trigger) by
+// name for the delete tools.
+type FleetAutomationItemInput struct {
+	Fleet string `json:"fleet" jsonschema:"fleet name"`
+	Name  string `json:"name" jsonschema:"name of the agent or trigger"`
+}
+
+func (s *service) mcpAgentDelete(ctx context.Context, _ *mcp.CallToolRequest, in FleetAutomationItemInput) (*mcp.CallToolResult, AutomationOutput, error) {
+	if in.Fleet == "" || in.Name == "" {
+		return nil, AutomationOutput{}, errors.New("fleet and name are required")
+	}
+	settings, err := s.mutateAutomation(ctx, in.Fleet, func(st fleet.FleetSettings) (fleet.FleetSettings, error) {
+		return fleet.DeleteAgent(st, in.Name)
+	})
+	if err != nil {
+		return nil, AutomationOutput{}, err
+	}
+	return nil, toMCPAutomation(settings), nil
+}
+
+// --- triggers ---
+
+type FleetTriggerCreateInput struct {
+	Fleet       string   `json:"fleet" jsonschema:"fleet name"`
+	Name        string   `json:"name" jsonschema:"trigger name, unique within the fleet"`
+	Type        string   `json:"type" jsonschema:"trigger type: schedule (cron) or webhook"`
+	Agents      []string `json:"agents" jsonschema:"names of the agents this trigger activates (at least one, each must exist in the fleet)"`
+	Prompt      string   `json:"prompt,omitempty" jsonschema:"prompt fed to the agents via ${PROMPT}"`
+	Cron        string   `json:"cron,omitempty" jsonschema:"schedule type: 5-field cron expression, e.g. 0 9 * * 1-5"`
+	WebhookName string   `json:"webhook_name,omitempty" jsonschema:"webhook type: name appended to the gateway webhook URL"`
+	FilterType  string   `json:"filter_type,omitempty" jsonschema:"webhook type: how events are matched, regex or jsonpath"`
+	Regex       string   `json:"regex,omitempty" jsonschema:"webhook regex filter: the event body must match this expression"`
+	JSONPath    string   `json:"json_path,omitempty" jsonschema:"webhook jsonpath filter: the JSON path selected from the event"`
+	JSONValue   string   `json:"json_value,omitempty" jsonschema:"webhook jsonpath filter: the value the selected path must equal"`
+}
+
+func triggerFromCreate(in FleetTriggerCreateInput) fleet.Trigger {
+	return fleet.Trigger{
+		Name:        in.Name,
+		Type:        fleet.TriggerType(in.Type),
+		AgentNames:  in.Agents,
+		Prompt:      in.Prompt,
+		Cron:        in.Cron,
+		WebhookName: in.WebhookName,
+		FilterType:  fleet.WebhookFilterType(in.FilterType),
+		Regex:       in.Regex,
+		JSONPath:    in.JSONPath,
+		JSONValue:   in.JSONValue,
+	}
+}
+
+func (s *service) mcpTriggerCreate(ctx context.Context, _ *mcp.CallToolRequest, in FleetTriggerCreateInput) (*mcp.CallToolResult, AutomationOutput, error) {
+	if in.Fleet == "" || in.Name == "" {
+		return nil, AutomationOutput{}, errors.New("fleet and name are required")
+	}
+	settings, err := s.mutateAutomation(ctx, in.Fleet, func(st fleet.FleetSettings) (fleet.FleetSettings, error) {
+		return fleet.AddTrigger(st, triggerFromCreate(in))
+	})
+	if err != nil {
+		return nil, AutomationOutput{}, err
+	}
+	return nil, toMCPAutomation(settings), nil
+}
+
+type FleetTriggerUpdateInput struct {
+	Fleet       string   `json:"fleet" jsonschema:"fleet name"`
+	Name        string   `json:"name" jsonschema:"name of the trigger to update"`
+	NewName     string   `json:"new_name,omitempty" jsonschema:"rename the trigger; omit to keep the name"`
+	Type        string   `json:"type,omitempty" jsonschema:"new type, schedule or webhook; omit to keep current"`
+	Agents      []string `json:"agents,omitempty" jsonschema:"replacement set of agent names; omit to keep current"`
+	Prompt      string   `json:"prompt,omitempty" jsonschema:"new prompt; omit to keep current"`
+	Cron        string   `json:"cron,omitempty" jsonschema:"new cron expression; omit to keep current"`
+	WebhookName string   `json:"webhook_name,omitempty" jsonschema:"new webhook name; omit to keep current"`
+	FilterType  string   `json:"filter_type,omitempty" jsonschema:"new webhook filter type, regex or jsonpath; omit to keep current"`
+	Regex       string   `json:"regex,omitempty" jsonschema:"new webhook regex; omit to keep current"`
+	JSONPath    string   `json:"json_path,omitempty" jsonschema:"new webhook JSON path; omit to keep current"`
+	JSONValue   string   `json:"json_value,omitempty" jsonschema:"new webhook JSON value; omit to keep current"`
+}
+
+func (s *service) mcpTriggerUpdate(ctx context.Context, _ *mcp.CallToolRequest, in FleetTriggerUpdateInput) (*mcp.CallToolResult, AutomationOutput, error) {
+	if in.Fleet == "" || in.Name == "" {
+		return nil, AutomationOutput{}, errors.New("fleet and name are required")
+	}
+	settings, err := s.mutateAutomation(ctx, in.Fleet, func(st fleet.FleetSettings) (fleet.FleetSettings, error) {
+		t, ok := fleet.FindTrigger(st.Triggers, in.Name)
+		if !ok {
+			return st, fmt.Errorf("trigger %q not found", in.Name)
+		}
+		// Empty means "keep current" (see mcpAgentUpdate).
+		if in.NewName != "" {
+			t.Name = in.NewName
+		}
+		if in.Type != "" {
+			t.Type = fleet.TriggerType(in.Type)
+		}
+		if len(in.Agents) > 0 {
+			t.AgentNames = in.Agents
+		}
+		if in.Prompt != "" {
+			t.Prompt = in.Prompt
+		}
+		if in.Cron != "" {
+			t.Cron = in.Cron
+		}
+		if in.WebhookName != "" {
+			t.WebhookName = in.WebhookName
+		}
+		if in.FilterType != "" {
+			t.FilterType = fleet.WebhookFilterType(in.FilterType)
+		}
+		if in.Regex != "" {
+			t.Regex = in.Regex
+		}
+		if in.JSONPath != "" {
+			t.JSONPath = in.JSONPath
+		}
+		if in.JSONValue != "" {
+			t.JSONValue = in.JSONValue
+		}
+		return fleet.UpdateTrigger(st, in.Name, t)
+	})
+	if err != nil {
+		return nil, AutomationOutput{}, err
+	}
+	return nil, toMCPAutomation(settings), nil
+}
+
+func (s *service) mcpTriggerDelete(ctx context.Context, _ *mcp.CallToolRequest, in FleetAutomationItemInput) (*mcp.CallToolResult, AutomationOutput, error) {
+	if in.Fleet == "" || in.Name == "" {
+		return nil, AutomationOutput{}, errors.New("fleet and name are required")
+	}
+	settings, err := s.mutateAutomation(ctx, in.Fleet, func(st fleet.FleetSettings) (fleet.FleetSettings, error) {
+		return fleet.DeleteTrigger(st, in.Name)
+	})
+	if err != nil {
+		return nil, AutomationOutput{}, err
+	}
+	return nil, toMCPAutomation(settings), nil
+}

--- a/internal/server/mcp_automation_test.go
+++ b/internal/server/mcp_automation_test.go
@@ -1,0 +1,196 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// seedBareFleet persists a single fleet with no instances and no automation, so
+// the automation tools have a fleet to mutate. Returns an MCP client session.
+func seedBareFleet(t *testing.T) *mcp.ClientSession {
+	t.Helper()
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Remote: "git@example.com:a.git"},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	return mcpConnect(t, newService())
+}
+
+// callErr calls a tool and returns its tool-error text, failing if the call
+// unexpectedly succeeded (mirrors the error-path checks in mcp_test.go).
+func callErr(t *testing.T, cs *mcp.ClientSession, name string, args map[string]any) string {
+	t.Helper()
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: name, Arguments: args})
+	if err != nil {
+		t.Fatalf("%s: transport error: %v", name, err)
+	}
+	if !res.IsError {
+		t.Fatalf("%s: expected a tool error, got %s", name, toolText(res))
+	}
+	return toolText(res)
+}
+
+func TestMCPAgentLifecycle(t *testing.T) {
+	cs := seedBareFleet(t)
+
+	// Create an agent; the returned config reflects it.
+	var out AutomationOutput
+	callJSON(t, cs, "fleet_agent_create", map[string]any{
+		"fleet": "alpha", "name": "builder", "backend": "coder", "system_prompt": "be terse",
+	}, &out)
+	if len(out.Agents) != 1 || out.Agents[0].Name != "builder" || out.Agents[0].Backend != "coder" {
+		t.Fatalf("create returned %+v", out.Agents)
+	}
+	// An unspecified command is normalized to the default (non-empty).
+	if out.Agents[0].Command == "" {
+		t.Errorf("command should default to non-empty, got empty")
+	}
+
+	// It survives a fresh read (persisted through SetFleetSettings).
+	var listed AutomationOutput
+	callJSON(t, cs, "fleet_automation_list", map[string]any{"fleet": "alpha"}, &listed)
+	if len(listed.Agents) != 1 || listed.Agents[0].SystemPrompt != "be terse" {
+		t.Fatalf("list returned %+v", listed.Agents)
+	}
+
+	// A duplicate name is a tool error.
+	if msg := callErr(t, cs, "fleet_agent_create", map[string]any{"fleet": "alpha", "name": "builder"}); !strings.Contains(msg, "already exists") {
+		t.Errorf("duplicate error = %q", msg)
+	}
+
+	// Update only the backend; the command is preserved (empty == keep).
+	var updated AutomationOutput
+	callJSON(t, cs, "fleet_agent_update", map[string]any{"fleet": "alpha", "name": "builder", "backend": "devcontainer"}, &updated)
+	if updated.Agents[0].Backend != "devcontainer" {
+		t.Errorf("backend not updated: %+v", updated.Agents[0])
+	}
+	if updated.Agents[0].SystemPrompt != "be terse" {
+		t.Errorf("system prompt should be preserved on partial update: %+v", updated.Agents[0])
+	}
+
+	// Delete it.
+	var afterDelete AutomationOutput
+	callJSON(t, cs, "fleet_agent_delete", map[string]any{"fleet": "alpha", "name": "builder"}, &afterDelete)
+	if len(afterDelete.Agents) != 0 {
+		t.Errorf("agent not deleted: %+v", afterDelete.Agents)
+	}
+}
+
+func TestMCPTriggerLifecycleAndRefs(t *testing.T) {
+	cs := seedBareFleet(t)
+
+	callJSON(t, cs, "fleet_agent_create", map[string]any{"fleet": "alpha", "name": "old"}, nil)
+
+	// Create a schedule trigger referencing the agent.
+	var out AutomationOutput
+	callJSON(t, cs, "fleet_trigger_create", map[string]any{
+		"fleet": "alpha", "name": "nightly", "type": "schedule",
+		"agents": []string{"old"}, "cron": "0 0 * * *", "prompt": "go",
+	}, &out)
+	if len(out.Triggers) != 1 || out.Triggers[0].Cron != "0 0 * * *" {
+		t.Fatalf("trigger create returned %+v", out.Triggers)
+	}
+
+	// Referencing an unknown agent is a tool error.
+	callErr(t, cs, "fleet_trigger_create", map[string]any{
+		"fleet": "alpha", "name": "bad", "type": "schedule", "agents": []string{"ghost"}, "cron": "* * * * *",
+	})
+
+	// Renaming the agent rewrites the trigger's reference.
+	var renamed AutomationOutput
+	callJSON(t, cs, "fleet_agent_update", map[string]any{"fleet": "alpha", "name": "old", "new_name": "new"}, &renamed)
+	if renamed.Agents[0].Name != "new" {
+		t.Fatalf("agent not renamed: %+v", renamed.Agents)
+	}
+	if got := renamed.Triggers[0].Agents; len(got) != 1 || got[0] != "new" {
+		t.Fatalf("trigger ref not rewritten on rename: %v", got)
+	}
+
+	// The now-referenced agent cannot be deleted.
+	if msg := callErr(t, cs, "fleet_agent_delete", map[string]any{"fleet": "alpha", "name": "new"}); !strings.Contains(msg, "referenced by trigger") {
+		t.Errorf("delete-referenced error = %q", msg)
+	}
+
+	// Delete the trigger, then the agent is free.
+	callJSON(t, cs, "fleet_trigger_delete", map[string]any{"fleet": "alpha", "name": "nightly"}, nil)
+	var done AutomationOutput
+	callJSON(t, cs, "fleet_agent_delete", map[string]any{"fleet": "alpha", "name": "new"}, &done)
+	if len(done.Agents) != 0 || len(done.Triggers) != 0 {
+		t.Fatalf("expected empty automation, got %+v", done)
+	}
+}
+
+func TestMCPTriggerUpdatePartial(t *testing.T) {
+	cs := seedBareFleet(t)
+	callJSON(t, cs, "fleet_agent_create", map[string]any{"fleet": "alpha", "name": "a"}, nil)
+	callJSON(t, cs, "fleet_trigger_create", map[string]any{
+		"fleet": "alpha", "name": "t", "type": "schedule", "agents": []string{"a"}, "cron": "0 0 * * *", "prompt": "keep",
+	}, nil)
+
+	// Change only the cron; the prompt and agents are preserved.
+	var out AutomationOutput
+	callJSON(t, cs, "fleet_trigger_update", map[string]any{"fleet": "alpha", "name": "t", "cron": "5 4 * * *"}, &out)
+	tr := out.Triggers[0]
+	if tr.Cron != "5 4 * * *" {
+		t.Errorf("cron not updated: %q", tr.Cron)
+	}
+	if tr.Prompt != "keep" {
+		t.Errorf("prompt should be preserved: %q", tr.Prompt)
+	}
+	if len(tr.Agents) != 1 || tr.Agents[0] != "a" {
+		t.Errorf("agents should be preserved: %v", tr.Agents)
+	}
+}
+
+func TestMCPAutomationUnknownFleet(t *testing.T) {
+	cs := seedBareFleet(t)
+	if msg := callErr(t, cs, "fleet_automation_list", map[string]any{"fleet": "ghost"}); !strings.Contains(msg, "not found") {
+		t.Errorf("unknown-fleet error = %q", msg)
+	}
+	if msg := callErr(t, cs, "fleet_agent_create", map[string]any{"fleet": "ghost", "name": "x"}); !strings.Contains(msg, "not found") {
+		t.Errorf("create unknown-fleet error = %q", msg)
+	}
+}
+
+func TestMCPAutomationMissingArgs(t *testing.T) {
+	cs := seedBareFleet(t)
+	// Missing required name -> input-schema validation tool error.
+	callErr(t, cs, "fleet_agent_create", map[string]any{"fleet": "alpha"})
+	// Empty fleet -> our own guard.
+	callErr(t, cs, "fleet_automation_list", map[string]any{"fleet": ""})
+}
+
+// TestMCPAutomationPreservesOtherSettings verifies a write through the
+// automation tools does not clobber unrelated FleetSettings fields (the
+// read-modify-write must carry them through).
+func TestMCPAutomationPreservesOtherSettings(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Settings: fleet.FleetSettings{ClaudeCodeMount: true, HomeDir: "/home/node"}},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	cs := mcpConnect(t, newService())
+
+	callJSON(t, cs, "fleet_agent_create", map[string]any{"fleet": "alpha", "name": "a"}, nil)
+
+	// Re-read raw state: the mount + home dir must still be set.
+	st, err := state.Load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	got := st.Fleets["alpha"].Settings
+	if !got.ClaudeCodeMount || got.HomeDir != "/home/node" {
+		t.Errorf("unrelated settings clobbered by automation write: %+v", got)
+	}
+	if len(got.Agents) != 1 {
+		t.Errorf("agent not persisted: %+v", got.Agents)
+	}
+}

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -117,6 +117,8 @@ func TestNewMCPServerRegistersAllTools(t *testing.T) {
 		"fleet_destroy_fleet", "fleet_clone", "fleet_rebuild", "fleet_job_status",
 		"fleet_exec", "fleet_session_spawn", "fleet_session_exec", "fleet_session_read",
 		"fleet_session_list",
+		"fleet_automation_list", "fleet_agent_create", "fleet_agent_update", "fleet_agent_delete",
+		"fleet_trigger_create", "fleet_trigger_update", "fleet_trigger_delete",
 	}
 	for _, name := range want {
 		if !got[name] {

--- a/internal/server/mcp_tools.go
+++ b/internal/server/mcp_tools.go
@@ -114,6 +114,36 @@ func registerMCPTools(srv *mcp.Server, s *service) {
 		Name:        "fleet_session_list",
 		Description: "List the tmux sessions inside a running instance (name, window count, creation time, attached). Returns an empty list when the instance has no sessions.",
 	}, s.mcpSessionList)
+
+	// --- automation (agents & triggers) ---
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "fleet_automation_list",
+		Description: "Read a fleet's automation config: its agents (automation workers) and triggers (what fires them). Returns {agents, triggers}.",
+	}, s.mcpAutomationList)
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "fleet_agent_create",
+		Description: "Create an automation agent in a fleet: a worker definition (launch command, system prompt, env backend) that triggers activate. Returns the fleet's resulting automation config.",
+	}, s.mcpAgentCreate)
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "fleet_agent_update",
+		Description: "Update an existing automation agent. Only the fields you pass change (omit one to keep its current value); use new_name to rename (trigger references follow). Returns the resulting automation config.",
+	}, s.mcpAgentUpdate)
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "fleet_agent_delete",
+		Description: "Delete an automation agent. Fails if a trigger still references it — detach it from that trigger first. Returns the resulting automation config.",
+	}, s.mcpAgentDelete)
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "fleet_trigger_create",
+		Description: "Create an automation trigger in a fleet: it activates one or more agents (with a prompt) on a cron schedule or a gateway webhook event. Returns the fleet's resulting automation config.",
+	}, s.mcpTriggerCreate)
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "fleet_trigger_update",
+		Description: "Update an existing automation trigger. Only the fields you pass change (omit one to keep its current value); use new_name to rename. Returns the resulting automation config.",
+	}, s.mcpTriggerUpdate)
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "fleet_trigger_delete",
+		Description: "Delete an automation trigger. Returns the fleet's resulting automation config.",
+	}, s.mcpTriggerDelete)
 }
 
 // --- shared shapes ---

--- a/internal/tui/automation_view.go
+++ b/internal/tui/automation_view.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
@@ -151,11 +152,8 @@ func triggerCountForAgent(f *fleet.Fleet, name string) int {
 	}
 	n := 0
 	for _, t := range f.Settings.Triggers {
-		for _, an := range t.AgentNames {
-			if an == name {
-				n++
-				break
-			}
+		if slices.Contains(t.AgentNames, name) {
+			n++
 		}
 	}
 	return n
@@ -186,8 +184,11 @@ func (fleetPage *fleetPage) deleteTrigger(m *model, fleetName string, idx int) t
 		return nil
 	}
 	name := f.Settings.Triggers[idx].Name
-	newSettings := f.Settings
-	newSettings.Triggers = removeTriggerAt(f.Settings.Triggers, idx)
+	newSettings, err := fleet.DeleteTrigger(f.Settings, name)
+	if err != nil {
+		m.message = fmt.Sprintf("Delete failed: %v", err)
+		return nil
+	}
 	if err := fleetPage.persistAutomationSettings(m, fleetName, newSettings); err != nil {
 		m.message = fmt.Sprintf("Delete failed: %v", err)
 		return nil
@@ -196,53 +197,26 @@ func (fleetPage *fleetPage) deleteTrigger(m *model, fleetName string, idx int) t
 	return nil
 }
 
-// deleteAgent removes the agent at idx and persists. An agent still referenced
-// by a trigger is not deleted — the user is told to detach it first, so a delete
-// can never orphan a trigger (which the server would then reject wholesale).
+// deleteAgent removes the agent at idx and persists. fleet.DeleteAgent refuses
+// to delete an agent a trigger still references (which would orphan the trigger,
+// rejected by the server wholesale) — the user is told to detach it first.
 func (fleetPage *fleetPage) deleteAgent(m *model, fleetName string, idx int) tea.Cmd {
 	f, ok := m.st.Fleets[fleetName]
 	if !ok || idx < 0 || idx >= len(f.Settings.Agents) {
 		return nil
 	}
 	name := f.Settings.Agents[idx].Name
-	for _, t := range f.Settings.Triggers {
-		for _, an := range t.AgentNames {
-			if an == name {
-				m.message = fmt.Sprintf("Agent %q is used by trigger %q — remove it there first", name, t.Name)
-				return nil
-			}
-		}
+	newSettings, err := fleet.DeleteAgent(f.Settings, name)
+	if err != nil {
+		m.message = err.Error()
+		return nil
 	}
-	newSettings := f.Settings
-	newSettings.Agents = removeAgentAt(f.Settings.Agents, idx)
 	if err := fleetPage.persistAutomationSettings(m, fleetName, newSettings); err != nil {
 		m.message = fmt.Sprintf("Delete failed: %v", err)
 		return nil
 	}
 	m.message = fmt.Sprintf("Deleted agent %q", name)
 	return nil
-}
-
-// removeTriggerAt / removeAgentAt return a NEW slice with the element at idx
-// removed (never mutating the original, so persist's revert restores it).
-func removeTriggerAt(in []fleet.Trigger, idx int) []fleet.Trigger {
-	out := make([]fleet.Trigger, 0, len(in)-1)
-	out = append(out, in[:idx]...)
-	out = append(out, in[idx+1:]...)
-	if len(out) == 0 {
-		return nil
-	}
-	return out
-}
-
-func removeAgentAt(in []fleet.Agent, idx int) []fleet.Agent {
-	out := make([]fleet.Agent, 0, len(in)-1)
-	out = append(out, in[:idx]...)
-	out = append(out, in[idx+1:]...)
-	if len(out) == 0 {
-		return nil
-	}
-	return out
 }
 
 // fleetAgents returns the named fleet's automation agents (nil if none).

--- a/internal/tui/dialog_automation_agent.go
+++ b/internal/tui/dialog_automation_agent.go
@@ -221,66 +221,35 @@ func (fleetPage *fleetPage) saveAutomationAgent(m *model) tea.Cmd {
 		SystemPrompt: st.systemPrompt,
 		Backend:      st.backend,
 	}
-	norm, err := fleet.NormalizeAgent(candidate)
-	if err != nil {
-		st.errMsg = err.Error()
-		return nil
-	}
 
 	f, ok := m.st.Fleets[st.fleetName]
 	if !ok {
 		return fleetPage.cancelAutomationAgent(m)
 	}
-	// Reject a duplicate name (against every other agent).
-	for i, a := range f.Settings.Agents {
-		if i != st.editIdx && a.Name == norm.Name {
-			st.errMsg = fmt.Sprintf("agent %q already exists", norm.Name)
-			return nil
-		}
-	}
 
-	newSettings := f.Settings
-	newAgents := append([]fleet.Agent(nil), f.Settings.Agents...)
-	if st.editIdx >= 0 && st.editIdx < len(newAgents) {
-		oldName := newAgents[st.editIdx].Name
-		newAgents[st.editIdx] = norm
-		// A rename must follow through to every trigger referencing the old
-		// name, or the server rejects the settings (unknown agent reference).
-		if oldName != norm.Name {
-			newSettings.Triggers = renameAgentInTriggers(f.Settings.Triggers, oldName, norm.Name)
-		}
+	// fleet.AddAgent/UpdateAgent own the shared invariants (normalize, reject a
+	// duplicate name, and — on rename — rewrite every trigger that references
+	// the old name so the server never sees a dangling reference).
+	var newSettings fleet.FleetSettings
+	var err error
+	if st.editIdx >= 0 && st.editIdx < len(f.Settings.Agents) {
+		oldName := f.Settings.Agents[st.editIdx].Name
+		newSettings, err = fleet.UpdateAgent(f.Settings, oldName, candidate)
 	} else {
-		newAgents = append(newAgents, norm)
+		newSettings, err = fleet.AddAgent(f.Settings, candidate)
 	}
-	newSettings.Agents = newAgents
+	if err != nil {
+		st.errMsg = err.Error()
+		return nil
+	}
 
 	if err := fleetPage.persistAutomationSettings(m, st.fleetName, newSettings); err != nil {
 		st.errMsg = err.Error()
 		return nil
 	}
 	fleetPage.mode = viewNormal
-	m.message = fmt.Sprintf("Saved agent %q", norm.Name)
+	m.message = fmt.Sprintf("Saved agent %q", strings.TrimSpace(candidate.Name))
 	return nil
-}
-
-// renameAgentInTriggers returns a deep copy of triggers with every reference to
-// oldName rewritten to newName (deep copy so the optimistic-revert in persist
-// never sees a mutated original).
-func renameAgentInTriggers(triggers []fleet.Trigger, oldName, newName string) []fleet.Trigger {
-	if len(triggers) == 0 {
-		return nil
-	}
-	out := make([]fleet.Trigger, len(triggers))
-	for i, t := range triggers {
-		t.AgentNames = append([]string(nil), t.AgentNames...)
-		for j, an := range t.AgentNames {
-			if an == oldName {
-				t.AgentNames[j] = newName
-			}
-		}
-		out[i] = t
-	}
-	return out
 }
 
 func (fleetPage *fleetPage) renderAutomationAgentDialog(m *model) string {

--- a/internal/tui/dialog_automation_trigger.go
+++ b/internal/tui/dialog_automation_trigger.go
@@ -382,37 +382,27 @@ func (fleetPage *fleetPage) saveAutomationTrigger(m *model) tea.Cmd {
 		JSONValue:   st.jsonValue,
 	}
 
-	agentNames := make(map[string]struct{}, len(f.Settings.Agents))
-	for _, a := range f.Settings.Agents {
-		agentNames[a.Name] = struct{}{}
+	// fleet.AddTrigger/UpdateTrigger own the shared invariants (normalize
+	// against the fleet's agents and reject a duplicate name).
+	var newSettings fleet.FleetSettings
+	var err error
+	if st.editIdx >= 0 && st.editIdx < len(f.Settings.Triggers) {
+		oldName := f.Settings.Triggers[st.editIdx].Name
+		newSettings, err = fleet.UpdateTrigger(f.Settings, oldName, candidate)
+	} else {
+		newSettings, err = fleet.AddTrigger(f.Settings, candidate)
 	}
-	norm, err := fleet.NormalizeTrigger(candidate, agentNames)
 	if err != nil {
 		st.errMsg = err.Error()
 		return nil
 	}
-	for i, t := range f.Settings.Triggers {
-		if i != st.editIdx && t.Name == norm.Name {
-			st.errMsg = fmt.Sprintf("trigger %q already exists", norm.Name)
-			return nil
-		}
-	}
-
-	newSettings := f.Settings
-	newTriggers := append([]fleet.Trigger(nil), f.Settings.Triggers...)
-	if st.editIdx >= 0 && st.editIdx < len(newTriggers) {
-		newTriggers[st.editIdx] = norm
-	} else {
-		newTriggers = append(newTriggers, norm)
-	}
-	newSettings.Triggers = newTriggers
 
 	if err := fleetPage.persistAutomationSettings(m, st.fleetName, newSettings); err != nil {
 		st.errMsg = err.Error()
 		return nil
 	}
 	fleetPage.mode = viewNormal
-	m.message = fmt.Sprintf("Saved trigger %q", norm.Name)
+	m.message = fmt.Sprintf("Saved trigger %q", strings.TrimSpace(candidate.Name))
 	return nil
 }
 


### PR DESCRIPTION
Closes #189.

Adds programmatic CRUD over a fleet's automation **agents** and **triggers** (the issue #188 model) through both the **CLI** and the **MCP** server, so the fleet admiral and scripts can configure automations without the TUI.

## CLI
- `fleet agent {list,create,edit,delete}` (aliases `ls`/`rm`)
- `fleet trigger {list,create,edit,delete}` (aliases `ls`/`rm`)
- `edit` changes only the flags you pass; agent `--rename` rewrites every trigger that references it.

```
fleet agent create my-project builder --system-prompt "Build and report"
fleet trigger create my-project nightly --agent builder --cron "0 0 * * *" --prompt "Run the nightly build"
fleet agent list my-project
fleet trigger list my-project
```

## MCP
`fleet_automation_list`, `fleet_agent_create` / `fleet_agent_update` / `fleet_agent_delete`, and `fleet_trigger_create` / `fleet_trigger_update` / `fleet_trigger_delete`. Every write returns the fleet's resulting `{agents, triggers}`; `update` merges (omit a field to keep its current value).

## Design
Automation lives inline on `FleetSettings`, and `SetFleetSettings` replaces the settings object wholesale, so every write is a **read-modify-write** that preserves the fields it doesn't touch (mounts, presets, …).

The shared invariants — unique names, **rename rewrites trigger references**, and **no-orphan deletes** (an agent a trigger still references can't be deleted) — now live once in `internal/fleet` (`AddAgent`/`UpdateAgent`/`DeleteAgent` + trigger equivalents, `FindAgent`/`FindTrigger`). The TUI automation dialogs were **refactored onto them**, removing their duplicated inline logic. The server still re-validates authoritatively in `SetFleetSettings`.

The proto↔domain agent/trigger converters are deliberately duplicated per layer (server / tui / cli) because depguard forbids client code from importing the server — the same boundary-driven duplication already present for these types.

## Tests
- `internal/fleet`: CRUD unit tests (rename rewrites all refs, delete guard, dup rejection, no input mutation).
- `internal/cli`: command tests via a stubbed server seam + a converter round-trip test.
- `internal/server`: full server-path MCP tests (GetState → mutate → SetFleetSettings → persist), including a "preserves unrelated settings" check.
- `integration/tests/392_automation_cli.sh`: end-to-end CLI CRUD against a real daemon.
- `SKILL.md` + `README` document the new tools and commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)