### PR TITLE
feat(automation): edit-dialog field reorder, one-line prompt, instant-save

### DIFF
--- a/internal/tui/automation_test.go
+++ b/internal/tui/automation_test.go
@@ -322,6 +322,87 @@ func TestEditAgentInstantSavesFieldCommit(t *testing.T) {
 	}
 }
 
+// TestEditTriggerTypeSwitchDoesNotFlashError: flipping Type while editing makes
+// the other type's required fields appear empty; that transient invalid state
+// must not flash a validation error, and must not persist over the last good one.
+func TestEditTriggerTypeSwitchDoesNotFlashError(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	seedTrigger(m) // valid schedule trigger "nightly"
+
+	fp.openEditTriggerDialog(m, "alpha", 0)
+	fp.triggerDlg.row = trigRowType
+	// Schedule → Webhook: webhook name/regex are still empty.
+	fp.updateAutomationTrigger(m, tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}})
+
+	if fp.triggerDlg.errMsg != "" {
+		t.Fatalf("a structural type switch must not flash an error, got %q", fp.triggerDlg.errMsg)
+	}
+	if got := m.st.Fleets["alpha"].Settings.Triggers[0].Type; got != fleet.TriggerSchedule {
+		t.Fatalf("incomplete webhook must not persist; type = %q, want schedule", got)
+	}
+	if fp.mode != viewAutomationTrigger {
+		t.Fatal("dialog should stay open during a multi-step type switch")
+	}
+
+	// Completing the webhook fields then makes it persist.
+	fp.triggerDlg.webhookName = "deploy"
+	fp.triggerDlg.regex = ".*"
+	fp.autosaveTrigger(m)
+	if got := m.st.Fleets["alpha"].Settings.Triggers[0]; got.Type != fleet.TriggerWebhook || got.WebhookName != "deploy" {
+		t.Fatalf("completed webhook should persist: %+v", got)
+	}
+}
+
+// TestEditTriggerCloseSignalsUnsavedChange: closing an edit left in an unsavable
+// state warns the user rather than discarding silently, and keeps the last good
+// state on disk.
+func TestEditTriggerCloseSignalsUnsavedChange(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	seedTrigger(m)
+
+	fp.openEditTriggerDialog(m, "alpha", 0)
+	fp.triggerDlg.name = "" // invalid — never persists
+	fp.updateAutomationTrigger(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+
+	if !strings.Contains(m.message, "not saved") {
+		t.Fatalf("closing with an unsavable edit should warn, got %q", m.message)
+	}
+	if got := m.st.Fleets["alpha"].Settings.Triggers[0].Name; got != "nightly" {
+		t.Fatalf("last good state must remain on disk; name = %q", got)
+	}
+}
+
+// TestEditTriggerCloseQuietWhenClean: closing a valid edit says nothing (it was
+// already instant-saved).
+func TestEditTriggerCloseQuietWhenClean(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	seedTrigger(m)
+
+	fp.openEditTriggerDialog(m, "alpha", 0)
+	fp.updateAutomationTrigger(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if m.message != "" {
+		t.Fatalf("closing a clean edit should be silent, got %q", m.message)
+	}
+}
+
+// TestEditAgentCloseSignalsUnsavedChange mirrors the trigger close-signal for the
+// agent dialog (which has no structural switches but can still be left invalid).
+func TestEditAgentCloseSignalsUnsavedChange(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	m.st.Fleets["alpha"].Settings.Agents = []fleet.Agent{{Name: "builder", Command: "echo hi", Backend: fleet.BackendDevcontainer}}
+
+	fp.openEditAgentDialog(m, "alpha", 0)
+	fp.agentDlg.name = "" // invalid
+	fp.updateAutomationAgent(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+
+	if !strings.Contains(m.message, "not saved") {
+		t.Fatalf("closing with an unsavable agent edit should warn, got %q", m.message)
+	}
+	if got := m.st.Fleets["alpha"].Settings.Agents[0].Name; got != "builder" {
+		t.Fatalf("last good agent must remain on disk; name = %q", got)
+	}
+}
+
 // TestTriggerWebhookURL confirms the dialog builds a copy-pasteable webhook URL
 // from the gateway-assigned base + the (escaped) name, and returns "" when either
 // piece is missing.

--- a/internal/tui/automation_test.go
+++ b/internal/tui/automation_test.go
@@ -192,10 +192,133 @@ func TestEditTriggerPreservesDisabled(t *testing.T) {
 	// The dialog's Enabled toggle flips it back on.
 	fp.openEditTriggerDialog(m, "alpha", 0)
 	fp.triggerDlg.row = trigRowEnabled
-	fp.toggleTriggerEnabled()
+	fp.toggleTriggerEnabled(m)
 	fp.saveAutomationTrigger(m)
 	if m.st.Fleets["alpha"].Settings.Triggers[0].Disabled {
 		t.Fatal("toggling Enabled in the dialog should re-enable the trigger")
+	}
+}
+
+// --- Instant-save: editing an existing agent/trigger persists on every change,
+// with no Save row; creating a new one still needs an explicit Save. ---
+
+func seedTrigger(m *model) *fleet.Fleet {
+	f := m.st.Fleets["alpha"]
+	f.Settings.Agents = []fleet.Agent{{Name: "a", Backend: fleet.BackendDevcontainer}}
+	f.Settings.Triggers = []fleet.Trigger{{Name: "nightly", Type: fleet.TriggerSchedule, AgentNames: []string{"a"}, Cron: "0 0 * * *"}}
+	return f
+}
+
+// TestTriggerSaveRowOnlyWhenCreating: the Save row exists for a new trigger and
+// is gone when editing (instant-save).
+func TestTriggerSaveRowOnlyWhenCreating(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	seedTrigger(m)
+
+	fp.openAddTriggerDialog(m, "alpha")
+	if !slices.Contains(fp.visibleTriggerRows(m), trigRowSave) {
+		t.Fatal("a new trigger must offer a Save row")
+	}
+	fp.openEditTriggerDialog(m, "alpha", 0)
+	if slices.Contains(fp.visibleTriggerRows(m), trigRowSave) {
+		t.Fatal("editing instant-saves; there must be no Save row")
+	}
+}
+
+// TestEditTriggerInstantSavesOnToggle: flipping Enabled while editing persists
+// immediately, without an explicit save, and leaves the dialog open.
+func TestEditTriggerInstantSavesOnToggle(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	seedTrigger(m)
+
+	fp.openEditTriggerDialog(m, "alpha", 0)
+	fp.triggerDlg.row = trigRowEnabled
+	fp.updateAutomationTrigger(m, tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}})
+
+	if !m.st.Fleets["alpha"].Settings.Triggers[0].Disabled {
+		t.Fatal("toggling Enabled should instant-save Disabled=true")
+	}
+	if fp.mode != viewAutomationTrigger {
+		t.Fatal("dialog should stay open after an instant-save toggle")
+	}
+}
+
+// TestEditTriggerInstantSavesFieldCommit: committing an inline text edit (enter)
+// persists immediately even though there is no Save row.
+func TestEditTriggerInstantSavesFieldCommit(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	seedTrigger(m)
+
+	fp.openEditTriggerDialog(m, "alpha", 0)
+	fp.triggerDlg.row = trigRowName
+	fp.updateAutomationTrigger(m, tea.KeyMsg{Type: tea.KeyEnter}) // activate field
+	fp.triggerDlg.input.SetValue("renamed")
+	fp.updateAutomationTrigger(m, tea.KeyMsg{Type: tea.KeyEnter}) // commit → instant-save
+
+	if got := m.st.Fleets["alpha"].Settings.Triggers[0].Name; got != "renamed" {
+		t.Fatalf("name not instant-saved: %q", got)
+	}
+}
+
+// TestEditTriggerAutosaveValidationKeepsLastGood: an edit that fails validation
+// (here, an empty name) surfaces an error and never persists, so the last good
+// state survives.
+func TestEditTriggerAutosaveValidationKeepsLastGood(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	seedTrigger(m)
+
+	fp.openEditTriggerDialog(m, "alpha", 0)
+	fp.triggerDlg.name = ""
+	fp.autosaveTrigger(m)
+
+	if fp.triggerDlg.errMsg == "" {
+		t.Fatal("clearing the name should surface a validation error")
+	}
+	if got := m.st.Fleets["alpha"].Settings.Triggers[0].Name; got != "nightly" {
+		t.Fatalf("invalid edit must not persist; name = %q, want nightly", got)
+	}
+}
+
+// TestAgentSaveRowOnlyWhenCreating: the agent dialog shows a Save button (and
+// counts it as a navigable row) only when creating; editing instant-saves.
+func TestAgentSaveRowOnlyWhenCreating(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	m.st.Fleets["alpha"].Settings.Agents = []fleet.Agent{{Name: "builder", Command: "echo hi", Backend: fleet.BackendDevcontainer}}
+
+	fp.openAddAgentDialog(m, "alpha")
+	if fp.agentDlg.rowCount() != agentRowCount {
+		t.Fatalf("new agent rowCount = %d, want %d", fp.agentDlg.rowCount(), agentRowCount)
+	}
+	if !strings.Contains(fp.renderAutomationAgentDialog(m), "[ Save ]") {
+		t.Fatal("a new agent must show the Save button")
+	}
+
+	fp.openEditAgentDialog(m, "alpha", 0)
+	if fp.agentDlg.rowCount() != agentRowSave {
+		t.Fatalf("edit agent rowCount = %d, want %d (Save excluded)", fp.agentDlg.rowCount(), agentRowSave)
+	}
+	if strings.Contains(fp.renderAutomationAgentDialog(m), "[ Save ]") {
+		t.Fatal("editing instant-saves; the Save button must be gone")
+	}
+}
+
+// TestEditAgentInstantSavesFieldCommit: committing an inline command edit while
+// editing an agent persists immediately and keeps the dialog open.
+func TestEditAgentInstantSavesFieldCommit(t *testing.T) {
+	m, fp := newAutomationModel(t)
+	m.st.Fleets["alpha"].Settings.Agents = []fleet.Agent{{Name: "builder", Command: "echo hi", Backend: fleet.BackendDevcontainer}}
+
+	fp.openEditAgentDialog(m, "alpha", 0)
+	fp.agentDlg.row = agentRowCommand
+	fp.updateAutomationAgent(m, tea.KeyMsg{Type: tea.KeyEnter}) // activate field
+	fp.agentDlg.input.SetValue("echo bye")
+	fp.updateAutomationAgent(m, tea.KeyMsg{Type: tea.KeyEnter}) // commit → instant-save
+
+	if got := m.st.Fleets["alpha"].Settings.Agents[0].Command; got != "echo bye" {
+		t.Fatalf("command not instant-saved: %q", got)
+	}
+	if fp.mode != viewAutomationAgent {
+		t.Fatal("dialog should stay open after an instant-save edit")
 	}
 }
 

--- a/internal/tui/dialog_automation_agent.go
+++ b/internal/tui/dialog_automation_agent.go
@@ -92,6 +92,15 @@ func (fleetPage *fleetPage) openEditAgentDialog(m *model, fleetName string, idx 
 	return nil
 }
 
+// rowCount is the number of navigable rows. Editing an existing agent is
+// instant-save and omits the Save row, so it stops one short of agentRowCount.
+func (st *automationAgentState) rowCount() int {
+	if st.editIdx >= 0 {
+		return agentRowSave
+	}
+	return agentRowCount
+}
+
 func (fleetPage *fleetPage) updateAutomationAgent(m *model, msg tea.Msg) tea.Cmd {
 	st := &fleetPage.agentDlg
 	key, ok := msg.(tea.KeyMsg)
@@ -103,6 +112,7 @@ func (fleetPage *fleetPage) updateAutomationAgent(m *model, msg tea.Msg) tea.Cmd
 		switch key.String() {
 		case "enter":
 			fleetPage.commitAgentField()
+			fleetPage.autosaveAgent(m)
 			return nil
 		case "esc":
 			st.fieldActive = false
@@ -120,21 +130,25 @@ func (fleetPage *fleetPage) updateAutomationAgent(m *model, msg tea.Msg) tea.Cmd
 	case "q", "esc", "ctrl+c":
 		return fleetPage.cancelAutomationAgent(m)
 	case "up", "k", "shift+tab":
-		st.row = (st.row - 1 + agentRowCount) % agentRowCount
+		n := st.rowCount()
+		st.row = (st.row - 1 + n) % n
 		return nil
 	case "down", "j", "tab":
-		st.row = (st.row + 1) % agentRowCount
+		n := st.rowCount()
+		st.row = (st.row + 1) % n
 		return nil
 	case "enter", " ":
 		return fleetPage.agentRowEnter(m)
 	case "left", "h":
 		if st.row == agentRowBackend {
 			st.backend = nextBackendType(st.backend, -1, allBackendTypes)
+			fleetPage.autosaveAgent(m)
 		}
 		return nil
 	case "right", "l":
 		if st.row == agentRowBackend {
 			st.backend = nextBackendType(st.backend, 1, allBackendTypes)
+			fleetPage.autosaveAgent(m)
 		}
 		return nil
 	}
@@ -165,6 +179,7 @@ func (fleetPage *fleetPage) agentRowEnter(m *model) tea.Cmd {
 		return editorCmd(editorTargetAgentSysPrompt, "sysprompt", st.systemPrompt)
 	case agentRowBackend:
 		st.backend = nextBackendType(st.backend, 1, allBackendTypes)
+		fleetPage.autosaveAgent(m)
 	case agentRowSave:
 		return fleetPage.saveAutomationAgent(m)
 	}
@@ -209,11 +224,57 @@ func (fleetPage *fleetPage) commitAgentField() {
 }
 
 func (fleetPage *fleetPage) cancelAutomationAgent(m *model) tea.Cmd {
-	fleetPage.agentDlg.fieldActive = false
-	fleetPage.agentDlg.input.Blur()
+	st := &fleetPage.agentDlg
+	st.fieldActive = false
+	st.input.Blur()
 	fleetPage.mode = viewNormal
-	m.message = "Cancelled"
+	// Editing is instant-save, so closing is just "done" — only a new (unsaved)
+	// agent is actually discarded.
+	if st.editIdx < 0 {
+		m.message = "Cancelled"
+	} else {
+		m.message = ""
+	}
 	return nil
+}
+
+// agentCandidate builds a fleet.Agent from the current form state.
+func (fleetPage *fleetPage) agentCandidate() fleet.Agent {
+	st := &fleetPage.agentDlg
+	return fleet.Agent{
+		Name:         st.name,
+		Command:      st.command,
+		SystemPrompt: st.systemPrompt,
+		Backend:      st.backend,
+	}
+}
+
+// autosaveAgent persists the form immediately when editing an existing agent
+// (instant-save, like the settings page). It is a no-op for a new agent, whose
+// explicit Save button owns creation. A validation/RPC failure surfaces inline
+// and leaves the last-good persisted state intact (the in-memory revert lives in
+// persistAutomationSettings); a success clears the error. A successful rename
+// rewrites every trigger that referenced the old name (fleet.UpdateAgent).
+func (fleetPage *fleetPage) autosaveAgent(m *model) {
+	st := &fleetPage.agentDlg
+	if st.editIdx < 0 {
+		return
+	}
+	f, ok := m.st.Fleets[st.fleetName]
+	if !ok || st.editIdx >= len(f.Settings.Agents) {
+		return
+	}
+	oldName := f.Settings.Agents[st.editIdx].Name
+	newSettings, err := fleet.UpdateAgent(f.Settings, oldName, fleetPage.agentCandidate())
+	if err != nil {
+		st.errMsg = err.Error()
+		return
+	}
+	if err := fleetPage.persistAutomationSettings(m, st.fleetName, newSettings); err != nil {
+		st.errMsg = err.Error()
+		return
+	}
+	st.errMsg = ""
 }
 
 func (fleetPage *fleetPage) saveAutomationAgent(m *model) tea.Cmd {
@@ -221,12 +282,7 @@ func (fleetPage *fleetPage) saveAutomationAgent(m *model) tea.Cmd {
 	if st.fieldActive {
 		fleetPage.commitAgentField()
 	}
-	candidate := fleet.Agent{
-		Name:         st.name,
-		Command:      st.command,
-		SystemPrompt: st.systemPrompt,
-		Backend:      st.backend,
-	}
+	candidate := fleetPage.agentCandidate()
 
 	f, ok := m.st.Fleets[st.fleetName]
 	if !ok {
@@ -290,13 +346,16 @@ func (fleetPage *fleetPage) renderAutomationAgentDialog(m *model) string {
 	fmt.Fprintf(&body, "%s%s %s\n", marker(agentRowCommand), dialogLabel.Render("Command: "), field(agentRowCommand, st.command, fleet.DefaultAgentCommand))
 	fmt.Fprintf(&body, "%s%s %s\n", marker(agentRowSystemPrompt), dialogLabel.Render("Sys prompt:"), promptFieldPreview(st.systemPrompt, "(optional, injected into ${SYS_PROMPT})"))
 	fmt.Fprintf(&body, "%s%s [ %s ]\n", marker(agentRowBackend), dialogLabel.Render("Backend: "), backendTypeLabel(st.backend))
-	fmt.Fprintf(&body, "%s%s\n", marker(agentRowSave), saveButtonLabel(st.row == agentRowSave))
+	// Editing instant-saves, so there is no Save row; a new agent keeps it.
+	if st.editIdx < 0 {
+		fmt.Fprintf(&body, "%s%s\n", marker(agentRowSave), saveButtonLabel(st.row == agentRowSave))
+	}
 
 	if st.errMsg != "" {
 		fmt.Fprintf(&body, "\n%s\n", errorStyle.Render(st.errMsg))
 	}
 	body.WriteString("\n")
-	body.WriteString(dialogHint.Render(automationHint(st.fieldActive, st.row == agentRowSystemPrompt)))
+	body.WriteString(dialogHint.Render(automationHint(st.fieldActive, st.row == agentRowSystemPrompt, st.editIdx >= 0)))
 
 	b.WriteString(dialogBox.Render(body.String()))
 	b.WriteString("\n")
@@ -311,14 +370,23 @@ func saveButtonLabel(selected bool) string {
 	return dimStyle.Render("[ Save ]")
 }
 
-// automationHint is the footer hint shared by the automation dialogs.
-// onEditorField promotes the "$EDITOR" affordance for the long free-text fields.
-func automationHint(fieldActive, onEditorField bool) string {
+// automationHint is the footer hint for the agent dialog. onEditorField promotes
+// the "$EDITOR" affordance for the long free-text fields. In edit mode every
+// change instant-saves, so the close key reads "Close" (nothing to cancel) and an
+// active field's enter reads "Save".
+func automationHint(fieldActive, onEditorField, isEdit bool) string {
 	if fieldActive {
+		if isEdit {
+			return "[enter] Save  [esc] Discard edit"
+		}
 		return "[enter] Done editing  [ctrl+c] Cancel"
 	}
-	if onEditorField {
-		return "[enter] Edit in $EDITOR  [j/k] Move  [q/esc] Cancel"
+	closeKey := "[q/esc] Cancel"
+	if isEdit {
+		closeKey = "[q/esc] Close"
 	}
-	return "[j/k] Move  [enter] Edit/Toggle  [h/l] Cycle  [q/esc] Cancel"
+	if onEditorField {
+		return "[enter] Edit in $EDITOR  [j/k] Move  " + closeKey
+	}
+	return "[j/k] Move  [enter] Edit/Toggle  [h/l] Cycle  " + closeKey
 }

--- a/internal/tui/dialog_automation_agent.go
+++ b/internal/tui/dialog_automation_agent.go
@@ -229,13 +229,31 @@ func (fleetPage *fleetPage) cancelAutomationAgent(m *model) tea.Cmd {
 	st.input.Blur()
 	fleetPage.mode = viewNormal
 	// Editing is instant-save, so closing is just "done" — only a new (unsaved)
-	// agent is actually discarded.
-	if st.editIdx < 0 {
+	// agent is actually discarded. If an edit was left in an unsavable state, say
+	// so rather than closing silently (the last good state stayed on disk).
+	switch {
+	case st.editIdx < 0:
 		m.message = "Cancelled"
-	} else {
+	case fleetPage.agentFormError(m) != nil:
+		m.message = "Closed; last change not saved: " + fleetPage.agentFormError(m).Error()
+	default:
 		m.message = ""
 	}
 	return nil
+}
+
+// agentFormError returns the validation error the current form would hit if saved
+// now, without persisting — used on close to tell the user when an instant-save
+// edit was left unsavable. nil when it would save.
+func (fleetPage *fleetPage) agentFormError(m *model) error {
+	st := &fleetPage.agentDlg
+	f, ok := m.st.Fleets[st.fleetName]
+	if !ok || st.editIdx < 0 || st.editIdx >= len(f.Settings.Agents) {
+		return nil
+	}
+	oldName := f.Settings.Agents[st.editIdx].Name
+	_, err := fleet.UpdateAgent(f.Settings, oldName, fleetPage.agentCandidate())
+	return err
 }
 
 // agentCandidate builds a fleet.Agent from the current form state.

--- a/internal/tui/dialog_automation_trigger.go
+++ b/internal/tui/dialog_automation_trigger.go
@@ -344,7 +344,9 @@ func (fleetPage *fleetPage) cycleTriggerType(m *model) {
 	}
 	// The applicable rows changed; park the cursor back on the type selector.
 	st.row = trigRowType
-	fleetPage.autosaveTrigger(m)
+	// Quiet: a Schedule⇄Webhook switch makes the other type's required fields
+	// appear empty, so don't flash a validation error for that transient state.
+	fleetPage.autosaveTriggerQuiet(m)
 }
 
 func (fleetPage *fleetPage) cycleFilterType(m *model) {
@@ -355,7 +357,8 @@ func (fleetPage *fleetPage) cycleFilterType(m *model) {
 		st.filterType = fleet.WebhookFilterRegex
 	}
 	st.row = trigRowFilterType
-	fleetPage.autosaveTrigger(m)
+	// Quiet: a Regex⇄json-path switch swaps in different required fields.
+	fleetPage.autosaveTriggerQuiet(m)
 }
 
 func (fleetPage *fleetPage) toggleTriggerAgent(m *model) {
@@ -432,10 +435,14 @@ func (fleetPage *fleetPage) cancelAutomationTrigger(m *model) tea.Cmd {
 	st.input.Blur()
 	fleetPage.mode = viewNormal
 	// Editing is instant-save, so closing is just "done" — only a new (unsaved)
-	// trigger is actually discarded.
-	if st.editIdx < 0 {
+	// trigger is actually discarded. If an edit was left in an unsavable state,
+	// say so rather than closing silently (the last good state stayed on disk).
+	switch {
+	case st.editIdx < 0:
 		m.message = "Cancelled"
-	} else {
+	case fleetPage.triggerFormError(m) != nil:
+		m.message = "Closed; last change not saved: " + fleetPage.triggerFormError(m).Error()
+	default:
 		m.message = ""
 	}
 	return nil
@@ -471,7 +478,17 @@ func (fleetPage *fleetPage) triggerCandidate(f *fleet.Fleet) fleet.Trigger {
 // explicit Save button owns creation. A validation/RPC failure surfaces inline
 // and leaves the last-good persisted state intact (the in-memory revert lives in
 // persistAutomationSettings); a success clears the error.
-func (fleetPage *fleetPage) autosaveTrigger(m *model) {
+func (fleetPage *fleetPage) autosaveTrigger(m *model) { fleetPage.autosaveTriggerImpl(m, false) }
+
+// autosaveTriggerQuiet is autosave for a structural selector switch (Type or
+// Filter), which legitimately leaves the now-required fields empty mid-edit. It
+// persists once the trigger validates but never flashes a validation error for
+// the incomplete intermediate state — it clears any stale error instead, since a
+// switch changes which fields even apply. The close-time check (triggerFormError)
+// is the backstop that still tells the user if they leave it unsavable.
+func (fleetPage *fleetPage) autosaveTriggerQuiet(m *model) { fleetPage.autosaveTriggerImpl(m, true) }
+
+func (fleetPage *fleetPage) autosaveTriggerImpl(m *model, quiet bool) {
 	st := &fleetPage.triggerDlg
 	if st.editIdx < 0 {
 		return
@@ -483,7 +500,11 @@ func (fleetPage *fleetPage) autosaveTrigger(m *model) {
 	oldName := f.Settings.Triggers[st.editIdx].Name
 	newSettings, err := fleet.UpdateTrigger(f.Settings, oldName, fleetPage.triggerCandidate(f))
 	if err != nil {
-		st.errMsg = err.Error()
+		if quiet {
+			st.errMsg = ""
+		} else {
+			st.errMsg = err.Error()
+		}
 		return
 	}
 	if err := fleetPage.persistAutomationSettings(m, st.fleetName, newSettings); err != nil {
@@ -491,6 +512,20 @@ func (fleetPage *fleetPage) autosaveTrigger(m *model) {
 		return
 	}
 	st.errMsg = ""
+}
+
+// triggerFormError returns the validation error the current form would hit if
+// saved now, without persisting — used on close to tell the user when an
+// instant-save edit was left in an unsavable state. nil when it would save.
+func (fleetPage *fleetPage) triggerFormError(m *model) error {
+	st := &fleetPage.triggerDlg
+	f, ok := m.st.Fleets[st.fleetName]
+	if !ok || st.editIdx < 0 || st.editIdx >= len(f.Settings.Triggers) {
+		return nil
+	}
+	oldName := f.Settings.Triggers[st.editIdx].Name
+	_, err := fleet.UpdateTrigger(f.Settings, oldName, fleetPage.triggerCandidate(f))
+	return err
 }
 
 func (fleetPage *fleetPage) saveAutomationTrigger(m *model) tea.Cmd {

--- a/internal/tui/dialog_automation_trigger.go
+++ b/internal/tui/dialog_automation_trigger.go
@@ -117,15 +117,14 @@ func (fleetPage *fleetPage) openEditTriggerDialog(m *model, fleetName string, id
 }
 
 // visibleTriggerRows is the ordered list of currently-applicable field ids.
+// Order: Name, Type, Enabled, Prompt, then the type-specific rows (webhook:
+// name, filter, regex/json — schedule: cron), then the Agents list, then the
+// webhook URL (last, after Agents), then Save.
 func (fleetPage *fleetPage) visibleTriggerRows(m *model) []int {
 	st := &fleetPage.triggerDlg
-	rows := []int{trigRowName, trigRowType, trigRowEnabled}
-	for i := range fleetAgents(m, st.fleetName) {
-		rows = append(rows, trigRowAgentBase+i)
-	}
-	rows = append(rows, trigRowPrompt)
+	rows := []int{trigRowName, trigRowType, trigRowEnabled, trigRowPrompt}
 	if st.triggerType == fleet.TriggerWebhook {
-		rows = append(rows, trigRowWebhookName, trigRowWebhookURL, trigRowFilterType)
+		rows = append(rows, trigRowWebhookName, trigRowFilterType)
 		if st.filterType == fleet.WebhookFilterJSONPath {
 			rows = append(rows, trigRowJSONPath, trigRowJSONValue)
 		} else {
@@ -134,7 +133,19 @@ func (fleetPage *fleetPage) visibleTriggerRows(m *model) []int {
 	} else {
 		rows = append(rows, trigRowCron)
 	}
-	return append(rows, trigRowSave)
+	for i := range fleetAgents(m, st.fleetName) {
+		rows = append(rows, trigRowAgentBase+i)
+	}
+	if st.triggerType == fleet.TriggerWebhook {
+		rows = append(rows, trigRowWebhookURL)
+	}
+	// Editing an existing trigger is instant-save (like the settings page): every
+	// change persists immediately, so there is no Save row. A new trigger still
+	// needs an explicit Save to create it.
+	if st.editIdx < 0 {
+		rows = append(rows, trigRowSave)
+	}
+	return rows
 }
 
 func (fleetPage *fleetPage) moveTriggerRow(m *model, delta int) {
@@ -162,6 +173,7 @@ func (fleetPage *fleetPage) updateAutomationTrigger(m *model, msg tea.Msg) tea.C
 		switch key.String() {
 		case "enter":
 			fleetPage.commitTriggerField()
+			fleetPage.autosaveTrigger(m)
 			return nil
 		case "esc":
 			st.fieldActive = false
@@ -189,7 +201,7 @@ func (fleetPage *fleetPage) updateAutomationTrigger(m *model, msg tea.Msg) tea.C
 	case " ":
 		return fleetPage.triggerRowToggle(m)
 	case "left", "h", "right", "l":
-		fleetPage.triggerRowCycle()
+		fleetPage.triggerRowCycle(m)
 		return nil
 	}
 
@@ -223,11 +235,11 @@ func (fleetPage *fleetPage) triggerRowEnter(m *model) tea.Cmd {
 	case isTriggerTextRow(st.row):
 		return fleetPage.activateTriggerField()
 	case st.row == trigRowType:
-		fleetPage.cycleTriggerType()
+		fleetPage.cycleTriggerType(m)
 	case st.row == trigRowEnabled:
-		fleetPage.toggleTriggerEnabled()
+		fleetPage.toggleTriggerEnabled(m)
 	case st.row == trigRowFilterType:
-		fleetPage.cycleFilterType()
+		fleetPage.cycleFilterType(m)
 	case st.row == trigRowWebhookURL:
 		return fleetPage.copyTriggerWebhookURL(m)
 	case st.row >= trigRowAgentBase:
@@ -291,13 +303,13 @@ func (fleetPage *fleetPage) triggerRowToggle(m *model) tea.Cmd {
 		fleetPage.toggleTriggerAgent(m)
 		return nil
 	case st.row == trigRowType:
-		fleetPage.cycleTriggerType()
+		fleetPage.cycleTriggerType(m)
 		return nil
 	case st.row == trigRowEnabled:
-		fleetPage.toggleTriggerEnabled()
+		fleetPage.toggleTriggerEnabled(m)
 		return nil
 	case st.row == trigRowFilterType:
-		fleetPage.cycleFilterType()
+		fleetPage.cycleFilterType(m)
 		return nil
 	}
 	return fleetPage.triggerRowEnter(m)
@@ -305,24 +317,25 @@ func (fleetPage *fleetPage) triggerRowToggle(m *model) tea.Cmd {
 
 // triggerRowCycle handles h/l on a selector row. Both selectors are two-valued,
 // so direction is immaterial — left and right just flip to the other option.
-func (fleetPage *fleetPage) triggerRowCycle() {
+func (fleetPage *fleetPage) triggerRowCycle(m *model) {
 	st := &fleetPage.triggerDlg
 	switch st.row {
 	case trigRowType:
-		fleetPage.cycleTriggerType()
+		fleetPage.cycleTriggerType(m)
 	case trigRowEnabled:
-		fleetPage.toggleTriggerEnabled()
+		fleetPage.toggleTriggerEnabled(m)
 	case trigRowFilterType:
-		fleetPage.cycleFilterType()
+		fleetPage.cycleFilterType(m)
 	}
 }
 
-func (fleetPage *fleetPage) toggleTriggerEnabled() {
+func (fleetPage *fleetPage) toggleTriggerEnabled(m *model) {
 	st := &fleetPage.triggerDlg
 	st.disabled = !st.disabled
+	fleetPage.autosaveTrigger(m)
 }
 
-func (fleetPage *fleetPage) cycleTriggerType() {
+func (fleetPage *fleetPage) cycleTriggerType(m *model) {
 	st := &fleetPage.triggerDlg
 	if st.triggerType == fleet.TriggerSchedule {
 		st.triggerType = fleet.TriggerWebhook
@@ -331,9 +344,10 @@ func (fleetPage *fleetPage) cycleTriggerType() {
 	}
 	// The applicable rows changed; park the cursor back on the type selector.
 	st.row = trigRowType
+	fleetPage.autosaveTrigger(m)
 }
 
-func (fleetPage *fleetPage) cycleFilterType() {
+func (fleetPage *fleetPage) cycleFilterType(m *model) {
 	st := &fleetPage.triggerDlg
 	if st.filterType == fleet.WebhookFilterRegex {
 		st.filterType = fleet.WebhookFilterJSONPath
@@ -341,6 +355,7 @@ func (fleetPage *fleetPage) cycleFilterType() {
 		st.filterType = fleet.WebhookFilterRegex
 	}
 	st.row = trigRowFilterType
+	fleetPage.autosaveTrigger(m)
 }
 
 func (fleetPage *fleetPage) toggleTriggerAgent(m *model) {
@@ -355,6 +370,7 @@ func (fleetPage *fleetPage) toggleTriggerAgent(m *model) {
 		st.agentSel = map[string]bool{}
 	}
 	st.agentSel[name] = !st.agentSel[name]
+	fleetPage.autosaveTrigger(m)
 }
 
 func (fleetPage *fleetPage) activateTriggerField() tea.Cmd {
@@ -411,11 +427,70 @@ func (fleetPage *fleetPage) commitTriggerField() {
 }
 
 func (fleetPage *fleetPage) cancelAutomationTrigger(m *model) tea.Cmd {
-	fleetPage.triggerDlg.fieldActive = false
-	fleetPage.triggerDlg.input.Blur()
+	st := &fleetPage.triggerDlg
+	st.fieldActive = false
+	st.input.Blur()
 	fleetPage.mode = viewNormal
-	m.message = "Cancelled"
+	// Editing is instant-save, so closing is just "done" — only a new (unsaved)
+	// trigger is actually discarded.
+	if st.editIdx < 0 {
+		m.message = "Cancelled"
+	} else {
+		m.message = ""
+	}
 	return nil
+}
+
+// triggerCandidate builds a fleet.Trigger from the current form state, selecting
+// agents in the fleet's stored order so the output is stable.
+func (fleetPage *fleetPage) triggerCandidate(f *fleet.Fleet) fleet.Trigger {
+	st := &fleetPage.triggerDlg
+	var selected []string
+	for _, a := range f.Settings.Agents {
+		if st.agentSel[a.Name] {
+			selected = append(selected, a.Name)
+		}
+	}
+	return fleet.Trigger{
+		Name:        st.name,
+		Type:        st.triggerType,
+		Disabled:    st.disabled,
+		AgentNames:  selected,
+		Prompt:      st.prompt,
+		Cron:        st.cron,
+		WebhookName: st.webhookName,
+		FilterType:  st.filterType,
+		Regex:       st.regex,
+		JSONPath:    st.jsonPath,
+		JSONValue:   st.jsonValue,
+	}
+}
+
+// autosaveTrigger persists the form immediately when editing an existing trigger
+// (instant-save, like the settings page). It is a no-op for a new trigger, whose
+// explicit Save button owns creation. A validation/RPC failure surfaces inline
+// and leaves the last-good persisted state intact (the in-memory revert lives in
+// persistAutomationSettings); a success clears the error.
+func (fleetPage *fleetPage) autosaveTrigger(m *model) {
+	st := &fleetPage.triggerDlg
+	if st.editIdx < 0 {
+		return
+	}
+	f, ok := m.st.Fleets[st.fleetName]
+	if !ok || st.editIdx >= len(f.Settings.Triggers) {
+		return
+	}
+	oldName := f.Settings.Triggers[st.editIdx].Name
+	newSettings, err := fleet.UpdateTrigger(f.Settings, oldName, fleetPage.triggerCandidate(f))
+	if err != nil {
+		st.errMsg = err.Error()
+		return
+	}
+	if err := fleetPage.persistAutomationSettings(m, st.fleetName, newSettings); err != nil {
+		st.errMsg = err.Error()
+		return
+	}
+	st.errMsg = ""
 }
 
 func (fleetPage *fleetPage) saveAutomationTrigger(m *model) tea.Cmd {
@@ -429,27 +504,7 @@ func (fleetPage *fleetPage) saveAutomationTrigger(m *model) tea.Cmd {
 		return fleetPage.cancelAutomationTrigger(m)
 	}
 
-	// Collect selected agents in the fleet's agent order (stable output).
-	var selected []string
-	for _, a := range f.Settings.Agents {
-		if st.agentSel[a.Name] {
-			selected = append(selected, a.Name)
-		}
-	}
-
-	candidate := fleet.Trigger{
-		Name:        st.name,
-		Type:        st.triggerType,
-		Disabled:    st.disabled,
-		AgentNames:  selected,
-		Prompt:      st.prompt,
-		Cron:        st.cron,
-		WebhookName: st.webhookName,
-		FilterType:  st.filterType,
-		Regex:       st.regex,
-		JSONPath:    st.jsonPath,
-		JSONValue:   st.jsonValue,
-	}
+	candidate := fleetPage.triggerCandidate(f)
 
 	// fleet.AddTrigger/UpdateTrigger own the shared invariants (normalize
 	// against the fleet's agents and reject a duplicate name).
@@ -507,6 +562,20 @@ func (fleetPage *fleetPage) renderAutomationTriggerDialog(m *model) string {
 	fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowName), dialogLabel.Render("Name:   "), field(trigRowName, st.name, "trigger-name"))
 	fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowType), dialogLabel.Render("Type:   "), selectorLabel(triggerTypeLabel(st.triggerType)))
 	fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowEnabled), dialogLabel.Render("Enabled:"), selectorLabel(enabledLabel(st.disabled)))
+	fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowPrompt), dialogLabel.Render("Prompt: "), promptFieldPreview(st.prompt, "(fed to the agent via ${PROMPT})"))
+
+	if st.triggerType == fleet.TriggerWebhook {
+		fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowWebhookName), dialogLabel.Render("Webhook:"), field(trigRowWebhookName, st.webhookName, "name (appended to gateway URL)"))
+		fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowFilterType), dialogLabel.Render("Filter: "), selectorLabel(filterTypeLabel(st.filterType)))
+		if st.filterType == fleet.WebhookFilterJSONPath {
+			fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowJSONPath), dialogLabel.Render("JSON path:"), field(trigRowJSONPath, st.jsonPath, "e.g. $.action (required)"))
+			fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowJSONValue), dialogLabel.Render("JSON value:"), field(trigRowJSONValue, st.jsonValue, "e.g. opened"))
+		} else {
+			fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowRegex), dialogLabel.Render("Regex:  "), field(trigRowRegex, st.regex, "event body must match"))
+		}
+	} else {
+		fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowCron), dialogLabel.Render("Cron:   "), field(trigRowCron, st.cron, "0 9 * * 1-5"))
+	}
 
 	// Agents multi-select.
 	body.WriteString(dialogLabel.Render("Agents: "))
@@ -522,29 +591,22 @@ func (fleetPage *fleetPage) renderAutomationTriggerDialog(m *model) string {
 		fmt.Fprintf(&body, "%s    %s %s\n", marker(trigRowAgentBase+i), box, a.Name)
 	}
 
-	fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowPrompt), dialogLabel.Render("Prompt: "), promptFieldPreview(st.prompt, "(fed to the agent via ${PROMPT})"))
-
+	// The webhook URL sits last (after Agents) — it is derived/copy-only, not a
+	// field the user fills in, so it reads as a footer to the form.
 	if st.triggerType == fleet.TriggerWebhook {
-		fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowWebhookName), dialogLabel.Render("Webhook:"), field(trigRowWebhookName, st.webhookName, "name (appended to gateway URL)"))
 		fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowWebhookURL), dialogLabel.Render("URL:    "), webhookURLDisplay(m, st.webhookName))
-		fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowFilterType), dialogLabel.Render("Filter: "), selectorLabel(filterTypeLabel(st.filterType)))
-		if st.filterType == fleet.WebhookFilterJSONPath {
-			fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowJSONPath), dialogLabel.Render("JSON path:"), field(trigRowJSONPath, st.jsonPath, "e.g. $.action (required)"))
-			fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowJSONValue), dialogLabel.Render("JSON value:"), field(trigRowJSONValue, st.jsonValue, "e.g. opened"))
-		} else {
-			fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowRegex), dialogLabel.Render("Regex:  "), field(trigRowRegex, st.regex, "event body must match"))
-		}
-	} else {
-		fmt.Fprintf(&body, "%s%s %s\n", marker(trigRowCron), dialogLabel.Render("Cron:   "), field(trigRowCron, st.cron, "0 9 * * 1-5"))
 	}
 
