### PR TITLE
feat: deliver automation webhook triggers via the fleet gateway (#193)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,18 @@ URL** appears under the Public MCP URL (computed by the gateway from its
 `--public-grpc-url` flag) — that value is what you feed another `fleet` as
 `FLEET_GATEWAY`. The toggles are independent: expose MCP, remote control, or both.
 
+A third, independent toggle — **Enable Webhook** — exposes this daemon's
+**automation webhook** endpoint through the same gateway. With it on, a read-only
+**Public Webhook URL** base appears (e.g. `https://gateway.example.com/webhook/<id>`),
+served on the gateway's public HTTP listener — no extra gateway flag needed. A
+remote system (CI, a SaaS webhook, `curl`) POSTs an event to
+`<public-webhook-url>/<name>`, where `<name>` is a [webhook trigger](#automation)
+you defined; the gateway relays it down the tunnel and fleetd fires that trigger's
+agents if the event passes the trigger's filter (a regex over the body, or a JSON
+path/value match). The trigger's create/edit dialog renders its full URL ready to
+paste into the remote system. With the toggle off, fleetd never negotiates the
+webhook feature, so the gateway 404s the route for this daemon.
+
 ### Use it from a remote agent
 
 Point the remote MCP client at the Public MCP URL, with the **same bearer token**

--- a/doc/gateway.md
+++ b/doc/gateway.md
@@ -55,10 +55,11 @@ the whole gateway.
 | Component | Package | Role |
 |-----------|---------|------|
 | **Shared tunnel protocol** | `internal/tunnel` | The register handshake (length‑prefixed JSON), the yamux session helpers, the per‑stream **tag** byte, and the gRPC‑stream→`net.Conn` adapter (`StreamConn` + raw codec). Imported by *both* ends; depends only on stdlib + yamux. |
-| **fleetd tunnel client** | `internal/server/remote` | `Manager` dials the gateway, registers, and serves inbound streams; `serveTunnel` demuxes them to MCP or gRPC. |
+| **fleetd tunnel client** | `internal/server/remote` | `Manager` dials the gateway, registers, and serves inbound streams; `serveTunnel` demuxes them to the MCP, gRPC, or webhook server by tag. |
 | **fleetd MCP server** | `internal/server/mcp.go` | The loopback MCP server (`127.0.0.1:<port>`), bearer‑token gated. |
 | **fleetd gRPC server (tunnel)** | `internal/server` | A second `grpc.Server` (same `FleetService`) behind a bearer‑token interceptor, fed by the demux. The local unix‑socket server stays auth‑less. |
-| **The gateway** | `internal/gateway` | Two listeners — public MCP (HTTP/1.1) and native gRPC (HTTP/2). The gRPC server hosts the transparent control proxy AND the fleetd `Register` method (`register.go`); plus the session registry and the `/mcp` route. An **isolated module** — imports only `internal/tunnel`, the stdlib, and `google.golang.org/grpc` (no fleetd internals). |
+| **fleetd webhook receiver** | `internal/server/webhook.go` | An `http.Server` fed by the demux (`TagWebhook`) that routes an inbound `POST /<name>` to the matching automation webhook trigger(s) and fires their agents. **Unauthenticated** — the unguessable public URL is the capability, like the MCP proxy. |
+| **The gateway** | `internal/gateway` | Two listeners — public HTTP/1.1 (serving `/mcp/<id>` AND `/webhook/<id>/<name>`) and native gRPC (HTTP/2). The gRPC server hosts the transparent control proxy AND the fleetd `Register` method (`register.go`); plus the session registry. An **isolated module** — imports only `internal/tunnel`, the stdlib, and `google.golang.org/grpc` (no fleetd internals). |
 | **Remote `fleet` client** | `internal/fleetclient` | `gatewayEndpoint` — an ordinary gRPC dial to the gateway's gRPC listener, routing by the `fleet-session` metadata header. |
 
 ---

--- a/fleetgrpc/config.pb.go
+++ b/fleetgrpc/config.pb.go
@@ -465,9 +465,14 @@ type RemoteMcpSettings struct {
 	// fleet_enabled gates the gateway gRPC endpoint ("Enable Remote Fleet"): when
 	// false fleetd does not negotiate the grpc tunnel feature, so the gateway
 	// rejects any remote `fleet` control RPCs aimed at this daemon.
-	FleetEnabled  bool `protobuf:"varint,3,opt,name=fleet_enabled,json=fleetEnabled,proto3" json:"fleet_enabled,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	FleetEnabled bool `protobuf:"varint,3,opt,name=fleet_enabled,json=fleetEnabled,proto3" json:"fleet_enabled,omitempty"`
+	// webhook_enabled gates the gateway webhook endpoint ("Enable Webhook"): when
+	// false fleetd does not negotiate the webhook tunnel feature, so the gateway
+	// does not serve <session-url>/webhook/<name> for this daemon. Independent of
+	// enabled/fleet_enabled — all three ride the SAME outbound tunnel.
+	WebhookEnabled bool `protobuf:"varint,4,opt,name=webhook_enabled,json=webhookEnabled,proto3" json:"webhook_enabled,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *RemoteMcpSettings) Reset() {
@@ -517,6 +522,13 @@ func (x *RemoteMcpSettings) GetGatewayUrl() string {
 func (x *RemoteMcpSettings) GetFleetEnabled() bool {
 	if x != nil {
 		return x.FleetEnabled
+	}
+	return false
+}
+
+func (x *RemoteMcpSettings) GetWebhookEnabled() bool {
+	if x != nil {
+		return x.WebhookEnabled
 	}
 	return false
 }
@@ -843,12 +855,13 @@ const file_config_proto_rawDesc = "" +
 	"\vauto_switch\x18\x02 \x01(\bH\x01R\n" +
 	"autoSwitch\x88\x01\x01B\x1e\n" +
 	"\x1c_multiple_browsers_per_fleetB\x0e\n" +
-	"\f_auto_switch\"s\n" +
+	"\f_auto_switch\"\x9c\x01\n" +
 	"\x11RemoteMcpSettings\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x1f\n" +
 	"\vgateway_url\x18\x02 \x01(\tR\n" +
 	"gatewayUrl\x12#\n" +
-	"\rfleet_enabled\x18\x03 \x01(\bR\ffleetEnabled\"\xd0\x03\n" +
+	"\rfleet_enabled\x18\x03 \x01(\bR\ffleetEnabled\x12'\n" +
+	"\x0fwebhook_enabled\x18\x04 \x01(\bR\x0ewebhookEnabled\"\xd0\x03\n" +
 	"\x06Config\x124\n" +
 	"\ageneral\x18\x01 \x01(\v2\x1a.fleetgrpc.GeneralSettingsR\ageneral\x12.\n" +
 	"\x05agent\x18\x02 \x01(\v2\x18.fleetgrpc.AgentSettingsR\x05agent\x127\n" +

--- a/fleetgrpc/config.proto
+++ b/fleetgrpc/config.proto
@@ -92,6 +92,11 @@ message RemoteMcpSettings {
   // false fleetd does not negotiate the grpc tunnel feature, so the gateway
   // rejects any remote `fleet` control RPCs aimed at this daemon.
   bool fleet_enabled = 3;
+  // webhook_enabled gates the gateway webhook endpoint ("Enable Webhook"): when
+  // false fleetd does not negotiate the webhook tunnel feature, so the gateway
+  // does not serve <session-url>/webhook/<name> for this daemon. Independent of
+  // enabled/fleet_enabled — all three ride the SAME outbound tunnel.
+  bool webhook_enabled = 4;
 }
 
 message Config {

--- a/fleetgrpc/watch.pb.go
+++ b/fleetgrpc/watch.pb.go
@@ -388,8 +388,14 @@ type RemoteMcpStatus struct {
 	// CONNECTED). Surfaced so a remote TUI can render the version of every hop in
 	// the control chain (tui -> gateway -> fleetd) and spot version skew.
 	GatewayVersion string `protobuf:"bytes,5,opt,name=gateway_version,json=gatewayVersion,proto3" json:"gateway_version,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// public_webhook_url is the gateway-assigned base URL for this daemon's
+	// automation webhooks (<public-url>/webhook/<id>). A webhook trigger's full
+	// URL is this base + "/" + the trigger's webhook name. Only set when state is
+	// CONNECTED and the webhook feature was negotiated (the user enabled "Enable
+	// Webhook"); empty otherwise (incl. from an old gateway).
+	PublicWebhookUrl string `protobuf:"bytes,6,opt,name=public_webhook_url,json=publicWebhookUrl,proto3" json:"public_webhook_url,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *RemoteMcpStatus) Reset() {
@@ -453,6 +459,13 @@ func (x *RemoteMcpStatus) GetPublicGrpcUrl() string {
 func (x *RemoteMcpStatus) GetGatewayVersion() string {
 	if x != nil {
 		return x.GatewayVersion
+	}
+	return ""
+}
+
+func (x *RemoteMcpStatus) GetPublicWebhookUrl() string {
+	if x != nil {
+		return x.PublicWebhookUrl
 	}
 	return ""
 }
@@ -732,14 +745,15 @@ const file_watch_proto_rawDesc = "" +
 	"\x0fruntime_changed\x18\a \x01(\v2\x19.fleetgrpc.RuntimeChangedH\x00R\x0eruntimeChanged\x12H\n" +
 	"\x11remote_mcp_status\x18\b \x01(\v2\x1a.fleetgrpc.RemoteMcpStatusH\x00R\x0fremoteMcpStatus\x122\n" +
 	"\tfile_copy\x18\t \x01(\v2\x13.fleetgrpc.FileCopyH\x00R\bfileCopyB\x06\n" +
-	"\x04kind\"\xc7\x01\n" +
+	"\x04kind\"\xf5\x01\n" +
 	"\x0fRemoteMcpStatus\x12.\n" +
 	"\x05state\x18\x01 \x01(\x0e2\x18.fleetgrpc.RemoteMcpConnR\x05state\x12\x1d\n" +
 	"\n" +
 	"public_url\x18\x02 \x01(\tR\tpublicUrl\x12\x14\n" +
 	"\x05error\x18\x03 \x01(\tR\x05error\x12&\n" +
 	"\x0fpublic_grpc_url\x18\x04 \x01(\tR\rpublicGrpcUrl\x12'\n" +
-	"\x0fgateway_version\x18\x05 \x01(\tR\x0egatewayVersion\"6\n" +
+	"\x0fgateway_version\x18\x05 \x01(\tR\x0egatewayVersion\x12,\n" +
+	"\x12public_webhook_url\x18\x06 \x01(\tR\x10publicWebhookUrl\"6\n" +
 	"\fStateChanged\x12&\n" +
 	"\x05state\x18\x01 \x01(\v2\x10.fleetgrpc.StateR\x05state\"F\n" +
 	"\x0eRuntimeChanged\x124\n" +

--- a/fleetgrpc/watch.proto
+++ b/fleetgrpc/watch.proto
@@ -101,6 +101,12 @@ message RemoteMcpStatus {
   // CONNECTED). Surfaced so a remote TUI can render the version of every hop in
   // the control chain (tui -> gateway -> fleetd) and spot version skew.
   string gateway_version = 5;
+  // public_webhook_url is the gateway-assigned base URL for this daemon's
+  // automation webhooks (<public-url>/webhook/<id>). A webhook trigger's full
+  // URL is this base + "/" + the trigger's webhook name. Only set when state is
+  // CONNECTED and the webhook feature was negotiated (the user enabled "Enable
+  // Webhook"); empty otherwise (incl. from an old gateway).
+  string public_webhook_url = 6;
 }
 
 // StateChanged is pushed whenever the authoritative PERSISTED model mutates. It

--- a/internal/fleet/automation.go
+++ b/internal/fleet/automation.go
@@ -231,6 +231,9 @@ func NormalizeTrigger(t Trigger, agentNames map[string]struct{}) (Trigger, error
 			if t.JSONPath == "" {
 				return Trigger{}, fmt.Errorf("trigger %q: webhook json path is empty", t.Name)
 			}
+			if err := ValidateJSONPath(t.JSONPath); err != nil {
+				return Trigger{}, fmt.Errorf("trigger %q: %w", t.Name, err)
+			}
 			t.JSONValue = strings.TrimSpace(t.JSONValue)
 			t.Regex = ""
 		default:

--- a/internal/fleet/automation_match.go
+++ b/internal/fleet/automation_match.go
@@ -1,0 +1,200 @@
+package fleet
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// automation_match.go decides whether an incoming webhook event fires a webhook
+// Trigger (issue #193 — the delivery side of the automation framework). The
+// gateway proxies a POST at <public-url>/webhook/<name> down to fleetd, which
+// finds the matching webhook triggers by name and asks each one — via
+// MatchesWebhook — whether THIS event body should activate its agents.
+//
+// The matcher is pure (body in, bool out) so it lives with the model and is
+// unit-tested without any tunnel/server machinery. It assumes the trigger was
+// already validated by NormalizeTrigger (regex compiles, json path non-empty),
+// but stays defensive anyway.
+
+// MatchesWebhook reports whether a webhook event with the given raw body should
+// fire this trigger. It is only meaningful for TriggerWebhook triggers; any
+// other type returns false.
+//
+//   - regex filter: the raw body must match the (already-validated) expression.
+//     An empty expression matches everything (treated as "no filter").
+//   - json-path filter: the body is parsed as JSON and the value at JSONPath is
+//     compared to JSONValue. An empty JSONValue is a presence check (fires when
+//     the path resolves to a non-null value). A body that is not valid JSON, or a
+//     path that does not resolve, never matches.
+func (t Trigger) MatchesWebhook(body []byte) bool {
+	if t.Type != TriggerWebhook {
+		return false
+	}
+	switch t.FilterType {
+	case WebhookFilterRegex:
+		re, err := regexp.Compile(t.Regex)
+		if err != nil {
+			return false
+		}
+		return re.Match(body)
+	case WebhookFilterJSONPath:
+		// UseNumber so a JSON number compares by its literal text ("5", "1.5")
+		// rather than float64's lossy/normalized formatting.
+		dec := json.NewDecoder(bytes.NewReader(body))
+		dec.UseNumber()
+		var data any
+		if err := dec.Decode(&data); err != nil {
+			return false
+		}
+		v, ok := jsonPathLookup(data, t.JSONPath)
+		if !ok {
+			return false
+		}
+		if t.JSONValue == "" {
+			return v != nil // presence check
+		}
+		return jsonValueEquals(v, t.JSONValue)
+	default:
+		return false
+	}
+}
+
+// jsonPathLookup resolves a minimal JSONPath against a decoded JSON value and
+// returns the value at that path. The supported subset is intentionally small —
+// the cases real webhook routing needs:
+//
+//	$.a.b        dotted object keys (leading $ optional)
+//	a.b[0].c     array indices
+//	$['a']['b']  bracketed/quoted object keys
+//	$[0].name    a leading array index
+//
+// Wildcards, filter expressions ([?(...)]), recursive descent (..) and slices
+// are NOT supported; a path using them simply does not resolve (returns false),
+// so a trigger relying on them never fires rather than firing on the wrong event.
+func jsonPathLookup(data any, path string) (any, bool) {
+	toks, ok := tokenizeJSONPath(path)
+	if !ok {
+		return nil, false
+	}
+	cur := data
+	for _, tok := range toks {
+		switch key := tok.(type) {
+		case string:
+			m, ok := cur.(map[string]any)
+			if !ok {
+				return nil, false
+			}
+			v, ok := m[key]
+			if !ok {
+				return nil, false
+			}
+			cur = v
+		case int:
+			a, ok := cur.([]any)
+			if !ok || key < 0 || key >= len(a) {
+				return nil, false
+			}
+			cur = a[key]
+		}
+	}
+	return cur, true
+}
+
+// tokenizeJSONPath parses the supported JSONPath subset into a sequence of
+// object-key (string) and array-index (int) tokens. It is STRICT: malformed
+// syntax — consecutive dots (`a..b`, recursive descent), a trailing dot (`a.`),
+// or a dot before a bracket (`a.[0]`) — returns false rather than being silently
+// normalized, so a misconfigured path fails CLOSED (no match, no spurious fire)
+// instead of matching the wrong JSON structure.
+func tokenizeJSONPath(path string) ([]any, bool) {
+	s := strings.TrimSpace(path)
+	s = strings.TrimPrefix(s, "$")
+	var toks []any
+	// expectKey is set right after a '.' separator: a key MUST follow it (not
+	// another '.', a '[', or end of input). A leading "$." is fine because
+	// expectKey starts false, so the first dot just enables the first key.
+	expectKey := false
+	for i := 0; i < len(s); {
+		switch s[i] {
+		case '.':
+			if expectKey {
+				return nil, false // ".." — empty path segment
+			}
+			expectKey = true
+			i++
+		case '[':
+			if expectKey {
+				return nil, false // ".[" — a dot must be followed by a key
+			}
+			end := strings.IndexByte(s[i:], ']')
+			if end < 0 {
+				return nil, false
+			}
+			inner := strings.TrimSpace(s[i+1 : i+end])
+			i += end + 1
+			if inner == "" {
+				return nil, false
+			}
+			if q := inner[0]; q == '\'' || q == '"' {
+				if len(inner) < 2 || inner[len(inner)-1] != q {
+					return nil, false
+				}
+				toks = append(toks, inner[1:len(inner)-1])
+				continue
+			}
+			n, err := strconv.Atoi(inner)
+			if err != nil {
+				return nil, false
+			}
+			toks = append(toks, n)
+		default:
+			// A bare object key runs until the next separator.
+			j := i
+			for j < len(s) && s[j] != '.' && s[j] != '[' {
+				j++
+			}
+			toks = append(toks, s[i:j])
+			expectKey = false
+			i = j
+		}
+	}
+	if expectKey {
+		return nil, false // trailing '.'
+	}
+	if len(toks) == 0 {
+		return nil, false
+	}
+	return toks, true
+}
+
+// ValidateJSONPath reports whether a JSONPath is well-formed for the supported
+// subset (see jsonPathLookup). NormalizeTrigger uses it to reject a malformed
+// path at configuration time, so the user gets immediate feedback instead of a
+// trigger that silently never fires.
+func ValidateJSONPath(path string) error {
+	if _, ok := tokenizeJSONPath(path); !ok {
+		return fmt.Errorf("invalid json path %q", path)
+	}
+	return nil
+}
+
+// jsonValueEquals reports whether a decoded JSON value equals the expected text.
+// Strings compare directly; numbers compare by their literal JSON text (because
+// the body was decoded with UseNumber); booleans compare as "true"/"false".
+// Containers and null never equal a scalar expectation.
+func jsonValueEquals(v any, expected string) bool {
+	switch x := v.(type) {
+	case string:
+		return x == expected
+	case bool:
+		return strconv.FormatBool(x) == expected
+	case json.Number:
+		return x.String() == expected
+	default:
+		return false
+	}
+}

--- a/internal/fleet/automation_match_test.go
+++ b/internal/fleet/automation_match_test.go
@@ -1,0 +1,99 @@
+package fleet
+
+import "testing"
+
+func TestMatchesWebhook_Regex(t *testing.T) {
+	tr := Trigger{Type: TriggerWebhook, FilterType: WebhookFilterRegex, Regex: `"action"\s*:\s*"opened"`}
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"match", `{"action": "opened", "number": 5}`, true},
+		{"no spaces", `{"action":"opened"}`, true},
+		{"different value", `{"action": "closed"}`, false},
+		{"absent", `{"number": 5}`, false},
+		{"empty body", ``, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := tr.MatchesWebhook([]byte(c.body)); got != c.want {
+				t.Fatalf("MatchesWebhook(%q) = %v, want %v", c.body, got, c.want)
+			}
+		})
+	}
+}
+
+func TestMatchesWebhook_RegexEmptyMatchesAll(t *testing.T) {
+	// An empty expression is a no-op filter (matches everything). NormalizeTrigger
+	// forbids empty regex, but the matcher must stay well-defined anyway.
+	tr := Trigger{Type: TriggerWebhook, FilterType: WebhookFilterRegex, Regex: ""}
+	if !tr.MatchesWebhook([]byte("anything at all")) {
+		t.Fatal("empty regex should match any body")
+	}
+}
+
+func TestMatchesWebhook_JSONPath(t *testing.T) {
+	cases := []struct {
+		name  string
+		path  string
+		value string
+		body  string
+		want  bool
+	}{
+		{"string equal", "$.action", "opened", `{"action":"opened"}`, true},
+		{"string not equal", "$.action", "opened", `{"action":"closed"}`, false},
+		{"no leading dollar", "action", "opened", `{"action":"opened"}`, true},
+		{"nested", "$.repository.name", "fleet-man", `{"repository":{"name":"fleet-man"}}`, true},
+		{"array index", "$.commits[0].id", "abc", `{"commits":[{"id":"abc"},{"id":"def"}]}`, true},
+		{"array index second", "$.commits[1].id", "def", `{"commits":[{"id":"abc"},{"id":"def"}]}`, true},
+		{"bracket key", "$['action']", "opened", `{"action":"opened"}`, true},
+		{"top-level array", "$[0].id", "abc", `[{"id":"abc"}]`, true},
+		{"number literal", "$.number", "5", `{"number":5}`, true},
+		{"number not equal", "$.number", "6", `{"number":5}`, false},
+		{"bool true", "$.draft", "true", `{"draft":true}`, true},
+		{"bool false", "$.draft", "false", `{"draft":false}`, true},
+		{"presence hit", "$.action", "", `{"action":"opened"}`, true},
+		{"presence miss", "$.action", "", `{"other":1}`, false},
+		{"presence null is absent", "$.action", "", `{"action":null}`, false},
+		{"path missing", "$.action", "opened", `{"other":"x"}`, false},
+		{"index out of range", "$.commits[5].id", "abc", `{"commits":[{"id":"abc"}]}`, false},
+		{"not json", "$.action", "opened", `not json at all`, false},
+		{"wrong container type", "$.action.deep", "x", `{"action":"opened"}`, false},
+		{"unsupported wildcard", "$.commits[*].id", "abc", `{"commits":[{"id":"abc"}]}`, false},
+		// Malformed paths fail CLOSED (never silently normalized to a valid path).
+		{"double dot rejected", "$.a..b", "x", `{"a":{"b":"x"}}`, false},
+		{"trailing dot rejected", "$.a.", "x", `{"a":"x"}`, false},
+		{"dot-bracket rejected", "$.a.[0]", "x", `{"a":["x"]}`, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tr := Trigger{Type: TriggerWebhook, FilterType: WebhookFilterJSONPath, JSONPath: c.path, JSONValue: c.value}
+			if got := tr.MatchesWebhook([]byte(c.body)); got != c.want {
+				t.Fatalf("MatchesWebhook path=%q value=%q body=%q = %v, want %v", c.path, c.value, c.body, got, c.want)
+			}
+		})
+	}
+}
+
+func TestMatchesWebhook_NonWebhookType(t *testing.T) {
+	tr := Trigger{Type: TriggerSchedule, FilterType: WebhookFilterRegex, Regex: ".*"}
+	if tr.MatchesWebhook([]byte("anything")) {
+		t.Fatal("a non-webhook trigger must never match a webhook event")
+	}
+}
+
+func TestValidateJSONPath(t *testing.T) {
+	valid := []string{"$.a", "a", "$.a.b", "a.b[0].c", "$['a']['b']", "$[0].name", "a[0][1]"}
+	for _, p := range valid {
+		if err := ValidateJSONPath(p); err != nil {
+			t.Errorf("ValidateJSONPath(%q) = %v, want nil", p, err)
+		}
+	}
+	invalid := []string{"", "$", "$.", "a..b", "a.", "$.a.[0]", "a[", "a[]", "a['x]"}
+	for _, p := range invalid {
+		if err := ValidateJSONPath(p); err == nil {
+			t.Errorf("ValidateJSONPath(%q) = nil, want an error", p)
+		}
+	}
+}

--- a/internal/fleet/automation_test.go
+++ b/internal/fleet/automation_test.go
@@ -99,13 +99,15 @@ func TestNormalizeTriggerWebhook(t *testing.T) {
 func TestNormalizeTriggerErrors(t *testing.T) {
 	agents := map[string]struct{}{"build": {}}
 	bad := []Trigger{
-		{Name: "", Type: TriggerSchedule, AgentNames: []string{"build"}, Cron: "* * * * *"},  // empty name
-		{Name: "x", Type: TriggerSchedule, AgentNames: nil, Cron: "* * * * *"},               // no agents
-		{Name: "x", Type: TriggerSchedule, AgentNames: []string{"ghost"}, Cron: "* * * * *"}, // unknown agent
-		{Name: "x", Type: TriggerSchedule, AgentNames: []string{"build"}, Cron: "nope"},      // bad cron
-		{Name: "x", Type: "bogus", AgentNames: []string{"build"}},                            // bad type
-		{Name: "x", Type: TriggerWebhook, AgentNames: []string{"build"}, WebhookName: ""},    // empty webhook name
-		{Name: "x", Type: TriggerWebhook, AgentNames: []string{"build"}, WebhookName: "w"},   // missing filter type
+		{Name: "", Type: TriggerSchedule, AgentNames: []string{"build"}, Cron: "* * * * *"},                                                       // empty name
+		{Name: "x", Type: TriggerSchedule, AgentNames: nil, Cron: "* * * * *"},                                                                    // no agents
+		{Name: "x", Type: TriggerSchedule, AgentNames: []string{"ghost"}, Cron: "* * * * *"},                                                      // unknown agent
+		{Name: "x", Type: TriggerSchedule, AgentNames: []string{"build"}, Cron: "nope"},                                                           // bad cron
+		{Name: "x", Type: "bogus", AgentNames: []string{"build"}},                                                                                 // bad type
+		{Name: "x", Type: TriggerWebhook, AgentNames: []string{"build"}, WebhookName: ""},                                                         // empty webhook name
+		{Name: "x", Type: TriggerWebhook, AgentNames: []string{"build"}, WebhookName: "w"},                                                        // missing filter type
+		{Name: "x", Type: TriggerWebhook, AgentNames: []string{"build"}, WebhookName: "w", FilterType: WebhookFilterRegex, Regex: "("},            // bad regex
+		{Name: "x", Type: TriggerWebhook, AgentNames: []string{"build"}, WebhookName: "w", FilterType: WebhookFilterJSONPath, JSONPath: "$.a..b"}, // malformed json path
 	}
 	for i, tr := range bad {
 		if _, err := NormalizeTrigger(tr, agents); err == nil {

--- a/internal/gateway/gateway_e2e_test.go
+++ b/internal/gateway/gateway_e2e_test.go
@@ -289,6 +289,55 @@ func TestGatewayEndToEnd(t *testing.T) {
 	}
 }
 
+// TestGatewayWebhookGatedOnFeature pins the webhook route + URL to the per-session
+// webhook feature: a session that does not negotiate it gets no webhook URL and a
+// 404 on the /webhook route (indistinguishable from an unknown id), while a
+// session that does negotiate it is minted a webhook base URL on the public base.
+func TestGatewayWebhookGatedOnFeature(t *testing.T) {
+	cert, pool := genTestTLS(t)
+	s, publicAddr, grpcAddr := startTestGateway(t, cert, "https://gw.example.com")
+
+	// (a) No webhook feature: URL withheld, route 404s.
+	reply := dialFleetd(t, grpcAddr, pool, "")
+	if reply.PublicWebhookURL != "" {
+		t.Fatalf("a non-webhook session must not get a webhook URL, got %q", reply.PublicWebhookURL)
+	}
+	id := publicIDOf(t, reply.PublicURL)
+	waitRegistered(t, s, id)
+
+	client := httpsClient(pool)
+	resp, err := client.Post("https://"+publicAddr+"/webhook/"+id+"/ci", "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("webhook POST: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("webhook route for a non-webhook session -> %d, want 404", resp.StatusCode)
+	}
+
+	// (b) Webhook feature negotiated: a webhook base URL is minted on the public base.
+	conn := openRegisterStream(t, grpcAddr, credentials.NewTLS(&tls.Config{RootCAs: pool, ServerName: "127.0.0.1"}))
+	if err := tunnel.WriteFrame(conn, tunnel.RegisterRequest{Features: []string{tunnel.FeatureWebhook}, ClientVersion: "vtest"}); err != nil {
+		t.Fatalf("write register: %v", err)
+	}
+	var wreply tunnel.RegisterReply
+	if err := tunnel.ReadFrame(conn, &wreply); err != nil {
+		t.Fatalf("read reply: %v", err)
+	}
+	if !strings.HasPrefix(wreply.PublicWebhookURL, "https://gw.example.com/webhook/") {
+		t.Fatalf("a webhook session should get a webhook URL, got %q", wreply.PublicWebhookURL)
+	}
+	if !tunnel.HasFeature(wreply.Features, tunnel.FeatureWebhook) {
+		t.Fatalf("webhook feature should be negotiated, got %v", wreply.Features)
+	}
+	// Complete the yamux handshake so the gateway binds (then tear down).
+	sess, err := tunnel.ClientSession(conn, io.Discard)
+	if err != nil {
+		t.Fatalf("client session: %v", err)
+	}
+	defer sess.Close()
+}
+
 // TestGatewayReportsVersionInRegisterReply verifies the gateway echoes its
 // configured build version in the register reply, so fleetd can surface it to
 // remote TUIs for control-chain version diagnostics. An unset version yields an

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -12,10 +12,12 @@ import (
 
 // proxy.go serves the public HTTP(S) endpoint. Agents connect to
 // <public-url>/mcp/<publicID>[/...]; each request is reverse-proxied down the
-// matching tunnel to fleetd's loopback MCP server. The gateway forwards the
-// Authorization header (the bearer token) untouched, so the daemon's auth stays
-// the real boundary. Native gRPC is served separately on its own h2c listener
-// (see grpc.go), not here.
+// matching tunnel to fleetd's loopback MCP server. Remote systems POST automation
+// events to <public-url>/webhook/<publicID>/<name>, reverse-proxied down the same
+// tunnel to fleetd's webhook receiver. The gateway forwards the Authorization
+// header (the bearer token) untouched, so the daemon's auth stays the real
+// boundary. Native gRPC is served separately on its own h2c listener (see
+// grpc.go), not here.
 
 // publicHandler builds the router for the public listener.
 func (s *Server) publicHandler() http.Handler {
@@ -25,6 +27,11 @@ func (s *Server) publicHandler() http.Handler {
 	// so the exact form is the common case; the subpath form is for completeness.
 	mux.HandleFunc("/mcp/{id}", s.handleMCP)
 	mux.HandleFunc("/mcp/{id}/{rest...}", s.handleMCP)
+	// Webhook delivery (issue #193): the trailing segment is the user-named
+	// webhook the trigger matches on. The subpath form lets a sender append extra
+	// path the remote system may require; fleetd routes on the first segment.
+	mux.HandleFunc("/webhook/{id}/{name}", s.handleWebhook)
+	mux.HandleFunc("/webhook/{id}/{name}/{rest...}", s.handleWebhook)
 	// Native gRPC is NOT served here — it has its own h2c listener (see grpc.go),
 	// because mixing h2c and HTTP/1.1 on one port is brittle and an L7 gRPC proxy
 	// needs a clean HTTP/2 endpoint.
@@ -69,6 +76,47 @@ func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
 		FlushInterval: -1,
 		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, _ error) {
 			// A tunnel that just dropped / is mid-reconnect: report a clean 502.
+			http.Error(w, "tunnel unavailable", http.StatusBadGateway)
+		},
+	}
+	rp.ServeHTTP(w, r)
+}
+
+// handleWebhook reverse-proxies one inbound automation event to fleetd's webhook
+// receiver over a TagWebhook tunnel stream. The session must have negotiated the
+// webhook feature (the user enabled "Enable Webhook"); otherwise the route is
+// dead and we 404 — identical treatment to an unknown id, so a probe can't tell a
+// webhook-disabled daemon from a non-existent one.
+func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	sess := s.reg.lookup(id)
+	if sess == nil || !sess.webhook.Load() {
+		http.Error(w, "unknown or expired session", http.StatusNotFound)
+		return
+	}
+
+	// fleetd's webhook receiver routes on the path, so forward the segments AFTER
+	// the session id: "/<name>" plus any extra path the sender appended. fleetd
+	// matches triggers on the first segment (the webhook name).
+	target := "/" + r.PathValue("name")
+	if rest := r.PathValue("rest"); rest != "" {
+		target += "/" + rest
+	}
+
+	rp := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = "http"
+			req.URL.Host = "tunnel" // ignored: the transport dials the yamux stream
+			req.URL.Path = target
+			req.Host = "" // fleetd's receiver doesn't care about Host
+		},
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return sess.open(tunnel.TagWebhook)
+			},
+		},
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, _ error) {
 			http.Error(w, "tunnel unavailable", http.StatusBadGateway)
 		},
 	}

