### PR TITLE
feat: bound + retry dotfiles install so a hang can't stall provisioning

### DIFF
--- a/internal/backend/cmd.go
+++ b/internal/backend/cmd.go
@@ -1,6 +1,8 @@
 package backend
 
 import (
+	"bytes"
+	"fmt"
 	"os/exec"
 	"time"
 )
@@ -56,6 +58,51 @@ func (c *Cmd) CombinedOutput() ([]byte, error) {
 	out, err := c.Cmd.CombinedOutput()
 	c.fireDone(start, err)
 	return out, err
+}
+
+// CombinedOutputWithTimeout is CombinedOutput with a deadline: it runs the
+// command, captures stdout+stderr, and — if the command does not finish within
+// timeout — kills it and returns a timeout error along with whatever output was
+// captured so far. A zero or negative timeout means no deadline (it defers to
+// CombinedOutput). Like the other run methods it fires onDone exactly once.
+//
+// exec.Cmd.CombinedOutput offers no deadline, so this drives the embedded raw
+// *exec.Cmd directly (Start + Wait in a goroutine, racing a timer). On timeout
+// it relies on Process.Kill plus WaitDelay rather than a context: Process.Kill
+// signals only the direct child, but WaitDelay force-closes the output pipe so
+// Wait returns even when a grandchild (devcontainer -> docker exec) inherited
+// it — the same approach as the server's gh-probe timeout. This keeps the
+// deadline self-contained without threading a context through the Backend
+// ExecCommand interface.
+func (c *Cmd) CombinedOutputWithTimeout(timeout time.Duration) ([]byte, error) {
+	if timeout <= 0 {
+		return c.CombinedOutput()
+	}
+	start := time.Now()
+	raw := c.Cmd
+	var buf bytes.Buffer
+	raw.Stdout = &buf
+	raw.Stderr = &buf
+	raw.WaitDelay = 3 * time.Second
+	if err := raw.Start(); err != nil {
+		c.fireDone(start, err)
+		return nil, err
+	}
+	done := make(chan error, 1)
+	go func() { done <- raw.Wait() }()
+	select {
+	case err := <-done:
+		c.fireDone(start, err)
+		return buf.Bytes(), err
+	case <-time.After(timeout):
+		if raw.Process != nil {
+			_ = raw.Process.Kill()
+		}
+		<-done // wait for the goroutine to observe the kill (bounded by WaitDelay)
+		err := fmt.Errorf("timed out after %s", timeout)
+		c.fireDone(start, err)
+		return buf.Bytes(), err
+	}
 }
 
 func (c *Cmd) fireDone(start time.Time, err error) {

--- a/internal/backend/cmd_test.go
+++ b/internal/backend/cmd_test.go
@@ -1,0 +1,81 @@
+package backend
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCombinedOutputWithTimeoutFast verifies the happy path: a command that
+// finishes well inside the deadline returns its combined output with no error,
+// and onDone fires exactly once.
+func TestCombinedOutputWithTimeoutFast(t *testing.T) {
+	var fired int
+	cmd := NewCmd(exec.Command("sh", "-c", "echo hello; echo oops 1>&2"), func(time.Duration, error) {
+		fired++
+	})
+
+	out, err := cmd.CombinedOutputWithTimeout(5 * time.Second)
+	if err != nil {
+		t.Fatalf("CombinedOutputWithTimeout returned error: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "hello") || !strings.Contains(got, "oops") {
+		t.Errorf("combined output = %q, want both stdout and stderr captured", got)
+	}
+	if fired != 1 {
+		t.Errorf("onDone fired %d times, want 1", fired)
+	}
+}
+
+// TestCombinedOutputWithTimeoutKills verifies that a command which overruns the
+// deadline is killed and reported as a timeout, and crucially that the call
+// returns promptly (≈ the timeout, not the command's full sleep) so a hung
+// install can never stall the caller.
+func TestCombinedOutputWithTimeoutKills(t *testing.T) {
+	var fired int
+	cmd := NewCmd(exec.Command("sh", "-c", "sleep 30"), func(time.Duration, error) {
+		fired++
+	})
+
+	start := time.Now()
+	_, err := cmd.CombinedOutputWithTimeout(100 * time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("CombinedOutputWithTimeout returned nil error for a hung command")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("error = %v, want a timeout error", err)
+	}
+	// Allow generous slack for the WaitDelay-bounded pipe drain, but it must be
+	// far short of the command's own 30s sleep.
+	if elapsed > 10*time.Second {
+		t.Errorf("CombinedOutputWithTimeout took %s, expected it to return shortly after the 100ms deadline", elapsed)
+	}
+	if fired != 1 {
+		t.Errorf("onDone fired %d times, want 1", fired)
+	}
+}
+
+// TestCombinedOutputWithTimeoutZeroNoDeadline verifies that a non-positive
+// timeout defers to the plain CombinedOutput (no deadline), still capturing
+// output and firing onDone once.
+func TestCombinedOutputWithTimeoutZeroNoDeadline(t *testing.T) {
+	var fired int
+	cmd := NewCmd(exec.Command("sh", "-c", "echo ok"), func(time.Duration, error) {
+		fired++
+	})
+
+	out, err := cmd.CombinedOutputWithTimeout(0)
+	if err != nil {
+		t.Fatalf("CombinedOutputWithTimeout(0) returned error: %v", err)
+	}
+	if !strings.Contains(string(out), "ok") {
+		t.Errorf("combined output = %q, want it to contain %q", string(out), "ok")
+	}
+	if fired != 1 {
+		t.Errorf("onDone fired %d times, want 1", fired)
+	}
+}

--- a/internal/create/dotfiles_install.go
+++ b/internal/create/dotfiles_install.go
@@ -1,0 +1,94 @@
+package create
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+var (
+	// dotfilesInstallTimeout bounds a single dotfiles-install attempt. A dotfiles
+	// install can hang indefinitely — a `git clone` stuck on an unreachable host,
+	// an install script blocked on input — and without a bound that hang stalls
+	// the entire instance creation. Overridable via FLEET_DOTFILES_INSTALL_TIMEOUT
+	// (a Go duration) so tests run in milliseconds.
+	dotfilesInstallTimeout = envDurationDefault("FLEET_DOTFILES_INSTALL_TIMEOUT", 2*time.Minute)
+
+	// dotfilesInstallAttempts is how many times the install is tried before giving
+	// up and starting the instance anyway. Each attempt is bounded by
+	// dotfilesInstallTimeout. Overridable via FLEET_DOTFILES_INSTALL_ATTEMPTS.
+	dotfilesInstallAttempts = envIntDefault("FLEET_DOTFILES_INSTALL_ATTEMPTS", 3)
+)
+
+// dotfilesExecer is the slice of backend.Backend installDotfiles needs: build a
+// command to run inside the workspace. Narrowing to this interface keeps the
+// retry logic unit-testable with a tiny fake instead of a full Backend.
+type dotfilesExecer interface {
+	ExecCommand(workspaceDir string, command []string) *backend.Cmd
+}
+
+// installDotfiles runs the dotfiles setup script inside the instance, bounded
+// and best-effort: each attempt is killed if it overruns dotfilesInstallTimeout
+// and the install is retried up to dotfilesInstallAttempts times. If every
+// attempt fails (or hangs), the failure is surfaced as a single warning and the
+// caller carries on — a broken dotfiles install must never block the instance
+// from coming up.
+//
+// On retries the script is prefixed with `rm -rf ~/dotfiles` because a killed
+// attempt can leave a partial clone behind, and dotfiles.SetupScript's
+// `[ ! -d ~/dotfiles ]` guard would then skip the reinstall — making the retry
+// a silent no-op. Clearing it first ensures each retry genuinely re-runs the
+// clone + install. This only ever fires after a failed attempt, so a legitimate
+// pre-existing ~/dotfiles (which makes attempt 1 a successful no-op) is never
+// touched.
+func installDotfiles(execer dotfilesExecer, fleetName, instanceName, wsDir, script string) {
+	var lastErr error
+	var lastOut string
+	for attempt := 1; attempt <= dotfilesInstallAttempts; attempt++ {
+		runScript := script
+		if attempt > 1 {
+			runScript = "rm -rf ~/dotfiles; " + script
+		}
+		cmd := execer.ExecCommand(wsDir, []string{"sh", "-c", runScript})
+		out, err := cmd.CombinedOutputWithTimeout(dotfilesInstallTimeout)
+		if err == nil {
+			return
+		}
+		lastErr, lastOut = err, strings.TrimSpace(string(out))
+	}
+
+	// All attempts failed. WriteWarn overwrites the per-instance warn file, so we
+	// emit a single summary rather than one warning per attempt.
+	state.WriteWarn(fleetName, instanceName, fmt.Sprintf(
+		"dotfiles install failed after %d attempt(s); instance started anyway: %v\n%s",
+		dotfilesInstallAttempts, lastErr, lastOut))
+}
+
+// envDurationDefault returns the Go duration parsed from the named env var, or
+// def when it is unset, blank, or unparseable (a non-positive value is also
+// rejected). The override exists so tests can shrink the dotfiles timeout to
+// milliseconds; production uses the defaults.
+func envDurationDefault(name string, def time.Duration) time.Duration {
+	if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return def
+}
+
+// envIntDefault returns the positive integer parsed from the named env var, or
+// def when it is unset, blank, non-numeric, or non-positive.
+func envIntDefault(name string, def int) int {
+	if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+		var n int
+		if _, err := fmt.Sscanf(v, "%d", &n); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}

--- a/internal/create/dotfiles_install_test.go
+++ b/internal/create/dotfiles_install_test.go
@@ -1,0 +1,122 @@
+package create
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+)
+
+// fakeExecer is a minimal dotfilesExecer that records the commands it is asked
+// to build and returns a backend.Cmd produced by make(attempt). attempt is
+// 1-based so tests can vary behaviour per try (e.g. hang then succeed).
+type fakeExecer struct {
+	scripts []string // the `sh -c <script>` argument captured per call
+	cmdFor  func(attempt int) *backend.Cmd
+}
+
+func (f *fakeExecer) ExecCommand(_ string, command []string) *backend.Cmd {
+	if len(command) == 3 {
+		f.scripts = append(f.scripts, command[2])
+	}
+	return f.cmdFor(len(f.scripts))
+}
+
+func sleepCmd() *backend.Cmd { return backend.NewCmd(exec.Command("sh", "-c", "sleep 30"), nil) }
+func okCmd() *backend.Cmd    { return backend.NewCmd(exec.Command("sh", "-c", "exit 0"), nil) }
+func failCmd() *backend.Cmd  { return backend.NewCmd(exec.Command("sh", "-c", "exit 1"), nil) }
+
+// withShortDotfilesKnobs shrinks the package-level timeout/attempts for the
+// duration of a test and restores them afterwards, so the retry loop runs in
+// milliseconds without containers.
+func withShortDotfilesKnobs(t *testing.T, timeout time.Duration, attempts int) {
+	t.Helper()
+	origTimeout, origAttempts := dotfilesInstallTimeout, dotfilesInstallAttempts
+	dotfilesInstallTimeout, dotfilesInstallAttempts = timeout, attempts
+	t.Cleanup(func() {
+		dotfilesInstallTimeout, dotfilesInstallAttempts = origTimeout, origAttempts
+	})
+}
+
+// TestInstallDotfilesRetriesOnHangThenWarns verifies the headline requirement:
+// a dotfiles install that hangs is killed after the timeout and retried up to
+// the attempt limit, after which a single warning is written and the caller
+// returns (so the instance starts anyway).
+func TestInstallDotfilesRetriesOnHangThenWarns(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	withShortDotfilesKnobs(t, 50*time.Millisecond, 3)
+
+	fe := &fakeExecer{cmdFor: func(int) *backend.Cmd { return sleepCmd() }}
+	start := time.Now()
+	installDotfiles(fe, "fleetx", "inst1", "/ws", "echo install")
+	elapsed := time.Since(start)
+
+	if len(fe.scripts) != 3 {
+		t.Fatalf("install attempted %d times, want 3", len(fe.scripts))
+	}
+	// 3 attempts × 50ms ≈ 150ms of deadlines; well under the 30s sleeps.
+	if elapsed > 15*time.Second {
+		t.Errorf("installDotfiles took %s; expected it to bail out via timeouts", elapsed)
+	}
+
+	warn, err := os.ReadFile(state.WarnPath("fleetx", "inst1"))
+	if err != nil {
+		t.Fatalf("expected a warning file after all attempts failed: %v", err)
+	}
+	if !strings.Contains(string(warn), "after 3 attempt") {
+		t.Errorf("warning = %q, want it to mention the attempt count", string(warn))
+	}
+}
+
+// TestInstallDotfilesSucceedsFirstTry verifies the common path: one successful
+// attempt, no retry, no warning, and no destructive rm-rf prefix.
+func TestInstallDotfilesSucceedsFirstTry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	withShortDotfilesKnobs(t, 5*time.Second, 3)
+
+	fe := &fakeExecer{cmdFor: func(int) *backend.Cmd { return okCmd() }}
+	installDotfiles(fe, "fleetx", "inst1", "/ws", "echo install")
+
+	if len(fe.scripts) != 1 {
+		t.Fatalf("install attempted %d times, want 1", len(fe.scripts))
+	}
+	if strings.Contains(fe.scripts[0], "rm -rf") {
+		t.Errorf("first attempt should not clear ~/dotfiles, got script %q", fe.scripts[0])
+	}
+	if _, err := os.Stat(state.WarnPath("fleetx", "inst1")); !os.IsNotExist(err) {
+		t.Errorf("expected no warning file on success, stat err = %v", err)
+	}
+}
+
+// TestInstallDotfilesRecoversOnRetry verifies that a transient failure is
+// retried and that the retry clears a possibly-partial ~/dotfiles before
+// re-running, then a later success stops the loop with no warning.
+func TestInstallDotfilesRecoversOnRetry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	withShortDotfilesKnobs(t, 5*time.Second, 3)
+
+	fe := &fakeExecer{cmdFor: func(attempt int) *backend.Cmd {
+		if attempt == 1 {
+			return failCmd()
+		}
+		return okCmd()
+	}}
+	installDotfiles(fe, "fleetx", "inst1", "/ws", "echo install")
+
+	if len(fe.scripts) != 2 {
+		t.Fatalf("install attempted %d times, want 2 (fail then succeed)", len(fe.scripts))
+	}
+	if strings.Contains(fe.scripts[0], "rm -rf ~/dotfiles") {
+		t.Errorf("first attempt must not clear ~/dotfiles, got %q", fe.scripts[0])
+	}
+	if !strings.HasPrefix(fe.scripts[1], "rm -rf ~/dotfiles;") {
+		t.Errorf("retry must clear a partial ~/dotfiles first, got %q", fe.scripts[1])
+	}
+	if _, err := os.Stat(state.WarnPath("fleetx", "inst1")); !os.IsNotExist(err) {
+		t.Errorf("expected no warning file once a retry succeeds, stat err = %v", err)
+	}
+}