-	fmt.Fprintf(&body, "%s%s\n", marker(trigRowSave), saveButtonLabel(st.row == trigRowSave))
+	// Editing instant-saves, so there is no Save row; a new trigger keeps it.
+	if st.editIdx < 0 {
+		fmt.Fprintf(&body, "%s%s\n", marker(trigRowSave), saveButtonLabel(st.row == trigRowSave))
+	}
 
 	if st.errMsg != "" {
 		fmt.Fprintf(&body, "\n%s\n", errorStyle.Render(st.errMsg))
 	}
 	body.WriteString("\n")
-	body.WriteString(dialogHint.Render(automationTriggerHint(st.fieldActive, st.row)))
+	body.WriteString(dialogHint.Render(automationTriggerHint(st.fieldActive, st.row, st.editIdx >= 0)))
 
 	b.WriteString(dialogBox.Render(body.String()))
 	b.WriteString("\n")
@@ -576,18 +638,28 @@ func filterTypeLabel(f fleet.WebhookFilterType) string {
 	return "regex"
 }
 
-func automationTriggerHint(fieldActive bool, row int) string {
+// automationTriggerHint is the footer hint for the trigger dialog. In edit mode
+// every change instant-saves, so the close key reads "Close" (nothing to cancel)
+// and an active field's enter reads "Save".
+func automationTriggerHint(fieldActive bool, row int, isEdit bool) string {
 	if fieldActive {
+		if isEdit {
+			return "[enter] Save  [esc] Discard edit"
+		}
 		return "[enter] Done editing  [ctrl+c] Cancel"
 	}
+	closeKey := "[q/esc] Cancel"
+	if isEdit {
+		closeKey = "[q/esc] Close"
+	}
 	if row == trigRowPrompt {
-		return "[enter] Edit in $EDITOR  [j/k] Move  [q/esc] Cancel"
+		return "[enter] Edit in $EDITOR  [j/k] Move  " + closeKey
 	}
 	if row >= trigRowAgentBase {
-		return "[j/k] Move  [space] Toggle agent  [enter] Edit/Cycle  [q/esc] Cancel"
+		return "[j/k] Move  [space] Toggle agent  [enter] Edit/Cycle  " + closeKey
 	}
 	if row == trigRowWebhookURL {
-		return "[j/k] Move  [enter] Copy URL  [q/esc] Cancel"
+		return "[j/k] Move  [enter] Copy URL  " + closeKey
 	}
-	return "[j/k] Move  [enter] Edit/Toggle  [h/l] Cycle  [q/esc] Cancel"
+	return "[j/k] Move  [enter] Edit/Toggle  [h/l] Cycle  " + closeKey
 }

--- a/internal/tui/editor.go
+++ b/internal/tui/editor.go
@@ -33,8 +33,11 @@ type editorFinishedMsg struct {
 }
 
 // promptPreviewWidth caps the one-line preview an editor-backed field shows in
-// the dialog.
-const promptPreviewWidth = 40
+// the dialog. It is the total budget for the whole preview (first line +
+// "(N lines)" suffix), sized to fit the narrowest caller: the agent dialog's
+// "Sys prompt:" label leaves ~32 cols inside the 50-wide dialog box, so the
+// preview never wraps to a second line.
+const promptPreviewWidth = 32
 
 // resolveEditor returns the user's preferred editor command — $VISUAL, then
 // $EDITOR — falling back to vi (the universal default, always present).
@@ -107,8 +110,10 @@ func (fleetPage *fleetPage) applyEditorResult(m *model, msg editorFinishedMsg) t
 	switch msg.target {
 	case editorTargetAgentSysPrompt:
 		fleetPage.agentDlg.systemPrompt = msg.value
+		fleetPage.autosaveAgent(m)
 	case editorTargetTriggerPrompt:
 		fleetPage.triggerDlg.prompt = msg.value
+		fleetPage.autosaveTrigger(m)
 	}
 	return nil
 }
