### PR TITLE
feat/automation-ux-tweaks Polish automation-mode UX (toggle, marker, $EDITOR)

### DIFF
--- a/fleetgrpc/domain.pb.go
+++ b/fleetgrpc/domain.pb.go
@@ -228,7 +228,12 @@ type Instance struct {
 	// finishes with warnings and clears it on the next successful create/start,
 	// so a TUI attaching AFTER the job finished still banners the warnings from a
 	// plain GetState/Watch snapshot (no dependency on the job-stream TTL).
-	Warnings      []string `protobuf:"bytes,13,rep,name=warnings,proto3" json:"warnings,omitempty"`
+	Warnings []string `protobuf:"bytes,13,rep,name=warnings,proto3" json:"warnings,omitempty"`
+	// Automated marks an instance the automation scheduler spawned for a trigger
+	// (issue #188). Plain bool: false == "not automated" == user-created, like the
+	// FleetSettings *Mount flags — the zero value carries the common case, so no
+	// optional is needed.
+	Automated     bool `protobuf:"varint,31,opt,name=automated,proto3" json:"automated,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -352,6 +357,13 @@ func (x *Instance) GetWarnings() []string {
 		return x.Warnings
 	}
 	return nil
+}
+
+func (x *Instance) GetAutomated() bool {
+	if x != nil {
+		return x.Automated
+	}
+	return false
 }
 
 // FleetSettings mirrors internal/fleet.FleetSettings. The three *Mount flags are
@@ -1022,7 +1034,7 @@ var File_domain_proto protoreflect.FileDescriptor
 
 const file_domain_proto_rawDesc = "" +
 	"\n" +
-	"\fdomain.proto\x12\tfleetgrpc\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc7\x04\n" +
+	"\fdomain.proto\x12\tfleetgrpc\x1a\x1fgoogle/protobuf/timestamp.proto\"\xe5\x04\n" +
 	"\bInstance\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12&\n" +
 	"\fdisplay_name\x18\x02 \x01(\tH\x00R\vdisplayName\x88\x01\x01\x12&\n" +
@@ -1038,7 +1050,8 @@ const file_domain_proto_rawDesc = "" +
 	" \x01(\tH\x05R\x03tag\x88\x01\x01\x12\x19\n" +
 	"\x05color\x18\v \x01(\tH\x06R\x05color\x88\x01\x01\x12\x1b\n" +
 	"\x06branch\x18\f \x01(\tH\aR\x06branch\x88\x01\x01\x12\x1a\n" +
-	"\bwarnings\x18\r \x03(\tR\bwarningsB\x0f\n" +
+	"\bwarnings\x18\r \x03(\tR\bwarnings\x12\x1c\n" +
+	"\tautomated\x18\x1f \x01(\bR\tautomatedB\x0f\n" +
 	"\r_display_nameB\x0f\n" +
 	"\r_container_idB\t\n" +
 	"\a_configB\x10\n" +

--- a/fleetgrpc/domain.proto
+++ b/fleetgrpc/domain.proto
@@ -130,6 +130,12 @@ message Instance {
   // plain GetState/Watch snapshot (no dependency on the job-stream TTL).
   repeated string warnings = 13;
 
+  // Automated marks an instance the automation scheduler spawned for a trigger
+  // (issue #188). Plain bool: false == "not automated" == user-created, like the
+  // FleetSettings *Mount flags — the zero value carries the common case, so no
+  // optional is needed.
+  bool automated = 31;
+
   // Reserved for forward/back compat across the version skew Hello tolerates.
   reserved 14 to 30;
 }

--- a/integration/tests/390_tui_automation_mode.sh
+++ b/integration/tests/390_tui_automation_mode.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Description: TUI automation mode (issue #188) — 'm' (or selecting the header's
-# [automations]/[instances] toggle with →/l and pressing enter) flips a fleet
-# between its instance view and its automation view (triggers + agents groups).
-# Adding an agent through the dialog persists it and shows it in the agents
-# group, and 'm' toggles back to the instance view.
+# mode-toggle icon, ↻/☰, with →/l and pressing enter) flips a fleet between its
+# instance view and its automation view (triggers + agents groups). Adding an
+# agent through the dialog persists it and shows it in the agents group, and 'm'
+# toggles back to the instance view.
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
@@ -17,9 +17,9 @@ tui_spawn
 tui_wait_for "alpha" 15
 
 # ===========================================
-# Instance view shows the [automations] toggle button.
+# Instance view shows the ↻ (→ automation) mode-toggle icon.
 # ===========================================
-tui_assert_contains "[automations]" "fleet header should offer the [automations] toggle"
+tui_assert_contains "↻" "fleet header should offer the ↻ automation toggle"
 
 # ===========================================
 # Keyboard selection: →/l focuses the header toggle and enter activates it,
@@ -30,18 +30,18 @@ info "selecting the toggle with 'l' and pressing enter to enter automation mode"
 tui_send l
 sleep 0.2
 tui_send Enter
-tui_wait_for "[instances]" 5
+tui_wait_for "☰" 5
 tui_assert_contains "triggers" "selecting the toggle + enter should open the automation view"
 
 info "pressing enter again to flip back to the instance view"
 tui_send Enter
-tui_wait_for "[automations]" 5
+tui_wait_for "↻" 5
 tui_assert_contains "alpha" "a second enter should return to the instance view"
 tui_send h   # deselect the toggle before the rest of the flow
 
 # ===========================================
 # 'm' switches the fleet to automation view: triggers + agents groups, the
-# "+ add" action rows, and the [instances] toggle.
+# "+ add" action rows, and the ☰ (→ instances) toggle.
 # ===========================================
 info "pressing 'm' to enter automation mode"
 tui_send m
@@ -49,7 +49,7 @@ tui_wait_for "triggers" 5
 tui_assert_contains "agents" "agents group header should be visible"
 tui_assert_contains "+ add trigger" "add-trigger action row missing"
 tui_assert_contains "+ add agent" "add-agent action row missing"
-tui_assert_contains "[instances]" "automation view should offer the [instances] toggle"
+tui_assert_contains "☰" "automation view should offer the ☰ instances toggle"
 
 # ===========================================
 # 'a' opens the add dialog for the group the cursor is in (not the add-instance
@@ -111,7 +111,7 @@ tui_wait_for "agents (0)" 10
 # ===========================================
 info "pressing 'm' to return to the instance view"
 tui_send m
-tui_wait_for "[automations]" 5
+tui_wait_for "↻" 5
 tui_assert_contains "alpha" "instance view should show the instance again"
 
 pass "TUI automation mode: toggle, add agent, toggle back"

--- a/integration/tests/390_tui_automation_mode.sh
+++ b/integration/tests/390_tui_automation_mode.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# Description: TUI automation mode (issue #188) — 'm' toggles a fleet between its
-# instance view and its automation view (triggers + agents groups). Adding an
-# agent through the dialog persists it and shows it in the agents group, and 'm'
-# toggles back to the instance view.
+# Description: TUI automation mode (issue #188) — 'm' (or selecting the header's
+# [automations]/[instances] toggle with →/l and pressing enter) flips a fleet
+# between its instance view and its automation view (triggers + agents groups).
+# Adding an agent through the dialog persists it and shows it in the agents
+# group, and 'm' toggles back to the instance view.
 set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
@@ -19,6 +20,24 @@ tui_wait_for "alpha" 15
 # Instance view shows the [automations] toggle button.
 # ===========================================
 tui_assert_contains "[automations]" "fleet header should offer the [automations] toggle"
+
+# ===========================================
+# Keyboard selection: →/l focuses the header toggle and enter activates it,
+# flipping to the automation view; a second enter flips back. (The cursor starts
+# on the fleet header.)
+# ===========================================
+info "selecting the toggle with 'l' and pressing enter to enter automation mode"
+tui_send l
+sleep 0.2
+tui_send Enter
+tui_wait_for "[instances]" 5
+tui_assert_contains "triggers" "selecting the toggle + enter should open the automation view"
+
+info "pressing enter again to flip back to the instance view"
+tui_send Enter
+tui_wait_for "[automations]" 5
+tui_assert_contains "alpha" "a second enter should return to the instance view"
+tui_send h   # deselect the toggle before the rest of the flow
 
 # ===========================================
 # 'm' switches the fleet to automation view: triggers + agents groups, the

--- a/integration/tests/390_tui_automation_mode.sh
+++ b/integration/tests/390_tui_automation_mode.sh
@@ -52,6 +52,18 @@ tui_assert_contains "+ add agent" "add-agent action row missing"
 tui_assert_contains "[instances]" "automation view should offer the [instances] toggle"
 
 # ===========================================
+# 'a' opens the add dialog for the group the cursor is in (not the add-instance
+# workflow). The cursor sits on the fleet header right after entering automation
+# mode, where 'a' adds a trigger. esc cancels, leaving the cursor on the header.
+# ===========================================
+info "pressing 'a' on the header opens the add-trigger dialog"
+tui_send a
+tui_wait_for "New trigger" 5
+tui_send Escape
+sleep 0.3
+tui_wait_for "+ add trigger" 5
+
+# ===========================================
 # Add an agent. From the fleet header the rows are: header, triggers,
 # + add trigger, agents, + add agent — four 'j' reach "+ add agent".
 # ===========================================
@@ -73,6 +85,26 @@ for _ in 1 2 3 4; do tui_send j; sleep 0.15; done
 tui_send Enter         # save
 tui_wait_for "agents (1)" 10
 tui_assert_contains "builder" "saved agent row should be visible"
+
+# ===========================================
+# 'd' on a trigger/agent confirms before deleting (rather than deleting
+# immediately). The cursor lands on the "builder" agent row after the save.
+# ===========================================
+info "pressing 'd' on the agent opens a confirm dialog"
+tui_send d
+tui_wait_for "Delete agent" 5
+tui_assert_contains "builder" "confirm prompt should name the agent"
+
+info "cancelling with 'n' keeps the agent"
+tui_send n
+sleep 0.3
+tui_wait_for "agents (1)" 5
+
+info "confirming with 'y' deletes the agent"
+tui_send d
+tui_wait_for "Delete agent" 5
+tui_send y
+tui_wait_for "agents (0)" 10
 
 # ===========================================
 # 'm' toggles back to the instance view.

--- a/internal/fleet/instance.go
+++ b/internal/fleet/instance.go
@@ -22,6 +22,10 @@ type Instance struct {
 	Tag          string         `json:"tag,omitempty"`
 	Color        string         `json:"color,omitempty"`
 	Branch       string         `json:"branch,omitempty"`
+	// Automated marks an instance the automation scheduler spawned for a trigger
+	// (issue #188), as opposed to one a user created. Set once at creation and
+	// never cleared; the TUI shows a marker in front of its name.
+	Automated bool `json:"automated,omitempty"`
 }
 
 // GetDisplayName returns the user-facing label for the instance. Legacy

--- a/internal/server/automation_convert_test.go
+++ b/internal/server/automation_convert_test.go
@@ -7,6 +7,18 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 )
 
+// TestInstanceAutomatedFlagToProto guards the automation-origin marker (issue
+// #188) across the instance wire mapping: a scheduler-spawned instance must
+// carry Automated=true to the TUI, and a user-created one must stay false.
+func TestInstanceAutomatedFlagToProto(t *testing.T) {
+	if !instanceToProto(&fleet.Instance{Name: "x", Automated: true}).GetAutomated() {
+		t.Fatal("instanceToProto should carry Automated=true")
+	}
+	if instanceToProto(&fleet.Instance{Name: "x"}).GetAutomated() {
+		t.Fatal("a non-automated instance should map to automated=false")
+	}
+}
+
 // TestFleetSettingsAutomationRoundTrip guards the agents/triggers wire mapping:
 // a settings value carrying automation agents + triggers must survive
 // legacy -> proto -> legacy unchanged, so a SetFleetSettings round-trip never

--- a/internal/server/convert.go
+++ b/internal/server/convert.go
@@ -152,6 +152,9 @@ func instanceToProto(i *fleet.Instance) *fleetgrpc.Instance {
 	if i.Branch != "" {
 		pi.Branch = strptr(i.Branch)
 	}
+	if i.Automated {
+		pi.Automated = true
+	}
 	// Warnings is a new field with no legacy state.json source; left nil here
 	// (it gets populated by jobs starting in Phase 4).
 	return pi

--- a/internal/server/jobs.go
+++ b/internal/server/jobs.go
@@ -439,7 +439,7 @@ func loadInstanceSnapshot(fleetName, instanceName string) *fleetgrpc.Instance {
 // startCreateInstanceJob pre-creates the StatusCreating record server-side
 // (this removes the client-side pre-create write that drove issue #63), then
 // starts the provisioning job.
-func (s *service) startCreateInstanceJob(req *fleetgrpc.CreateInstanceRequest) (*job, error) {
+func (s *service) startCreateInstanceJob(req *fleetgrpc.CreateInstanceRequest, automated bool) (*job, error) {
 	fleetName, instanceName := req.GetFleet(), req.GetInstance()
 	if fleetName == "" || instanceName == "" {
 		return nil, status.Error(codes.InvalidArgument, "fleet and instance are required")
@@ -477,6 +477,7 @@ func (s *service) startCreateInstanceJob(req *fleetgrpc.CreateInstanceRequest) (
 			Status:       fleet.StatusCreating,
 			Backend:      backendType,
 			Branch:       req.GetBranch(),
+			Automated:    automated,
 		})
 	})
 	if err != nil {
@@ -494,7 +495,7 @@ func (s *service) startCreateInstanceJob(req *fleetgrpc.CreateInstanceRequest) (
 
 // CreateInstance starts the provisioning job and relays its events.
 func (s *service) CreateInstance(req *fleetgrpc.CreateInstanceRequest, stream fleetgrpc.FleetService_CreateInstanceServer) error {
-	j, err := s.startCreateInstanceJob(req)
+	j, err := s.startCreateInstanceJob(req, false)
 	if err != nil {
 		return err
 	}

--- a/internal/server/mcp_tools.go
+++ b/internal/server/mcp_tools.go
@@ -356,7 +356,7 @@ func (s *service) mcpUp(ctx context.Context, _ *mcp.CallToolRequest, in FleetUpI
 	if in.Branch != "" {
 		req.Branch = &in.Branch
 	}
-	j, err := s.startCreateInstanceJob(req)
+	j, err := s.startCreateInstanceJob(req, false)
 	if err != nil {
 		return nil, FleetJobOutput{}, mcpErr(err)
 	}

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -368,7 +368,7 @@ var createAutomationInstance = func(s *service, fleetName string, ag fleet.Agent
 		Fleet:    fleetName,
 		Instance: instName,
 		Backend:  backendToProto(ag.Backend),
-	}); err != nil {
+	}, true); err != nil {
 		return "", err
 	}
 	return instName, nil

--- a/internal/server/schedule_test.go
+++ b/internal/server/schedule_test.go
@@ -18,6 +18,38 @@ func scheduleFleet(triggers []fleet.Trigger, agents []fleet.Agent) map[string]*f
 	}
 }
 
+func TestCreateAutomationInstanceMarksAutomated(t *testing.T) {
+	// The real scheduler create path must persist Automated=true so the TUI can
+	// badge the instance. Stub the async provisioning job to a no-op so only the
+	// synchronous record creation is under test.
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha"},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	orig := jobRunCreate
+	jobRunCreate = func(string, string, string, string, bool, fleet.BackendType) error { return nil }
+	defer func() { jobRunCreate = orig }()
+
+	s, _, cleanup := newTestServer(t)
+	defer cleanup()
+
+	name, err := createAutomationInstance(s, "alpha", fleet.Agent{Name: "builder", Backend: fleet.BackendDevcontainer}, time.Now())
+	if err != nil {
+		t.Fatalf("createAutomationInstance: %v", err)
+	}
+
+	st, _ := state.Load()
+	inst, err := st.Fleets["alpha"].GetInstance(name)
+	if err != nil {
+		t.Fatalf("instance %q not found: %v", name, err)
+	}
+	if !inst.Automated {
+		t.Fatalf("scheduler-spawned instance should be marked Automated: %+v", inst)
+	}
+}
+
 func TestDueSchedulesFiresOncePerMinute(t *testing.T) {
 	// 2026-06-22 is a Monday at 09:00.
 	now := time.Date(2026, 6, 22, 9, 0, 30, 0, time.UTC)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -684,7 +684,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						// rendered (it would otherwise be truncated off-screen).
 						page.cursor = idx
 						page.armadaSel.focused = false
-						page.tagSelected = true
+						page.rightSelected = true
 						hit = true
 					case page.rows[idx].kind == rowFleetHeader &&
 						page.rows[idx].toggleX1 > page.rows[idx].toggleX0 &&
@@ -695,7 +695,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						// than collapsing the fleet like a click elsewhere on the row.
 						page.cursor = idx
 						page.armadaSel.focused = false
-						page.tagSelected = false
+						page.rightSelected = false
 						synthesizedKey = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}}
 						hit = true
 					case page.rows[idx].selectable():
@@ -704,7 +704,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						// the synthesized Space/Enter acts on the clicked row
 						// rather than (re)opening the dropdown.
 						page.armadaSel.focused = false
-						page.tagSelected = false
+						page.rightSelected = false
 						hit = true
 						if page.rows[idx].kind == rowInstance {
 							synthesizedKey = tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -689,7 +689,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					case page.rows[idx].kind == rowFleetHeader &&
 						page.rows[idx].toggleX1 > page.rows[idx].toggleX0 &&
 						mouseMsg.X >= page.rows[idx].toggleX0 && mouseMsg.X < page.rows[idx].toggleX1:
-						// Clicking the [automations]/[instances] button on a fleet
+						// Clicking the ⟳/☰ button on a fleet
 						// header toggles that fleet's automation mode (issue #188),
 						// synthesizing the same `m` the keyboard path uses — rather
 						// than collapsing the fleet like a click elsewhere on the row.

--- a/internal/tui/auto_tag_nav_test.go
+++ b/internal/tui/auto_tag_nav_test.go
@@ -194,19 +194,19 @@ func TestKeySelectDeselectInlinePR(t *testing.T) {
 	runes := func(r rune) tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}} }
 
 	fp.Update(m, runes('l'))
-	if !fp.tagSelected {
+	if !fp.rightSelected {
 		t.Fatalf("l should select the inline PR status")
 	}
 	fp.Update(m, runes('h'))
-	if fp.tagSelected {
+	if fp.rightSelected {
 		t.Fatalf("h should deselect")
 	}
 	fp.Update(m, tea.KeyMsg{Type: tea.KeyRight})
-	if !fp.tagSelected {
+	if !fp.rightSelected {
 		t.Fatalf("right should select")
 	}
 	fp.Update(m, tea.KeyMsg{Type: tea.KeyLeft})
-	if fp.tagSelected {
+	if fp.rightSelected {
 		t.Fatalf("left should deselect")
 	}
 }
@@ -216,7 +216,7 @@ func TestKeySpaceOpensPRWhenSelected(t *testing.T) {
 	// the session the cursor happens to sit on.
 	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning}
 	fp, m := cursorOnInlinePR(t, inst, prStatusWithRefs(ref(5, "https://x/pull/5", "t")))
-	fp.tagSelected = true
+	fp.rightSelected = true
 	cmd := fp.Update(m, tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}})
 	if cmd == nil {
 		t.Fatalf("space in the PR sub-mode should open the PR (non-nil cmd)")
@@ -232,9 +232,9 @@ func TestKeySpaceOpensPRWhenSelected(t *testing.T) {
 func TestKeySelectClearedByVerticalMove(t *testing.T) {
 	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning}
 	fp, m := cursorOnInlinePR(t, inst, prStatusWithRefs(ref(1, "https://x/pull/1", "t")))
-	fp.tagSelected = true
+	fp.rightSelected = true
 	fp.Update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}}) // up to instance row
-	if fp.tagSelected {
+	if fp.rightSelected {
 		t.Fatalf("vertical move should clear the selection")
 	}
 }
@@ -250,7 +250,7 @@ func TestKeyLWithoutInlinePRDoesNotSelect(t *testing.T) {
 		}
 	}
 	fp.Update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
-	if fp.tagSelected {
+	if fp.rightSelected {
 		t.Fatalf("l on a row without an inline PR must not select")
 	}
 }
@@ -258,11 +258,11 @@ func TestKeyLWithoutInlinePRDoesNotSelect(t *testing.T) {
 func TestBuildRowsClearsStaleSelection(t *testing.T) {
 	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning}
 	fp, m := cursorOnInlinePR(t, inst, prStatusWithRefs(ref(1, "https://x/pull/1", "t")))
-	fp.tagSelected = true
+	fp.rightSelected = true
 	// PR closes: clear the runtime PR status, rebuild — selection must drop.
 	m.runtime[rtKey("alpha", "agent-1")] = &fleetgrpc.InstanceRuntime{Fleet: "alpha", Instance: "agent-1"}
 	fp.buildRows(m)
-	if fp.tagSelected {
+	if fp.rightSelected {
 		t.Fatalf("buildRows should clear selection once the inline PR is gone")
 	}
 }
@@ -301,7 +301,7 @@ func TestMouseClickOnInlinePROpensPR(t *testing.T) {
 	}
 	next, _ := m.Update(click)
 	nm := next.(model)
-	if !nm.fleetPage.tagSelected {
+	if !nm.fleetPage.rightSelected {
 		t.Errorf("click on the inline PR should select it")
 	}
 	if !strings.Contains(nm.message, "99") {

--- a/internal/tui/automation_marker_test.go
+++ b/internal/tui/automation_marker_test.go
@@ -58,6 +58,20 @@ func TestViewFleetListMarksAutomatedInstance(t *testing.T) {
 	}
 }
 
+// TestAutomationLabelColorsFollowInstancePattern locks the hierarchy to mirror
+// the instance view (fleet blue → instance white → session blue): the triggers/
+// agents group header is white (not blue), while trigger/agent items keep the
+// blue session color.
+func TestAutomationLabelColorsFollowInstancePattern(t *testing.T) {
+	blue := lipgloss.Color("39") // fleetExpandedStyle / sessionStyle foreground
+	if automationGroupStyle.GetForeground() == blue {
+		t.Error("triggers/agents group header should be white, not blue")
+	}
+	if sessionStyle.GetForeground() != blue {
+		t.Error("trigger/agent items use sessionStyle, expected to be blue (color 39)")
+	}
+}
+
 // TestProtoInstanceToLegacyCarriesAutomated guards the TUI-side half of the
 // instance wire mapping (the server-side half is covered in the server package).
 func TestProtoInstanceToLegacyCarriesAutomated(t *testing.T) {

--- a/internal/tui/automation_marker_test.go
+++ b/internal/tui/automation_marker_test.go
@@ -51,11 +51,11 @@ func TestAutomatedMarkerKeepsStatusAligned(t *testing.T) {
 }
 
 // TestAutomationMarkFitsNameColumn guards the alignment contract: the trailing
-// marker (a leading space + the glyph) must render to exactly
+// marker (a space, the glyph, a space) must render to exactly
 // instanceAutoMarkWidth cells — the amount the name is truncated to make room —
 // or the status column (and the PR-status second line) drifts on automated rows.
 func TestAutomationMarkFitsNameColumn(t *testing.T) {
-	if w := lipgloss.Width(" " + automationMark); w != instanceAutoMarkWidth {
+	if w := lipgloss.Width(" " + automationMark + " "); w != instanceAutoMarkWidth {
 		t.Fatalf("trailing auto-mark %q renders %d cells, name column reserves %d", automationMark, w, instanceAutoMarkWidth)
 	}
 }

--- a/internal/tui/automation_marker_test.go
+++ b/internal/tui/automation_marker_test.go
@@ -1,0 +1,70 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TestAutomationMarkFitsReservedSlot guards the alignment contract: the marker
+// plus its trailing space must render to exactly instanceAutoMarkWidth cells, or
+// the status column (and the PR-status second line) drifts on automated rows.
+func TestAutomationMarkFitsReservedSlot(t *testing.T) {
+	if w := lipgloss.Width(automationMark + " "); w != instanceAutoMarkWidth {
+		t.Fatalf("auto-mark %q renders %d cells, reserved slot is %d", automationMark, w, instanceAutoMarkWidth)
+	}
+}
+
+// TestViewFleetListMarksAutomatedInstance verifies the ⟳ origin marker (issue
+// #188) renders only on automation-spawned instance rows.
+func TestViewFleetListMarksAutomatedInstance(t *testing.T) {
+	auto := &fleet.Instance{Name: "nightly-run", Status: fleet.StatusRunning, Automated: true}
+	manual := &fleet.Instance{Name: "my-fix", Status: fleet.StatusRunning}
+	fp := newFleetPage()
+	m := &model{
+		st: &state.State{
+			Fleets: map[string]*fleet.Fleet{
+				"alpha": {Name: "alpha", Instances: []*fleet.Instance{auto, manual}},
+			},
+		},
+		sessionStore: NewSessionStore(),
+		fleetPage:    fp,
+		width:        120,
+	}
+	fp.buildRows(m)
+	view := fp.viewFleetList(m)
+
+	var autoLine, manualLine string
+	for _, ln := range strings.Split(view, "\n") {
+		if strings.Contains(ln, "nightly-run") {
+			autoLine = ln
+		}
+		if strings.Contains(ln, "my-fix") {
+			manualLine = ln
+		}
+	}
+	if autoLine == "" || manualLine == "" {
+		t.Fatalf("both instance rows should render:\n%s", view)
+	}
+	if !strings.Contains(autoLine, automationMark) {
+		t.Errorf("the automated instance row should carry the %q marker: %q", automationMark, autoLine)
+	}
+	if strings.Contains(manualLine, automationMark) {
+		t.Errorf("the manual instance row must not carry the marker: %q", manualLine)
+	}
+}
+
+// TestProtoInstanceToLegacyCarriesAutomated guards the TUI-side half of the
+// instance wire mapping (the server-side half is covered in the server package).
+func TestProtoInstanceToLegacyCarriesAutomated(t *testing.T) {
+	if !protoInstanceToLegacy(&fleetgrpc.Instance{Name: "x", Automated: true}).Automated {
+		t.Fatal("protoInstanceToLegacy should carry Automated=true")
+	}
+	if protoInstanceToLegacy(&fleetgrpc.Instance{Name: "x"}).Automated {
+		t.Fatal("an absent automated flag should map to false")
+	}
+}

--- a/internal/tui/automation_marker_test.go
+++ b/internal/tui/automation_marker_test.go
@@ -8,14 +8,55 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
-// TestAutomationMarkFitsReservedSlot guards the alignment contract: the marker
-// plus its trailing space must render to exactly instanceAutoMarkWidth cells, or
-// the status column (and the PR-status second line) drifts on automated rows.
-func TestAutomationMarkFitsReservedSlot(t *testing.T) {
-	if w := lipgloss.Width(automationMark + " "); w != instanceAutoMarkWidth {
-		t.Fatalf("auto-mark %q renders %d cells, reserved slot is %d", automationMark, w, instanceAutoMarkWidth)
+// TestAutomatedMarkerKeepsStatusAligned proves the trailing ⟳ doesn't shift the
+// status column: an automated row and a differently-named manual row must land
+// "running" at the same column (the marker lives inside the fixed name column).
+func TestAutomatedMarkerKeepsStatusAligned(t *testing.T) {
+	auto := &fleet.Instance{Name: "robo-job", Status: fleet.StatusRunning, Automated: true}
+	manual := &fleet.Instance{Name: "a-longer-manual-name", Status: fleet.StatusRunning}
+	fp := newFleetPage()
+	m := &model{
+		st: &state.State{Fleets: map[string]*fleet.Fleet{
+			"alpha": {Name: "alpha", Instances: []*fleet.Instance{auto, manual}},
+		}},
+		sessionStore: NewSessionStore(),
+		fleetPage:    fp,
+		width:        120,
+	}
+	fp.buildRows(m)
+	view := fp.viewFleetList(m)
+
+	// Visual column (cell width), NOT byte index — the ⟳ is multi-byte, so a byte
+	// offset would differ even when the rendered columns line up.
+	statusCol := func(rowName string) int {
+		for _, ln := range strings.Split(view, "\n") {
+			if strings.Contains(ln, rowName) {
+				plain := ansi.Strip(ln)
+				if idx := strings.Index(plain, "running"); idx >= 0 {
+					return lipgloss.Width(plain[:idx])
+				}
+				return -1
+			}
+		}
+		t.Fatalf("row for %q not found:\n%s", rowName, view)
+		return -1
+	}
+	a, b := statusCol("robo-job"), statusCol("a-longer-manual-name")
+	if a < 0 || a != b {
+		t.Fatalf("status column misaligned: automated=%d manual=%d", a, b)
+	}
+}
+
+// TestAutomationMarkFitsNameColumn guards the alignment contract: the trailing
+// marker (a leading space + the glyph) must render to exactly
+// instanceAutoMarkWidth cells — the amount the name is truncated to make room —
+// or the status column (and the PR-status second line) drifts on automated rows.
+func TestAutomationMarkFitsNameColumn(t *testing.T) {
+	if w := lipgloss.Width(" " + automationMark); w != instanceAutoMarkWidth {
+		t.Fatalf("trailing auto-mark %q renders %d cells, name column reserves %d", automationMark, w, instanceAutoMarkWidth)
 	}
 }
 

--- a/internal/tui/automation_test.go
+++ b/internal/tui/automation_test.go
@@ -163,6 +163,143 @@ func TestDeleteAgentBlockedWhenReferenced(t *testing.T) {
 	}
 }
 
+// cursorToKind parks the cursor on the first row of the given kind.
+func cursorToKind(t *testing.T, fp *fleetPage, k rowKind) {
+	t.Helper()
+	for i, r := range fp.rows {
+		if r.kind == k {
+			fp.cursor = i
+			return
+		}
+	}
+	t.Fatalf("no row of kind %v in %v", k, rowKinds(fp))
+}
+
+// automationModelWithItems builds a fleet in automation mode carrying one agent
+// ("builder") and one schedule trigger ("nightly") that does NOT reference it,
+// so deletes aren't blocked by the reference guard.
+func automationModelWithItems(t *testing.T) (*model, *fleetPage) {
+	t.Helper()
+	m, fp := newAutomationModel(t)
+	f := m.st.Fleets["alpha"]
+	f.Settings.Agents = []fleet.Agent{{Name: "builder", Backend: fleet.BackendDevcontainer}}
+	f.Settings.Triggers = []fleet.Trigger{{Name: "nightly", Type: fleet.TriggerSchedule, Cron: "0 0 * * *"}}
+	fp.toggleAutomationMode(m, "alpha")
+	return m, fp
+}
+
+func TestAddKeyOpensTriggerDialogInTriggersGroup(t *testing.T) {
+	m, fp := automationModelWithItems(t)
+	for _, k := range []rowKind{rowAutomationTriggers, rowTrigger, rowNewTrigger} {
+		cursorToKind(t, fp, k)
+		fp.Update(m, key('a'))
+		if fp.mode != viewAutomationTrigger {
+			t.Fatalf("a on %v should open the add-trigger dialog, mode=%v", k, fp.mode)
+		}
+		fp.mode = viewNormal
+	}
+}
+
+func TestAddKeyOpensAgentDialogInAgentsGroup(t *testing.T) {
+	m, fp := automationModelWithItems(t)
+	for _, k := range []rowKind{rowAutomationAgents, rowAgent, rowNewAgent} {
+		cursorToKind(t, fp, k)
+		fp.Update(m, key('a'))
+		if fp.mode != viewAutomationAgent {
+			t.Fatalf("a on %v should open the add-agent dialog, mode=%v", k, fp.mode)
+		}
+		fp.mode = viewNormal
+	}
+}
+
+func TestAddKeyOnHeaderInAutomationModeAddsTrigger(t *testing.T) {
+	m, fp := automationModelWithItems(t)
+	cursorToFleetHeaderHelper(t, fp)
+	fp.Update(m, key('a'))
+	if fp.mode != viewAutomationTrigger {
+		t.Fatalf("a on the header in automation mode should add a trigger, mode=%v", fp.mode)
+	}
+}
+
+func TestAddKeyOnHeaderInInstanceModeDoesNotAddTrigger(t *testing.T) {
+	// In the instance view, 'a' must NOT route into the trigger dialog — it
+	// belongs to the add-instance path (whatever that resolves to here).
+	m, fp := newAutomationModel(t)
+	cursorToFleetHeaderHelper(t, fp)
+	fp.Update(m, key('a'))
+	if fp.mode == viewAutomationTrigger {
+		t.Fatal("a on the header in instance mode must not open the add-trigger dialog")
+	}
+}
+
+func TestDeleteTriggerAsksToConfirm(t *testing.T) {
+	m, fp := automationModelWithItems(t)
+	cursorToKind(t, fp, rowTrigger)
+
+	fp.Update(m, key('d'))
+	if fp.mode != viewConfirmDeleteAutomation {
+		t.Fatalf("d on a trigger should open the confirm dialog, mode=%v", fp.mode)
+	}
+	if len(m.st.Fleets["alpha"].Settings.Triggers) != 1 {
+		t.Fatal("the trigger must not be deleted before the user confirms")
+	}
+	if fp.autoDel.kind != rowTrigger || fp.autoDel.name != "nightly" {
+		t.Fatalf("confirm target wrong: %+v", fp.autoDel)
+	}
+
+	fp.Update(m, key('y'))
+	if len(m.st.Fleets["alpha"].Settings.Triggers) != 0 {
+		t.Fatal("y should delete the trigger")
+	}
+	if fp.mode != viewNormal {
+		t.Fatalf("dialog should close after confirm, mode=%v", fp.mode)
+	}
+}
+
+func TestDeleteAgentConfirmCancelKeepsIt(t *testing.T) {
+	m, fp := automationModelWithItems(t)
+	cursorToKind(t, fp, rowAgent)
+
+	fp.Update(m, key('d'))
+	if fp.mode != viewConfirmDeleteAutomation || fp.autoDel.kind != rowAgent {
+		t.Fatalf("d on an agent should open the confirm dialog for it, mode=%v target=%+v", fp.mode, fp.autoDel)
+	}
+
+	fp.Update(m, key('n'))
+	if len(m.st.Fleets["alpha"].Settings.Agents) != 1 {
+		t.Fatal("n should cancel — the agent must survive")
+	}
+	if fp.mode != viewNormal {
+		t.Fatalf("dialog should close after cancel, mode=%v", fp.mode)
+	}
+}
+
+func TestDeleteReferencedAgentSkipsConfirm(t *testing.T) {
+	// A referenced agent is refused up front: no confirm dialog, no deletion.
+	m, fp := newAutomationModel(t)
+	f := m.st.Fleets["alpha"]
+	f.Settings.Agents = []fleet.Agent{{Name: "a", Backend: fleet.BackendDevcontainer}}
+	f.Settings.Triggers = []fleet.Trigger{{Name: "t", Type: fleet.TriggerSchedule, AgentNames: []string{"a"}, Cron: "* * * * *"}}
+	fp.toggleAutomationMode(m, "alpha")
+	cursorToKind(t, fp, rowAgent)
+
+	fp.Update(m, key('d'))
+	if fp.mode != viewNormal {
+		t.Fatalf("a referenced agent must not open the confirm dialog, mode=%v", fp.mode)
+	}
+	if len(f.Settings.Agents) != 1 {
+		t.Fatal("a referenced agent must not be deleted")
+	}
+	if !strings.Contains(m.message, "used by trigger") {
+		t.Fatalf("expected a 'used by trigger' message, got %q", m.message)
+	}
+}
+
+func cursorToFleetHeaderHelper(t *testing.T, fp *fleetPage) {
+	t.Helper()
+	cursorToKind(t, fp, rowFleetHeader)
+}
+
 func TestHeaderToggleButtonMouseClick(t *testing.T) {
 	mp, fp := newAutomationModel(t)
 	m := *mp

--- a/internal/tui/automation_test.go
+++ b/internal/tui/automation_test.go
@@ -320,7 +320,7 @@ func TestHeaderToggleButtonMouseClick(t *testing.T) {
 	}
 	next, _ := m.Update(click)
 	if !next.(model).fleetPage.automationMode["alpha"] {
-		t.Fatal("clicking the [automations] button should toggle automation mode on")
+		t.Fatal("clicking the ⟳ toggle should switch automation mode on")
 	}
 
 	// A click elsewhere on the header (before the button) must NOT toggle — it
@@ -349,7 +349,7 @@ func TestAutomationViewRenders(t *testing.T) {
 	fp.toggleAutomationMode(m, "alpha")
 
 	out := fp.viewFleetList(m)
-	for _, want := range []string{"[instances]", "triggers", "agents", "nightly", "builder", "+ add trigger", "+ add agent"} {
+	for _, want := range []string{"[ " + instancesMark + " ]", "triggers", "agents", "nightly", "builder", "+ add trigger", "+ add agent"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("automation view missing %q\n%s", want, out)
 		}

--- a/internal/tui/automation_view.go
+++ b/internal/tui/automation_view.go
@@ -205,13 +205,9 @@ func (fleetPage *fleetPage) deleteAgent(m *model, fleetName string, idx int) tea
 		return nil
 	}
 	name := f.Settings.Agents[idx].Name
-	for _, t := range f.Settings.Triggers {
-		for _, an := range t.AgentNames {
-			if an == name {
-				m.message = fmt.Sprintf("Agent %q is used by trigger %q — remove it there first", name, t.Name)
-				return nil
-			}
-		}
+	if t := agentReferencedBy(f, name); t != "" {
+		m.message = fmt.Sprintf("Agent %q is used by trigger %q — remove it there first", name, t)
+		return nil
 	}
 	newSettings := f.Settings
 	newSettings.Agents = removeAgentAt(f.Settings.Agents, idx)
@@ -221,6 +217,81 @@ func (fleetPage *fleetPage) deleteAgent(m *model, fleetName string, idx int) tea
 	}
 	m.message = fmt.Sprintf("Deleted agent %q", name)
 	return nil
+}
+
+// agentReferencedBy returns the name of a trigger that fires the named agent, or
+// "" if none. A referenced agent can't be deleted — doing so would orphan the
+// trigger (which the server rejects wholesale).
+func agentReferencedBy(f *fleet.Fleet, agentName string) string {
+	for _, t := range f.Settings.Triggers {
+		for _, an := range t.AgentNames {
+			if an == agentName {
+				return t.Name
+			}
+		}
+	}
+	return ""
+}
+
+// autoDeleteState records the trigger/agent a confirm dialog
+// (viewConfirmDeleteAutomation) will delete on yes. kind is rowTrigger or
+// rowAgent; name is snapshotted for the prompt text.
+type autoDeleteState struct {
+	kind  rowKind
+	fleet string
+	idx   int
+	name  string
+}
+
+// openConfirmDeleteAutomation arms the trigger/agent delete confirmation for the
+// item under the cursor. A referenced agent is refused up front — no point
+// confirming a delete the server would reject (mirrors deleteAgent's guard).
+func (fleetPage *fleetPage) openConfirmDeleteAutomation(m *model, r *row) tea.Cmd {
+	f, ok := m.st.Fleets[r.fleetName]
+	if !ok {
+		return nil
+	}
+	var name string
+	switch r.kind {
+	case rowTrigger:
+		if r.autoIdx < 0 || r.autoIdx >= len(f.Settings.Triggers) {
+			return nil
+		}
+		name = f.Settings.Triggers[r.autoIdx].Name
+	case rowAgent:
+		if r.autoIdx < 0 || r.autoIdx >= len(f.Settings.Agents) {
+			return nil
+		}
+		name = f.Settings.Agents[r.autoIdx].Name
+		if t := agentReferencedBy(f, name); t != "" {
+			m.message = fmt.Sprintf("Agent %q is used by trigger %q — remove it there first", name, t)
+			return nil
+		}
+	default:
+		return nil
+	}
+	fleetPage.autoDel = autoDeleteState{kind: r.kind, fleet: r.fleetName, idx: r.autoIdx, name: name}
+	fleetPage.mode = viewConfirmDeleteAutomation
+	return nil
+}
+
+// automationAddTarget reports which automation item 'a' should add for the given
+// row — rowTrigger or rowAgent — and whether the row is in a fleet's automation
+// view at all. The triggers group (its header, items, and "+ add" row) adds a
+// trigger; the agents group adds an agent; a fleet header in automation mode
+// defaults to a trigger (the first group). Returns ok=false elsewhere.
+func (fleetPage *fleetPage) automationAddTarget(r *row) (rowKind, bool) {
+	switch r.kind {
+	case rowAutomationTriggers, rowTrigger, rowNewTrigger:
+		return rowTrigger, true
+	case rowAutomationAgents, rowAgent, rowNewAgent:
+		return rowAgent, true
+	case rowFleetHeader:
+		if fleetPage.automationMode[r.fleetName] {
+			return rowTrigger, true
+		}
+	}
+	return rowFleetHeader, false
 }
 
 // removeTriggerAt / removeAgentAt return a NEW slice with the element at idx

--- a/internal/tui/automation_view.go
+++ b/internal/tui/automation_view.go
@@ -68,7 +68,7 @@ func (fleetPage *fleetPage) renderAutomationRow(m *model, r row, cursor string, 
 		if collapsed {
 			arrow = "▶ "
 		}
-		style := fleetExpandedStyle
+		style := automationGroupStyle
 		if isSelected {
 			style = selectedStyle
 		}

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -727,6 +727,7 @@ func protoInstanceToLegacy(pi *fleetgrpc.Instance) *fleet.Instance {
 		Tag:          pi.GetTag(),
 		Color:        pi.GetColor(),
 		Branch:       pi.GetBranch(),
+		Automated:    pi.GetAutomated(),
 	}
 	if ts := pi.GetCreatedAt(); ts != nil {
 		inst.CreatedAt = ts.AsTime()

--- a/internal/tui/dialog_automation_agent.go
+++ b/internal/tui/dialog_automation_agent.go
@@ -139,7 +139,10 @@ func (fleetPage *fleetPage) updateAutomationAgent(m *model, msg tea.Msg) tea.Cmd
 		return nil
 	}
 
-	if isDialogTextKey(key) && agentRowIsText(st.row) {
+	// A printable key activates an inline text field and feeds the key. The
+	// editor-backed system prompt is excluded — it opens $EDITOR on enter instead
+	// (inline typing makes no sense for many-line text).
+	if isDialogTextKey(key) && agentRowIsText(st.row) && st.row != agentRowSystemPrompt {
 		blink := fleetPage.activateAgentField()
 		var cmd tea.Cmd
 		st.input, cmd = st.input.Update(msg)
@@ -155,8 +158,11 @@ func agentRowIsText(row int) bool {
 func (fleetPage *fleetPage) agentRowEnter(m *model) tea.Cmd {
 	st := &fleetPage.agentDlg
 	switch st.row {
-	case agentRowName, agentRowCommand, agentRowSystemPrompt:
+	case agentRowName, agentRowCommand:
 		return fleetPage.activateAgentField()
+	case agentRowSystemPrompt:
+		// The system prompt is often many lines — edit it in $EDITOR, not inline.
+		return editorCmd(editorTargetAgentSysPrompt, "sysprompt", st.systemPrompt)
 	case agentRowBackend:
 		st.backend = nextBackendType(st.backend, 1, allBackendTypes)
 	case agentRowSave:
@@ -313,7 +319,7 @@ func (fleetPage *fleetPage) renderAutomationAgentDialog(m *model) string {
 	fmt.Fprintf(&body, "%s\n\n", dialogTitle.Render(title))
 	fmt.Fprintf(&body, "%s%s %s\n", marker(agentRowName), dialogLabel.Render("Name:    "), field(agentRowName, st.name, "agent-name"))
 	fmt.Fprintf(&body, "%s%s %s\n", marker(agentRowCommand), dialogLabel.Render("Command: "), field(agentRowCommand, st.command, fleet.DefaultAgentCommand))
-	fmt.Fprintf(&body, "%s%s %s\n", marker(agentRowSystemPrompt), dialogLabel.Render("Sys prompt:"), field(agentRowSystemPrompt, st.systemPrompt, "(optional, injected into ${SYS_PROMPT})"))
+	fmt.Fprintf(&body, "%s%s %s\n", marker(agentRowSystemPrompt), dialogLabel.Render("Sys prompt:"), promptFieldPreview(st.systemPrompt, "(optional, injected into ${SYS_PROMPT})"))
 	fmt.Fprintf(&body, "%s%s [ %s ]\n", marker(agentRowBackend), dialogLabel.Render("Backend: "), backendTypeLabel(st.backend))
 	fmt.Fprintf(&body, "%s%s\n", marker(agentRowSave), saveButtonLabel(st.row == agentRowSave))
 
@@ -321,7 +327,7 @@ func (fleetPage *fleetPage) renderAutomationAgentDialog(m *model) string {
 		fmt.Fprintf(&body, "\n%s\n", errorStyle.Render(st.errMsg))
 	}
 	body.WriteString("\n")
-	body.WriteString(dialogHint.Render(automationHint(st.fieldActive)))
+	body.WriteString(dialogHint.Render(automationHint(st.fieldActive, st.row == agentRowSystemPrompt)))
 
 	b.WriteString(dialogBox.Render(body.String()))
 	b.WriteString("\n")
@@ -337,9 +343,13 @@ func saveButtonLabel(selected bool) string {
 }
 
 // automationHint is the footer hint shared by the automation dialogs.
-func automationHint(fieldActive bool) string {
+// onEditorField promotes the "$EDITOR" affordance for the long free-text fields.
+func automationHint(fieldActive, onEditorField bool) string {
 	if fieldActive {
 		return "[enter] Done editing  [ctrl+c] Cancel"
+	}
+	if onEditorField {
+		return "[enter] Edit in $EDITOR  [j/k] Move  [q/esc] Cancel"
 	}
 	return "[j/k] Move  [enter] Edit/Toggle  [h/l] Cycle  [q/esc] Cancel"
 }

--- a/internal/tui/dialog_automation_trigger.go
+++ b/internal/tui/dialog_automation_trigger.go
@@ -188,7 +188,9 @@ func (fleetPage *fleetPage) updateAutomationTrigger(m *model, msg tea.Msg) tea.C
 		return nil
 	}
 
-	if isDialogTextKey(key) && isTriggerTextRow(st.row) {
+	// A printable key activates an inline text field and feeds the key. The
+	// editor-backed prompt is excluded — it opens $EDITOR on enter instead.
+	if isDialogTextKey(key) && isTriggerTextRow(st.row) && st.row != trigRowPrompt {
 		blink := fleetPage.activateTriggerField()
 		var cmd tea.Cmd
 		st.input, cmd = st.input.Update(msg)
@@ -210,6 +212,9 @@ func isTriggerTextRow(row int) bool {
 func (fleetPage *fleetPage) triggerRowEnter(m *model) tea.Cmd {
 	st := &fleetPage.triggerDlg
 	switch {
+	case st.row == trigRowPrompt:
+		// The prompt is often many lines — edit it in $EDITOR, not inline.
+		return editorCmd(editorTargetTriggerPrompt, "prompt", st.prompt)
 	case isTriggerTextRow(st.row):
 		return fleetPage.activateTriggerField()
 	case st.row == trigRowType:
@@ -462,7 +467,7 @@ func (fleetPage *fleetPage) renderAutomationTriggerDialog(m *model) string {
 		fmt.Fprintf(&body, "%s    %s %s\n", marker(trigRowAgentBase+i), box, a.Name)
 	}
 
-	fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowPrompt), dialogLabel.Render("Prompt: "), field(trigRowPrompt, st.prompt, "(fed to the agent via ${PROMPT})"))
+	fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowPrompt), dialogLabel.Render("Prompt: "), promptFieldPreview(st.prompt, "(fed to the agent via ${PROMPT})"))
 
 	if st.triggerType == fleet.TriggerWebhook {
 		fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowWebhookName), dialogLabel.Render("Webhook:"), field(trigRowWebhookName, st.webhookName, "name (appended to gateway URL)"))
@@ -509,6 +514,9 @@ func filterTypeLabel(f fleet.WebhookFilterType) string {
 func automationTriggerHint(fieldActive bool, row int) string {
 	if fieldActive {
 		return "[enter] Done editing  [ctrl+c] Cancel"
+	}
+	if row == trigRowPrompt {
+		return "[enter] Edit in $EDITOR  [j/k] Move  [q/esc] Cancel"
 	}
 	if row >= trigRowAgentBase {
 		return "[j/k] Move  [space] Toggle agent  [enter] Edit/Cycle  [q/esc] Cancel"

--- a/internal/tui/dialog_confirm.go
+++ b/internal/tui/dialog_confirm.go
@@ -149,6 +149,30 @@ func (fleetPage *fleetPage) updateConfirmDeleteSession(m *model, msg tea.Msg) te
 	return nil
 }
 
+// updateConfirmDeleteAutomation handles the trigger/agent deletion confirmation
+// dialog. The actual removal + persistence stays in deleteTrigger/deleteAgent;
+// this just gates them behind a yes.
+func (fleetPage *fleetPage) updateConfirmDeleteAutomation(m *model, msg tea.Msg) tea.Cmd {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return nil
+	}
+	switch keyMsg.String() {
+	case "y", "Y", "enter":
+		fleetPage.mode = viewNormal
+		d := fleetPage.autoDel
+		if d.kind == rowAgent {
+			return fleetPage.deleteAgent(m, d.fleet, d.idx)
+		}
+		return fleetPage.deleteTrigger(m, d.fleet, d.idx)
+
+	case "n", "N", "esc", "q", "Q", "ctrl+c":
+		fleetPage.mode = viewNormal
+		m.message = "Cancelled"
+	}
+	return nil
+}
+
 // ===========================================
 // Backend Type Helpers
 // ===========================================
@@ -214,6 +238,26 @@ func (fleetPage *fleetPage) renderConfirmDeleteFleetWarnDialog(m *model) string 
 		dialogHint.Render("[y] Confirm destroy  [n/q/esc] Cancel"),
 	)
 	b.WriteString(warnBox.Render(warnDialog))
+	b.WriteString("\n")
+
+	return b.String()
+}
+
+func (fleetPage *fleetPage) renderConfirmDeleteAutomationDialog(m *model) string {
+	var b strings.Builder
+	b.WriteString("\n")
+	noun := "trigger"
+	if fleetPage.autoDel.kind == rowAgent {
+		noun = "agent"
+	}
+	dialog := fmt.Sprintf(
+		"%s\n\n%s\n\n%s",
+		dialogTitle.Render("Delete "+noun),
+		dialogLabel.Render(fmt.Sprintf("Remove %s %q from %s?",
+			noun, fleetPage.autoDel.name, fleetPage.autoDel.fleet)),
+		dialogHint.Render("[y] Yes  [n/q/esc] No"),
+	)
+	b.WriteString(dialogBox.Render(dialog))
 	b.WriteString("\n")
 
 	return b.String()

--- a/internal/tui/editor.go
+++ b/internal/tui/editor.go
@@ -1,0 +1,129 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// editor.go backs the "edit this field in $EDITOR" experience for the automation
+// dialogs' long free-text fields — an agent's system prompt and a trigger's
+// prompt. Inline single-line editing is miserable for many-line text, so
+// selecting one of these fields opens the user's $EDITOR on a temp file and
+// reads the result back when they exit.
+
+// editorTarget identifies which dialog field an $EDITOR session feeds back into.
+type editorTarget int
+
+const (
+	editorTargetAgentSysPrompt editorTarget = iota
+	editorTargetTriggerPrompt
+)
+
+// editorFinishedMsg carries an $EDITOR session's result back to the dialog that
+// launched it. On err the field is left unchanged.
+type editorFinishedMsg struct {
+	target editorTarget
+	value  string
+	err    error
+}
+
+// promptPreviewWidth caps the one-line preview an editor-backed field shows in
+// the dialog.
+const promptPreviewWidth = 40
+
+// resolveEditor returns the user's preferred editor command — $VISUAL, then
+// $EDITOR — falling back to vi (the universal default, always present).
+func resolveEditor() string {
+	if e := strings.TrimSpace(os.Getenv("VISUAL")); e != "" {
+		return e
+	}
+	if e := strings.TrimSpace(os.Getenv("EDITOR")); e != "" {
+		return e
+	}
+	return "vi"
+}
+
+// editorCmd launches $EDITOR on `current` (seeded into a temp file) and reads the
+// result back into an editorFinishedMsg for `target`. It is a package var so
+// tests can stub the side effects (temp file + process exec). The editor runs via
+// `sh -c` so an $EDITOR carrying arguments (e.g. "code --wait") works — the same
+// way git invokes its editor.
+var editorCmd = func(target editorTarget, nameHint, current string) tea.Cmd {
+	f, err := os.CreateTemp("", "fleet-"+nameHint+"-*.md")
+	if err != nil {
+		return func() tea.Msg { return editorFinishedMsg{target: target, err: err} }
+	}
+	path := f.Name()
+	_, writeErr := f.WriteString(current)
+	closeErr := f.Close()
+	if writeErr != nil || closeErr != nil {
+		os.Remove(path)
+		if writeErr == nil {
+			writeErr = closeErr
+		}
+		return func() tea.Msg { return editorFinishedMsg{target: target, err: writeErr} }
+	}
+
+	return execProcess(buildEditorCommand(path), func(runErr error) tea.Msg {
+		defer os.Remove(path)
+		if runErr != nil {
+			return editorFinishedMsg{target: target, err: runErr}
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return editorFinishedMsg{target: target, err: readErr}
+		}
+		// Drop the editor's trailing newline(s) so the value matches what inline
+		// typing would have produced.
+		return editorFinishedMsg{target: target, value: strings.TrimRight(string(data), "\n")}
+	})
+}
+
+// buildEditorCommand returns the *exec.Cmd that opens the user's editor on path.
+// $EDITOR runs through `sh -c` so an editor carrying arguments (e.g. "code
+// --wait") is honored, exactly as git invokes GIT_EDITOR.
+func buildEditorCommand(path string) *exec.Cmd {
+	return exec.Command("sh", "-c", resolveEditor()+" "+shellQuoteSingle(path))
+}
+
+// shellQuoteSingle single-quotes s for safe inclusion in a `sh -c` string.
+func shellQuoteSingle(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// applyEditorResult writes an $EDITOR session's result back into the dialog field
+// it targeted. The dialog scratch survives the suspend — the TUI is paused while
+// the editor runs, so the mode can't have changed underneath us.
+func (fleetPage *fleetPage) applyEditorResult(m *model, msg editorFinishedMsg) tea.Cmd {
+	if msg.err != nil {
+		m.message = fmt.Sprintf("Editor error: %v", msg.err)
+		return nil
+	}
+	switch msg.target {
+	case editorTargetAgentSysPrompt:
+		fleetPage.agentDlg.systemPrompt = msg.value
+	case editorTargetTriggerPrompt:
+		fleetPage.triggerDlg.prompt = msg.value
+	}
+	return nil
+}
+
+// promptFieldPreview renders a one-line preview of an editor-backed field's
+// (possibly multi-line) value for the dialog: the first line, truncated, with a
+// dim line count when there is more than one line. Empty shows the placeholder.
+func promptFieldPreview(value, placeholder string) string {
+	if value == "" {
+		return dimStyle.Render(placeholder)
+	}
+	lines := strings.Split(value, "\n")
+	preview := ansi.Truncate(lines[0], promptPreviewWidth, "…")
+	if len(lines) > 1 {
+		preview += dimStyle.Render(fmt.Sprintf("  (%d lines)", len(lines)))
+	}
+	return preview
+}

--- a/internal/tui/editor_test.go
+++ b/internal/tui/editor_test.go
@@ -1,0 +1,189 @@
+package tui
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestBuildEditorCommandRoundTrip drives the real shell invocation with a
+// non-interactive fake editor that CARRIES AN ARGUMENT (proving `sh -c` handles
+// editors-with-args like "code --wait"): it must receive the temp-file path and
+// the edit must round-trip back from disk.
+func TestBuildEditorCommandRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(path, []byte("seed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("VISUAL", "")
+	// $EDITOR is itself `sh -c <script> _`, so the real path lands as $1.
+	t.Setenv("EDITOR", `sh -c 'printf "edited\n" > "$1"' _`)
+
+	if err := buildEditorCommand(path).Run(); err != nil {
+		t.Fatalf("fake editor run: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimRight(string(got), "\n") != "edited" {
+		t.Fatalf("file not edited through the editor command: %q", got)
+	}
+}
+
+func TestResolveEditorPrecedence(t *testing.T) {
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", "")
+	if got := resolveEditor(); got != "vi" {
+		t.Errorf("with neither set, editor = %q, want vi", got)
+	}
+	t.Setenv("EDITOR", "nano")
+	if got := resolveEditor(); got != "nano" {
+		t.Errorf("EDITOR = %q, want nano", got)
+	}
+	t.Setenv("VISUAL", "code --wait")
+	if got := resolveEditor(); got != "code --wait" {
+		t.Errorf("VISUAL should win over EDITOR, got %q", got)
+	}
+}
+
+func TestShellQuoteSingle(t *testing.T) {
+	if got := shellQuoteSingle("/tmp/a b.md"); got != "'/tmp/a b.md'" {
+		t.Errorf("spaces: got %q", got)
+	}
+	if got := shellQuoteSingle("it's"); got != `'it'\''s'` {
+		t.Errorf("embedded quote: got %q", got)
+	}
+}
+
+func TestPromptFieldPreview(t *testing.T) {
+	if got := promptFieldPreview("", "placeholder"); !strings.Contains(got, "placeholder") {
+		t.Errorf("empty value should show the placeholder, got %q", got)
+	}
+	if got := promptFieldPreview("one line", "ph"); got != "one line" {
+		t.Errorf("single line preview = %q, want %q", got, "one line")
+	}
+	multi := promptFieldPreview("first line\nsecond\nthird", "ph")
+	if !strings.Contains(multi, "first line") || !strings.Contains(multi, "(3 lines)") {
+		t.Errorf("multi-line preview = %q, want first line + (3 lines)", multi)
+	}
+}
+
+func TestEditorResultSetsAgentSysPrompt(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	fp.openAddAgentDialog(m, "alpha")
+	fp.Update(m, editorFinishedMsg{target: editorTargetAgentSysPrompt, value: "line1\nline2"})
+	if fp.agentDlg.systemPrompt != "line1\nline2" {
+		t.Errorf("sys prompt = %q, want the edited value", fp.agentDlg.systemPrompt)
+	}
+}
+
+func TestEditorResultSetsTriggerPrompt(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	fp.openAddTriggerDialog(m, "alpha")
+	fp.Update(m, editorFinishedMsg{target: editorTargetTriggerPrompt, value: "do the thing"})
+	if fp.triggerDlg.prompt != "do the thing" {
+		t.Errorf("trigger prompt = %q, want the edited value", fp.triggerDlg.prompt)
+	}
+}
+
+func TestEditorResultErrorSurfacesMessageAndKeepsValue(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	fp.openAddAgentDialog(m, "alpha")
+	fp.agentDlg.systemPrompt = "keep me"
+	fp.Update(m, editorFinishedMsg{target: editorTargetAgentSysPrompt, err: errors.New("boom")})
+	if !strings.Contains(m.message, "boom") {
+		t.Errorf("editor error should surface in the message, got %q", m.message)
+	}
+	if fp.agentDlg.systemPrompt != "keep me" {
+		t.Errorf("an editor error must leave the field unchanged, got %q", fp.agentDlg.systemPrompt)
+	}
+}
+
+func TestAgentEnterOnSysPromptOpensEditor(t *testing.T) {
+	orig := editorCmd
+	var gotTarget editorTarget
+	var gotCurrent string
+	called := false
+	editorCmd = func(target editorTarget, _, current string) tea.Cmd {
+		called, gotTarget, gotCurrent = true, target, current
+		return nil
+	}
+	defer func() { editorCmd = orig }()
+
+	m, fp := newAutomationModel(t)
+	fp.openAddAgentDialog(m, "alpha")
+	fp.agentDlg.systemPrompt = "existing prompt"
+	fp.agentDlg.row = agentRowSystemPrompt
+	fp.agentRowEnter(m)
+
+	if !called || gotTarget != editorTargetAgentSysPrompt || gotCurrent != "existing prompt" {
+		t.Fatalf("editor not launched for sys prompt: called=%v target=%v current=%q", called, gotTarget, gotCurrent)
+	}
+	if fp.agentDlg.fieldActive {
+		t.Error("the sys prompt is editor-backed and must not inline-activate")
+	}
+}
+
+func TestAgentEnterOnNameActivatesInline(t *testing.T) {
+	orig := editorCmd
+	called := false
+	editorCmd = func(editorTarget, string, string) tea.Cmd { called = true; return nil }
+	defer func() { editorCmd = orig }()
+
+	m, fp := newAutomationModel(t)
+	fp.openAddAgentDialog(m, "alpha")
+	fp.agentDlg.row = agentRowName
+	fp.agentRowEnter(m)
+
+	if called {
+		t.Error("the name field must not open the editor")
+	}
+	if !fp.agentDlg.fieldActive {
+		t.Error("the name field should inline-activate")
+	}
+}
+
+func TestAgentTypingOnSysPromptDoesNotInlineActivate(t *testing.T) {
+	orig := editorCmd
+	editorCmd = func(editorTarget, string, string) tea.Cmd { return nil }
+	defer func() { editorCmd = orig }()
+
+	m, fp := newAutomationModel(t)
+	fp.openAddAgentDialog(m, "alpha")
+	fp.agentDlg.row = agentRowSystemPrompt
+	fp.updateAutomationAgent(m, key('x'))
+	if fp.agentDlg.fieldActive {
+		t.Error("typing on the editor-backed sys prompt must not inline-activate it")
+	}
+}
+
+func TestTriggerEnterOnPromptOpensEditor(t *testing.T) {
+	orig := editorCmd
+	var gotTarget editorTarget
+	var gotCurrent string
+	called := false
+	editorCmd = func(target editorTarget, _, current string) tea.Cmd {
+		called, gotTarget, gotCurrent = true, target, current
+		return nil
+	}
+	defer func() { editorCmd = orig }()
+
+	m, fp := newAutomationModel(t)
+	fp.openAddTriggerDialog(m, "alpha")
+	fp.triggerDlg.prompt = "trigger prompt"
+	fp.triggerDlg.row = trigRowPrompt
+	fp.triggerRowEnter(m)
+
+	if !called || gotTarget != editorTargetTriggerPrompt || gotCurrent != "trigger prompt" {
+		t.Fatalf("editor not launched for trigger prompt: called=%v target=%v current=%q", called, gotTarget, gotCurrent)
+	}
+	if fp.triggerDlg.fieldActive {
+		t.Error("the trigger prompt is editor-backed and must not inline-activate")
+	}
+}

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -127,6 +127,9 @@ func (fleetPage *fleetPage) Update(m *model, msg tea.Msg) tea.Cmd {
 	// runtimeChangedMsg handler in the model-level Update now — the server pushes
 	// session changes on the runtime stream, replacing the old client poll.)
 	switch msg.(type) {
+	case editorFinishedMsg:
+		return fleetPage.applyEditorResult(m, msg.(editorFinishedMsg))
+
 	case operationDoneMsg:
 		fleetPage.buildRows(m)
 		return nil

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -76,6 +76,7 @@ type fleetPage struct {
 	autoCollapsed map[string]bool
 	triggerDlg    automationTriggerState // add/edit-trigger dialog
 	agentDlg      automationAgentState   // add/edit-agent dialog
+	autoDel       autoDeleteState        // pending trigger/agent delete (viewConfirmDeleteAutomation)
 }
 
 // newFleetPage creates a new fleet page with default state.
@@ -219,6 +220,8 @@ func (fleetPage *fleetPage) Update(m *model, msg tea.Msg) tea.Cmd {
 		return fleetPage.updateAutomationTrigger(m, msg)
 	case viewAutomationAgent:
 		return fleetPage.updateAutomationAgent(m, msg)
+	case viewConfirmDeleteAutomation:
+		return fleetPage.updateConfirmDeleteAutomation(m, msg)
 	case viewLayoutPreset:
 		return fleetPage.updateLayoutPreset(m, msg)
 	case viewRenameSession:

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -44,7 +44,7 @@ type fleetPage struct {
 	// rightSelected is true when the cursor row's right-hand element is
 	// horizontally selected — →/l selects it (drawn pink), ←/h deselects, enter
 	// activates it. Two row kinds carry such an element: an instance's PR-status
-	// auto tag (enter opens the PR) and a fleet header's [automations]/[instances]
+	// auto tag (enter opens the PR) and a fleet header's ⟳/☰
 	// mode toggle (enter flips automation mode). Cleared on any vertical cursor
 	// move. See currentRowHasRightElement / activateRightSelection.
 	rightSelected bool

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -41,11 +41,13 @@ type fleetPage struct {
 	choosePR   choosePRState      // multi-PR chooser (open which PR?)
 	lpFlow     *layoutPresetFlow  // open preset creation/edit flow (nil unless mode == viewLayoutPreset)
 
-	// tagSelected is true when the cursor's instance has its auto-tag (PR status)
-	// horizontally selected — →/l selects it (drawn pink in [ ]), ←/h deselects,
-	// enter opens the PR. Meaningful only while the cursor is on an instance row
-	// whose auto-tag is navigable; cleared on any vertical cursor move.
-	tagSelected bool
+	// rightSelected is true when the cursor row's right-hand element is
+	// horizontally selected — →/l selects it (drawn pink), ←/h deselects, enter
+	// activates it. Two row kinds carry such an element: an instance's PR-status
+	// auto tag (enter opens the PR) and a fleet header's [automations]/[instances]
+	// mode toggle (enter flips automation mode). Cleared on any vertical cursor
+	// move. See currentRowHasRightElement / activateRightSelection.
+	rightSelected bool
 
 	textInput        textinput.Model
 	branchInput      textinput.Model

--- a/internal/tui/page_fleet_keys.go
+++ b/internal/tui/page_fleet_keys.go
@@ -76,7 +76,7 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 		case "up", "k":
 			// Up from the top row focuses the Armada selector (one stop above
 			// the list); otherwise move within the rows.
-			fleetPage.tagSelected = false
+			fleetPage.rightSelected = false
 			if fleetPage.cursor == fleetPage.firstSelectable() {
 				fleetPage.armadaSel.focused = true
 			} else {
@@ -85,7 +85,7 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 
 		case "down", "j":
 			// Down from the bottom row wraps up to the Armada selector.
-			fleetPage.tagSelected = false
+			fleetPage.rightSelected = false
 			if fleetPage.cursor == fleetPage.lastSelectable() {
 				fleetPage.armadaSel.focused = true
 			} else {
@@ -98,19 +98,20 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			return fleetPage.openArmadaSelect(m)
 
 		case "shift+up", "K":
-			fleetPage.tagSelected = false
+			fleetPage.rightSelected = false
 			fleetPage.moveCursorToInstance(-1)
 
 		case "shift+down", "J":
-			fleetPage.tagSelected = false
+			fleetPage.rightSelected = false
 			fleetPage.moveCursorToInstance(1)
 
 		case " ", "tab":
-			// In the PR-selection sub-mode the cursor sits on a child row whose
-			// normal space/tab action would connect/create a session; intercept it
-			// to open the PR, matching enter and the focused help text.
-			if fleetPage.tagSelected {
-				return fleetPage.openSelectedPR(m)
+			// When a right-hand element is selected the cursor's normal space/tab
+			// action (connect/create a session, expand/collapse a header) is
+			// intercepted to activate that element instead — matching enter and the
+			// focused help text.
+			if fleetPage.rightSelected {
+				return fleetPage.activateRightSelection(m)
 			}
 			if r := fleetPage.currentRow(); r != nil {
 				switch r.kind {
@@ -297,10 +298,11 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			}
 
 		case "enter":
-			// A selected auto tag intercepts enter to open the PR; otherwise the
-			// row's normal action runs.
-			if fleetPage.tagSelected {
-				return fleetPage.openSelectedPR(m)
+			// A selected right-hand element intercepts enter to activate itself
+			// (open the PR, or flip the mode toggle); otherwise the row's normal
+			// action runs.
+			if fleetPage.rightSelected {
+				return fleetPage.activateRightSelection(m)
 			}
 			return fleetPage.handleEnter(m)
 
@@ -444,15 +446,16 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			return nil
 
 		case "right", "l":
-			// Select the inline PR status on the current row (the auto tag rides
-			// the first child row of an expanded instance) so enter opens the PR.
-			// No-op when the cursor isn't on a row carrying a navigable PR status.
-			if len(fleetPage.selectedInlinePR(m)) > 0 {
-				fleetPage.tagSelected = true
+			// Select the current row's right-hand element — a fleet header's
+			// [automations]/[instances] mode toggle, or an expanded instance's
+			// inline PR status — so enter activates it. No-op on rows that carry
+			// no such element.
+			if fleetPage.currentRowHasRightElement(m) {
+				fleetPage.rightSelected = true
 			}
 
 		case "left", "h":
-			fleetPage.tagSelected = false
+			fleetPage.rightSelected = false
 
 		case "L":
 			_, instance := fleetPage.selectedInstance(m)
@@ -673,6 +676,23 @@ func (fleetPage *fleetPage) handleEnter(m *model) tea.Cmd {
 	return nil
 }
 
+// activateRightSelection runs the action of the selected right-hand element on
+// the cursor row: flipping automation mode on a fleet header (keeping the toggle
+// focused so enter flips back), or opening the PR on a PR-carrying child row.
+// Mirrors the row-kind split in currentRowHasRightElement.
+func (fleetPage *fleetPage) activateRightSelection(m *model) tea.Cmd {
+	r := fleetPage.currentRow()
+	if r == nil {
+		return nil
+	}
+	if r.kind == rowFleetHeader {
+		fleetPage.toggleAutomationMode(m, r.fleetName)
+		fleetPage.rightSelected = true // keep the toggle focused for repeat flips
+		return nil
+	}
+	return fleetPage.openSelectedPR(m)
+}
+
 // ===========================================
 // Help Keys
 // ===========================================
@@ -698,10 +718,17 @@ func (fleetPage *fleetPage) contextualHelpKeysBase(m *model) []string {
 		return withArmadaHint([]string{"n: new fleet", "q: quit"})
 	}
 
-	// A selected inline PR status puts the row in a focused sub-mode (the cursor
-	// always sits on the PR-carrying child row while selected): only the
-	// PR-navigation keys apply.
-	if fleetPage.tagSelected {
+	// A selected right-hand element puts the row in a focused sub-mode: only the
+	// activate/deselect keys apply. The two such elements are a fleet header's
+	// mode toggle and an instance's inline PR status.
+	if fleetPage.rightSelected {
+		if r.kind == rowFleetHeader {
+			action := "enter: automations"
+			if fleetPage.automationMode[r.fleetName] {
+				action = "enter: instances"
+			}
+			return withArmadaHint([]string{action, "←/h: deselect", "j/k: navigate", "q: quit"})
+		}
 		return withArmadaHint([]string{"enter: open PR", "←/h: deselect", "j/k: navigate", "q: quit"})
 	}
 
@@ -712,7 +739,7 @@ func (fleetPage *fleetPage) contextualHelpKeysBase(m *model) []string {
 			toggle = "m: instances"
 		}
 		return withArmadaHint([]string{
-			"j/k: navigate", "space/enter: expand/collapse", toggle, "e: edit fleet",
+			"j/k: navigate", "→/l: select", "space/enter: expand/collapse", toggle, "e: edit fleet",
 			"a: add instance", "n: new fleet", "d: delete fleet", "r: refresh", "q: quit",
 		})
 

--- a/internal/tui/page_fleet_keys.go
+++ b/internal/tui/page_fleet_keys.go
@@ -206,11 +206,8 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			if r == nil || r.kind == rowSettings || r.kind == rowLeaveFocus || r.kind == rowNewSession {
 				break
 			}
-			if r.kind == rowTrigger {
-				return fleetPage.deleteTrigger(m, r.fleetName, r.autoIdx)
-			}
-			if r.kind == rowAgent {
-				return fleetPage.deleteAgent(m, r.fleetName, r.autoIdx)
+			if r.kind == rowTrigger || r.kind == rowAgent {
+				return fleetPage.openConfirmDeleteAutomation(m, r)
 			}
 			if r.kind == rowAutomationTriggers || r.kind == rowAutomationAgents || r.kind == rowNewTrigger || r.kind == rowNewAgent {
 				break
@@ -238,6 +235,15 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			if r == nil {
 				m.message = "No fleet selected"
 				break
+			}
+			// In a fleet's automation view, 'a' adds a trigger or an agent
+			// (depending on which group the cursor sits in) rather than an
+			// instance, which would make no sense here.
+			if kind, ok := fleetPage.automationAddTarget(r); ok {
+				if kind == rowAgent {
+					return fleetPage.openAddAgentDialog(m, r.fleetName)
+				}
+				return fleetPage.openAddTriggerDialog(m, r.fleetName)
 			}
 			if r.kind == rowInstance || r.kind == rowSession || r.kind == rowNewSession {
 				instance := r.instance
@@ -735,22 +741,32 @@ func (fleetPage *fleetPage) contextualHelpKeysBase(m *model) []string {
 	switch r.kind {
 	case rowFleetHeader:
 		toggle := "m: automations"
+		addHint := "a: add instance"
 		if fleetPage.automationMode[r.fleetName] {
 			toggle = "m: instances"
+			addHint = "a: add trigger"
 		}
 		return withArmadaHint([]string{
 			"j/k: navigate", "→/l: select", "space/enter: expand/collapse", toggle, "e: edit fleet",
-			"a: add instance", "n: new fleet", "d: delete fleet", "r: refresh", "q: quit",
+			addHint, "n: new fleet", "d: delete fleet", "r: refresh", "q: quit",
 		})
 
 	case rowAutomationTriggers, rowAutomationAgents:
+		noun := "trigger"
+		if r.kind == rowAutomationAgents {
+			noun = "agent"
+		}
 		return withArmadaHint([]string{
-			"j/k: navigate", "space/enter: expand/collapse", "m: instances", "q: quit",
+			"j/k: navigate", "space/enter: expand/collapse", "a: add " + noun, "m: instances", "q: quit",
 		})
 
 	case rowTrigger, rowAgent:
+		noun := "trigger"
+		if r.kind == rowAgent {
+			noun = "agent"
+		}
 		return withArmadaHint([]string{
-			"j/k: navigate", "enter/e: edit", "d: delete", "m: instances", "q: quit",
+			"j/k: navigate", "enter/e: edit", "a: add " + noun, "d: delete", "m: instances", "q: quit",
 		})
 
 	case rowNewTrigger, rowNewAgent:

--- a/internal/tui/page_fleet_keys.go
+++ b/internal/tui/page_fleet_keys.go
@@ -453,7 +453,7 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 
 		case "right", "l":
 			// Select the current row's right-hand element — a fleet header's
-			// [automations]/[instances] mode toggle, or an expanded instance's
+			// ⟳/☰ mode toggle, or an expanded instance's
 			// inline PR status — so enter activates it. No-op on rows that carry
 			// no such element.
 			if fleetPage.currentRowHasRightElement(m) {

--- a/internal/tui/page_fleet_rows.go
+++ b/internal/tui/page_fleet_rows.go
@@ -230,7 +230,7 @@ func (fleetPage *fleetPage) currentRow() *row {
 
 // currentRowHasRightElement reports whether the cursor row carries a right-hand
 // element that →/l can select and enter can activate: a fleet header's
-// [automations]/[instances] mode toggle, or an expanded instance's inline PR
+// ⟳/☰ mode toggle, or an expanded instance's inline PR
 // status.
 func (fleetPage *fleetPage) currentRowHasRightElement(m *model) bool {
 	r := fleetPage.currentRow()

--- a/internal/tui/page_fleet_rows.go
+++ b/internal/tui/page_fleet_rows.go
@@ -97,11 +97,11 @@ func (fleetPage *fleetPage) buildRows(m *model) {
 		fleetPage.moveCursor(1)
 	}
 
-	// Drop a stale auto-tag selection if the cursor no longer sits on a row whose
-	// inline PR status is navigable (e.g. the PR closed, or a rebuild moved the
+	// Drop a stale right-hand selection if the cursor no longer sits on a row with
+	// a selectable right-hand element (e.g. a PR closed, or a rebuild moved the
 	// cursor off the row carrying it).
-	if fleetPage.tagSelected && len(fleetPage.selectedInlinePR(m)) == 0 {
-		fleetPage.tagSelected = false
+	if fleetPage.rightSelected && !fleetPage.currentRowHasRightElement(m) {
+		fleetPage.rightSelected = false
 	}
 }
 
@@ -202,7 +202,7 @@ func (fleetPage *fleetPage) toggleAutomationMode(m *model, name string) {
 		return
 	}
 	fleetPage.automationMode[name] = !fleetPage.automationMode[name]
-	fleetPage.tagSelected = false
+	fleetPage.rightSelected = false
 	fleetPage.buildRows(m)
 	fleetPage.cursorToFleetHeader(name)
 }
@@ -226,6 +226,18 @@ func (fleetPage *fleetPage) currentRow() *row {
 		return nil
 	}
 	return &fleetPage.rows[fleetPage.cursor]
+}
+
+// currentRowHasRightElement reports whether the cursor row carries a right-hand
+// element that →/l can select and enter can activate: a fleet header's
+// [automations]/[instances] mode toggle, or an expanded instance's inline PR
+// status.
+func (fleetPage *fleetPage) currentRowHasRightElement(m *model) bool {
+	r := fleetPage.currentRow()
+	if r == nil {
+		return false
+	}
+	return r.kind == rowFleetHeader || len(m.rowInlinePRRefs(*r)) > 0
 }
 
 // firstSelectable returns the index of the first selectable row (-1 if none).

--- a/internal/tui/page_fleet_toggle_select_test.go
+++ b/internal/tui/page_fleet_toggle_select_test.go
@@ -1,0 +1,105 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// cursorOnFleetHeader builds a single-fleet model ("alpha") and parks the cursor
+// on its header row, where the [automations]/[instances] mode toggle lives.
+func cursorOnFleetHeader(t *testing.T) (*fleetPage, *model) {
+	t.Helper()
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning}
+	fp := newFleetPage()
+	m := autoTagModel(fp, inst, false, nil)
+	fp.buildRows(m)
+	for i, r := range fp.rows {
+		if r.kind == rowFleetHeader {
+			fp.cursor = i
+			return fp, m
+		}
+	}
+	t.Fatalf("no fleet header row built")
+	return nil, nil
+}
+
+func TestRightSelectFlipsAutomationMode(t *testing.T) {
+	fp, m := cursorOnFleetHeader(t)
+
+	if fp.automationMode["alpha"] {
+		t.Fatal("fleet should start in instance mode")
+	}
+	fp.Update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if !fp.rightSelected {
+		t.Fatal("l should select the header's mode toggle")
+	}
+
+	// enter activates the toggle: flip to automation mode, keeping it focused.
+	fp.Update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if !fp.automationMode["alpha"] {
+		t.Fatal("enter on the selected toggle should switch to automation mode")
+	}
+	if !fp.rightSelected {
+		t.Fatal("the toggle should stay focused after flipping so enter flips back")
+	}
+	if r := fp.currentRow(); r == nil || r.kind != rowFleetHeader {
+		t.Fatalf("cursor should rest on the fleet header after toggling, got %#v", r)
+	}
+
+	// enter again flips back to the instance view.
+	fp.Update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if fp.automationMode["alpha"] {
+		t.Fatal("a second enter should switch back to instance mode")
+	}
+}
+
+func TestRightSelectHeaderDeselect(t *testing.T) {
+	fp, m := cursorOnFleetHeader(t)
+	fp.Update(m, tea.KeyMsg{Type: tea.KeyRight})
+	if !fp.rightSelected {
+		t.Fatal("right should select the toggle")
+	}
+	fp.Update(m, tea.KeyMsg{Type: tea.KeyLeft})
+	if fp.rightSelected {
+		t.Fatal("left should deselect the toggle")
+	}
+}
+
+func TestRightSelectHeaderClearedByVerticalMove(t *testing.T) {
+	fp, m := cursorOnFleetHeader(t)
+	fp.rightSelected = true
+	fp.Update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if fp.rightSelected {
+		t.Fatal("a vertical move should clear the toggle selection")
+	}
+}
+
+func TestSpaceFlipsModeWhenToggleSelected(t *testing.T) {
+	// While the toggle is selected, space must flip the mode rather than
+	// collapse/expand the fleet (the header's normal space action).
+	fp, m := cursorOnFleetHeader(t)
+	fp.rightSelected = true
+	fp.Update(m, tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}})
+	if !fp.automationMode["alpha"] {
+		t.Fatal("space on the selected toggle should switch to automation mode")
+	}
+	if fp.collapsed["alpha"] {
+		t.Fatal("space on the selected toggle must not collapse the fleet")
+	}
+}
+
+func TestRightSelectNoOpWithoutRightElement(t *testing.T) {
+	// On a plain instance row (no header toggle, no inline PR) →/l selects nothing.
+	fp, m := cursorOnFleetHeader(t)
+	for i, r := range fp.rows {
+		if r.kind == rowInstance {
+			fp.cursor = i
+		}
+	}
+	fp.Update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if fp.rightSelected {
+		t.Fatal("l on a row with no right-hand element must not select")
+	}
+}

--- a/internal/tui/page_fleet_view.go
+++ b/internal/tui/page_fleet_view.go
@@ -503,6 +503,8 @@ func (fleetPage *fleetPage) viewActiveDialog(m *model) string {
 		return fleetPage.renderRenameSessionDialog(m)
 	case viewConfirmDeleteSession:
 		return fleetPage.renderConfirmDeleteSessionDialog(m)
+	case viewConfirmDeleteAutomation:
+		return fleetPage.renderConfirmDeleteAutomationDialog(m)
 	case viewConfirmBrowserSwitch:
 		return fleetPage.renderConfirmBrowserSwitchDialog(m)
 	case viewArmadaSelect:

--- a/internal/tui/page_fleet_view.go
+++ b/internal/tui/page_fleet_view.go
@@ -19,11 +19,12 @@ const (
 	instanceNameWidth = 22
 
 	// instanceAutoMarkWidth is the cell width the trailing automation marker
-	// (" ⟳", issue #188) occupies INSIDE the fixed-width name column on an
-	// automation-spawned instance row. The name is truncated this much shorter to
+	// (" ⟳ " — a space on each side, issue #188) occupies INSIDE the fixed-width
+	// name column on an automation-spawned instance row. The trailing space keeps
+	// the glyph off the status word. The name is truncated this much shorter to
 	// make room, so the marker never widens the column or shifts the status word —
 	// and user-created rows keep their original, un-indented position.
-	instanceAutoMarkWidth = 2
+	instanceAutoMarkWidth = 3
 
 	// instanceStatusCol is the column where the status word starts on an instance
 	// row, and the indent the PR-status second line is rendered at so it sits
@@ -321,7 +322,8 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			// user-created rows are not indented at all.
 			markerSuffix, nameBudget := "", instanceNameWidth
 			if instance.Automated {
-				markerSuffix = " " + automationMarkStyle.Render(automationMark)
+				// A space on each side: one off the name, one off the status.
+				markerSuffix = " " + automationMarkStyle.Render(automationMark) + " "
 				nameBudget -= instanceAutoMarkWidth
 			}
 

--- a/internal/tui/page_fleet_view.go
+++ b/internal/tui/page_fleet_view.go
@@ -52,9 +52,16 @@ const (
 	// the child row's session label.
 	prStatusClickColumn = listContentXOffset + instanceStatusCol
 
-	// automationMark is the glyph shown before an automation-spawned instance's
-	// name (issue #188) — a clockwise loop reading as "runs on a schedule".
+	// automationMark is the automation motif (issue #188) — a clockwise loop
+	// reading as "runs on a schedule" — trailing automation-spawned instance names.
 	automationMark = "⟳"
+
+	// automationToggleMark / instancesMark are the mode-toggle button glyphs: ↻
+	// (instance view → switch to automation) and ☰ (automation view → switch to the
+	// instance list). ↻ is a lighter cycle arrow than automationMark's ⟳ — it sits
+	// better centered inside the [ ] button.
+	automationToggleMark = "↻"
+	instancesMark        = "☰"
 )
 
 // renderChildRowLine renders an instance child row (a session/group row or the
@@ -178,14 +185,14 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			}
 
 			// The fleet header carries a mode-toggle "button" (issue #188): the
-			// instance view shows the instance count plus an [automations] switch;
-			// the automation view shows an [instances] switch. 'm' (or a click on
-			// the button — see app.go) toggles it. We record the button's absolute
+			// instance view shows the instance count plus a [ ↻ ] switch (→ automation);
+			// the automation view shows a [ ☰ ] switch (→ instances). 'm' (or a click
+			// on the button — see app.go) toggles it. We record the button's absolute
 			// column span here so the click handler can hit-test it.
 			var suffix, toggleText string
-			// The toggle button highlights (pink) when the header's right-hand
-			// element is selected via →/l, mirroring the inline PR status; the
-			// instance count stays dim either way.
+			// The toggle icon highlights (pink) when the header's right-hand element
+			// is selected via →/l, mirroring the inline PR status; the instance count
+			// stays dim either way.
 			toggleStyle := dimStyle
 			if isSelected && fleetPage.rightSelected {
 				toggleStyle = selectedStyle
@@ -193,16 +200,16 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			// Columns before the suffix: cursor(2) + arrow(2) + name width.
 			labelStart := listContentXOffset + 4 + lipgloss.Width(r.fleetName)
 			if fleetPage.automationMode[r.fleetName] {
-				toggleText = "[instances]"
+				toggleText = "[ " + instancesMark + " ]"
 				suffix = dimStyle.Render(" ") + toggleStyle.Render(toggleText)
-				labelStart += 1 // a single leading space precedes the label
+				labelStart += 1 // a single leading space precedes the button
 			} else {
 				count := 0
 				if f, ok := m.st.Fleets[r.fleetName]; ok {
 					count = len(f.Instances)
 				}
 				countPart := fmt.Sprintf(" (%d) ", count)
-				toggleText = "[automations]"
+				toggleText = "[ " + automationToggleMark + " ]"
 				suffix = dimStyle.Render(countPart) + toggleStyle.Render(toggleText)
 				labelStart += lipgloss.Width(countPart)
 			}

--- a/internal/tui/page_fleet_view.go
+++ b/internal/tui/page_fleet_view.go
@@ -18,17 +18,18 @@ const (
 	// the main status word regardless of how long the instance name is.
 	instanceNameWidth = 22
 
-	// instanceAutoMarkWidth reserves a fixed 2-cell slot just before the instance
-	// name for the automation marker — the ⟳ glyph on automation-spawned instances
-	// (issue #188), blank otherwise — so names, and the status column, stay aligned
-	// whether or not a row carries the marker.
+	// instanceAutoMarkWidth is the cell width the trailing automation marker
+	// (" ⟳", issue #188) occupies INSIDE the fixed-width name column on an
+	// automation-spawned instance row. The name is truncated this much shorter to
+	// make room, so the marker never widens the column or shifts the status word —
+	// and user-created rows keep their original, un-indented position.
 	instanceAutoMarkWidth = 2
 
 	// instanceStatusCol is the column where the status word starts on an instance
 	// row, and the indent the PR-status second line is rendered at so it sits
 	// under that status. It is the sum of the row's fixed prefix cells: cursor(2)
-	// + gap(4) + arrow(2) + throbber(1) + gap(1) + auto-mark(2) + name + gap(1).
-	instanceStatusCol = 2 + 4 + 2 + 1 + 1 + instanceAutoMarkWidth + instanceNameWidth + 1
+	// + gap(4) + arrow(2) + throbber(1) + gap(1) + name + gap(1).
+	instanceStatusCol = 2 + 4 + 2 + 1 + 1 + instanceNameWidth + 1
 
 	// sessionLabelCol is the column an instance child row's label starts at:
 	// cursor(2) + the 8-space child indent (the "%s        %s" child-row format).
@@ -313,39 +314,43 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 				}
 			}
 
+			// Automation-spawned instances (issue #188) trail their name with a ⟳
+			// marker. It lives INSIDE the fixed-width name column — the name is
+			// truncated instanceAutoMarkWidth cells shorter to make room — so the
+			// marker never widens the column or shifts the status word, and
+			// user-created rows are not indented at all.
+			markerSuffix, nameBudget := "", instanceNameWidth
+			if instance.Automated {
+				markerSuffix = " " + automationMarkStyle.Render(automationMark)
+				nameBudget -= instanceAutoMarkWidth
+			}
+
 			// Truncate (with an ellipsis) before padding so a long name can't push
 			// the status column right and knock the PR-status second line below it
 			// out of alignment. Pad by VISUAL width (lipgloss.Width), not fmt's
 			// rune count, so a name with wide runes (CJK / emoji) still lands the
 			// status at exactly instanceStatusCol.
-			name := ansi.Truncate(instance.GetDisplayName(), instanceNameWidth, "…")
-			nameRaw := name + strings.Repeat(" ", max(0, instanceNameWidth-lipgloss.Width(name)))
+			name := ansi.Truncate(instance.GetDisplayName(), nameBudget, "…")
+			pad := strings.Repeat(" ", max(0, instanceNameWidth-lipgloss.Width(name)-lipgloss.Width(markerSuffix)))
 			var arrowStyled, nameStyled string
 			switch {
 			case isSelected && instanceColorHasCustom(instance.Color):
 				colorStyle := instanceColorStyle(instance.Color).Bold(true)
 				arrowStyled = colorStyle.Render(arrow)
-				nameStyled = colorStyle.Render(nameRaw)
+				nameStyled = colorStyle.Render(name)
 			case isSelected:
 				arrowStyled = selectedStyle.Render(arrow)
-				nameStyled = selectedStyle.Render(nameRaw)
+				nameStyled = selectedStyle.Render(name)
 			case instanceColorHasCustom(instance.Color):
 				colorStyle := instanceColorStyle(instance.Color)
 				arrowStyled = colorStyle.Render(arrow)
-				nameStyled = colorStyle.Render(nameRaw)
+				nameStyled = colorStyle.Render(name)
 			default:
 				arrowStyled = arrow
-				nameStyled = nameRaw
+				nameStyled = name
 			}
-			// Automation-spawned instances (issue #188) carry a ⟳ marker in the
-			// reserved auto-mark slot just before the name; user-created ones leave
-			// it blank. Both render to instanceAutoMarkWidth cells so names — and
-			// the status column — stay aligned regardless.
-			autoMark := strings.Repeat(" ", instanceAutoMarkWidth)
-			if instance.Automated {
-				autoMark = automationMarkStyle.Render(automationMark) + " "
-			}
-			paddedName := arrowStyled + throbber + " " + autoMark + nameStyled
+			// name + marker + padding together fill the fixed name column.
+			paddedName := arrowStyled + throbber + " " + nameStyled + markerSuffix + pad
 
 			backendIcon := "⬡"
 			switch instance.Backend {

--- a/internal/tui/page_fleet_view.go
+++ b/internal/tui/page_fleet_view.go
@@ -18,11 +18,17 @@ const (
 	// the main status word regardless of how long the instance name is.
 	instanceNameWidth = 22
 
+	// instanceAutoMarkWidth reserves a fixed 2-cell slot just before the instance
+	// name for the automation marker — the ⟳ glyph on automation-spawned instances
+	// (issue #188), blank otherwise — so names, and the status column, stay aligned
+	// whether or not a row carries the marker.
+	instanceAutoMarkWidth = 2
+
 	// instanceStatusCol is the column where the status word starts on an instance
 	// row, and the indent the PR-status second line is rendered at so it sits
 	// under that status. It is the sum of the row's fixed prefix cells: cursor(2)
-	// + gap(4) + arrow(2) + throbber(1) + gap(1) + name + gap(1).
-	instanceStatusCol = 2 + 4 + 2 + 1 + 1 + instanceNameWidth + 1
+	// + gap(4) + arrow(2) + throbber(1) + gap(1) + auto-mark(2) + name + gap(1).
+	instanceStatusCol = 2 + 4 + 2 + 1 + 1 + instanceAutoMarkWidth + instanceNameWidth + 1
 
 	// sessionLabelCol is the column an instance child row's label starts at:
 	// cursor(2) + the 8-space child indent (the "%s        %s" child-row format).
@@ -43,6 +49,10 @@ const (
 	// status begins, used to tell a click on the PR status apart from a click on
 	// the child row's session label.
 	prStatusClickColumn = listContentXOffset + instanceStatusCol
+
+	// automationMark is the glyph shown before an automation-spawned instance's
+	// name (issue #188) — a clockwise loop reading as "runs on a schedule".
+	automationMark = "⟳"
 )
 
 // renderChildRowLine renders an instance child row (a session/group row or the
@@ -327,7 +337,15 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 				arrowStyled = arrow
 				nameStyled = nameRaw
 			}
-			paddedName := arrowStyled + throbber + " " + nameStyled
+			// Automation-spawned instances (issue #188) carry a ⟳ marker in the
+			// reserved auto-mark slot just before the name; user-created ones leave
+			// it blank. Both render to instanceAutoMarkWidth cells so names — and
+			// the status column — stay aligned regardless.
+			autoMark := strings.Repeat(" ", instanceAutoMarkWidth)
+			if instance.Automated {
+				autoMark = automationMarkStyle.Render(automationMark) + " "
+			}
+			paddedName := arrowStyled + throbber + " " + autoMark + nameStyled
 
 			backendIcon := "⬡"
 			switch instance.Backend {

--- a/internal/tui/page_fleet_view.go
+++ b/internal/tui/page_fleet_view.go
@@ -171,11 +171,18 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			// the button — see app.go) toggles it. We record the button's absolute
 			// column span here so the click handler can hit-test it.
 			var suffix, toggleText string
+			// The toggle button highlights (pink) when the header's right-hand
+			// element is selected via →/l, mirroring the inline PR status; the
+			// instance count stays dim either way.
+			toggleStyle := dimStyle
+			if isSelected && fleetPage.rightSelected {
+				toggleStyle = selectedStyle
+			}
 			// Columns before the suffix: cursor(2) + arrow(2) + name width.
 			labelStart := listContentXOffset + 4 + lipgloss.Width(r.fleetName)
 			if fleetPage.automationMode[r.fleetName] {
 				toggleText = "[instances]"
-				suffix = dimStyle.Render(" " + toggleText)
+				suffix = dimStyle.Render(" ") + toggleStyle.Render(toggleText)
 				labelStart += 1 // a single leading space precedes the label
 			} else {
 				count := 0
@@ -184,7 +191,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 				}
 				countPart := fmt.Sprintf(" (%d) ", count)
 				toggleText = "[automations]"
-				suffix = dimStyle.Render(countPart + toggleText)
+				suffix = dimStyle.Render(countPart) + toggleStyle.Render(toggleText)
 				labelStart += lipgloss.Width(countPart)
 			}
 			fleetPage.rows[i].toggleX0 = labelStart
@@ -231,7 +238,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			if isSelected {
 				style = selectedStyle
 			}
-			listContent.WriteString(m.renderChildRowLine(cursor, label, style, r, isSelected && fleetPage.tagSelected))
+			listContent.WriteString(m.renderChildRowLine(cursor, label, style, r, isSelected && fleetPage.rightSelected))
 			listContent.WriteString("\n")
 
 		} else if r.kind == rowNewSession {
@@ -240,7 +247,7 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 			if isSelected {
 				style = selectedStyle
 			}
-			listContent.WriteString(m.renderChildRowLine(cursor, label, style, r, isSelected && fleetPage.tagSelected))
+			listContent.WriteString(m.renderChildRowLine(cursor, label, style, r, isSelected && fleetPage.rightSelected))
 			listContent.WriteString("\n")
 
 		} else if r.kind == rowInstance {

--- a/internal/tui/rows.go
+++ b/internal/tui/rows.go
@@ -41,7 +41,7 @@ type row struct {
 	// Settings.Agents (rowAgent) — the automation item this row renders/edits.
 	autoIdx int
 	// toggleX0/toggleX1 record the absolute terminal column span of the
-	// [automations]/[instances] mode-toggle button on a rowFleetHeader (set
+	// ⟳/☰ mode-toggle icon on a rowFleetHeader (set
 	// during View). A left click landing in [toggleX0, toggleX1) toggles the
 	// fleet's automation mode instead of collapsing it. toggleX1 == toggleX0
 	// means "no button here".

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -44,6 +44,12 @@ var (
 	dimStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("240"))
 
+	// automationMarkStyle colors the ⟳ marker on automation-spawned instances
+	// (issue #188): a calm cyan that reads as a distinct origin badge without
+	// competing with the status word or the agent indicators.
+	automationMarkStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("44"))
+
 	statusRunningStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("42"))
 

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -151,6 +151,12 @@ var (
 	newSessionStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("241"))
 
+	// Automation view group labels (triggers/agents). They mirror the instance
+	// view's hierarchy: fleet header blue, the group white like an instance name,
+	// and the trigger/agent items under it blue (sessionStyle) like sessions. Bold
+	// weight reads as a group header.
+	automationGroupStyle = lipgloss.NewStyle().Bold(true)
+
 	// Keybindings dialog
 	keybindingsDialogBox = lipgloss.NewStyle().
 				Border(lipgloss.RoundedBorder()).

--- a/internal/tui/view_mode.go
+++ b/internal/tui/view_mode.go
@@ -35,4 +35,5 @@ const (
 	viewChoosePR
 	viewAutomationTrigger
 	viewAutomationAgent
+	viewConfirmDeleteAutomation
 )


### PR DESCRIPTION
## Summary

A sweep of UX polish for the per-fleet **automation mode** (issue #188 / PR #194), done iteratively:

- **Keyboard-selectable mode toggle** — generalized the PR-status "select the element to the right" pattern (`tagSelected` → `rightSelected`): →/l focuses the header's mode toggle, enter flips it, mirroring the inline PR-status interaction.
- **Fixed `a`/`d` in the automation view** — `a` now opens the add-trigger/add-agent dialog by cursor position (was starting the create-instance flow); `d` on a trigger/agent now confirms before deleting (was deleting immediately). A referenced agent is still refused up front.
- **Origin marker for automation-spawned instances** — new persisted `Automated` flag (`fleet.Instance` + proto `Instance` field 31 + both converters + the scheduler's create path), surfaced as a calm-cyan `⟳` trailing the instance name. It lives inside the fixed-width name column, so the status column / PR-status alignment never shifts.
- **Less blue in the automation view** — the triggers/agents group headers render white (like instance names) while items keep the session blue, mirroring the instance view's fleet→instance→session hierarchy.
- **Edit long prompts in `\$EDITOR`** — the agent's Sys prompt and the trigger's Prompt open the user's `\$EDITOR` on a temp file (via `sh -c "\$EDITOR …"`, `\$VISUAL`>`\$EDITOR`>`vi`) instead of single-line inline typing; the dialog shows a one-line preview and the result is routed back through a resume message.
- **Icon mode-toggle** — replaced the `[automations]`/`[instances]` text with `[ ↻ ]` (→ automation) / `[ ☰ ]` (→ instances); the per-instance marker keeps the heavier `⟳`.

Notes:
- The server-side change is additive — `Automated bool` is set only by the scheduler's create path; the CreateInstance RPC and MCP create pass `false`. The flag survives the create→running lifecycle (`markInstanceRunning` is an in-place RMW).
- Unit coverage across all of the above (selection routing, confirm dialogs, the marker render + alignment guard + converters + the real scheduler path, the `\$EDITOR` round-trip through a real shell). itest 390 extended for the keyboard toggle, the `a`/`d` paths, and the `↻`/`☰` icon assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)