--- a/internal/create/provision.go
+++ b/internal/create/provision.go
@@ -2,7 +2,6 @@ package create
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/agentdetect"
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
@@ -111,17 +110,15 @@ func finishProvision(instanceBackend backend.Backend, fleetName, instanceName, w
 		state.WriteWarn(fleetName, instanceName, fmt.Sprintf("image cache: %v", err))
 	}
 
-	// Auto-install dotfiles. A failure here is non-fatal — the instance is still
-	// usable, so we surface the error as a warning rather than blocking.
+	// Auto-install dotfiles. Best-effort and bounded: a dotfiles install that
+	// hangs (e.g. a git clone stuck on an unreachable host) must not stall the
+	// whole instance creation, so installDotfiles kills each attempt after a
+	// timeout and retries a few times before giving up and letting the instance
+	// start anyway. A failure is surfaced as a warning rather than blocking.
 	config, _ := state.LoadConfig()
 	if config != nil && config.DotfilesSettings.AutoInstall {
 		if script := dotfiles.SetupScript(config); script != "" {
-			cmd := instanceBackend.ExecCommand(wsDir, []string{"sh", "-c", script})
-			out, err := cmd.CombinedOutput()
-			if err != nil {
-				detail := strings.TrimSpace(string(out))
-				state.WriteWarn(fleetName, instanceName, fmt.Sprintf("dotfiles install failed: %v\n%s", err, detail))
-			}
+			installDotfiles(instanceBackend, fleetName, instanceName, wsDir, script)
 		}
 	}
 


