### PR TITLE
feat(automation): hand the triggering event to spawned agents

### DIFF
--- a/internal/server/automation_event_test.go
+++ b/internal/server/automation_event_test.go
@@ -1,0 +1,172 @@
+package server
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+func TestTriggerEventPayload(t *testing.T) {
+	now := time.Date(2026, 6, 22, 9, 30, 15, 0, time.UTC)
+
+	// Webhook: the raw request body is the payload, verbatim.
+	body := []byte(`{"action":"opened","number":7}`)
+	web := &triggerEvent{kind: fleet.TriggerWebhook, body: body, firedAt: now}
+	if got := web.payload(); !bytes.Equal(got, body) {
+		t.Fatalf("webhook payload = %q, want %q", got, body)
+	}
+
+	// Schedule: no external payload, so the fire time stands in.
+	sch := &triggerEvent{kind: fleet.TriggerSchedule, firedAt: now}
+	if got, want := string(sch.payload()), "2026-06-22T09:30:15Z\n"; got != want {
+		t.Fatalf("schedule payload = %q, want %q", got, want)
+	}
+}
+
+func TestAppendEventPrompt(t *testing.T) {
+	path := "/tmp/fleet-event-20260622T093015Z"
+
+	web := &triggerEvent{kind: fleet.TriggerWebhook, triggerName: "ci", webhookName: "ci"}
+	got := appendEventPrompt("fix the build", web, path)
+	for _, want := range []string{"fix the build", "\n\n---\n", `"ci" webhook trigger`, path, "read that file"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("webhook prompt missing %q:\n%s", want, got)
+		}
+	}
+
+	sch := &triggerEvent{kind: fleet.TriggerSchedule, triggerName: "nightly"}
+	got = appendEventPrompt("run the report", sch, path)
+	for _, want := range []string{"run the report", `"nightly" schedule trigger`, path} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("schedule prompt missing %q:\n%s", want, got)
+		}
+	}
+
+	// A blank prompt becomes just the note (no leading separator/whitespace).
+	got = appendEventPrompt("   ", web, path)
+	if strings.HasPrefix(got, " ") || strings.Contains(got, "---") {
+		t.Fatalf("blank prompt should yield just the note, got:\n%s", got)
+	}
+	if !strings.HasPrefix(got, "This session was started automatically") {
+		t.Fatalf("blank prompt note unexpected start:\n%s", got)
+	}
+}
+
+func TestAutomationEventPath(t *testing.T) {
+	// UTC, fixed prefix, second-granular stamp — stable and collision-free within
+	// a single (fresh-per-run) instance.
+	got := automationEventPath(time.Date(2026, 6, 22, 9, 30, 15, 0, time.FixedZone("x", 3600)))
+	if want := "/tmp/fleet-event-20260622T083015Z"; got != want {
+		t.Fatalf("event path = %q, want %q", got, want)
+	}
+}
+
+// TestWriteAutomationEventFile drives the real base64-over-stdin write by stubbing
+// the copy exec seam to run the same argv locally — so a payload of arbitrary
+// bytes round-trips through `base64 -d` exactly as it would inside a container.
+func TestWriteAutomationEventFile(t *testing.T) {
+	dir := t.TempDir()
+	orig := copyIntoExecCommand
+	copyIntoExecCommand = func(_ *fleet.Instance, argv []string) *exec.Cmd {
+		return exec.Command(argv[0], argv[1:]...)
+	}
+	t.Cleanup(func() { copyIntoExecCommand = orig })
+
+	cases := map[string][]byte{
+		"binary": {0x00, 0x01, 'h', 'i', 0xff, '\n', 0x04},
+		"json":   []byte(`{"a":1,"b":"two"}` + "\n"),
+		"empty":  {},
+	}
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(dir, name)
+			if err := writeAutomationEventFile(&fleet.Instance{}, path, data); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read back: %v", err)
+			}
+			if !bytes.Equal(got, data) {
+				t.Fatalf("round-trip mismatch: got %q want %q", got, data)
+			}
+		})
+	}
+}
+
+// TestFireTriggerAgentsAttachesEvent confirms both fire paths hang the right
+// triggerEvent off each watched agent: a webhook carries its body, a schedule
+// carries none (its payload is synthesized from the fire time at launch).
+func TestFireTriggerAgentsAttachesEvent(t *testing.T) {
+	st := &state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Settings: fleet.FleetSettings{
+			Agents: []fleet.Agent{{Name: "a", Backend: fleet.BackendDevcontainer}},
+		}},
+	}}
+	origLoad := scheduleLoadState
+	scheduleLoadState = func() (*state.State, error) { return st, nil }
+	origCreate := createAutomationInstance
+	createAutomationInstance = func(_ *service, _ string, ag fleet.Agent, _ time.Time) (string, error) {
+		return "inst-" + ag.Name, nil
+	}
+	t.Cleanup(func() { scheduleLoadState = origLoad; createAutomationInstance = origCreate })
+
+	s := &service{}
+	now := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
+
+	// Webhook path: body rides through to the event.
+	body := []byte(`{"ref":"main"}`)
+	sched := newScheduler()
+	wtrig := fleet.Trigger{Name: "ci", Type: fleet.TriggerWebhook, AgentNames: []string{"a"}, WebhookName: "ci"}
+	s.fireWebhookBatch(sched, []webhookFire{{fleet: "alpha", trigger: wtrig, body: body}}, now)
+	ev := sched.watched["alpha/inst-a"].event
+	if ev == nil {
+		t.Fatal("webhook agent has no event")
+	}
+	if ev.kind != fleet.TriggerWebhook || ev.triggerName != "ci" || ev.webhookName != "ci" {
+		t.Fatalf("webhook event fields wrong: %+v", ev)
+	}
+	if !bytes.Equal(ev.body, body) {
+		t.Fatalf("webhook event body = %q, want %q", ev.body, body)
+	}
+
+	// Schedule path: nil body, kind=schedule, fire time recorded.
+	sched = newScheduler()
+	strig := fleet.Trigger{Name: "nightly", Type: fleet.TriggerSchedule, AgentNames: []string{"a"}}
+	s.fireTriggerAgents(sched, "alpha", strig, []fleet.Agent{{Name: "a"}}, now, nil)
+	ev = sched.watched["alpha/inst-a"].event
+	if ev == nil {
+		t.Fatal("schedule agent has no event")
+	}
+	if ev.kind != fleet.TriggerSchedule || ev.body != nil || !ev.firedAt.Equal(now) {
+		t.Fatalf("schedule event fields wrong: %+v", ev)
+	}
+}
+
+// TestServeWebhookCarriesBodyToFire confirms the request body survives the whole
+// receiver→scheduler hand-off, so the agent really gets the event it fired on.
+func TestServeWebhookCarriesBodyToFire(t *testing.T) {
+	s := newService()
+	st := webhookState(fleet.Trigger{
+		Name: "deploy", Type: fleet.TriggerWebhook, AgentNames: []string{"a"},
+		WebhookName: "deploy", FilterType: fleet.WebhookFilterRegex, Regex: `"env":"prod"`,
+	})
+	payload := `{"env":"prod","sha":"abc123"}`
+	if w := postWebhook(t, s, st, "deploy", payload); w.Code != 200 {
+		t.Fatalf("status = %d, body=%q", w.Code, w.Body.String())
+	}
+	batch := drainBatch(s)
+	if len(batch) != 1 {
+		t.Fatalf("expected 1 fire, got %d", len(batch))
+	}
+	if string(batch[0].body) != payload {
+		t.Fatalf("fire body = %q, want %q", batch[0].body, payload)
+	}
+}

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"strings"
@@ -90,6 +91,34 @@ type watchedAgent struct {
 	// screen-diff fallback). Lazily created/replaced in automationActivity.
 	detector     agentdetect.Detector
 	detectorTool state.AgentTool
+	// event describes the trigger firing that spawned this agent. At launch its
+	// payload is written into the instance and a note pointing at that file is
+	// appended to the prompt, so the agent knows what fired it. Nil only if a
+	// future caller spawns an agent outside the trigger path.
+	event *triggerEvent
+}
+
+// triggerEvent carries the context of the trigger firing that spawned an agent:
+// what fired it (schedule vs webhook), when, and — for a webhook — the request
+// body. launchAutomationCommand materializes payload() into a file inside the
+// instance and tells the agent where to read it (appendEventPrompt), so the
+// agent can act on the actual event rather than the static prompt alone.
+type triggerEvent struct {
+	kind        fleet.TriggerType
+	triggerName string
+	firedAt     time.Time
+	webhookName string // webhook only
+	body        []byte // webhook request body; nil for schedule triggers
+}
+
+// payload returns the bytes written to the in-instance event file: the raw
+// webhook body for a webhook trigger, or the fire time for a schedule trigger
+// (which carries no external payload of its own).
+func (e *triggerEvent) payload() []byte {
+	if e.kind == fleet.TriggerWebhook {
+		return e.body
+	}
+	return []byte(e.firedAt.UTC().Format(time.RFC3339) + "\n")
 }
 
 func (w *watchedAgent) key() string { return w.fleet + "/" + w.instance }