--- a/internal/gateway/register.go
+++ b/internal/gateway/register.go
@@ -24,7 +24,7 @@ import (
 // gatewayFeatures lists the optional tunnel features this gateway supports and
 // offers in the register handshake. fleetd advertises what IT supports; the
 // negotiated set is the intersection.
-var gatewayFeatures = []string{tunnel.FeatureGRPC}
+var gatewayFeatures = []string{tunnel.FeatureGRPC, tunnel.FeatureWebhook}
 
 // tunnelServiceDesc registers the Register bidi method on the gateway's grpc.Server.
 // Its ServiceName/StreamName compose to tunnel.RegisterMethod.
@@ -89,16 +89,21 @@ func (s *Server) bindTunnel(ctx context.Context, conn net.Conn, remote string) e
 		return err
 	}
 
-	// Negotiate optional tunnel features (gRPC). Only features BOTH ends support
-	// become active; an old fleetd (no Features) negotiates none. A daemon with
-	// remote fleet disabled does not request grpc, so none is negotiated and the
-	// gateway's gRPC route stays dead for this session — its Public GRPC URL is
-	// withheld accordingly.
+	// Negotiate optional tunnel features (gRPC, webhook). Only features BOTH ends
+	// support become active; an old fleetd (no Features) negotiates none. A daemon
+	// with a traffic kind disabled does not request its feature, so it is not
+	// negotiated and the matching gateway route stays dead for this session — its
+	// computed public URL is withheld accordingly.
 	reply.Features = tunnel.Negotiate(req.Features, gatewayFeatures)
 	grpcOn := tunnel.HasFeature(reply.Features, tunnel.FeatureGRPC)
 	sess.grpc.Store(grpcOn)
 	if !grpcOn {
 		reply.PublicGRPCURL = ""
+	}
+	webhookOn := tunnel.HasFeature(reply.Features, tunnel.FeatureWebhook)
+	sess.webhook.Store(webhookOn)
+	if !webhookOn {
+		reply.PublicWebhookURL = ""
 	}
 
 	// Echo the gateway's build version so fleetd can surface it (over