@@ -116,14 +121,24 @@ func (fleetPage *fleetPage) applyEditorResult(m *model, msg editorFinishedMsg) t
 // promptFieldPreview renders a one-line preview of an editor-backed field's
 // (possibly multi-line) value for the dialog: the first line, truncated, with a
 // dim line count when there is more than one line. Empty shows the placeholder.
+// The first line is truncated to leave room for the suffix so the whole preview
+// stays within promptPreviewWidth and never wraps to a second line.
 func promptFieldPreview(value, placeholder string) string {
 	if value == "" {
 		return dimStyle.Render(placeholder)
 	}
 	lines := strings.Split(value, "\n")
-	preview := ansi.Truncate(lines[0], promptPreviewWidth, "…")
+	suffix := ""
+	budget := promptPreviewWidth
 	if len(lines) > 1 {
-		preview += dimStyle.Render(fmt.Sprintf("  (%d lines)", len(lines)))
+		suffix = fmt.Sprintf("  (%d lines)", len(lines))
+		if budget -= len(suffix); budget < 1 {
+			budget = 1
+		}
+	}
+	preview := ansi.Truncate(lines[0], budget, "…")
+	if suffix != "" {
+		preview += dimStyle.Render(suffix)
 	}
 	return preview
 }


### PR DESCRIPTION
Three UX tweaks to the automation agent/trigger dialogs.