### PR DESCRIPTION
## Problem

If a dotfiles install hangs during instance creation, the **entire instance creation hangs** — possibly forever. `finishProvision` ran the dotfiles install via a plain `CombinedOutput` with no deadline, so a `git clone` stuck on an unreachable host (or an install script blocked on input) would never return.

## Fix

The dotfiles install is now **bounded and retried**, staying best-effort:

- **2-minute timeout per attempt.** If an attempt doesn't complete in time it's killed.
- **Up to 3 attempts total.** After the last attempt the instance **starts anyway**, with the failure surfaced as a single warning (same best-effort contract as before).
- **Retries clear a partial `~/dotfiles` first.** A killed `git clone` can leave a partial directory behind, which would make `SetupScript`'s `[ ! -d ~/dotfiles ]` guard skip the reinstall — turning the retry into a silent no-op. Prefixing `rm -rf ~/dotfiles` on retries (never on the first attempt) makes each retry genuinely re-run.

## How

- **`backend.Cmd.CombinedOutputWithTimeout(timeout)`** — `CombinedOutput` with a deadline. Drives the embedded `*exec.Cmd` directly (Start + Wait racing a timer) and kills on overrun via `Process.Kill` + `WaitDelay`, mirroring the existing `runProbeWithTimeout` in the server's gh-probe path so a grandchild (`devcontainer` → `docker exec`) holding the output pipe can't wedge `Wait`. A zero/negative timeout defers to plain `CombinedOutput`.
- **`create.installDotfiles(...)`** — the bounded retry loop. Depends on a narrow `dotfilesExecer` seam so the logic is unit-tested without containers. Knobs are overridable for tests/ops via `FLEET_DOTFILES_INSTALL_TIMEOUT` and `FLEET_DOTFILES_INSTALL_ATTEMPTS`.

## Tests

- `internal/backend/cmd_test.go` — fast command returns combined output + fires `onDone` once; a hung command (`sleep 30`) times out promptly and is killed; zero timeout defers to `CombinedOutput`.
- `internal/create/dotfiles_install_test.go` — hang → 3 attempts then one warning (instance proceeds); success on first try → no retry, no `rm -rf`, no warning; failure-then-success → retry clears `~/dotfiles` and stops on success with no warning.

## Notes / limitations

- `Process.Kill` signals the host-side direct child; a truly hung network `clone` that isn't writing output may linger as an orphan until the OS/network gives up — but provisioning no longer **waits** on it, which is the point. (Perfectly reaping the in-container process tree would require `docker exec` cleanup and is out of scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)