@@ -115,11 +144,12 @@ const webhookFireBuffer = 64
 // webhookFire is a matched automation webhook event handed from the (concurrent)
 // webhook receiver to the scheduler goroutine, which spawns the trigger's agents.
 // The receiver has already evaluated the trigger's filter against the event body;
-// only the static trigger Prompt (not the body) feeds the agents, matching the
-// schedule path.
+// body carries that same payload through so each spawned agent can be handed the
+// event it fired on (written into its instance and referenced from the prompt).
 type webhookFire struct {
 	fleet   string
 	trigger fleet.Trigger
+	body    []byte
 }
 
 // runScheduler is the automation loop; it returns when ctx is cancelled. It
@@ -166,7 +196,7 @@ func (s *service) fireWebhookBatch(sched *scheduler, batch []webhookFire, now ti
 			flog.Warn("automation: webhook trigger has no live agents", "fleet", f.fleet, "trigger", f.trigger.Name)
 			continue
 		}
-		s.fireTriggerAgents(sched, f.fleet, f.trigger, agents, now)
+		s.fireTriggerAgents(sched, f.fleet, f.trigger, agents, now, f.body)
 	}
 }
 
@@ -184,7 +214,9 @@ func (s *service) schedulerTick(ctx context.Context, sched *scheduler, now time.
 	fired := false
 	for _, due := range dueSchedules(st.Fleets, now, sched.lastFired) {
 		agents := agentsForTrigger(st.Fleets[due.fleet], due.trigger)
-		if s.fireTriggerAgents(sched, due.fleet, due.trigger, agents, now) {
+		// Schedule triggers carry no external payload — the event file gets the
+		// fire time (see triggerEvent.payload), so pass a nil body here.
+		if s.fireTriggerAgents(sched, due.fleet, due.trigger, agents, now, nil) {
 			fired = true
 		}
 	}
@@ -203,10 +235,12 @@ func (s *service) schedulerTick(ctx context.Context, sched *scheduler, now time.
 
 // fireTriggerAgents spawns one instance per agent the trigger activates and
 // registers each in the watch set, returning whether anything was spawned (the
-// caller reloads state when so, see schedulerTick). Shared by the schedule path
-// and the webhook path; it only mutates sched.watched, so it MUST run on the
-// scheduler goroutine.
-func (s *service) fireTriggerAgents(sched *scheduler, fleetName string, trigger fleet.Trigger, agents []fleet.Agent, now time.Time) bool {
+// caller reloads state when so, see schedulerTick). body is the webhook request
+// payload (nil for schedule triggers); it rides each watched agent's event so
+// the launch can hand it to the agent. Shared by the schedule path and the
+// webhook path; it only mutates sched.watched, so it MUST run on the scheduler
+// goroutine.
+func (s *service) fireTriggerAgents(sched *scheduler, fleetName string, trigger fleet.Trigger, agents []fleet.Agent, now time.Time, body []byte) bool {
 	fired := false
 	for _, ag := range agents {
 		instName, err := createAutomationInstance(s, fleetName, ag, now)
@@ -223,6 +257,13 @@ func (s *service) fireTriggerAgents(sched *scheduler, fleetName string, trigger 
 			systemPrompt: ag.SystemPrompt,
 			spawnedAt:    now,
 			lastActive:   now,
+			event: &triggerEvent{
+				kind:        trigger.Type,
+				triggerName: trigger.Name,
+				firedAt:     now,
+				webhookName: trigger.WebhookName,
+				body:        body,
+			},
 		}
 		sched.watched[w.key()] = w
 		fired = true
@@ -451,14 +492,71 @@ var createAutomationInstance = func(s *service, fleetName string, ag fleet.Agent
 // may apt-install tmux on first use.
 var launchAutomationCommand = func(ctx context.Context, s *service, w *watchedAgent, inst *fleet.Instance) {
 	session := tui.ResolveSessionName(inst.Name, "agent")
-	command := fleet.SubstituteAgentCommand(w.command, w.prompt, w.systemPrompt)
+	prompt := w.prompt
+	var eventPath string
+	if w.event != nil {
+		eventPath = automationEventPath(w.event.firedAt)
+		prompt = appendEventPrompt(prompt, w.event, eventPath)
+	}
+	command := fleet.SubstituteAgentCommand(w.command, prompt, w.systemPrompt)
 	script := buildAgentLaunchScript(session, command)
 	b := s.hub.backendFor(inst)
 	go func() {
+		// Write the trigger payload into the instance BEFORE launching the agent,
+		// so the file the prompt points at already exists the moment the agent
+		// starts. Best-effort: a write failure still launches the agent (it just
+		// finds no event file) rather than dropping the whole run.
+		if w.event != nil {
+			if err := writeAutomationEventFile(inst, eventPath, w.event.payload()); err != nil {
+				flog.Warn("automation: write event file failed", "instance", inst.Name, "path", eventPath, "err", err)
+			}
+		}
 		if out, err := b.RunScript(inst.ContainerID, script); err != nil {
 			flog.Error("automation: launch agent failed", "instance", inst.Name, "err", err, "out", strings.TrimSpace(out))
 		}
 	}()
+}
+
+// automationEventPath is where a run's trigger payload is written inside its
+// instance. Each automation run gets a fresh container, so a single fixed-prefix,
+// time-stamped name never collides within one instance.
+func automationEventPath(firedAt time.Time) string {
+	return "/tmp/fleet-event-" + firedAt.UTC().Format("20060102T150405Z")
+}
+
+// appendEventPrompt appends a note to the agent prompt naming what fired the run
+// and where its payload was written, so the agent reads the actual event rather
+// than working from the static prompt alone. A blank prompt becomes just the note.
+func appendEventPrompt(prompt string, e *triggerEvent, path string) string {
+	var detail string
+	if e.kind == fleet.TriggerWebhook {
+		detail = fmt.Sprintf("Its payload has been written to %s in this instance — read that file for the event details.", path)
+	} else {
+		detail = fmt.Sprintf("The time it fired has been written to %s in this instance.", path)
+	}
+	note := fmt.Sprintf("This session was started automatically by the %q %s trigger. %s", e.triggerName, e.kind, detail)
+	if strings.TrimSpace(prompt) == "" {
+		return note
+	}
+	return prompt + "\n\n---\n" + note
+}
+
+// writeAutomationEventFile writes data to path inside the instance. It reuses the
+// fleet-copy exec seam (copyIntoExecCommand) and streams the payload as base64
+// over STDIN, decoded in-container — so a payload of any size avoids the argv
+// length limit a shell-embedded write would hit, arbitrary bytes survive intact,
+// and the base64 text stays clean over the codespaces backend's exec PTY (which
+// mangles raw binary). A package var so tests can stub the exec.
+var writeAutomationEventFile = func(inst *fleet.Instance, path string, data []byte) error {
+	cmd := copyIntoExecCommand(inst, []string{"sh", "-c", "base64 -d > " + dotfiles.ShQuote(path)})
+	cmd.Stdin = strings.NewReader(base64.StdEncoding.EncodeToString(data))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		if msg := strings.TrimSpace(string(out)); msg != "" {
+			return fmt.Errorf("%w: %s", err, msg)
+		}
+		return err
+	}
+	return nil
 }
 
 // buildAgentLaunchScript builds the in-container snippet that brings up the agent

--- a/internal/server/webhook.go
+++ b/internal/server/webhook.go
@@ -116,7 +116,7 @@ func collectWebhookFires(st *state.State, name string, body []byte) (fires []web
 				continue // a disabled trigger still exists (200, not 404) but never fires
 			}
 			if t.MatchesWebhook(body) {
-				fires = append(fires, webhookFire{fleet: fleetName, trigger: t})
+				fires = append(fires, webhookFire{fleet: fleetName, trigger: t, body: body})
 			}
 		}
 	}


### PR DESCRIPTION
## What

Automation-spawned agents now receive context about the event that triggered them. The static trigger prompt alone doesn't tell an agent *what just happened* — a webhook fired with *which* payload, or *when* a schedule ran. This wires that through.

At launch, each run's event payload is written into its instance at `/tmp/fleet-event-<timestamp>`, and a note is appended **after** the user prompt pointing the agent at that file:

- **webhook** triggers → the raw request body
- **schedule** triggers → the fire time (RFC3339)

Example appended note:

> This session was started automatically by the `"deploy"` webhook trigger. Its payload has been written to `/tmp/fleet-event-20260622T090000Z` in this instance — read that file for the event details.

## How

- **Thread the webhook body through.** It was read for filter matching and then discarded; `webhookFire` now carries it from the receiver to the scheduler, and `fireTriggerAgents` hangs a `triggerEvent` (kind, trigger name, fire time, webhook name, body) off each `watchedAgent`.
- **Write the payload into the instance** by reusing the fleet-copy exec seam (`copyIntoExecCommand`), streaming the payload as **base64 over stdin** and decoding in-container. This dodges the `MAX_ARG_STRLEN` (~128 KiB) limit a shell-embedded write would hit on a ~1 MiB webhook body, keeps arbitrary bytes intact, and stays PTY-safe over the codespaces backend's exec (which mangles raw binary). The write happens in the launch goroutine *before* the agent starts, so the file exists the moment it's referenced. Best-effort: a write failure still launches the agent (it just finds no file) rather than dropping the run.
- **Augment the prompt before substitution** so the note rides `${PROMPT}` exactly like the user prompt does — no keystroke injection.

## Tests

New `automation_event_test.go`:
- `payload()` for both trigger kinds
- `appendEventPrompt` (webhook/schedule/blank-prompt cases)
- `automationEventPath` format
- `writeAutomationEventFile` round-trips arbitrary bytes (binary/json/empty) through real `base64 -d`
- `fireTriggerAgents` attaches the right event on both paths
- end-to-end: the request body survives `serveWebhook` → scheduler hand-off

`go build`, `go vet ./...`, and `go test ./internal/server/ ./internal/fleet/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)