--- a/internal/gateway/registry.go
+++ b/internal/gateway/registry.go
@@ -139,11 +139,18 @@ func (r *registry) claim(req tunnel.RegisterRequest) (s *session, reply tunnel.R
 // PublicGRPCURL is included whenever the gateway has a public gRPC base; the
 // register handler clears it again when the connection does not negotiate the
 // grpc feature, so an MCP-only daemon never sees a gRPC URL it can't serve.
+//
+// PublicWebhookURL is always computed from the public base — webhooks ride the
+// gateway's public HTTP listener (the same one that serves /mcp), so no separate
+// operator-configured base is needed (unlike gRPC's --public-grpc-url). The
+// register handler clears it when the connection does not negotiate the webhook
+// feature, so a daemon that didn't enable webhooks never sees a URL it can't serve.
 func (r *registry) reply(s *session) tunnel.RegisterReply {
 	reply := tunnel.RegisterReply{
-		SessionID:    s.secret,
-		PublicURL:    s.publicURL,
-		SessionToken: r.signer.mint(s.secret, s.publicID),
+		SessionID:        s.secret,
+		PublicURL:        s.publicURL,
+		PublicWebhookURL: r.publicBase + "/webhook/" + s.publicID,
+		SessionToken:     r.signer.mint(s.secret, s.publicID),
 	}
 	if r.grpcBase != "" {
 		reply.PublicGRPCURL = r.grpcBase + "/grpc/" + s.publicID

--- a/internal/gateway/session.go
+++ b/internal/gateway/session.go
@@ -41,6 +41,13 @@ type session struct {
 	// public-request goroutines, and re-set on reconnect.
 	grpc atomic.Bool
 
+	// webhook reports whether THIS connection negotiated FeatureWebhook. When set,
+	// the gateway serves the /webhook/<id>/<name> route and tags every stream it
+	// opens (so fleetd can demux). Like grpc it forces the tagged-stream wire, so
+	// either feature alone switches the tunnel into tag-demux mode. Atomic for the
+	// same cross-goroutine reasons as grpc.
+	webhook atomic.Bool
+
 	mu sync.Mutex
 	ym *yamux.Session // current live tunnel; nil until bind; replaced on reconnect
 	// closedAt is when the current tunnel was first observed closed (zero while
@@ -111,10 +118,11 @@ func (s *session) open(tag byte) (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	// When this connection negotiated gRPC, fleetd demuxes streams by a leading
-	// tag byte, so the gateway must write it as the first bytes of every stream.
-	// Legacy (un-negotiated) sessions get untagged streams (the old MCP wire).
-	if s.grpc.Load() {
+	// When this connection negotiated a tagging feature (gRPC or webhook), fleetd
+	// demuxes streams by a leading tag byte, so the gateway must write it as the
+	// first bytes of every stream. Legacy (un-negotiated) sessions get untagged
+	// streams (the old MCP wire).
+	if s.grpc.Load() || s.webhook.Load() {
 		if err := tunnel.WriteTag(conn, tag); err != nil {
 			_ = conn.Close()
 			return nil, err

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -48,13 +48,13 @@ func (s *service) SetConfig(_ context.Context, req *fleetgrpc.SetConfigRequest) 
 	// calling it while muWrite is held cannot deadlock. nil during tests that use
 	// newService() without a serve loop.
 	if s.remote != nil {
-		s.remote.Reconcile(saved.RemoteMcpSettings.Enabled, saved.RemoteMcpSettings.FleetEnabled, saved.RemoteMcpSettings.GatewayURL)
+		s.remote.Reconcile(saved.RemoteMcpSettings.Enabled, saved.RemoteMcpSettings.FleetEnabled, saved.RemoteMcpSettings.WebhookEnabled, saved.RemoteMcpSettings.GatewayURL)
 	}
 
 	// The remote-gateway fields are the ones whose effects outlive this RPC (the
 	// tunnel supervisor reacts to them), so call them out; the manager logs the
 	// resulting connection transitions itself.
-	flog.Info("config updated", "remoteMcp", saved.RemoteMcpSettings.Enabled, "remoteFleet", saved.RemoteMcpSettings.FleetEnabled, "gateway", saved.RemoteMcpSettings.GatewayURL)
+	flog.Info("config updated", "remoteMcp", saved.RemoteMcpSettings.Enabled, "remoteFleet", saved.RemoteMcpSettings.FleetEnabled, "webhook", saved.RemoteMcpSettings.WebhookEnabled, "gateway", saved.RemoteMcpSettings.GatewayURL)
 
 	return &fleetgrpc.SetConfigReply{Config: configToProto(saved)}, nil
 }
@@ -67,16 +67,17 @@ func configToProto(c *state.Config) *fleetgrpc.Config {
 		return &fleetgrpc.Config{}
 	}
 	pc := &fleetgrpc.Config{
-		General:        &fleetgrpc.GeneralSettings{},
-		Agent:          &fleetgrpc.AgentSettings{ToolSelection: string(c.AgentSettings.ToolSelection)},
-		Dotfiles:       &fleetgrpc.DotfilesSettings{AutoInstall: c.DotfilesSettings.AutoInstall},
-		Coder:          &fleetgrpc.CoderSettings{},
-		Codespaces:     &fleetgrpc.CodespacesSettings{},
-		Browser:        &fleetgrpc.BrowserSettings{},
+		General:    &fleetgrpc.GeneralSettings{},
+		Agent:      &fleetgrpc.AgentSettings{ToolSelection: string(c.AgentSettings.ToolSelection)},
+		Dotfiles:   &fleetgrpc.DotfilesSettings{AutoInstall: c.DotfilesSettings.AutoInstall},
+		Coder:      &fleetgrpc.CoderSettings{},
+		Codespaces: &fleetgrpc.CodespacesSettings{},
+		Browser:    &fleetgrpc.BrowserSettings{},
 		RemoteMcp: &fleetgrpc.RemoteMcpSettings{
-			Enabled:      c.RemoteMcpSettings.Enabled,
-			GatewayUrl:   c.RemoteMcpSettings.GatewayURL,
-			FleetEnabled: c.RemoteMcpSettings.FleetEnabled,
+			Enabled:        c.RemoteMcpSettings.Enabled,
+			GatewayUrl:     c.RemoteMcpSettings.GatewayURL,
+			FleetEnabled:   c.RemoteMcpSettings.FleetEnabled,
+			WebhookEnabled: c.RemoteMcpSettings.WebhookEnabled,
 		},
 		DefaultBackend: backendToProto(fleet.BackendType(c.DefaultBackend)),
 	}
@@ -205,6 +206,7 @@ func protoConfigToLegacy(pc *fleetgrpc.Config) *state.Config {
 		c.RemoteMcpSettings.Enabled = rm.GetEnabled()
 		c.RemoteMcpSettings.GatewayURL = rm.GetGatewayUrl()
 		c.RemoteMcpSettings.FleetEnabled = rm.GetFleetEnabled()
+		c.RemoteMcpSettings.WebhookEnabled = rm.GetWebhookEnabled()
 	}
 
 	c.DefaultBackend = backendProtoToString(pc.GetDefaultBackend())

--- a/internal/server/grpc_remote_e2e_test.go
+++ b/internal/server/grpc_remote_e2e_test.go
@@ -148,7 +148,7 @@ func grpcStack(t *testing.T) (dial func(withToken bool) *grpc.ClientConn, token 
 	// Both toggles on: remote MCP (the tunnel's base traffic) AND remote fleet
 	// (without which the grpc feature is no longer advertised, and every
 	// remote-control RPC under test here would be refused).
-	mgr.Reconcile(true, true, "https://gw.example.com")
+	mgr.Reconcile(true, true, false, "https://gw.example.com")
 
 	// Wait for CONNECTED and derive the session id from the MCP public URL.
 	var publicURL string

--- a/internal/server/mcp_remote_e2e_test.go
+++ b/internal/server/mcp_remote_e2e_test.go
@@ -173,7 +173,7 @@ func remoteMCPStack(t *testing.T) (publicMCPURL, publicBase, token string, pool 
 		remote.WithDialFunc(registerDialFunc(grpcLn.Addr().String(), gwCreds)),
 	)
 	go mgr.Run(ctx)
-	mgr.Reconcile(true, false, "https://gw.example.com")
+	mgr.Reconcile(true, false, false, "https://gw.example.com")
 
 	// Wait for CONNECTED and the gateway-assigned public URL.
 	deadline := time.After(10 * time.Second)

--- a/internal/server/remote/manager.go
+++ b/internal/server/remote/manager.go
@@ -37,19 +37,20 @@ const (
 	handshakeTimeout = 15 * time.Second
 )
 
-// desiredState is the latest config the manager should converge to. mcp and
-// grpc are the two independent exposure toggles ("Enable Remote MCP" / "Enable
-// Remote Fleet"); the tunnel connects while EITHER is on, and each gates its own
-// traffic kind on that shared tunnel.
+// desiredState is the latest config the manager should converge to. mcp, grpc
+// and webhook are the three independent exposure toggles ("Enable Remote MCP" /
+// "Enable Remote Fleet" / "Enable Webhook"); the tunnel connects while ANY is on,
+// and each gates its own traffic kind on that shared tunnel.
 type desiredState struct {
 	mcp        bool
 	grpc       bool
+	webhook    bool
 	gatewayURL string
 }
 
 // on reports whether the tunnel should be up at all.
 func (d desiredState) on() bool {
-	return (d.mcp || d.grpc) && d.gatewayURL != ""
+	return (d.mcp || d.grpc || d.webhook) && d.gatewayURL != ""
 }
 
 // Manager supervises the outbound tunnel. Construct with NewManager and drive
@@ -69,6 +70,11 @@ type Manager struct {
 	// the Manager advertises FeatureGRPC, and on a gateway that negotiates it,
 	// demuxes tagged streams (grpc streams are pushed here). nil = MCP only.
 	grpcLis *ChanListener
+
+	// webhookLis, when set, enables tunneling the daemon's automation webhook
+	// receiver: the Manager advertises FeatureWebhook, and on a gateway that
+	// negotiates it, demuxes TagWebhook streams to this listener. nil = no webhook.
+	webhookLis *ChanListener
 
 	mu            sync.Mutex
 	desired       desiredState
@@ -96,17 +102,29 @@ func WithGRPCListener(lis *ChanListener) Option {
 	return func(m *Manager) { m.grpcLis = lis }
 }
 
+// WithWebhookListener enables tunneling the daemon's automation webhook receiver.
+// lis is fed demuxed TagWebhook streams and is Served by an http.Server in the
+// daemon (the webhook receiver — unauthenticated, since the unguessable public
+// URL is the capability). Without this option the Manager tunnels no webhooks.
+func WithWebhookListener(lis *ChanListener) Option {
+	return func(m *Manager) { m.webhookLis = lis }
+}
+
 // features lists the tunnel capabilities this Manager requests in its
-// RegisterRequest for the attempt's desired state. FeatureGRPC is advertised
-// only when a gRPC listener is wired AND the user enabled remote fleet — NOT
-// negotiating the feature is what makes the gateway's gRPC endpoint dead for
-// this session (the gateway rejects fleet-session RPCs for it), so a disabled
-// daemon never sees incoming gRPC commands at all.
+// RegisterRequest for the attempt's desired state. Each feature is advertised
+// only when its listener is wired AND the user enabled that traffic kind — NOT
+// negotiating a feature is what makes the matching gateway endpoint dead for this
+// session (the gateway withholds its URL and 404s/​rejects requests for it), so a
+// disabled daemon never sees that traffic at all.
 func (m *Manager) features(d desiredState) []string {
+	var f []string
 	if m.grpcLis != nil && d.grpc {
-		return []string{tunnel.FeatureGRPC}
+		f = append(f, tunnel.FeatureGRPC)
 	}
-	return nil
+	if m.webhookLis != nil && d.webhook {
+		f = append(f, tunnel.FeatureWebhook)
+	}
+	return f
 }
 
 // NewManager builds a Manager that reverse-proxies to the loopback MCP server on
@@ -129,11 +147,12 @@ func NewManager(mcpPort int, clientVersion string, publish func(*fleetgrpc.Remot
 	return m
 }
 
-// Reconcile records the desired config and nudges the supervisor. mcpEnabled
-// and fleetEnabled are the two exposure toggles (remote MCP / remote fleet
-// control). It is NON-BLOCKING: it sets state, cancels any in-flight attempt so
-// it re-evaluates, and signals the loop — so it is safe to call while holding
-// other locks (e.g. the service's config-write lock in SetConfig).
+// Reconcile records the desired config and nudges the supervisor. mcpEnabled,
+// fleetEnabled and webhookEnabled are the three exposure toggles (remote MCP /
+// remote fleet control / automation webhooks). It is NON-BLOCKING: it sets state,
+// cancels any in-flight attempt so it re-evaluates, and signals the loop — so it
+// is safe to call while holding other locks (e.g. the service's config-write lock
+// in SetConfig).
 //
 // An UNCHANGED desired state is a strict no-op. SetConfig calls Reconcile on
 // EVERY config save, and most saves don't touch the remote settings — those
@@ -141,8 +160,8 @@ func NewManager(mcpPort int, clientVersion string, publish func(*fleetgrpc.Remot
 // FLEET_GATEWAY) that tunnel carries the SetConfig RPC's own reply: cancelling
 // the attempt would tear down the yamux session mid-RPC and the client would
 // see its successful save fail with an Unavailable/EOF.
-func (m *Manager) Reconcile(mcpEnabled, fleetEnabled bool, gatewayURL string) {
-	next := desiredState{mcp: mcpEnabled, grpc: fleetEnabled, gatewayURL: strings.TrimSpace(gatewayURL)}
+func (m *Manager) Reconcile(mcpEnabled, fleetEnabled, webhookEnabled bool, gatewayURL string) {
+	next := desiredState{mcp: mcpEnabled, grpc: fleetEnabled, webhook: webhookEnabled, gatewayURL: strings.TrimSpace(gatewayURL)}
 	m.mu.Lock()
 	if next == m.desired {
 		m.mu.Unlock()
@@ -246,13 +265,14 @@ func (m *Manager) Run(ctx context.Context) {
 // established-then-dropped connection).
 func (m *Manager) connectAndServe(ctx context.Context, d desiredState) (registered bool, err error) {
 	gatewayURL := d.gatewayURL
-	// The whole remote surface depends on the local MCP stack: the tunnel-facing
-	// gRPC server is only wired when MCP is up (its bearer token IS the MCP
-	// token), so with mcpPort == 0 even a remote-fleet-only tunnel could serve
-	// nothing. Fail the attempt — an explicit error in the settings page beats a
-	// "connected" tunnel that silently serves neither traffic kind.
+	// The whole remote surface depends on the local MCP stack: the tunnel comes up
+	// only when MCP is up (its loopback port is the tunnel's anchor, and the
+	// tunnel-facing gRPC server's bearer token IS the MCP token), so with
+	// mcpPort == 0 even a remote-fleet- or webhook-only tunnel could serve nothing.
+	// Fail the attempt — an explicit error in the settings page beats a
+	// "connected" tunnel that silently serves no traffic kind.
 	if m.mcpPort == 0 {
-		return false, fmt.Errorf("local MCP server is not running (required for remote MCP and remote fleet)")
+		return false, fmt.Errorf("local MCP server is not running (required for remote MCP, remote fleet, and webhooks)")
 	}
 
 	conn, err := m.dial(ctx, gatewayURL)
@@ -288,14 +308,15 @@ func (m *Manager) connectAndServe(ctx context.Context, d desiredState) (register
 	// public URLs.
 	registered = true
 	_ = saveSession(sessionFile{
-		SessionID:     reply.SessionID,
-		SessionToken:  reply.SessionToken,
-		PublicURL:     reply.PublicURL,
-		PublicGRPCURL: reply.PublicGRPCURL,
-		GatewayURL:    gatewayURL,
+		SessionID:        reply.SessionID,
+		SessionToken:     reply.SessionToken,
+		PublicURL:        reply.PublicURL,
+		PublicGRPCURL:    reply.PublicGRPCURL,
+		PublicWebhookURL: reply.PublicWebhookURL,
+		GatewayURL:       gatewayURL,
 	})
-	flog.Info("remote gateway connected", "gateway", gatewayURL, "publicURL", reply.PublicURL, "publicGrpcURL", reply.PublicGRPCURL, "gatewayVersion", reply.GatewayVersion)
-	m.publish(statusConnected(reply.PublicURL, reply.PublicGRPCURL, reply.GatewayVersion))
+	flog.Info("remote gateway connected", "gateway", gatewayURL, "publicURL", reply.PublicURL, "publicGrpcURL", reply.PublicGRPCURL, "publicWebhookURL", reply.PublicWebhookURL, "gatewayVersion", reply.GatewayVersion)
+	m.publish(statusConnected(reply.PublicURL, reply.PublicGRPCURL, reply.PublicWebhookURL, reply.GatewayVersion))
 
 	session, err := tunnel.ClientSession(conn, m.logOut)
 	if err != nil {
@@ -304,18 +325,27 @@ func (m *Manager) connectAndServe(ctx context.Context, d desiredState) (register
 	defer session.Close()
 	// The serve loop unblocks when the session/conn closes — on a peer drop, or
 	// when stopOnCancel closes the conn on ctx cancel (shutdown / Reconcile
-	// teardown). Use the demuxing path only when the gateway negotiated gRPC (only
-	// requested when remote fleet is enabled AND a gRPC listener is wired);
-	// otherwise the streams are untagged (legacy MCP wire). Either path serves a
+	// teardown). Use the demuxing path when the gateway negotiated gRPC and/or
+	// webhook (each only requested when its toggle is on AND its listener is
+	// wired); pass nil for a NON-negotiated kind so its streams are rejected.
+	// Otherwise the streams are untagged (legacy MCP wire). Either path serves a
 	// traffic kind only while its toggle is on — a toggle flip mid-connection
 	// lands here again via Reconcile's attempt cancel + reconnect.
-	if m.grpcLis != nil && tunnel.HasFeature(reply.Features, tunnel.FeatureGRPC) {
-		return registered, serveTunnel(session, m.mcpPort, m.grpcLis, d.mcp)
+	grpcLis := m.grpcLis
+	if !tunnel.HasFeature(reply.Features, tunnel.FeatureGRPC) {
+		grpcLis = nil
+	}
+	webhookLis := m.webhookLis
+	if !tunnel.HasFeature(reply.Features, tunnel.FeatureWebhook) {
+		webhookLis = nil
+	}
+	if grpcLis != nil || webhookLis != nil {
+		return registered, serveTunnel(session, m.mcpPort, grpcLis, webhookLis, d.mcp)
 	}
 	if !d.mcp {
-		// Remote-fleet-only, but the gateway did not negotiate gRPC (old gateway).
-		// Nothing may be served: park on the session, closing every stream the
-		// gateway pushes, until it drops or the attempt is cancelled.
+		// Remote-fleet/webhook-only, but the gateway negotiated no tagging feature
+		// (old gateway). Nothing may be served: park on the session, closing every
+		// stream the gateway pushes, until it drops or the attempt is cancelled.
 		return registered, serveReject(session)
 	}
 	return registered, serveProxy(session, m.mcpPort)

--- a/internal/server/remote/manager_test.go
+++ b/internal/server/remote/manager_test.go
@@ -81,6 +81,42 @@ func TestFeaturesGatedOnFleetEnabled(t *testing.T) {
 	}
 }
 
+// TestFeaturesGatedOnWebhookEnabled pins the "Enable Webhook" gate, mirroring the
+// grpc gate: the webhook feature is requested ONLY when a webhook listener is
+// wired AND the user enabled webhooks. The two features compose independently —
+// enabling both requests both.
+func TestFeaturesGatedOnWebhookEnabled(t *testing.T) {
+	discard := func(*fleetgrpc.RemoteMcpStatus) {}
+	webhookOnly := NewManager(1, "v", discard, WithWebhookListener(NewChanListener()))
+	both := NewManager(1, "v", discard, WithGRPCListener(NewChanListener()), WithWebhookListener(NewChanListener()))
+	noLis := NewManager(1, "v", discard)
+
+	if got := webhookOnly.features(desiredState{webhook: true}); !tunnel.HasFeature(got, tunnel.FeatureWebhook) {
+		t.Fatalf("webhook enabled + listener wired should request webhook, got %v", got)
+	}
+	if got := webhookOnly.features(desiredState{webhook: false}); len(got) != 0 {
+		t.Fatalf("webhook disabled must request no features, got %v", got)
+	}
+	if got := noLis.features(desiredState{webhook: true}); len(got) != 0 {
+		t.Fatalf("no webhook listener must request no features, got %v", got)
+	}
+	got := both.features(desiredState{grpc: true, webhook: true})
+	if !tunnel.HasFeature(got, tunnel.FeatureGRPC) || !tunnel.HasFeature(got, tunnel.FeatureWebhook) {
+		t.Fatalf("both enabled should request both features, got %v", got)
+	}
+}
+
+// TestDesiredOnWithWebhook confirms the tunnel comes up for a webhook-only daemon
+// (no remote MCP, no remote fleet) as long as a gateway URL is set.
+func TestDesiredOnWithWebhook(t *testing.T) {
+	if !(desiredState{webhook: true, gatewayURL: "https://gw"}).on() {
+		t.Fatal("webhook-only with a gateway URL should bring the tunnel up")
+	}
+	if (desiredState{webhook: true}).on() {
+		t.Fatal("webhook-only without a gateway URL must stay off")
+	}
+}
+
 func TestNextBackoffCaps(t *testing.T) {
 	d := initialBackoff
 	for i := 0; i < 20; i++ {
@@ -188,10 +224,11 @@ func waitForState(t *testing.T, ch <-chan *fleetgrpc.RemoteMcpStatus, want fleet
 }
 
 // newManagerForTest builds a Manager whose dial reaches addr over TLS trusting
-// pool, with status pushed to the returned channel.
-func newManagerForTest(mcpPort int, addr string, pool *x509.CertPool) (*Manager, <-chan *fleetgrpc.RemoteMcpStatus) {
+// pool, with status pushed to the returned channel. Extra options (e.g. a webhook
+// listener) compose on top.
+func newManagerForTest(mcpPort int, addr string, pool *x509.CertPool, opts ...Option) (*Manager, <-chan *fleetgrpc.RemoteMcpStatus) {
 	statusCh := make(chan *fleetgrpc.RemoteMcpStatus, 64)
-	m := NewManager(mcpPort, "vtest", func(st *fleetgrpc.RemoteMcpStatus) { statusCh <- st })
+	m := NewManager(mcpPort, "vtest", func(st *fleetgrpc.RemoteMcpStatus) { statusCh <- st }, opts...)
 	m.dial = func(ctx context.Context, _ string) (net.Conn, error) {
 		d := &tls.Dialer{Config: &tls.Config{RootCAs: pool, ServerName: "127.0.0.1"}}
 		return d.DialContext(ctx, "tcp", addr)
@@ -253,7 +290,7 @@ func TestManagerConnectsServesAndDisables(t *testing.T) {
 	defer cancel()
 	go m.Run(ctx)
 
-	m.Reconcile(true, false, "https://gw.example.com")
+	m.Reconcile(true, false, false, "https://gw.example.com")
 
 	connected := waitForState(t, statusCh, fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED, 5*time.Second)
 	if connected.GetPublicUrl() != "https://gw/mcp/sess-A" {
@@ -286,7 +323,7 @@ func TestManagerConnectsServesAndDisables(t *testing.T) {
 	}
 
 	// Disable -> tears down to UNSPECIFIED.
-	m.Reconcile(false, false, "https://gw.example.com")
+	m.Reconcile(false, false, false, "https://gw.example.com")
 	waitForState(t, statusCh, fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_UNSPECIFIED, 5*time.Second)
 }
 
@@ -347,7 +384,7 @@ func TestManagerStickyReconnect(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go m.Run(ctx)
-	m.Reconcile(true, false, "https://gw.example.com")
+	m.Reconcile(true, false, false, "https://gw.example.com")
 
 	// First registration: no prior session id or resume token.
 	if got := waitForReg(t, regs, 5*time.Second); got.SessionID != "" || got.SessionToken != "" {
@@ -360,6 +397,84 @@ func TestManagerStickyReconnect(t *testing.T) {
 	}
 	// And it lands CONNECTED on the kept connection.
 	waitForState(t, statusCh, fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED, 5*time.Second)
+}
+
+// TestManagerWebhookOnlyReconnect verifies a webhook-only daemon (no remote MCP,
+// no remote fleet) connects, re-requests the webhook feature on a forced
+// reconnect, and re-publishes the gateway-assigned Public Webhook URL — the
+// partial-feature-set reconnect path.
+func TestManagerWebhookOnlyReconnect(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cert, pool := genTestTLS(t)
+	mcp := newFakeMCP()
+	defer mcp.srv.Close()
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{Certificates: []tls.Certificate{cert}})
+	if err != nil {
+		t.Fatalf("tls listen: %v", err)
+	}
+	defer ln.Close()
+
+	regs := make(chan tunnel.RegisterRequest, 8)
+	var conns atomic.Int32
+	gwDone := make(chan struct{})
+	defer close(gwDone)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close()
+				var req tunnel.RegisterRequest
+				if err := tunnel.ReadFrame(conn, &req); err != nil {
+					return
+				}
+				n := conns.Add(1)
+				regs <- req
+				// Negotiate webhook (echo it) and hand back a webhook URL, like the
+				// real gateway does for a webhook-enabled session.
+				reply := tunnel.RegisterReply{SessionID: "wh-1", SessionToken: "tok", PublicURL: "https://gw/mcp/wh-1"}
+				if tunnel.HasFeature(req.Features, tunnel.FeatureWebhook) {
+					reply.Features = []string{tunnel.FeatureWebhook}
+					reply.PublicWebhookURL = "https://gw/webhook/wh-1"
+				}
+				if err := tunnel.WriteFrame(conn, reply); err != nil {
+					return
+				}
+				if n == 1 {
+					return // drop to force a reconnect
+				}
+				sess, err := tunnel.ServerSession(conn, io.Discard)
+				if err != nil {
+					return
+				}
+				defer sess.Close()
+				<-gwDone
+			}(conn)
+		}
+	}()
+
+	m, statusCh := newManagerForTest(mcp.port(t), ln.Addr().String(), pool, WithWebhookListener(NewChanListener()))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.Run(ctx)
+	// Webhook-only: mcp=false, fleet=false, webhook=true.
+	m.Reconcile(false, false, true, "https://gw.example.com")
+
+	// Both registrations must request the webhook feature.
+	for i := range 2 {
+		got := waitForReg(t, regs, 5*time.Second)
+		if !tunnel.HasFeature(got.Features, tunnel.FeatureWebhook) {
+			t.Fatalf("registration %d did not request the webhook feature: %v", i+1, got.Features)
+		}
+	}
+	// And it lands CONNECTED with the webhook URL published.
+	st := waitForState(t, statusCh, fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED, 5*time.Second)
+	if st.GetPublicWebhookUrl() != "https://gw/webhook/wh-1" {
+		t.Fatalf("CONNECTED status missing the webhook URL, got %q", st.GetPublicWebhookUrl())
+	}
 }
 
 func waitForReg(t *testing.T, ch <-chan tunnel.RegisterRequest, timeout time.Duration) tunnel.RegisterRequest {
@@ -426,14 +541,14 @@ func TestManagerReconcileIdempotentKeepsTunnel(t *testing.T) {
 	defer cancel()
 	go m.Run(ctx)
 
-	m.Reconcile(true, false, "https://gw.example.com")
+	m.Reconcile(true, false, false, "https://gw.example.com")
 	waitForReg(t, regs, 5*time.Second)
 	waitForState(t, statusCh, fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED, 5*time.Second)
 
 	// Same desired state — what SetConfig does for the common "saved an
 	// unrelated setting" case. The padded URL pins that the comparison happens
 	// AFTER TrimSpace, matching what Reconcile stores.
-	m.Reconcile(true, false, "  https://gw.example.com  ")
+	m.Reconcile(true, false, false, "  https://gw.example.com  ")
 
 	// The established tunnel must stay up: no new registration and no status
 	// transition away from CONNECTED within the observation window.
@@ -501,8 +616,8 @@ func TestManagerReconcileDisableConverges(t *testing.T) {
 	go m.Run(ctx)
 
 	for i := 0; i < 30; i++ {
-		m.Reconcile(true, false, "https://gw.example.com")
-		m.Reconcile(false, false, "https://gw.example.com")
+		m.Reconcile(true, false, false, "https://gw.example.com")
+		m.Reconcile(false, false, false, "https://gw.example.com")
 	}
 
 	// After the toggles settle, the LAST state observed must be UNSPECIFIED —
@@ -545,7 +660,7 @@ func TestManagerErrorsWhenMcpDown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go m.Run(ctx)
-	m.Reconcile(true, false, "https://gw.example.com")
+	m.Reconcile(true, false, false, "https://gw.example.com")
 
 	st := waitForState(t, statusCh, fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_ERROR, 5*time.Second)
 	if st.GetError() == "" {

--- a/internal/server/remote/proxy.go
+++ b/internal/server/remote/proxy.go
@@ -20,11 +20,12 @@ import (
 //   - serveProxy (legacy / MCP-only gateway): every stream is an HTTP request,
 //     served by one http.Server over the whole session and reverse-proxied to the
 //     loopback MCP server.
-//   - serveTunnel (FeatureGRPC negotiated): every stream begins with a tag byte;
-//     fleetd reads it and dispatches — TagMCP streams go to the MCP http.Server,
-//     TagGRPC streams are spliced (as raw net.Conns) to the daemon's tunnel-facing
-//     gRPC server. One stream per request/connection means MCP requests, SSE, and
-//     native gRPC (incl. bidi) never interleave.
+//   - serveTunnel (FeatureGRPC and/or FeatureWebhook negotiated): every stream
+//     begins with a tag byte; fleetd reads it and dispatches — TagMCP streams go
+//     to the MCP http.Server, TagGRPC streams are spliced (as raw net.Conns) to
+//     the daemon's tunnel-facing gRPC server, TagWebhook streams go to the webhook
+//     receiver's http.Server. One stream per request/connection means MCP
+//     requests, SSE, native gRPC (incl. bidi), and webhooks never interleave.
 
 // mcpReverseProxy builds the reverse proxy to the loopback MCP server.
 func mcpReverseProxy(mcpPort int) http.Handler {
@@ -70,20 +71,22 @@ func serveReject(session *yamux.Session) error {
 	}
 }
 
-// serveTunnel serves a session whose streams are TAG-prefixed (FeatureGRPC
-// negotiated): it reads each stream's tag and routes it. MCP streams feed a local
-// http.Server — unless remote MCP is disabled (mcpOn false: a remote-fleet-only
-// tunnel), in which case they are rejected; gRPC streams feed grpcLis (the
-// daemon's tunnel-facing gRPC server, which is shared across reconnects and NOT
-// closed here). Returns when the session errors.
-func serveTunnel(session *yamux.Session, mcpPort int, grpcLis *ChanListener, mcpOn bool) error {
+// serveTunnel serves a session whose streams are TAG-prefixed (FeatureGRPC and/or
+// FeatureWebhook negotiated): it reads each stream's tag and routes it. MCP
+// streams feed a local http.Server — unless remote MCP is disabled (mcpOn false:
+// a remote-fleet/webhook-only tunnel), in which case they are rejected; gRPC
+// streams feed grpcLis and webhook streams feed webhookLis (both shared across
+// reconnects and NOT closed here). A nil grpcLis/webhookLis means that traffic
+// kind was not negotiated, so its streams are rejected. Returns when the session
+// errors.
+func serveTunnel(session *yamux.Session, mcpPort int, grpcLis, webhookLis *ChanListener, mcpOn bool) error {
 	var mcpLis *ChanListener
 	if mcpOn {
 		mcpLis = NewChanListener()
 		mcpSrv := &http.Server{Handler: mcpReverseProxy(mcpPort)}
 		// Closing the server closes mcpLis (so its Accept unblocks) and drops the
-		// per-connection MCP requests; grpcLis is NOT closed — it outlives this
-		// connection so reconnects reuse the same gRPC server.
+		// per-connection MCP requests; grpcLis/webhookLis are NOT closed — they
+		// outlive this connection so reconnects reuse the same servers.
 		defer mcpSrv.Close()
 		go func() { _ = mcpSrv.Serve(mcpLis) }()
 	}
@@ -93,15 +96,15 @@ func serveTunnel(session *yamux.Session, mcpPort int, grpcLis *ChanListener, mcp
 		if err != nil {
 			return err
 		}
-		go dispatchStream(stream, mcpLis, grpcLis)
+		go dispatchStream(stream, mcpLis, grpcLis, webhookLis)
 	}
 }
 
 // dispatchStream reads the leading tag byte and routes the (tag-stripped) stream
-// to the MCP or gRPC listener. A nil listener means that traffic kind is
+// to the MCP, gRPC, or webhook listener. A nil listener means that traffic kind is
 // disabled, so its streams are rejected. An unreadable tag or unknown value
 // closes the stream without disturbing the others.
-func dispatchStream(stream net.Conn, mcpLis, grpcLis *ChanListener) {
+func dispatchStream(stream net.Conn, mcpLis, grpcLis, webhookLis *ChanListener) {
 	tag, err := tunnel.ReadTag(stream)
 	if err != nil {
 		_ = stream.Close()
@@ -112,6 +115,8 @@ func dispatchStream(stream net.Conn, mcpLis, grpcLis *ChanListener) {
 		mcpLis.Push(stream)
 	case tag == tunnel.TagGRPC && grpcLis != nil:
 		grpcLis.Push(stream)
+	case tag == tunnel.TagWebhook && webhookLis != nil:
+		webhookLis.Push(stream)
 	default:
 		_ = stream.Close()
 	}

--- a/internal/server/remote/serve_tunnel_test.go
+++ b/internal/server/remote/serve_tunnel_test.go
@@ -34,7 +34,7 @@ func TestServeTunnelDemux(t *testing.T) {
 
 	grpcLis := NewChanListener()
 	defer grpcLis.Close()
-	go func() { _ = serveTunnel(fleetdSession, mcp.port(t), grpcLis, true) }()
+	go func() { _ = serveTunnel(fleetdSession, mcp.port(t), grpcLis, nil, true) }()
 
 	// --- TagGRPC: the post-tag bytes must arrive intact on grpcLis. ---
 	gstream, err := gwSession.Open()
@@ -111,7 +111,7 @@ func TestServeTunnelRejectsMcpWhenDisabled(t *testing.T) {
 
 	grpcLis := NewChanListener()
 	defer grpcLis.Close()
-	go func() { _ = serveTunnel(fleetdSession, 0, grpcLis, false) }()
+	go func() { _ = serveTunnel(fleetdSession, 0, grpcLis, nil, false) }()
 
 	// --- TagMCP: closed unanswered (no HTTP response, the read just fails). ---
 	mstream, err := gwSession.Open()
@@ -158,6 +158,101 @@ func TestServeTunnelRejectsMcpWhenDisabled(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("grpc-tagged stream never reached the gRPC listener")
+	}
+}
+
+// TestServeTunnelWebhookDispatch covers a webhook-only tunnel (Enable Webhook on,
+// MCP/fleet off): TagWebhook streams route to the webhook listener with bytes
+// intact, while TagMCP and TagGRPC streams (neither negotiated) are closed.
+func TestServeTunnelWebhookDispatch(t *testing.T) {
+	fleetdConn, gwConn := tcpPair(t)
+	fleetdSession, err := tunnel.ClientSession(fleetdConn, io.Discard)
+	if err != nil {
+		t.Fatalf("client session: %v", err)
+	}
+	defer fleetdSession.Close()
+	gwSession, err := tunnel.ServerSession(gwConn, io.Discard)
+	if err != nil {
+		t.Fatalf("server session: %v", err)
+	}
+	defer gwSession.Close()
+
+	webhookLis := NewChanListener()
+	defer webhookLis.Close()
+	// grpcLis nil + mcpOn false: only webhook streams may be served.
+	go func() { _ = serveTunnel(fleetdSession, 0, nil, webhookLis, false) }()
+
+	// --- TagWebhook: post-tag bytes arrive intact on webhookLis. ---
+	wstream, err := gwSession.Open()
+	if err != nil {
+		t.Fatalf("open webhook stream: %v", err)
+	}
+	if err := tunnel.WriteTag(wstream, tunnel.TagWebhook); err != nil {
+		t.Fatalf("write webhook tag: %v", err)
+	}
+	if _, err := io.WriteString(wstream, "hello-webhook"); err != nil {
+		t.Fatalf("write webhook bytes: %v", err)
+	}
+	got := make(chan string, 1)
+	go func() {
+		c, err := webhookLis.Accept()
+		if err != nil {
+			got <- "ERR:" + err.Error()
+			return
+		}
+		b := make([]byte, len("hello-webhook"))
+		if _, err := io.ReadFull(c, b); err != nil {
+			got <- "READ:" + err.Error()
+			return
+		}
+		got <- string(b)
+	}()
+	select {
+	case s := <-got:
+		if s != "hello-webhook" {
+			t.Fatalf("webhook stream payload = %q, want hello-webhook", s)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("webhook-tagged stream never reached the webhook listener")
+	}
+
+	// --- TagGRPC: not negotiated → closed unanswered, loop survives. ---
+	gstream, err := gwSession.Open()
+	if err != nil {
+		t.Fatalf("open grpc stream: %v", err)
+	}
+	_ = tunnel.WriteTag(gstream, tunnel.TagGRPC)
+	_ = gstream.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if _, err := gstream.Read(make([]byte, 1)); err == nil {
+		t.Fatal("grpc stream should be closed when only webhook is negotiated")
+	}
+
+	// The loop still serves webhooks after the rejected stream.
+	wstream2, err := gwSession.Open()
+	if err != nil {
+		t.Fatalf("open webhook stream 2: %v", err)
+	}
+	_ = tunnel.WriteTag(wstream2, tunnel.TagWebhook)
+	if _, err := io.WriteString(wstream2, "again"); err != nil {
+		t.Fatalf("write webhook bytes 2: %v", err)
+	}
+	go func() {
+		c, err := webhookLis.Accept()
+		if err != nil {
+			got <- "ERR:" + err.Error()
+			return
+		}
+		b := make([]byte, len("again"))
+		_, _ = io.ReadFull(c, b)
+		got <- string(b)
+	}()
+	select {
+	case s := <-got:
+		if s != "again" {
+			t.Fatalf("second webhook payload = %q, want again", s)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("webhook loop stalled after a rejected grpc stream")
 	}
 }
 

--- a/internal/server/remote/session.go
+++ b/internal/server/remote/session.go
@@ -25,7 +25,11 @@ type sessionFile struct {
 	// registration ("" when the grpc feature was not negotiated or the gateway
 	// has no --public-grpc-url). Recorded for parity with PublicURL.
 	PublicGRPCURL string `json:"public_grpc_url,omitempty"`
-	GatewayURL    string `json:"gateway_url"`
+	// PublicWebhookURL is the gateway-assigned Public Webhook base URL from the
+	// last registration ("" when the webhook feature was not negotiated).
+	// Recorded for parity with PublicURL.
+	PublicWebhookURL string `json:"public_webhook_url,omitempty"`
+	GatewayURL       string `json:"gateway_url"`
 }
 
 // loadSession returns the persisted session IF it was issued for gatewayURL. A

--- a/internal/server/remote/status.go
+++ b/internal/server/remote/status.go
@@ -15,12 +15,13 @@ func statusConnecting() *fleetgrpc.RemoteMcpStatus {
 	return &fleetgrpc.RemoteMcpStatus{State: fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTING}
 }
 
-func statusConnected(publicURL, publicGRPCURL, gatewayVersion string) *fleetgrpc.RemoteMcpStatus {
+func statusConnected(publicURL, publicGRPCURL, publicWebhookURL, gatewayVersion string) *fleetgrpc.RemoteMcpStatus {
 	return &fleetgrpc.RemoteMcpStatus{
-		State:          fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
-		PublicUrl:      publicURL,
-		PublicGrpcUrl:  publicGRPCURL,
-		GatewayVersion: gatewayVersion,
+		State:            fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
+		PublicUrl:        publicURL,
+		PublicGrpcUrl:    publicGRPCURL,
+		PublicWebhookUrl: publicWebhookURL,
+		GatewayVersion:   gatewayVersion,
 	}
 }
 

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -107,9 +107,26 @@ func newScheduler() *scheduler {
 	}
 }
 
+// webhookFireBuffer is how many matched webhook events may queue between
+// scheduler drains before the receiver starts shedding (503). The scheduler
+// drains one per loop turn, so this only fills under a sustained burst.
+const webhookFireBuffer = 64
+
+// webhookFire is a matched automation webhook event handed from the (concurrent)
+// webhook receiver to the scheduler goroutine, which spawns the trigger's agents.
+// The receiver has already evaluated the trigger's filter against the event body;
+// only the static trigger Prompt (not the body) feeds the agents, matching the
+// schedule path.
+type webhookFire struct {
+	fleet   string
+	trigger fleet.Trigger
+}
+
 // runScheduler is the automation loop; it returns when ctx is cancelled. It
 // ticks once immediately so a trigger whose cron matches the current minute
-// fires promptly on daemon start instead of waiting up to a full interval.
+// fires promptly on daemon start instead of waiting up to a full interval, and
+// drains webhook fires between ticks so a delivered event spawns its agents
+// promptly. Both paths run on THIS goroutine, so sched's maps stay lock-free.
 func (s *service) runScheduler(ctx context.Context) {
 	sched := newScheduler()
 	ticker := time.NewTicker(scheduleTickInterval)
@@ -120,7 +137,36 @@ func (s *service) runScheduler(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+		case batch := <-s.webhookFires:
+			s.fireWebhookBatch(sched, batch, time.Now())
 		}
+	}
+}
+
+// fireWebhookBatch spawns the agents of every matched webhook trigger in a
+// request's batch, on the SCHEDULER goroutine (so it touches sched.watched
+// without locking, like the schedule path). The receiver already matched each
+// trigger's filter; here we just resolve each fleet's CURRENT agents (state may
+// have changed since delivery) and spawn them. The next loop iteration's
+// schedulerTick reloads state and services the freshly-watched agents (launch on
+// running, reap on idle), so webhook-spawned agents ride the exact same lifecycle
+// as scheduled ones.
+func (s *service) fireWebhookBatch(sched *scheduler, batch []webhookFire, now time.Time) {
+	if len(batch) == 0 {
+		return
+	}
+	st, err := scheduleLoadState()
+	if err != nil {
+		flog.Warn("automation: webhook load state failed", "err", err)
+		return
+	}
+	for _, f := range batch {
+		agents := agentsForTrigger(st.Fleets[f.fleet], f.trigger)
+		if len(agents) == 0 {
+			flog.Warn("automation: webhook trigger has no live agents", "fleet", f.fleet, "trigger", f.trigger.Name)
+			continue
+		}
+		s.fireTriggerAgents(sched, f.fleet, f.trigger, agents, now)
 	}
 }
 
@@ -137,23 +183,8 @@ func (s *service) schedulerTick(ctx context.Context, sched *scheduler, now time.
 	}
 	fired := false
 	for _, due := range dueSchedules(st.Fleets, now, sched.lastFired) {
-		for _, ag := range agentsForTrigger(st.Fleets[due.fleet], due.trigger) {
-			instName, err := createAutomationInstance(s, due.fleet, ag, now)
-			if err != nil {
-				flog.Warn("automation: create instance failed", "fleet", due.fleet, "agent", ag.Name, "err", err)
-				continue
-			}
-			flog.Info("automation: trigger fired", "fleet", due.fleet, "trigger", due.trigger.Name, "agent", ag.Name, "instance", instName)
-			w := &watchedAgent{
-				fleet:        due.fleet,
-				instance:     instName,
-				command:      ag.Command,
-				prompt:       due.trigger.Prompt,
-				systemPrompt: ag.SystemPrompt,
-				spawnedAt:    now,
-				lastActive:   now,
-			}
-			sched.watched[w.key()] = w
+		agents := agentsForTrigger(st.Fleets[due.fleet], due.trigger)
+		if s.fireTriggerAgents(sched, due.fleet, due.trigger, agents, now) {
 			fired = true
 		}
 	}
@@ -168,6 +199,35 @@ func (s *service) schedulerTick(ctx context.Context, sched *scheduler, now time.
 		}
 	}
 	s.serviceWatched(ctx, sched, st, now)
+}
+
+// fireTriggerAgents spawns one instance per agent the trigger activates and
+// registers each in the watch set, returning whether anything was spawned (the
+// caller reloads state when so, see schedulerTick). Shared by the schedule path
+// and the webhook path; it only mutates sched.watched, so it MUST run on the
+// scheduler goroutine.
+func (s *service) fireTriggerAgents(sched *scheduler, fleetName string, trigger fleet.Trigger, agents []fleet.Agent, now time.Time) bool {
+	fired := false
+	for _, ag := range agents {
+		instName, err := createAutomationInstance(s, fleetName, ag, now)
+		if err != nil {
+			flog.Warn("automation: create instance failed", "fleet", fleetName, "agent", ag.Name, "err", err)
+			continue
+		}
+		flog.Info("automation: trigger fired", "fleet", fleetName, "trigger", trigger.Name, "agent", ag.Name, "instance", instName)
+		w := &watchedAgent{
+			fleet:        fleetName,
+			instance:     instName,
+			command:      ag.Command,
+			prompt:       trigger.Prompt,
+			systemPrompt: ag.SystemPrompt,
+			spawnedAt:    now,
+			lastActive:   now,
+		}
+		sched.watched[w.key()] = w
+		fired = true
+	}
+	return fired
 }
 
 // scheduledFire is one trigger that should fire now.

--- a/internal/server/schedule_test.go
+++ b/internal/server/schedule_test.go
@@ -297,6 +297,76 @@ func TestServiceWatchedConcurrentProbesReapAll(t *testing.T) {
 	}
 }
 
+// TestFireWebhookBatchSpawns exercises the webhook critical path on the scheduler
+// goroutine: a delivered fire batch resolves the trigger's agents and registers
+// each as a watched instance (the same lifecycle scheduled triggers use).
+func TestFireWebhookBatchSpawns(t *testing.T) {
+	st := &state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Settings: fleet.FleetSettings{
+			Agents: []fleet.Agent{
+				{Name: "a", Command: "cmdA", SystemPrompt: "sysA", Backend: fleet.BackendDevcontainer},
+				{Name: "b", Command: "cmdB", Backend: fleet.BackendDevcontainer},
+			},
+		}},
+	}}
+	origLoad := scheduleLoadState
+	scheduleLoadState = func() (*state.State, error) { return st, nil }
+	origCreate := createAutomationInstance
+	var created []string
+	createAutomationInstance = func(_ *service, _ string, ag fleet.Agent, _ time.Time) (string, error) {
+		name := "inst-" + ag.Name
+		created = append(created, name)
+		return name, nil
+	}
+	t.Cleanup(func() { scheduleLoadState = origLoad; createAutomationInstance = origCreate })
+
+	s := &service{}
+	sched := newScheduler()
+	now := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
+
+	// One trigger activating both agents, with a prompt.
+	trig := fleet.Trigger{Name: "ci", Type: fleet.TriggerWebhook, AgentNames: []string{"a", "b"}, WebhookName: "ci", Prompt: "go"}
+	s.fireWebhookBatch(sched, []webhookFire{{fleet: "alpha", trigger: trig}}, now)
+
+	if len(created) != 2 {
+		t.Fatalf("expected 2 instances created, got %v", created)
+	}
+	wa := sched.watched["alpha/inst-a"]
+	if wa == nil {
+		t.Fatal("agent a was not registered in the watch set")
+	}
+	if wa.command != "cmdA" || wa.systemPrompt != "sysA" || wa.prompt != "go" {
+		t.Fatalf("watched agent a carries the wrong fields: %+v", wa)
+	}
+	if sched.watched["alpha/inst-b"] == nil {
+		t.Fatal("agent b was not registered in the watch set")
+	}
+}
+
+// TestFireWebhookBatchSkipsMissingAgents confirms a fire whose trigger references
+// an agent that no longer exists is skipped (no crash, no watch entry), per fleet.
+func TestFireWebhookBatchSkipsMissingAgents(t *testing.T) {
+	st := &state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Settings: fleet.FleetSettings{Agents: nil}}, // no agents
+	}}
+	origLoad := scheduleLoadState
+	scheduleLoadState = func() (*state.State, error) { return st, nil }
+	origCreate := createAutomationInstance
+	createAutomationInstance = func(*service, string, fleet.Agent, time.Time) (string, error) {
+		t.Fatal("createAutomationInstance must not run when the trigger has no live agents")
+		return "", nil
+	}
+	t.Cleanup(func() { scheduleLoadState = origLoad; createAutomationInstance = origCreate })
+
+	s := &service{}
+	sched := newScheduler()
+	trig := fleet.Trigger{Name: "ci", Type: fleet.TriggerWebhook, AgentNames: []string{"gone"}, WebhookName: "ci"}
+	s.fireWebhookBatch(sched, []webhookFire{{fleet: "alpha", trigger: trig}}, time.Now())
+	if len(sched.watched) != 0 {
+		t.Fatalf("no watch entries expected, got %d", len(sched.watched))
+	}
+}
+
 func TestEnvDurationDefault(t *testing.T) {
 	const name = "FLEET_TEST_DURATION_KNOB"
 	def := 2 * time.Minute

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"syscall"
 	"time"
@@ -138,14 +139,24 @@ func Serve(ctx context.Context) error {
 		}()
 	}
 
-	// Tunnel-facing gRPC server: exposes the SAME FleetService as the local unix
-	// socket, but gated by the MCP bearer token (the local socket stays auth-less).
-	// It is Served over an in-memory listener fed by the tunnel demux, so there is
-	// no extra port/socket; the gateway tunnels gRPC alongside MCP whenever both
-	// ends negotiate FeatureGRPC. Only wired when MCP is up (we have a port +
-	// token); enabling remote MCP in config exposes this too (one toggle).
+	// Tunnel-facing servers fed by the gateway tunnel demux (no extra port/socket):
+	//   - gRPC: the SAME FleetService as the local unix socket, but gated by the
+	//     MCP bearer token (the local socket stays auth-less). Tunneled whenever
+	//     both ends negotiate FeatureGRPC.
+	//   - webhook: the automation webhook receiver, UNauthenticated (the unguessable
+	//     public URL is the capability, like the MCP proxy). Tunneled whenever both
+	//     ends negotiate FeatureWebhook.
+	// Both ride the same tunnel and are only wired when MCP is up (we need its
+	// loopback port for the tunnel to come up at all). The webhook receiver, unlike
+	// gRPC, does NOT need the MCP token, so it is wired independently of it.
 	var remoteOpts []remote.Option
 	if mcpPort != 0 {
+		webhookLis := remote.NewChanListener()
+		webhookSrv := &http.Server{Handler: svc.webhookHandler()}
+		go func() { _ = webhookSrv.Serve(webhookLis) }()
+		defer webhookSrv.Close()
+		remoteOpts = append(remoteOpts, remote.WithWebhookListener(webhookLis))
+
 		if token, err := loadOrCreateMCPToken(); err == nil {
 			grpcLis := remote.NewChanListener()
 			authUnary, authStream := bearerAuthInterceptors(token)
@@ -172,7 +183,7 @@ func Serve(ctx context.Context) error {
 	}, remoteOpts...)
 	go svc.remote.Run(hubCtx)
 	if cfg, err := state.LoadConfig(); err == nil {
-		svc.remote.Reconcile(cfg.RemoteMcpSettings.Enabled, cfg.RemoteMcpSettings.FleetEnabled, cfg.RemoteMcpSettings.GatewayURL)
+		svc.remote.Reconcile(cfg.RemoteMcpSettings.Enabled, cfg.RemoteMcpSettings.FleetEnabled, cfg.RemoteMcpSettings.WebhookEnabled, cfg.RemoteMcpSettings.GatewayURL)
 	} else {
 		flog.Warn("remote mcp: load config", "err", err)
 	}

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -52,10 +52,27 @@ type service struct {
 	// buildkitReconciling coalesces the TUI-connect buildkit re-ensure so that
 	// several TUIs opening at once trigger one sweep, not one per client.
 	buildkitReconciling atomic.Bool
+
+	// webhookFires carries matched automation webhook events from the (concurrent)
+	// webhook receiver to the single-goroutine scheduler, which spawns + watches
+	// the agents. One channel send carries ALL of a request's matched triggers as
+	// a batch, so a request enqueues all-or-nothing — a sender that retries after a
+	// 503 can't double-fire triggers that already enqueued. Buffered so a burst of
+	// events doesn't block the receiver; a full channel makes the receiver shed
+	// (503) rather than block (see webhook.go). Drained only while runScheduler is
+	// running (the real serve loop); tests that use newService() read it directly.
+	webhookFires chan []webhookFire
 }
 
 func newService() *service {
-	return &service{startedAt: time.Now(), hub: newHub(), jobs: newJobManager(), shutdownCh: make(chan struct{}), bgCtx: context.Background()}
+	return &service{
+		startedAt:    time.Now(),
+		hub:          newHub(),
+		jobs:         newJobManager(),
+		shutdownCh:   make(chan struct{}),
+		bgCtx:        context.Background(),
+		webhookFires: make(chan []webhookFire, webhookFireBuffer),
+	}
 }
 
 // reconcileTimeout bounds the TUI-connect buildkit reconcile so a slow/wedged

--- a/internal/server/webhook.go
+++ b/internal/server/webhook.go
@@ -1,0 +1,154 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// webhook.go is fleetd's side of the automation webhook (issue #193 — the
+// delivery the #188 framework deferred). The gateway accepts a POST at
+// <public-url>/webhook/<name> and reverse-proxies it down a TagWebhook tunnel
+// stream to the http.Server this handler backs. Each request is one inbound
+// event: its path names the webhook, its body is matched against every webhook
+// trigger (across all fleets) carrying that name, and matching triggers fire
+// their agents via the scheduler.
+//
+// There is NO auth here, by design: the gateway only forwards events for a
+// session whose unguessable public URL the user chose to share, and that URL IS
+// the capability — the same security model as the gateway's MCP proxy.
+
+// maxWebhookBodySize bounds the event body fleetd reads for filter matching, so a
+// huge or hostile POST can't exhaust memory. 1 MiB comfortably covers real
+// webhook payloads — only the small routing fields a regex / json path inspects
+// matter, not the whole delivery.
+const maxWebhookBodySize = 1 << 20
+
+// webhookEnqueueTimeout bounds how long the receiver waits to hand a matched
+// event to the scheduler before shedding it (503). The scheduler drains between
+// ticks, so this only trips under sustained overload.
+const webhookEnqueueTimeout = 5 * time.Second
+
+// webhookHandler returns the http.Handler fleetd serves over the tunnel's
+// TagWebhook streams.
+func (s *service) webhookHandler() http.Handler {
+	return http.HandlerFunc(s.serveWebhook)
+}
+
+// serveWebhook routes one inbound webhook event to the matching triggers.
+func (s *service) serveWebhook(w http.ResponseWriter, r *http.Request) {
+	name := firstPathSegment(r.URL.Path)
+	if name == "" {
+		http.Error(w, "webhook name required", http.StatusBadRequest)
+		return
+	}
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxWebhookBodySize))
+	if err != nil {
+		http.Error(w, "request body too large or unreadable", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	st, err := scheduleLoadState()
+	if err != nil {
+		flog.Warn("webhook: load state failed", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	fires, nameFound := collectWebhookFires(st, name, body)
+	if !nameFound {
+		// No trigger anywhere carries this name. Same 404 the gateway gives an
+		// unknown id, so a probe can't enumerate configured webhook names.
+		http.Error(w, "no webhook trigger with that name", http.StatusNotFound)
+		return
+	}
+
+	if len(fires) == 0 {
+		// Name found, but no trigger's filter matched this event — accepted, nothing
+		// to do. Returning 200 (not 404) tells the sender the webhook is wired.
+		flog.Info("webhook: received", "name", name, "fired", 0)
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "received: no trigger matched the event\n")
+		return
+	}
+
+	// Hand the WHOLE matched set to the scheduler as one batch — an all-or-nothing
+	// enqueue. Webhook senders retry on a non-2xx, so a partial enqueue (some fires
+	// in, then a 503) would re-fire the already-queued triggers on retry; a single
+	// send makes the request atomic, so a 503 means nothing fired and the retry is
+	// clean.
+	if !s.enqueueWebhookFires(r.Context(), fires) {
+		flog.Warn("webhook: enqueue shed", "name", name, "triggers", len(fires))
+		http.Error(w, "fleet scheduler busy, retry shortly", http.StatusServiceUnavailable)
+		return
+	}
+
+	flog.Info("webhook: received", "name", name, "fired", len(fires))
+	w.WriteHeader(http.StatusOK)
+	_, _ = fmt.Fprintf(w, "received: %d trigger(s) fired\n", len(fires))
+}
+
+// collectWebhookFires scans every fleet for webhook triggers named name and
+// returns the subset whose filter matches body, plus whether ANY trigger with
+// that name exists at all (to distinguish 404 from "matched nothing"). Firing all
+// matches across all fleets is intentional: webhook names are per-fleet in the
+// model, so the same name can legitimately drive triggers in several fleets, and
+// the common single-match case degenerates to exactly one fire.
+func collectWebhookFires(st *state.State, name string, body []byte) (fires []webhookFire, nameFound bool) {
+	for fleetName, f := range st.Fleets {
+		if f == nil {
+			continue
+		}
+		for _, t := range f.Settings.Triggers {
+			if t.Type != fleet.TriggerWebhook || t.WebhookName != name {
+				continue
+			}
+			nameFound = true
+			if t.MatchesWebhook(body) {
+				fires = append(fires, webhookFire{fleet: fleetName, trigger: t})
+			}
+		}
+	}
+	return fires, nameFound
+}
+
+// enqueueWebhookFires hands a request's matched events to the scheduler goroutine
+// as ONE batch (so the enqueue is atomic — see serveWebhook), bounded by
+// webhookEnqueueTimeout and the request's own context. It returns false when the
+// scheduler can't accept the batch in time (overloaded) or the request was
+// cancelled — the caller turns that into a 503.
+func (s *service) enqueueWebhookFires(ctx context.Context, fires []webhookFire) bool {
+	if s.webhookFires == nil || len(fires) == 0 {
+		return false
+	}
+	timer := time.NewTimer(webhookEnqueueTimeout)
+	defer timer.Stop()
+	select {
+	case s.webhookFires <- fires:
+		return true
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return false
+	}
+}
+
+// firstPathSegment returns the first path segment (the webhook name), trimming
+// the leading slash and dropping any extra path the sender appended. The path is
+// already percent-decoded by net/http, so a name with spaces/specials matches the
+// trigger's raw WebhookName.
+func firstPathSegment(p string) string {
+	p = strings.TrimPrefix(p, "/")
+	if i := strings.IndexByte(p, '/'); i >= 0 {
+		p = p[:i]
+	}
+	return p
+}

--- a/internal/server/webhook_remote_e2e_test.go
+++ b/internal/server/webhook_remote_e2e_test.go
@@ -1,0 +1,169 @@
+package server
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetpaths"
+	"github.com/BenjaminBenetti/fleet-man/internal/gateway"
+	"github.com/BenjaminBenetti/fleet-man/internal/server/remote"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+	"google.golang.org/grpc/credentials"
+)
+
+// webhook_remote_e2e_test.go is the full-stack integration test for the webhook
+// delivery feature (issue #193): a REAL webhook receiver (svc.webhookHandler) is
+// exposed through a REAL gateway by a REAL remote.Manager tunnel, and a REAL HTTP
+// client POSTs an event to the gateway-minted public webhook URL. A success
+// proves the whole path — HTTPS → gateway /webhook route → TagWebhook tunnel
+// stream → fleetd demux → webhook receiver → trigger match → scheduler enqueue.
+
+// webhookStack stands up the full real stack with one webhook trigger ("ci",
+// regex `"action":"opened"`) and returns the gateway-minted public webhook base
+// URL, a cert pool trusting the gateway, and the service (whose webhookFires
+// channel the test drains to confirm a fire).
+func webhookStack(t *testing.T) (publicWebhookBase string, pool *x509.CertPool, svc *service) {
+	t.Helper()
+	isolateFleetDir(t)
+	if err := os.MkdirAll(fleetpaths.Dir(), 0o700); err != nil {
+		t.Fatalf("mkdir fleet dir: %v", err)
+	}
+
+	svc = newService()
+	// Stub the persisted state with a single webhook trigger. The receiver loads
+	// via scheduleLoadState, so this drives matching without touching disk.
+	origLoad := scheduleLoadState
+	scheduleLoadState = func() (*state.State, error) {
+		return &state.State{Fleets: map[string]*fleet.Fleet{
+			"alpha": {Name: "alpha", Settings: fleet.FleetSettings{
+				Agents: []fleet.Agent{{Name: "a"}},
+				Triggers: []fleet.Trigger{{
+					Name: "ci", Type: fleet.TriggerWebhook, AgentNames: []string{"a"},
+					WebhookName: "ci", FilterType: fleet.WebhookFilterRegex, Regex: `"action":"opened"`,
+				}},
+			}},
+		}}, nil
+	}
+	t.Cleanup(func() { scheduleLoadState = origLoad })
+
+	// The tunnel requires the local MCP server up (its loopback port), even though
+	// this test only exercises webhooks.
+	mcpHTTP, mcpPort := startMCPServer(svc)
+	if mcpHTTP == nil {
+		t.Fatal("MCP server failed to start")
+	}
+	t.Cleanup(func() { _ = mcpHTTP.Close() })
+
+	// Real webhook receiver served over the in-memory tunnel listener.
+	webhookLis := remote.NewChanListener()
+	webhookSrv := &http.Server{Handler: svc.webhookHandler()}
+	go func() { _ = webhookSrv.Serve(webhookLis) }()
+	t.Cleanup(func() { _ = webhookSrv.Close() })
+
+	// Real gateway on ephemeral TLS listeners.
+	var certPath, keyPath string
+	pool, certPath, keyPath = genTestTLSFiles(t)
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		t.Fatalf("load keypair: %v", err)
+	}
+	serverTLS := &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}
+	publicLn, err := tls.Listen("tcp", "127.0.0.1:0", serverTLS)
+	if err != nil {
+		t.Fatalf("public listen: %v", err)
+	}
+	t.Cleanup(func() { _ = publicLn.Close() })
+	grpcLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("grpc listen: %v", err)
+	}
+	t.Cleanup(func() { _ = grpcLn.Close() })
+	publicBase := "https://" + publicLn.Addr().String()
+
+	gw, err := gateway.New(gateway.Config{PublicURL: publicBase, TLSCert: certPath, TLSKey: keyPath})
+	if err != nil {
+		t.Fatalf("gateway.New: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = gw.ServeListeners(ctx, publicLn, grpcLn) }()
+
+	// Real fleetd tunnel manager, webhook-only (MCP/fleet off).
+	statusCh := make(chan *fleetgrpc.RemoteMcpStatus, 64)
+	gwCreds := credentials.NewTLS(&tls.Config{RootCAs: pool, ServerName: "127.0.0.1"})
+	mgr := remote.NewManager(mcpPort, "e2e",
+		func(st *fleetgrpc.RemoteMcpStatus) { statusCh <- st },
+		remote.WithDialFunc(registerDialFunc(grpcLn.Addr().String(), gwCreds)),
+		remote.WithWebhookListener(webhookLis),
+	)
+	go mgr.Run(ctx)
+	mgr.Reconcile(false, false, true, "https://gw.example.com")
+
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case st := <-statusCh:
+			if st.GetState() == fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED {
+				if st.GetPublicWebhookUrl() == "" {
+					t.Fatal("CONNECTED status missing public webhook URL")
+				}
+				return st.GetPublicWebhookUrl(), pool, svc
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for the webhook tunnel to connect")
+		}
+	}
+}
+
+// TestWebhookDeliveryEndToEnd POSTs a matching event to the gateway's public
+// webhook URL and confirms the trigger fires (a fire is enqueued to the scheduler).
+func TestWebhookDeliveryEndToEnd(t *testing.T) {
+	base, pool, svc := webhookStack(t)
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool, ServerName: "127.0.0.1"}}}
+
+	resp, err := client.Post(base+"/ci", "application/json", strings.NewReader(`{"action":"opened"}`))
+	if err != nil {
+		t.Fatalf("POST webhook through the tunnel: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("webhook POST -> %d, want 200", resp.StatusCode)
+	}
+
+	select {
+	case batch := <-svc.webhookFires:
+		if len(batch) != 1 || batch[0].fleet != "alpha" || batch[0].trigger.Name != "ci" {
+			t.Fatalf("unexpected fire batch through the tunnel: %+v", batch)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("event delivered but no trigger fire was enqueued")
+	}
+}
+
+// TestWebhookUnknownName404 confirms an event for a name no trigger carries is
+// rejected end to end with 404 (and fires nothing).
+func TestWebhookUnknownName404(t *testing.T) {
+	base, pool, svc := webhookStack(t)
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool, ServerName: "127.0.0.1"}}}
+
+	resp, err := client.Post(base+"/does-not-exist", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("POST webhook: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("unknown webhook name -> %d, want 404", resp.StatusCode)
+	}
+	if b := drainBatch(svc); b != nil {
+		t.Fatalf("no fire expected for an unknown name, got %+v", b)
+	}
+}

--- a/internal/server/webhook_test.go
+++ b/internal/server/webhook_test.go
@@ -1,0 +1,262 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// webhookState builds a state with the given webhook triggers under fleet
+// "alpha", all referencing a single agent "a".
+func webhookState(triggers ...fleet.Trigger) *state.State {
+	return &state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Settings: fleet.FleetSettings{
+			Agents:   []fleet.Agent{{Name: "a"}},
+			Triggers: triggers,
+		}},
+	}}
+}
+
+// postWebhook drives serveWebhook with a POST to /<name> carrying body and
+// returns the recorder. The state seam is stubbed for the duration of the call.
+func postWebhook(t *testing.T, s *service, st *state.State, name, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	orig := scheduleLoadState
+	scheduleLoadState = func() (*state.State, error) { return st, nil }
+	t.Cleanup(func() { scheduleLoadState = orig })
+
+	req := httptest.NewRequest(http.MethodPost, "/"+name, strings.NewReader(body))
+	w := httptest.NewRecorder()
+	s.serveWebhook(w, req)
+	return w
+}
+
+// drainBatch returns the next queued fire batch (non-blocking), or nil if none.
+func drainBatch(s *service) []webhookFire {
+	select {
+	case b := <-s.webhookFires:
+		return b
+	default:
+		return nil
+	}
+}
+
+func TestServeWebhook_RegexMatchFires(t *testing.T) {
+	s := newService()
+	st := webhookState(fleet.Trigger{
+		Name: "ci", Type: fleet.TriggerWebhook, AgentNames: []string{"a"},
+		WebhookName: "ci", FilterType: fleet.WebhookFilterRegex, Regex: `"action":"opened"`,
+	})
+
+	w := postWebhook(t, s, st, "ci", `{"action":"opened"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	b := drainBatch(s)
+	if len(b) != 1 {
+		t.Fatalf("expected a 1-trigger batch, got %v", b)
+	}
+	if b[0].fleet != "alpha" || b[0].trigger.Name != "ci" {
+		t.Fatalf("unexpected fire: %+v", b[0])
+	}
+}
+
+func TestServeWebhook_NoFilterMatchNoFire(t *testing.T) {
+	s := newService()
+	st := webhookState(fleet.Trigger{
+		Name: "ci", Type: fleet.TriggerWebhook, AgentNames: []string{"a"},
+		WebhookName: "ci", FilterType: fleet.WebhookFilterRegex, Regex: `"action":"opened"`,
+	})
+
+	// Name is found, but the body doesn't match the filter → 200, no fire.
+	w := postWebhook(t, s, st, "ci", `{"action":"closed"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if b := drainBatch(s); b != nil {
+		t.Fatalf("no fire expected when the filter doesn't match, got %+v", b)
+	}
+}
+
+func TestServeWebhook_UnknownName404(t *testing.T) {
+	s := newService()
+	st := webhookState(fleet.Trigger{
+		Name: "ci", Type: fleet.TriggerWebhook, AgentNames: []string{"a"},
+		WebhookName: "ci", FilterType: fleet.WebhookFilterRegex, Regex: ".*",
+	})
+
+	w := postWebhook(t, s, st, "nope", `{}`)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+	if b := drainBatch(s); b != nil {
+		t.Fatalf("no fire expected for an unknown name, got %+v", b)
+	}
+}
+
+func TestServeWebhook_EmptyName400(t *testing.T) {
+	s := newService()
+	st := webhookState()
+	// A bare "/" path → no name.
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(""))
+	orig := scheduleLoadState
+	scheduleLoadState = func() (*state.State, error) { return st, nil }
+	t.Cleanup(func() { scheduleLoadState = orig })
+	w := httptest.NewRecorder()
+	s.serveWebhook(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestServeWebhook_JSONPathMatchFires(t *testing.T) {
+	s := newService()
+	st := webhookState(fleet.Trigger{
+		Name: "deploy", Type: fleet.TriggerWebhook, AgentNames: []string{"a"},
+		WebhookName: "deploy", FilterType: fleet.WebhookFilterJSONPath,
+		JSONPath: "$.ref", JSONValue: "refs/heads/main",
+	})
+
+	w := postWebhook(t, s, st, "deploy", `{"ref":"refs/heads/main","after":"abc"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if b := drainBatch(s); len(b) != 1 || b[0].trigger.Name != "deploy" {
+		t.Fatalf("expected the deploy trigger to fire, got %+v", b)
+	}
+}
+
+func TestServeWebhook_FiresAllFleetsWithName(t *testing.T) {
+	s := newService()
+	st := &state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Settings: fleet.FleetSettings{
+			Agents:   []fleet.Agent{{Name: "a"}},
+			Triggers: []fleet.Trigger{{Name: "t", Type: fleet.TriggerWebhook, AgentNames: []string{"a"}, WebhookName: "shared", FilterType: fleet.WebhookFilterRegex, Regex: ".*"}},
+		}},
+		"beta": {Name: "beta", Settings: fleet.FleetSettings{
+			Agents:   []fleet.Agent{{Name: "a"}},
+			Triggers: []fleet.Trigger{{Name: "t", Type: fleet.TriggerWebhook, AgentNames: []string{"a"}, WebhookName: "shared", FilterType: fleet.WebhookFilterRegex, Regex: ".*"}},
+		}},
+	}}
+
+	w := postWebhook(t, s, st, "shared", `anything`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	// All matches for one request arrive as a SINGLE batch (atomic enqueue).
+	b := drainBatch(s)
+	if len(b) != 2 {
+		t.Fatalf("expected a 2-trigger batch, got %v", b)
+	}
+	fleets := map[string]bool{b[0].fleet: true, b[1].fleet: true}
+	if !fleets["alpha"] || !fleets["beta"] {
+		t.Fatalf("expected fires for both fleets, got %v", fleets)
+	}
+}
+
+// TestServeWebhook_MultiFleetSelectiveFilter confirms that when two fleets carry
+// the same webhook name but different filters, only the trigger whose filter
+// actually matches the event fires (selective routing, not fire-everything).
+func TestServeWebhook_MultiFleetSelectiveFilter(t *testing.T) {
+	s := newService()
+	st := &state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Settings: fleet.FleetSettings{
+			Agents:   []fleet.Agent{{Name: "a"}},
+			Triggers: []fleet.Trigger{{Name: "t", Type: fleet.TriggerWebhook, AgentNames: []string{"a"}, WebhookName: "shared", FilterType: fleet.WebhookFilterJSONPath, JSONPath: "$.env", JSONValue: "prod"}},
+		}},
+		"beta": {Name: "beta", Settings: fleet.FleetSettings{
+			Agents:   []fleet.Agent{{Name: "a"}},
+			Triggers: []fleet.Trigger{{Name: "t", Type: fleet.TriggerWebhook, AgentNames: []string{"a"}, WebhookName: "shared", FilterType: fleet.WebhookFilterJSONPath, JSONPath: "$.env", JSONValue: "staging"}},
+		}},
+	}}
+
+	// env=prod matches only alpha's trigger.
+	w := postWebhook(t, s, st, "shared", `{"env":"prod"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	b := drainBatch(s)
+	if len(b) != 1 || b[0].fleet != "alpha" {
+		t.Fatalf("only alpha's prod trigger should fire, got %+v", b)
+	}
+}
+
+// TestServeWebhook_MultiTriggerShedIsAtomic confirms a request with MULTIPLE
+// matching triggers enqueues all-or-nothing: when the scheduler can't accept the
+// batch, the handler returns 503 and NOTHING is enqueued — so a sender retry can't
+// double-fire a trigger that "partially" went through (the bug the batch design
+// prevents).
+func TestServeWebhook_MultiTriggerShedIsAtomic(t *testing.T) {
+	s := &service{webhookFires: make(chan []webhookFire)} // unbuffered, no drainer
+	st := &state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Settings: fleet.FleetSettings{
+			Agents:   []fleet.Agent{{Name: "a"}},
+			Triggers: []fleet.Trigger{{Name: "t", Type: fleet.TriggerWebhook, AgentNames: []string{"a"}, WebhookName: "shared", FilterType: fleet.WebhookFilterRegex, Regex: ".*"}},
+		}},
+		"beta": {Name: "beta", Settings: fleet.FleetSettings{
+			Agents:   []fleet.Agent{{Name: "a"}},
+			Triggers: []fleet.Trigger{{Name: "t", Type: fleet.TriggerWebhook, AgentNames: []string{"a"}, WebhookName: "shared", FilterType: fleet.WebhookFilterRegex, Regex: ".*"}},
+		}},
+	}}
+	orig := scheduleLoadState
+	scheduleLoadState = func() (*state.State, error) { return st, nil }
+	t.Cleanup(func() { scheduleLoadState = orig })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest(http.MethodPost, "/shared", strings.NewReader("x")).WithContext(ctx)
+	w := httptest.NewRecorder()
+	s.serveWebhook(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", w.Code)
+	}
+	if b := drainBatch(s); b != nil {
+		t.Fatalf("a shed request must enqueue NOTHING (no partial fire), got %+v", b)
+	}
+}
+
+func TestServeWebhook_SchedulerBusy503(t *testing.T) {
+	// Unbuffered channel with no drainer + an already-cancelled request context:
+	// enqueueWebhookFires can't hand off and the ctx.Done branch wins deterministically.
+	s := &service{webhookFires: make(chan []webhookFire)}
+	st := webhookState(fleet.Trigger{
+		Name: "ci", Type: fleet.TriggerWebhook, AgentNames: []string{"a"},
+		WebhookName: "ci", FilterType: fleet.WebhookFilterRegex, Regex: ".*",
+	})
+	orig := scheduleLoadState
+	scheduleLoadState = func() (*state.State, error) { return st, nil }
+	t.Cleanup(func() { scheduleLoadState = orig })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest(http.MethodPost, "/ci", strings.NewReader("x")).WithContext(ctx)
+	w := httptest.NewRecorder()
+	s.serveWebhook(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestServeWebhook_BodyTooLarge(t *testing.T) {
+	s := newService()
+	st := webhookState(fleet.Trigger{
+		Name: "ci", Type: fleet.TriggerWebhook, AgentNames: []string{"a"},
+		WebhookName: "ci", FilterType: fleet.WebhookFilterRegex, Regex: ".*",
+	})
+	orig := scheduleLoadState
+	scheduleLoadState = func() (*state.State, error) { return st, nil }
+	t.Cleanup(func() { scheduleLoadState = orig })
+
+	big := strings.Repeat("x", maxWebhookBodySize+1)
+	req := httptest.NewRequest(http.MethodPost, "/ci", strings.NewReader(big))
+	w := httptest.NewRecorder()
+	s.serveWebhook(w, req)
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", w.Code)
+	}
+}

--- a/internal/state/remote_mcp_settings.go
+++ b/internal/state/remote_mcp_settings.go
@@ -30,4 +30,12 @@ type RemoteMcpSettings struct {
 	// When off, fleetd does not negotiate the grpc tunnel feature, so the
 	// gateway rejects any incoming gRPC commands aimed at this daemon.
 	FleetEnabled bool `json:"fleet_enabled,omitempty"`
+
+	// WebhookEnabled ("Enable Webhook") exposes this daemon's automation webhook
+	// endpoint through the gateway so a remote system can POST to
+	// <public-url>/webhook/<name> and fire a matching webhook trigger's agents.
+	// When off, fleetd does not negotiate the webhook tunnel feature, so the
+	// gateway does not serve the webhook route for this daemon. Independent of
+	// Enabled/FleetEnabled — all three ride the SAME outbound tunnel.
+	WebhookEnabled bool `json:"webhook_enabled,omitempty"`
 }

--- a/internal/tui/automation_test.go
+++ b/internal/tui/automation_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	tea "github.com/charmbracelet/bubbletea"
@@ -130,17 +131,53 @@ func TestVisibleTriggerRowsByType(t *testing.T) {
 		t.Fatalf("schedule rows wrong: %v", rows)
 	}
 
+	// The webhook URL row shows only for webhook triggers.
+	if slices.Contains(rows, trigRowWebhookURL) {
+		t.Fatalf("schedule trigger should not show the webhook URL row: %v", rows)
+	}
+
 	st.triggerType = fleet.TriggerWebhook
 	st.filterType = fleet.WebhookFilterRegex
 	rows = fp.visibleTriggerRows(m)
 	if !slices.Contains(rows, trigRowRegex) || slices.Contains(rows, trigRowCron) || slices.Contains(rows, trigRowJSONPath) {
 		t.Fatalf("webhook+regex rows wrong: %v", rows)
 	}
+	if !slices.Contains(rows, trigRowWebhookURL) {
+		t.Fatalf("webhook trigger should show the URL row: %v", rows)
+	}
 
 	st.filterType = fleet.WebhookFilterJSONPath
 	rows = fp.visibleTriggerRows(m)
 	if !slices.Contains(rows, trigRowJSONPath) || !slices.Contains(rows, trigRowJSONValue) || slices.Contains(rows, trigRowRegex) {
 		t.Fatalf("webhook+jsonpath rows wrong: %v", rows)
+	}
+}
+
+// TestTriggerWebhookURL confirms the dialog builds a copy-pasteable webhook URL
+// from the gateway-assigned base + the (escaped) name, and returns "" when either
+// piece is missing.
+func TestTriggerWebhookURL(t *testing.T) {
+	m, _ := newAutomationModel(t)
+
+	// No base URL yet (webhook not connected) → empty regardless of name.
+	if got := triggerWebhookURL(m, "deploy"); got != "" {
+		t.Fatalf("URL should be empty with no gateway base, got %q", got)
+	}
+
+	m.remoteMcpStatus = &fleetgrpc.RemoteMcpStatus{
+		State:            fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
+		PublicWebhookUrl: "https://gw.example.com/webhook/abc123",
+	}
+	if got, want := triggerWebhookURL(m, "deploy"), "https://gw.example.com/webhook/abc123/deploy"; got != want {
+		t.Fatalf("URL = %q, want %q", got, want)
+	}
+	// A name with a space is percent-escaped so the URL stays valid.
+	if got, want := triggerWebhookURL(m, "my hook"), "https://gw.example.com/webhook/abc123/my%20hook"; got != want {
+		t.Fatalf("escaped URL = %q, want %q", got, want)
+	}
+	// Empty name → empty (the row shows a hint instead).
+	if got := triggerWebhookURL(m, "  "); got != "" {
+		t.Fatalf("URL should be empty with a blank name, got %q", got)
 	}
 }
 

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -536,9 +536,10 @@ func configToProto(c *configutil.Config) *fleetgrpc.Config {
 		Codespaces: &fleetgrpc.CodespacesSettings{},
 		Browser:    &fleetgrpc.BrowserSettings{},
 		RemoteMcp: &fleetgrpc.RemoteMcpSettings{
-			Enabled:      c.RemoteMcpSettings.Enabled,
-			GatewayUrl:   c.RemoteMcpSettings.GatewayURL,
-			FleetEnabled: c.RemoteMcpSettings.FleetEnabled,
+			Enabled:        c.RemoteMcpSettings.Enabled,
+			GatewayUrl:     c.RemoteMcpSettings.GatewayURL,
+			FleetEnabled:   c.RemoteMcpSettings.FleetEnabled,
+			WebhookEnabled: c.RemoteMcpSettings.WebhookEnabled,
 		},
 		DefaultBackend: backendStringToProto(c.DefaultBackend),
 	}
@@ -830,6 +831,7 @@ func protoConfigToLegacy(pc *fleetgrpc.Config) *configutil.Config {
 		c.RemoteMcpSettings.Enabled = rm.GetEnabled()
 		c.RemoteMcpSettings.GatewayURL = rm.GetGatewayUrl()
 		c.RemoteMcpSettings.FleetEnabled = rm.GetFleetEnabled()
+		c.RemoteMcpSettings.WebhookEnabled = rm.GetWebhookEnabled()
 	}
 	c.DefaultBackend = backendProtoToString(pc.GetDefaultBackend())
 	return c

--- a/internal/tui/dialog_automation_trigger.go
+++ b/internal/tui/dialog_automation_trigger.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
@@ -24,6 +25,7 @@ const (
 	trigRowPrompt
 	trigRowCron
 	trigRowWebhookName
+	trigRowWebhookURL
 	trigRowFilterType
 	trigRowRegex
 	trigRowJSONPath
@@ -120,7 +122,7 @@ func (fleetPage *fleetPage) visibleTriggerRows(m *model) []int {
 	}
 	rows = append(rows, trigRowPrompt)
 	if st.triggerType == fleet.TriggerWebhook {
-		rows = append(rows, trigRowWebhookName, trigRowFilterType)
+		rows = append(rows, trigRowWebhookName, trigRowWebhookURL, trigRowFilterType)
 		if st.filterType == fleet.WebhookFilterJSONPath {
 			rows = append(rows, trigRowJSONPath, trigRowJSONValue)
 		} else {
@@ -216,12 +218,58 @@ func (fleetPage *fleetPage) triggerRowEnter(m *model) tea.Cmd {
 		fleetPage.cycleTriggerType()
 	case st.row == trigRowFilterType:
 		fleetPage.cycleFilterType()
+	case st.row == trigRowWebhookURL:
+		return fleetPage.copyTriggerWebhookURL(m)
 	case st.row >= trigRowAgentBase:
 		fleetPage.toggleTriggerAgent(m)
 	case st.row == trigRowSave:
 		return fleetPage.saveAutomationTrigger(m)
 	}
 	return nil
+}
+
+// copyTriggerWebhookURL copies this webhook trigger's full gateway URL to the
+// clipboard. It needs both a live gateway-assigned base URL (webhook enabled +
+// tunnel connected) and a webhook name to form a complete address.
+func (fleetPage *fleetPage) copyTriggerWebhookURL(m *model) tea.Cmd {
+	url := triggerWebhookURL(m, fleetPage.triggerDlg.webhookName)
+	if url == "" {
+		if remoteWebhookBaseURL(m) == "" {
+			m.message = "No webhook URL yet — enable Webhook in Settings and connect to the gateway"
+		} else {
+			m.message = "Set a webhook name first"
+		}
+		return nil
+	}
+	m.message = "Webhook URL copied to clipboard"
+	return copyToClipboardCmd(url)
+}
+
+// triggerWebhookURL builds the full webhook URL for a trigger: the gateway-
+// assigned base + "/" + the (path-escaped) name. Empty when either piece is
+// missing. The name is escaped so a name with spaces/specials yields a valid,
+// copy-pasteable URL; fleetd percent-decodes it back to the raw name on delivery.
+func triggerWebhookURL(m *model, name string) string {
+	base := remoteWebhookBaseURL(m)
+	name = strings.TrimSpace(name)
+	if base == "" || name == "" {
+		return ""
+	}
+	return strings.TrimRight(base, "/") + "/" + url.PathEscape(name)
+}
+
+// webhookURLDisplay renders the URL row's value: the full copy-pasteable URL once
+// both the gateway base and a name exist, or a dim hint explaining what's still
+// missing. The base only appears once the user enabled Webhook in Settings AND
+// the gateway tunnel connected (it is a server-pushed computed value).
+func webhookURLDisplay(m *model, name string) string {
+	if remoteWebhookBaseURL(m) == "" {
+		return dimStyle.Render("(enable Webhook in Settings; the URL appears once the gateway connects)")
+	}
+	if strings.TrimSpace(name) == "" {
+		return dimStyle.Render("(set a webhook name above)")
+	}
+	return triggerWebhookURL(m, name) + "  " + dimStyle.Render("press enter to copy")
 }
 
 // triggerRowToggle is space: toggle an agent or cycle a selector; otherwise it
@@ -466,6 +514,7 @@ func (fleetPage *fleetPage) renderAutomationTriggerDialog(m *model) string {
 
 	if st.triggerType == fleet.TriggerWebhook {
 		fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowWebhookName), dialogLabel.Render("Webhook:"), field(trigRowWebhookName, st.webhookName, "name (appended to gateway URL)"))
+		fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowWebhookURL), dialogLabel.Render("URL:    "), webhookURLDisplay(m, st.webhookName))
 		fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowFilterType), dialogLabel.Render("Filter: "), selectorLabel(filterTypeLabel(st.filterType)))
 		if st.filterType == fleet.WebhookFilterJSONPath {
 			fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowJSONPath), dialogLabel.Render("JSON path:"), field(trigRowJSONPath, st.jsonPath, "e.g. $.action (required)"))
@@ -512,6 +561,9 @@ func automationTriggerHint(fieldActive bool, row int) string {
 	}
 	if row >= trigRowAgentBase {
 		return "[j/k] Move  [space] Toggle agent  [enter] Edit/Cycle  [q/esc] Cancel"
+	}
+	if row == trigRowWebhookURL {
+		return "[j/k] Move  [enter] Copy URL  [q/esc] Cancel"
 	}
 	return "[j/k] Move  [enter] Edit/Toggle  [h/l] Cycle  [q/esc] Cancel"
 }

--- a/internal/tui/page_settings.go
+++ b/internal/tui/page_settings.go
@@ -43,14 +43,16 @@ const (
 	settingsItemBrowserMultiple   = 600 // browser settings start here
 	settingsItemBrowserAutoSwitch = 601
 
-	settingsItemRemoteMcpEnabled    = 700 // fleet remote (MCP) settings start here
-	settingsItemRemoteMcpGatewayURL = 701
-	settingsItemRemoteMcpCopyLocal  = 702 // copy local mcp.json snippet to clipboard
-	settingsItemRemoteMcpCopyRemote = 703 // copy gateway mcp.json snippet to clipboard
-	settingsItemRemoteFleetEnabled  = 704 // expose the gRPC control surface through the gateway
-	settingsItemRemoteMcpPublicURL  = 705 // copy the gateway-assigned public MCP URL
-	settingsItemRemoteGrpcPublicURL = 706 // copy the gateway-assigned public gRPC URL
-	settingsItemRemoteMcpToken      = 707 // copy the bearer token (~/.fleet/mcp.token)
+	settingsItemRemoteMcpEnabled       = 700 // fleet remote (MCP) settings start here
+	settingsItemRemoteMcpGatewayURL    = 701
+	settingsItemRemoteMcpCopyLocal     = 702 // copy local mcp.json snippet to clipboard
+	settingsItemRemoteMcpCopyRemote    = 703 // copy gateway mcp.json snippet to clipboard
+	settingsItemRemoteFleetEnabled     = 704 // expose the gRPC control surface through the gateway
+	settingsItemRemoteMcpPublicURL     = 705 // copy the gateway-assigned public MCP URL
+	settingsItemRemoteGrpcPublicURL    = 706 // copy the gateway-assigned public gRPC URL
+	settingsItemRemoteMcpToken         = 707 // copy the bearer token (~/.fleet/mcp.token)
+	settingsItemRemoteWebhookEnabled   = 708 // expose the automation webhook endpoint through the gateway
+	settingsItemRemoteWebhookPublicURL = 709 // copy the gateway-assigned public webhook base URL
 
 	// Fleet armada: the "+ Remote Fleet" button has a fixed id; registered
 	// remotes get base+i. The base is placed FAR above every other block (and
@@ -78,7 +80,8 @@ func isArmadaRemoteItem(item int) bool { return item >= settingsItemArmadaBase }
 func isCopyRow(item int) bool {
 	switch item {
 	case settingsItemRemoteMcpCopyLocal, settingsItemRemoteMcpCopyRemote,
-		settingsItemRemoteMcpPublicURL, settingsItemRemoteGrpcPublicURL, settingsItemRemoteMcpToken:
+		settingsItemRemoteMcpPublicURL, settingsItemRemoteGrpcPublicURL, settingsItemRemoteMcpToken,
+		settingsItemRemoteWebhookPublicURL:
 		return true
 	}
 	return false
@@ -153,9 +156,10 @@ const (
 // bounce it). Declared locally because the TUI must not import internal/state
 // and configutil doesn't alias the RemoteMcpSettings type.
 type remoteSettingsSnapshot struct {
-	mcpEnabled   bool
-	fleetEnabled bool
-	gatewayURL   string
+	mcpEnabled     bool
+	fleetEnabled   bool
+	webhookEnabled bool
+	gatewayURL     string
 }
 
 // snapshotRemoteSettings extracts the tunnel-relevant settings from config.
@@ -164,9 +168,10 @@ func snapshotRemoteSettings(config *configutil.Config) remoteSettingsSnapshot {
 		return remoteSettingsSnapshot{}
 	}
 	return remoteSettingsSnapshot{
-		mcpEnabled:   config.RemoteMcpSettings.Enabled,
-		fleetEnabled: config.RemoteMcpSettings.FleetEnabled,
-		gatewayURL:   config.RemoteMcpSettings.GatewayURL,
+		mcpEnabled:     config.RemoteMcpSettings.Enabled,
+		fleetEnabled:   config.RemoteMcpSettings.FleetEnabled,
+		webhookEnabled: config.RemoteMcpSettings.WebhookEnabled,
+		gatewayURL:     config.RemoteMcpSettings.GatewayURL,
 	}
 }
 
@@ -309,12 +314,15 @@ var settingsSections = []settingsSection{
 			if m.config != nil && m.config.RemoteMcpSettings.Enabled {
 				items = append(items, settingsItemRemoteMcpCopyRemote)
 			}
-			items = append(items, settingsItemRemoteMcpEnabled, settingsItemRemoteFleetEnabled, settingsItemRemoteMcpGatewayURL)
+			items = append(items, settingsItemRemoteMcpEnabled, settingsItemRemoteFleetEnabled, settingsItemRemoteWebhookEnabled, settingsItemRemoteMcpGatewayURL)
 			if m.config != nil && m.config.RemoteMcpSettings.Enabled {
 				items = append(items, settingsItemRemoteMcpPublicURL)
 			}
 			if m.config != nil && m.config.RemoteMcpSettings.FleetEnabled {
 				items = append(items, settingsItemRemoteGrpcPublicURL)
+			}
+			if m.config != nil && m.config.RemoteMcpSettings.WebhookEnabled {
+				items = append(items, settingsItemRemoteWebhookPublicURL)
 			}
 			if m.config != nil && (m.config.RemoteMcpSettings.Enabled || m.config.RemoteMcpSettings.FleetEnabled) {
 				items = append(items, settingsItemRemoteMcpToken)
@@ -587,6 +595,38 @@ func (settingsPage *settingsPage) toggleRemoteFleetEnabled(m *model) {
 	m.message = fmt.Sprintf("Remote Fleet set to %s", label)
 }
 
+// toggleRemoteWebhookEnabled flips the "Enable Webhook" preference — exposing
+// this daemon's automation webhook endpoint through the gateway so remote systems
+// can POST events to <public-url>/webhook/<name> — and saves. Like the Remote
+// Fleet toggle it sits ABOVE the rows it reveals/hides (only the Public Webhook
+// URL row, further down), so this row's index is preserved and no cursor re-pin
+// is needed. Reverts on a failed save (unless the failure is the expected tunnel
+// bounce from a remote client).
+func (settingsPage *settingsPage) toggleRemoteWebhookEnabled(m *model) {
+	if m.config == nil {
+		m.config = configutil.DefaultConfig()
+	}
+	current := m.config.RemoteMcpSettings.WebhookEnabled
+	next := !current
+	m.config.RemoteMcpSettings.WebhookEnabled = next
+	if err := setConfigRemote(m.config); err != nil {
+		if settingsPage.remoteSaveBounced(m, err) {
+			settingsPage.serverRemote = snapshotRemoteSettings(m.config)
+			m.message = remoteSettingsSavedMsg
+			return
+		}
+		m.config.RemoteMcpSettings.WebhookEnabled = current
+		m.message = fmt.Sprintf("Failed to save settings: %v", err)
+		return
+	}
+	settingsPage.serverRemote = snapshotRemoteSettings(m.config)
+	label := "off"
+	if next {
+		label = "on"
+	}
+	m.message = fmt.Sprintf("Webhook set to %s", label)
+}
+
 // toggleAutoInstall toggles the dotfiles auto-install setting.
 func (settingsPage *settingsPage) toggleAutoInstall(m *model) {
 	if m.config == nil {
@@ -740,6 +780,45 @@ func remoteGrpcStatusValue(m *model) string {
 	}
 }
 
+// remoteWebhookBaseURL returns the live gateway-assigned Public Webhook base URL,
+// or "" when the tunnel is not (yet) connected or the gateway withheld it. The
+// full URL for a webhook trigger is this base + "/" + the trigger's webhook name.
+func remoteWebhookBaseURL(m *model) string {
+	if m.remoteMcpStatus == nil {
+		return ""
+	}
+	return m.remoteMcpStatus.GetPublicWebhookUrl()
+}
+
+// remoteWebhookStatusValue renders the Public Webhook URL line from the same
+// pushed tunnel status as remoteMcpStatusValue (one tunnel carries every traffic
+// kind, so they share connection state). A connected tunnel with no webhook URL
+// means the gateway withheld it — it is old, or registered this session before
+// webhooks were enabled (the reconnect that negotiates webhook refreshes it).
+func remoteWebhookStatusValue(m *model) string {
+	st := m.remoteMcpStatus
+	if st == nil {
+		return dimStyle.Render("(not connected)")
+	}
+	switch st.GetState() {
+	case fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED:
+		if url := st.GetPublicWebhookUrl(); url != "" {
+			return statusRunningStyle.Render("connected") + "  " + url
+		}
+		return statusRunningStyle.Render("connected") + "  " + dimStyle.Render("(gateway provided no public webhook URL)")
+	case fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTING:
+		return m.spinner.View() + " connecting…"
+	case fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_ERROR:
+		msg := st.GetError()
+		if msg == "" {
+			msg = "connection failed"
+		}
+		return statusCreatingStyle.Render("error") + "  " + dimStyle.Render(msg)
+	default: // UNSPECIFIED / not yet connected
+		return dimStyle.Render("(not connected)")
+	}
+}
+
 // localMcpConfigJSON returns the mcp.json snippet for the loopback MCP server,
 // matching the README. It uses the ${FLEET_MCP_URL}/${FLEET_MCP_TOKEN} env vars
 // written to ~/.fleet/mcp.env so the snippet survives port changes.
@@ -850,6 +929,8 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 				settingsPage.toggleRemoteMcpEnabled(m)
 			} else if item == settingsItemRemoteFleetEnabled {
 				settingsPage.toggleRemoteFleetEnabled(m)
+			} else if item == settingsItemRemoteWebhookEnabled {
+				settingsPage.toggleRemoteWebhookEnabled(m)
 			} else if item == settingsItemCoderPreset {
 				settingsPage.cycleCoderPreset(m, -1)
 			} else if item == settingsItemCodespacesMachine {
@@ -878,6 +959,8 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 				settingsPage.toggleRemoteMcpEnabled(m)
 			} else if item == settingsItemRemoteFleetEnabled {
 				settingsPage.toggleRemoteFleetEnabled(m)
+			} else if item == settingsItemRemoteWebhookEnabled {
+				settingsPage.toggleRemoteWebhookEnabled(m)
 			} else if item == settingsItemCoderPreset {
 				settingsPage.cycleCoderPreset(m, 1)
 			} else if item == settingsItemCodespacesMachine {
@@ -921,6 +1004,10 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 				settingsPage.toggleRemoteFleetEnabled(m)
 				return nil
 			}
+			if item == settingsItemRemoteWebhookEnabled {
+				settingsPage.toggleRemoteWebhookEnabled(m)
+				return nil
+			}
 			if item == settingsItemRemoteMcpCopyLocal {
 				m.message = "Local MCP config copied to clipboard"
 				return copyToClipboardCmd(localMcpConfigJSON())
@@ -950,6 +1037,15 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 					return nil
 				}
 				m.message = "Public GRPC URL copied to clipboard"
+				return copyToClipboardCmd(url)
+			}
+			if item == settingsItemRemoteWebhookPublicURL {
+				url := remoteWebhookBaseURL(m)
+				if url == "" {
+					m.message = "No public webhook URL yet — connect to the gateway first"
+					return nil
+				}
+				m.message = "Public webhook URL copied to clipboard"
 				return copyToClipboardCmd(url)
 			}
 			if item == settingsItemRemoteMcpToken {
@@ -1504,6 +1600,14 @@ func (settingsPage *settingsPage) viewSettings(m *model) string {
 			recordRow(settingsItemRemoteFleetEnabled, settingsPage.renderSettingsRow(m, currentItem == settingsItemRemoteFleetEnabled, "Enable Remote Fleet", fleetEnabledValue))
 			listContent.WriteString("\n")
 
+			webhookEnabledValue := "[ off ]"
+			if config.RemoteMcpSettings.WebhookEnabled {
+				webhookEnabledValue = "[ on ]"
+			}
+			webhookEnabledValue += "\n" + strings.Repeat(" ", 21) + dimStyle.Render("Expose automation webhook triggers at the gateway public url so remote systems can fire them")
+			recordRow(settingsItemRemoteWebhookEnabled, settingsPage.renderSettingsRow(m, currentItem == settingsItemRemoteWebhookEnabled, "Enable Webhook", webhookEnabledValue))
+			listContent.WriteString("\n")
+
 			gatewayValue := config.RemoteMcpSettings.GatewayURL
 			if gatewayValue == "" && !(settingsPage.editing && currentItem == settingsItemRemoteMcpGatewayURL) {
 				gatewayValue = dimStyle.Render("(not set)")
@@ -1533,6 +1637,14 @@ func (settingsPage *settingsPage) viewSettings(m *model) string {
 					grpcValue += "  " + dimStyle.Render("press enter to copy")
 				}
 				recordRow(settingsItemRemoteGrpcPublicURL, settingsPage.renderSettingsRow(m, currentItem == settingsItemRemoteGrpcPublicURL, "Public GRPC URL", grpcValue))
+			}
+			if config.RemoteMcpSettings.WebhookEnabled {
+				listContent.WriteString("\n")
+				webhookValue := remoteWebhookStatusValue(m)
+				if remoteWebhookBaseURL(m) != "" {
+					webhookValue += "  " + dimStyle.Render("press enter to copy base URL")
+				}
+				recordRow(settingsItemRemoteWebhookPublicURL, settingsPage.renderSettingsRow(m, currentItem == settingsItemRemoteWebhookPublicURL, "Public Webhook URL", webhookValue))
 			}
 			if config.RemoteMcpSettings.Enabled || config.RemoteMcpSettings.FleetEnabled {
 				listContent.WriteString("\n")

--- a/internal/tui/page_settings_test.go
+++ b/internal/tui/page_settings_test.go
@@ -496,6 +496,108 @@ func TestRemoteGrpcStatusValueRendersStates(t *testing.T) {
 // TestToggleRemoteFleetEnabledPersists confirms pressing enter on the Enable
 // Remote Fleet row flips the setting and persists it through the
 // setConfigRemote seam, leaving the MCP toggle untouched.
+// TestSettingsSectionIncludesRemoteWebhook confirms the "Enable Webhook" toggle
+// is navigable under the remote toggles and that the navigable Public Webhook URL
+// copy row renders once the feature is enabled.
+func TestSettingsSectionIncludesRemoteWebhook(t *testing.T) {
+	sp := newSettingsPage()
+	cfg := state.DefaultConfig()
+	cfg.RemoteMcpSettings.WebhookEnabled = true
+	m := &model{config: cfg, toolStatus: allToolsFound(), spinner: spinner.New(), width: 120}
+
+	items := sp.visibleItems(m)
+	if !slices.Contains(items, settingsItemRemoteWebhookEnabled) {
+		t.Fatal("webhook toggle missing from settings nav")
+	}
+	if !slices.Contains(items, settingsItemRemoteWebhookPublicURL) {
+		t.Fatal("Public Webhook URL row missing when webhook is enabled")
+	}
+
+	out := sp.viewSettings(m)
+	if !strings.Contains(out, "Enable Webhook") {
+		t.Fatal("settings view missing the Enable Webhook row")
+	}
+	if !strings.Contains(out, "Public Webhook URL") {
+		t.Fatal("settings view missing the computed Public Webhook URL row when enabled")
+	}
+
+	// Disabled: the URL row is hidden, the toggle stays.
+	m.config.RemoteMcpSettings.WebhookEnabled = false
+	items = sp.visibleItems(m)
+	if !slices.Contains(items, settingsItemRemoteWebhookEnabled) {
+		t.Fatal("webhook toggle should always be navigable")
+	}
+	if slices.Contains(items, settingsItemRemoteWebhookPublicURL) {
+		t.Fatal("Public Webhook URL row must be hidden while webhook is disabled")
+	}
+}
+
+// TestCopyRemoteWebhookURL confirms enter on the Public Webhook URL row copies the
+// raw gateway-assigned base URL, and no-ops with guidance when none is assigned.
+func TestCopyRemoteWebhookURL(t *testing.T) {
+	sp := newSettingsPage()
+	cfg := state.DefaultConfig()
+	cfg.RemoteMcpSettings.WebhookEnabled = true
+	m := &model{config: cfg, toolStatus: allToolsFound(), currentPage: sp, fleetPage: newFleetPage(), spinner: spinner.New()}
+
+	// No status yet: enter copies nothing and explains why.
+	sp.cursor = settingsPositionOf(sp, m, settingsItemRemoteWebhookPublicURL)
+	if cmd := sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter}); cmd != nil {
+		t.Fatal("enter on Public Webhook URL with no URL should not copy")
+	}
+	if !strings.Contains(m.message, "No public webhook URL") {
+		t.Fatalf("missing webhook guidance message, got %q", m.message)
+	}
+
+	// Connected with an assigned URL: the row copies the raw base URL.
+	const webhookURL = "https://gw.example.com/webhook/abc123"
+	m.remoteMcpStatus = &fleetgrpc.RemoteMcpStatus{
+		State:            fleetgrpc.RemoteMcpConn_REMOTE_MCP_CONN_CONNECTED,
+		PublicWebhookUrl: webhookURL,
+	}
+	sp.cursor = settingsPositionOf(sp, m, settingsItemRemoteWebhookPublicURL)
+	if got := capturedClipboard(t, sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter})); got != webhookURL {
+		t.Fatalf("Public Webhook URL copied %q, want the raw URL %q", got, webhookURL)
+	}
+	if !strings.Contains(m.message, "Public webhook URL copied") {
+		t.Fatalf("missing webhook copy confirmation, got %q", m.message)
+	}
+}
+
+// TestToggleRemoteWebhookEnabledPersists confirms pressing enter on the Enable
+// Webhook row flips the setting and persists it through the setConfigRemote seam,
+// without disturbing the other remote toggles.
+func TestToggleRemoteWebhookEnabledPersists(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	origSetConfig := setConfigRemote
+	setConfigRemote = func(c *state.Config) error { return state.SaveConfig(c) }
+	defer func() { setConfigRemote = origSetConfig }()
+
+	sp := newSettingsPage()
+	m := &model{config: state.DefaultConfig(), toolStatus: allToolsFound(), currentPage: sp, fleetPage: newFleetPage(), spinner: spinner.New()}
+	sp.cursor = settingsPositionOf(sp, m, settingsItemRemoteWebhookEnabled)
+
+	sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if !m.config.RemoteMcpSettings.WebhookEnabled {
+		t.Fatal("webhook enabled should be true after toggle")
+	}
+	if m.config.RemoteMcpSettings.Enabled || m.config.RemoteMcpSettings.FleetEnabled {
+		t.Fatal("toggling webhook must not flip the other remote surfaces")
+	}
+	loaded, err := state.LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !loaded.RemoteMcpSettings.WebhookEnabled {
+		t.Fatal("toggle did not persist to disk")
+	}
+	if got := sp.settingsCursorItem(m); got != settingsItemRemoteWebhookEnabled {
+		t.Fatalf("cursor slid off the webhook toggle: got item %d", got)
+	}
+}
+
 func TestToggleRemoteFleetEnabledPersists(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/tunnel/tag.go
+++ b/internal/tunnel/tag.go
@@ -6,9 +6,12 @@ import "io"
 // negotiated. Every yamux stream the gateway opens then begins with a single TAG
 // byte that tells fleetd how to handle the rest of the stream:
 //
-//	TagMCP  → the stream carries an HTTP request for the loopback MCP server.
-//	TagGRPC → the stream carries a raw native-gRPC (HTTP/2) connection that fleetd
-//	          splices to its gRPC server.
+//	TagMCP     → the stream carries an HTTP request for the loopback MCP server.
+//	TagGRPC    → the stream carries a raw native-gRPC (HTTP/2) connection that fleetd
+//	             splices to its gRPC server.
+//	TagWebhook → the stream carries an HTTP request for the automation webhook
+//	             receiver (an inbound POST the gateway accepted at
+//	             <public-url>/webhook/<name>).
 //
 // The gateway writes the tag as the FIRST bytes of the stream, before relaying
 // any client/payload bytes, so fleetd can read it immediately without sniffing
@@ -17,11 +20,13 @@ import "io"
 // RegisterRequest/RegisterReply handshake.
 //
 // Because an un-upgraded peer does not know about tags, tags are used ONLY when
-// FeatureGRPC is in the negotiated feature set (see tunnel.go); otherwise the
-// tunnel stays byte-for-byte the legacy MCP-only stream.
+// a tagging feature (FeatureGRPC or FeatureWebhook) is in the negotiated feature
+// set (see tunnel.go); otherwise the tunnel stays byte-for-byte the legacy
+// MCP-only stream.
 const (
-	TagMCP  byte = 0x00
-	TagGRPC byte = 0x01
+	TagMCP     byte = 0x00
+	TagGRPC    byte = 0x01
+	TagWebhook byte = 0x02
 )
 
 // WriteTag writes a single stream-type tag byte.

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -72,6 +72,14 @@ type RegisterReply struct {
 	// feature is negotiated AND the gateway is configured with a public gRPC base
 	// URL (--public-grpc-url); empty otherwise (incl. from an old gateway).
 	PublicGRPCURL string `json:"public_grpc_url,omitempty"`
+	// PublicWebhookURL is the gateway-assigned base URL for this daemon's
+	// automation webhooks (<public-url>/webhook/<id>). A webhook trigger's full
+	// URL is this base + "/" + the trigger's webhook name. Only set when the
+	// webhook feature is negotiated; empty otherwise (incl. from an old gateway).
+	// Unlike PublicGRPCURL it rides the SAME public base as the MCP URL (the
+	// gateway serves webhooks on its public HTTP listener), so no separate
+	// gateway base URL is needed.
+	PublicWebhookURL string `json:"public_webhook_url,omitempty"`
 	// SessionToken is a JWT, signed with the gateway's session key, encoding
 	// this session's ids. fleetd persists it with the session id and presents
 	// both on reconnect, so the session (and its public URL) survives a gateway
@@ -92,6 +100,14 @@ type RegisterReply struct {
 // it is in the negotiated set, the gateway tags each opened stream (see tag.go)
 // and serves the gRPC proxy route, and fleetd demuxes tagged streams.
 const FeatureGRPC = "grpc"
+
+// FeatureWebhook negotiates tunneling the daemon's automation webhook receiver
+// alongside MCP. When it is in the negotiated set, the gateway tags each opened
+// stream (see tag.go), serves the public /webhook/<id>/<name> route, and mints a
+// PublicWebhookURL; fleetd demuxes TagWebhook streams to its webhook receiver.
+// Like FeatureGRPC it forces the tagged-stream wire, so either feature alone is
+// enough to switch the tunnel into demux mode.
+const FeatureWebhook = "webhook"
 
 // RegisterMethod is the gRPC full-method fleetd opens (a bidi stream) on the
 // gateway's gRPC port to register and carry the reverse tunnel. The gateway's


### PR DESCRIPTION
Closes #193. Builds on the automation framework (#188), which modeled webhook triggers but explicitly deferred **delivery** — this PR wires it end to end.

## What it does
A remote system (CI, a SaaS webhook, `curl`) `POST`s an event to `<gateway-public-url>/webhook/<name>`, where `<name>` is a webhook trigger you defined. The gateway relays it down the existing reverse tunnel to fleetd, which finds every webhook trigger carrying that name (across all fleets), evaluates each trigger's filter against the event body, and fires the matching triggers' automation agents.

## Transport (rides the existing tunnel)
- **tunnel**: new `TagWebhook` stream tag, `FeatureWebhook` negotiation, `RegisterReply.PublicWebhookURL`.
- **gateway**: public `/webhook/{id}/{name}` route reverse-proxies down a `TagWebhook` stream; the route is **gated on per-session feature negotiation** (a daemon that didn't enable webhooks 404s, indistinguishable from an unknown id). The webhook base URL is minted from the gateway's existing public base — no new gateway flag, since webhooks ride the public HTTP listener.
- **server/remote**: the manager advertises `FeatureWebhook` when enabled; `serveTunnel` demuxes `TagWebhook` to a webhook `ChanListener`; the serve-decision now handles every `{mcp, grpc, webhook}` on/off combination, including **webhook-only**.

## Receiver + firing
`internal/server/webhook.go` routes `POST /<name>` → matches triggers → filters (regex over the body, or a strict dependency-free JSONPath subset) → hands the **whole matched set to the single-goroutine scheduler as one atomic batch**. The batch is the key design choice: webhook senders retry on non-2xx, so a partial enqueue (some fires in, then a 503) would re-fire the already-queued triggers on retry — one channel send per request makes it all-or-nothing. Webhook-spawned agents reuse the exact `watchedAgent` launch/idle-reap lifecycle as scheduled ones.

## Settings & trigger UI
- **Enable Webhook** toggle + a copyable **Public Webhook URL** row under *Settings → Fleet MCP* (mirrors *Enable Remote MCP* / *Enable Remote Fleet*).
- The trigger create/edit dialog renders the trigger's **full webhook URL** (base + escaped name), selectable for quick copy.

## Security
No auth on the webhook endpoint by design — same model as the gateway's MCP proxy: the unguessable public URL **is** the capability. The gateway only relays events for a session whose URL the user chose to share.

## Tests
Matcher unit tests (incl. malformed-path fail-closed), gateway feature gating, `serveTunnel` `TagWebhook` dispatch, manager negotiation + webhook-only reconnect, the webhook handler (name routing across fleets, filter selectivity, status codes, atomic shed), scheduler-consumes-fire, and a full `HTTPS → gateway → tunnel → fire` e2e. `go test ./...`, `go vet`, `golangci-lint` (0 issues, depguard boundary intact), and `-race` on the concurrency paths all pass.

A pre-merge adversarial multi-agent review drove several refinements: the atomic-batch enqueue, a strict (fail-closed) JSONPath tokenizer with config-time validation, and the added scheduler/reconnect/multi-fleet test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)