## 1. Edit-trigger field reorder
Reordered the trigger dialog to a single canonical order, applied to both navigation (`visibleTriggerRows`) and rendering:

> Name → Type → Enabled → Prompt → [Webhook → Filter → Regex | JSON path+value] → [Cron] → Agents → [URL] → Save

Prompt moves up under Enabled, Agents drops to just above the (former) Save, and the derived webhook URL sits last as a copy-only footer.

## 2. One-line prompt preview
The editor-backed prompt / sys-prompt preview could wrap to a second line inside the 50-wide dialog box. `promptFieldPreview` now budgets the **whole** preview (first line + `(N lines)` suffix) to a width that fits the narrowest dialog row, truncating instead of wrapping.

## 3. Instant-save when editing
Editing an existing agent or trigger now saves immediately, matching every other settings page in fleet:

- Every change persists right away via new `autosaveTrigger` / `autosaveAgent` helpers (text-field commit, `$EDITOR` return, Type/Enabled/Filter/Backend selectors, agent multi-select).
- The **Save row is gone** in edit mode (navigation + render); `q`/`esc` just closes ("Close", not "Cancel").
- A validation failure (empty name, bad cron, incomplete webhook, …) surfaces inline and does **not** persist — the last-good state is kept, reusing the existing optimistic `persistAutomationSettings` revert.
- **Creating** a new agent/trigger is unchanged — the explicit Save still owns creation; `autosave*` is a no-op there.

Shared `triggerCandidate` / `agentCandidate` builders keep the autosave and explicit-save paths from drifting.

## Tests
- `go build ./...` + `go vet ./internal/tui/` clean.
- Added 6 tests: Save-row present-when-new / absent-when-editing (trigger + agent), instant-save on toggle and on field-commit (trigger + agent), and validation-failure-keeps-last-good.
- Full `internal/tui` and `internal/fleet` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)