### PR TITLE
feat(automation): record per-trigger event logs, viewable via TUI/CLI/MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ fleet agent create my-project nightly-builder --system-prompt "Build and report"
 fleet trigger create my-project nightly --agent nightly-builder --cron "0 0 * * *" --prompt "Run the nightly build"
 fleet agent list my-project
 fleet trigger list my-project
+fleet trigger logs my-project nightly   # inspect a trigger's recorded firings
 ```
 
 ## TUI Keybindings
@@ -125,7 +126,7 @@ fleet trigger list my-project
 | `d` | Delete instance/fleet |
 | `c` | Open VS Code |
 | `R` | Rebuild instance (preserves workspace) |
-| `L` | View logs |
+| `L` | View logs (instance logs, or a selected trigger's event logs in the automation view) |
 | `→/l`, `←/h` | Select / deselect the PR-status auto tag |
 | `enter` (on PR status) | Open the PR in a browser |
 | `A` | Switch armada (remote fleet) |
@@ -189,9 +190,9 @@ Tools mirror the non-interactive CLI: `fleet_list`, `fleet_status`,
 the tmux session tools `fleet_session_spawn` / `fleet_session_exec` /
 `fleet_session_read` / `fleet_session_list`, and the automation CRUD tools
 `fleet_automation_list`, `fleet_agent_create` / `fleet_agent_update` /
-`fleet_agent_delete`, and `fleet_trigger_create` / `fleet_trigger_update` /
-`fleet_trigger_delete` (mirroring the `fleet agent` and `fleet trigger` CLI
-commands).
+`fleet_agent_delete`, `fleet_trigger_create` / `fleet_trigger_update` /
+`fleet_trigger_delete`, and `fleet_trigger_logs` (mirroring the `fleet agent` and
+`fleet trigger` CLI commands).
 Interactive, open-ended commands (`fleet shell`, log following) are intentionally
 not exposed.
 

--- a/fleetgrpc/exec.pb.go
+++ b/fleetgrpc/exec.pb.go
@@ -1444,7 +1444,7 @@ func (x *TriggerLogsRequest) GetTrigger() string {
 type TriggerLogsReply struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// logs is every recorded event log concatenated (oldest first), each preceded
-	// by a "=== event-<timestamp>.log ===" separator. Empty when none recorded.
+	// by a "===== event-<timestamp>.log =====" separator. Empty when none recorded.
 	Logs string `protobuf:"bytes,1,opt,name=logs,proto3" json:"logs,omitempty"`
 	// count is how many event logs were concatenated.
 	Count         int32 `protobuf:"varint,2,opt,name=count,proto3" json:"count,omitempty"`

--- a/fleetgrpc/exec.pb.go
+++ b/fleetgrpc/exec.pb.go
@@ -1382,6 +1382,120 @@ func (x *ResolveLogsCommandReply) GetArgv() []string {
 	return nil
 }
 
+// TriggerLogs reads back an automation trigger's recorded event logs. Each time
+// a trigger fires, the daemon writes the firing's payload (the webhook body, or
+// the schedule fire-time) to a per-trigger log directory, keeping the most
+// recent 100. This returns them concatenated (oldest first), so a client can
+// inspect what fired an automation after the fact — the TUI's 'L' pager, the
+// `fleet trigger logs` CLI, and the fleet_trigger_logs MCP tool all read here.
+// A trigger that has never fired returns empty logs with count 0 (not an error).
+type TriggerLogsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Fleet         string                 `protobuf:"bytes,1,opt,name=fleet,proto3" json:"fleet,omitempty"`
+	Trigger       string                 `protobuf:"bytes,2,opt,name=trigger,proto3" json:"trigger,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TriggerLogsRequest) Reset() {
+	*x = TriggerLogsRequest{}
+	mi := &file_exec_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TriggerLogsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TriggerLogsRequest) ProtoMessage() {}
+
+func (x *TriggerLogsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_exec_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TriggerLogsRequest.ProtoReflect.Descriptor instead.
+func (*TriggerLogsRequest) Descriptor() ([]byte, []int) {
+	return file_exec_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *TriggerLogsRequest) GetFleet() string {
+	if x != nil {
+		return x.Fleet
+	}
+	return ""
+}
+
+func (x *TriggerLogsRequest) GetTrigger() string {
+	if x != nil {
+		return x.Trigger
+	}
+	return ""
+}
+
+type TriggerLogsReply struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// logs is every recorded event log concatenated (oldest first), each preceded
+	// by a "=== event-<timestamp>.log ===" separator. Empty when none recorded.
+	Logs string `protobuf:"bytes,1,opt,name=logs,proto3" json:"logs,omitempty"`
+	// count is how many event logs were concatenated.
+	Count         int32 `protobuf:"varint,2,opt,name=count,proto3" json:"count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TriggerLogsReply) Reset() {
+	*x = TriggerLogsReply{}
+	mi := &file_exec_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TriggerLogsReply) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TriggerLogsReply) ProtoMessage() {}
+
+func (x *TriggerLogsReply) ProtoReflect() protoreflect.Message {
+	mi := &file_exec_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TriggerLogsReply.ProtoReflect.Descriptor instead.
+func (*TriggerLogsReply) Descriptor() ([]byte, []int) {
+	return file_exec_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *TriggerLogsReply) GetLogs() string {
+	if x != nil {
+		return x.Logs
+	}
+	return ""
+}
+
+func (x *TriggerLogsReply) GetCount() int32 {
+	if x != nil {
+		return x.Count
+	}
+	return 0
+}
+
 // GetCoderTemplateParams fetches a Coder template's active-version rich
 // parameters + preset names (the TUI's coder settings dialog used to call the
 // coder backend's REST helpers directly). The server owns backend access.
@@ -1394,7 +1508,7 @@ type GetCoderTemplateParamsRequest struct {
 
 func (x *GetCoderTemplateParamsRequest) Reset() {
 	*x = GetCoderTemplateParamsRequest{}
-	mi := &file_exec_proto_msgTypes[19]
+	mi := &file_exec_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1406,7 +1520,7 @@ func (x *GetCoderTemplateParamsRequest) String() string {
 func (*GetCoderTemplateParamsRequest) ProtoMessage() {}
 
 func (x *GetCoderTemplateParamsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_exec_proto_msgTypes[19]
+	mi := &file_exec_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1419,7 +1533,7 @@ func (x *GetCoderTemplateParamsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoderTemplateParamsRequest.ProtoReflect.Descriptor instead.
 func (*GetCoderTemplateParamsRequest) Descriptor() ([]byte, []int) {
-	return file_exec_proto_rawDescGZIP(), []int{19}
+	return file_exec_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *GetCoderTemplateParamsRequest) GetTemplate() string {
@@ -1445,7 +1559,7 @@ type CoderRichParameter struct {
 
 func (x *CoderRichParameter) Reset() {
 	*x = CoderRichParameter{}
-	mi := &file_exec_proto_msgTypes[20]
+	mi := &file_exec_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1457,7 +1571,7 @@ func (x *CoderRichParameter) String() string {
 func (*CoderRichParameter) ProtoMessage() {}
 
 func (x *CoderRichParameter) ProtoReflect() protoreflect.Message {
-	mi := &file_exec_proto_msgTypes[20]
+	mi := &file_exec_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1470,7 +1584,7 @@ func (x *CoderRichParameter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CoderRichParameter.ProtoReflect.Descriptor instead.
 func (*CoderRichParameter) Descriptor() ([]byte, []int) {
-	return file_exec_proto_rawDescGZIP(), []int{20}
+	return file_exec_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *CoderRichParameter) GetName() string {
@@ -1518,7 +1632,7 @@ type GetCoderTemplateParamsReply struct {
 
 func (x *GetCoderTemplateParamsReply) Reset() {
 	*x = GetCoderTemplateParamsReply{}
-	mi := &file_exec_proto_msgTypes[21]
+	mi := &file_exec_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1530,7 +1644,7 @@ func (x *GetCoderTemplateParamsReply) String() string {
 func (*GetCoderTemplateParamsReply) ProtoMessage() {}
 
 func (x *GetCoderTemplateParamsReply) ProtoReflect() protoreflect.Message {
-	mi := &file_exec_proto_msgTypes[21]
+	mi := &file_exec_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1543,7 +1657,7 @@ func (x *GetCoderTemplateParamsReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCoderTemplateParamsReply.ProtoReflect.Descriptor instead.
 func (*GetCoderTemplateParamsReply) Descriptor() ([]byte, []int) {
-	return file_exec_proto_rawDescGZIP(), []int{21}
+	return file_exec_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *GetCoderTemplateParamsReply) GetParameters() []*CoderRichParameter {
@@ -1573,7 +1687,7 @@ type GetBrowserConfigRequest struct {
 
 func (x *GetBrowserConfigRequest) Reset() {
 	*x = GetBrowserConfigRequest{}
-	mi := &file_exec_proto_msgTypes[22]
+	mi := &file_exec_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1585,7 +1699,7 @@ func (x *GetBrowserConfigRequest) String() string {
 func (*GetBrowserConfigRequest) ProtoMessage() {}
 
 func (x *GetBrowserConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_exec_proto_msgTypes[22]
+	mi := &file_exec_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1598,7 +1712,7 @@ func (x *GetBrowserConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBrowserConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetBrowserConfigRequest) Descriptor() ([]byte, []int) {
-	return file_exec_proto_rawDescGZIP(), []int{22}
+	return file_exec_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetBrowserConfigRequest) GetFleet() string {
@@ -1627,7 +1741,7 @@ type GetBrowserConfigReply struct {
 
 func (x *GetBrowserConfigReply) Reset() {
 	*x = GetBrowserConfigReply{}
-	mi := &file_exec_proto_msgTypes[23]
+	mi := &file_exec_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1639,7 +1753,7 @@ func (x *GetBrowserConfigReply) String() string {
 func (*GetBrowserConfigReply) ProtoMessage() {}
 
 func (x *GetBrowserConfigReply) ProtoReflect() protoreflect.Message {
-	mi := &file_exec_proto_msgTypes[23]
+	mi := &file_exec_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1652,7 +1766,7 @@ func (x *GetBrowserConfigReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBrowserConfigReply.ProtoReflect.Descriptor instead.
 func (*GetBrowserConfigReply) Descriptor() ([]byte, []int) {
-	return file_exec_proto_rawDescGZIP(), []int{23}
+	return file_exec_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetBrowserConfigReply) GetInitialUrl() string {
@@ -1690,7 +1804,7 @@ type PrepareBrowserRequest struct {
 
 func (x *PrepareBrowserRequest) Reset() {
 	*x = PrepareBrowserRequest{}
-	mi := &file_exec_proto_msgTypes[24]
+	mi := &file_exec_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1702,7 +1816,7 @@ func (x *PrepareBrowserRequest) String() string {
 func (*PrepareBrowserRequest) ProtoMessage() {}
 
 func (x *PrepareBrowserRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_exec_proto_msgTypes[24]
+	mi := &file_exec_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1715,7 +1829,7 @@ func (x *PrepareBrowserRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareBrowserRequest.ProtoReflect.Descriptor instead.
 func (*PrepareBrowserRequest) Descriptor() ([]byte, []int) {
-	return file_exec_proto_rawDescGZIP(), []int{24}
+	return file_exec_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *PrepareBrowserRequest) GetFleet() string {
@@ -1755,7 +1869,7 @@ type PrepareBrowserReply struct {
 
 func (x *PrepareBrowserReply) Reset() {
 	*x = PrepareBrowserReply{}
-	mi := &file_exec_proto_msgTypes[25]
+	mi := &file_exec_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1767,7 +1881,7 @@ func (x *PrepareBrowserReply) String() string {
 func (*PrepareBrowserReply) ProtoMessage() {}
 
 func (x *PrepareBrowserReply) ProtoReflect() protoreflect.Message {
-	mi := &file_exec_proto_msgTypes[25]
+	mi := &file_exec_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1780,7 +1894,7 @@ func (x *PrepareBrowserReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareBrowserReply.ProtoReflect.Descriptor instead.
 func (*PrepareBrowserReply) Descriptor() ([]byte, []int) {
-	return file_exec_proto_rawDescGZIP(), []int{25}
+	return file_exec_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *PrepareBrowserReply) GetInitialUrl() string {
@@ -1883,7 +1997,13 @@ const file_exec_proto_rawDesc = "" +
 	"\x05fleet\x18\x01 \x01(\tR\x05fleet\x12\x1a\n" +
 	"\binstance\x18\x02 \x01(\tR\binstance\"-\n" +
 	"\x17ResolveLogsCommandReply\x12\x12\n" +
-	"\x04argv\x18\x01 \x03(\tR\x04argv\";\n" +
+	"\x04argv\x18\x01 \x03(\tR\x04argv\"D\n" +
+	"\x12TriggerLogsRequest\x12\x14\n" +
+	"\x05fleet\x18\x01 \x01(\tR\x05fleet\x12\x18\n" +
+	"\atrigger\x18\x02 \x01(\tR\atrigger\"<\n" +
+	"\x10TriggerLogsReply\x12\x12\n" +
+	"\x04logs\x18\x01 \x01(\tR\x04logs\x12\x14\n" +
+	"\x05count\x18\x02 \x01(\x05R\x05count\";\n" +
 	"\x1dGetCoderTemplateParamsRequest\x12\x1a\n" +
 	"\btemplate\x18\x01 \x01(\tR\btemplate\"\xa6\x01\n" +
 	"\x12CoderRichParameter\x12\x12\n" +
@@ -1928,7 +2048,7 @@ func file_exec_proto_rawDescGZIP() []byte {
 	return file_exec_proto_rawDescData
 }
 
-var file_exec_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_exec_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_exec_proto_goTypes = []any{
 	(*ExecIn)(nil),                        // 0: fleetgrpc.ExecIn
 	(*ExecStart)(nil),                     // 1: fleetgrpc.ExecStart
@@ -1949,28 +2069,30 @@ var file_exec_proto_goTypes = []any{
 	(*CopyIntoReply)(nil),                 // 16: fleetgrpc.CopyIntoReply
 	(*ResolveLogsCommandRequest)(nil),     // 17: fleetgrpc.ResolveLogsCommandRequest
 	(*ResolveLogsCommandReply)(nil),       // 18: fleetgrpc.ResolveLogsCommandReply
-	(*GetCoderTemplateParamsRequest)(nil), // 19: fleetgrpc.GetCoderTemplateParamsRequest
-	(*CoderRichParameter)(nil),            // 20: fleetgrpc.CoderRichParameter
-	(*GetCoderTemplateParamsReply)(nil),   // 21: fleetgrpc.GetCoderTemplateParamsReply
-	(*GetBrowserConfigRequest)(nil),       // 22: fleetgrpc.GetBrowserConfigRequest
-	(*GetBrowserConfigReply)(nil),         // 23: fleetgrpc.GetBrowserConfigReply
-	(*PrepareBrowserRequest)(nil),         // 24: fleetgrpc.PrepareBrowserRequest
-	(*PrepareBrowserReply)(nil),           // 25: fleetgrpc.PrepareBrowserReply
-	nil,                                   // 26: fleetgrpc.ExecStart.EnvEntry
-	nil,                                   // 27: fleetgrpc.ResolveExecCommandReply.EnvEntry
-	(*timestamppb.Timestamp)(nil),         // 28: google.protobuf.Timestamp
+	(*TriggerLogsRequest)(nil),            // 19: fleetgrpc.TriggerLogsRequest
+	(*TriggerLogsReply)(nil),              // 20: fleetgrpc.TriggerLogsReply
+	(*GetCoderTemplateParamsRequest)(nil), // 21: fleetgrpc.GetCoderTemplateParamsRequest
+	(*CoderRichParameter)(nil),            // 22: fleetgrpc.CoderRichParameter
+	(*GetCoderTemplateParamsReply)(nil),   // 23: fleetgrpc.GetCoderTemplateParamsReply
+	(*GetBrowserConfigRequest)(nil),       // 24: fleetgrpc.GetBrowserConfigRequest
+	(*GetBrowserConfigReply)(nil),         // 25: fleetgrpc.GetBrowserConfigReply
+	(*PrepareBrowserRequest)(nil),         // 26: fleetgrpc.PrepareBrowserRequest
+	(*PrepareBrowserReply)(nil),           // 27: fleetgrpc.PrepareBrowserReply
+	nil,                                   // 28: fleetgrpc.ExecStart.EnvEntry
+	nil,                                   // 29: fleetgrpc.ResolveExecCommandReply.EnvEntry
+	(*timestamppb.Timestamp)(nil),         // 30: google.protobuf.Timestamp
 }
 var file_exec_proto_depIdxs = []int32{
 	1,  // 0: fleetgrpc.ExecIn.start:type_name -> fleetgrpc.ExecStart
 	2,  // 1: fleetgrpc.ExecIn.resize:type_name -> fleetgrpc.ExecResize
-	26, // 2: fleetgrpc.ExecStart.env:type_name -> fleetgrpc.ExecStart.EnvEntry
+	28, // 2: fleetgrpc.ExecStart.env:type_name -> fleetgrpc.ExecStart.EnvEntry
 	4,  // 3: fleetgrpc.ExecOut.exit:type_name -> fleetgrpc.ExecExit
-	27, // 4: fleetgrpc.ResolveExecCommandReply.env:type_name -> fleetgrpc.ResolveExecCommandReply.EnvEntry
-	28, // 5: fleetgrpc.LogLine.at:type_name -> google.protobuf.Timestamp
+	29, // 4: fleetgrpc.ResolveExecCommandReply.env:type_name -> fleetgrpc.ResolveExecCommandReply.EnvEntry
+	30, // 5: fleetgrpc.LogLine.at:type_name -> google.protobuf.Timestamp
 	10, // 6: fleetgrpc.ForwardChunk.open:type_name -> fleetgrpc.ForwardOpen
 	13, // 7: fleetgrpc.CopyFileChunk.meta:type_name -> fleetgrpc.CopyFileMeta
 	15, // 8: fleetgrpc.CopyIntoChunk.open:type_name -> fleetgrpc.CopyIntoOpen
-	20, // 9: fleetgrpc.GetCoderTemplateParamsReply.parameters:type_name -> fleetgrpc.CoderRichParameter
+	22, // 9: fleetgrpc.GetCoderTemplateParamsReply.parameters:type_name -> fleetgrpc.CoderRichParameter
 	10, // [10:10] is the sub-list for method output_type
 	10, // [10:10] is the sub-list for method input_type
 	10, // [10:10] is the sub-list for extension type_name
@@ -2007,14 +2129,14 @@ func file_exec_proto_init() {
 		(*CopyIntoChunk_Open)(nil),
 		(*CopyIntoChunk_Data)(nil),
 	}
-	file_exec_proto_msgTypes[24].OneofWrappers = []any{}
+	file_exec_proto_msgTypes[26].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_exec_proto_rawDesc), len(file_exec_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   28,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/fleetgrpc/exec.proto
+++ b/fleetgrpc/exec.proto
@@ -214,6 +214,26 @@ message ResolveLogsCommandReply {
   repeated string argv = 1;
 }
 
+// TriggerLogs reads back an automation trigger's recorded event logs. Each time
+// a trigger fires, the daemon writes the firing's payload (the webhook body, or
+// the schedule fire-time) to a per-trigger log directory, keeping the most
+// recent 100. This returns them concatenated (oldest first), so a client can
+// inspect what fired an automation after the fact — the TUI's 'L' pager, the
+// `fleet trigger logs` CLI, and the fleet_trigger_logs MCP tool all read here.
+// A trigger that has never fired returns empty logs with count 0 (not an error).
+message TriggerLogsRequest {
+  string fleet = 1;
+  string trigger = 2;
+}
+
+message TriggerLogsReply {
+  // logs is every recorded event log concatenated (oldest first), each preceded
+  // by a "=== event-<timestamp>.log ===" separator. Empty when none recorded.
+  string logs = 1;
+  // count is how many event logs were concatenated.
+  int32 count = 2;
+}
+
 // =====================================================================
 // CODER TEMPLATE PARAMETERS — read the Coder API server-side
 // =====================================================================

--- a/fleetgrpc/exec.proto
+++ b/fleetgrpc/exec.proto
@@ -228,7 +228,7 @@ message TriggerLogsRequest {
 
 message TriggerLogsReply {
   // logs is every recorded event log concatenated (oldest first), each preceded
-  // by a "=== event-<timestamp>.log ===" separator. Empty when none recorded.
+  // by a "===== event-<timestamp>.log =====" separator. Empty when none recorded.
   string logs = 1;
   // count is how many event logs were concatenated.
   int32 count = 2;

--- a/fleetgrpc/service.pb.go
+++ b/fleetgrpc/service.pb.go
@@ -26,7 +26,7 @@ const file_service_proto_rawDesc = "" +
 	"\n" +
 	"\rservice.proto\x12\tfleetgrpc\x1a\farmada.proto\x1a\rcontrol.proto\x1a\vwatch.proto\x1a\n" +
 	"jobs.proto\x1a\fconfig.proto\x1a\n" +
-	"exec.proto\x1a\rinspect.proto2\xca\x15\n" +
+	"exec.proto\x1a\rinspect.proto2\x95\x16\n" +
 	"\fFleetService\x127\n" +
 	"\x05Hello\x12\x17.fleetgrpc.HelloRequest\x1a\x15.fleetgrpc.HelloReply\x12@\n" +
 	"\bShutdown\x12\x1a.fleetgrpc.ShutdownRequest\x1a\x18.fleetgrpc.ShutdownReply\x12[\n" +
@@ -56,7 +56,8 @@ const file_service_proto_rawDesc = "" +
 	"\x04Exec\x12\x11.fleetgrpc.ExecIn\x1a\x12.fleetgrpc.ExecOut(\x010\x01\x12^\n" +
 	"\x12ResolveExecCommand\x12$.fleetgrpc.ResolveExecCommandRequest\x1a\".fleetgrpc.ResolveExecCommandReply\x12^\n" +
 	"\x12ResolveLogsCommand\x12$.fleetgrpc.ResolveLogsCommandRequest\x1a\".fleetgrpc.ResolveLogsCommandReply\x124\n" +
-	"\x04Logs\x12\x16.fleetgrpc.LogsRequest\x1a\x12.fleetgrpc.LogLine0\x01\x12?\n" +
+	"\x04Logs\x12\x16.fleetgrpc.LogsRequest\x1a\x12.fleetgrpc.LogLine0\x01\x12I\n" +
+	"\vTriggerLogs\x12\x1d.fleetgrpc.TriggerLogsRequest\x1a\x1b.fleetgrpc.TriggerLogsReply\x12?\n" +
 	"\aForward\x12\x17.fleetgrpc.ForwardChunk\x1a\x17.fleetgrpc.ForwardChunk(\x010\x01\x12B\n" +
 	"\bCopyFile\x12\x1a.fleetgrpc.CopyFileRequest\x1a\x18.fleetgrpc.CopyFileChunk0\x01\x12@\n" +
 	"\bCopyInto\x12\x18.fleetgrpc.CopyIntoChunk\x1a\x18.fleetgrpc.CopyIntoReply(\x01\x12I\n" +
@@ -95,37 +96,39 @@ var file_service_proto_goTypes = []any{
 	(*ResolveExecCommandRequest)(nil),     // 26: fleetgrpc.ResolveExecCommandRequest
 	(*ResolveLogsCommandRequest)(nil),     // 27: fleetgrpc.ResolveLogsCommandRequest
 	(*LogsRequest)(nil),                   // 28: fleetgrpc.LogsRequest
-	(*ForwardChunk)(nil),                  // 29: fleetgrpc.ForwardChunk
-	(*CopyFileRequest)(nil),               // 30: fleetgrpc.CopyFileRequest
-	(*CopyIntoChunk)(nil),                 // 31: fleetgrpc.CopyIntoChunk
-	(*InspectRepoRequest)(nil),            // 32: fleetgrpc.InspectRepoRequest
-	(*GetCoderTemplateParamsRequest)(nil), // 33: fleetgrpc.GetCoderTemplateParamsRequest
-	(*GetBrowserConfigRequest)(nil),       // 34: fleetgrpc.GetBrowserConfigRequest
-	(*PrepareBrowserRequest)(nil),         // 35: fleetgrpc.PrepareBrowserRequest
-	(*HelloReply)(nil),                    // 36: fleetgrpc.HelloReply
-	(*ShutdownReply)(nil),                 // 37: fleetgrpc.ShutdownReply
-	(*FleetTUIConnectedReply)(nil),        // 38: fleetgrpc.FleetTUIConnectedReply
-	(*GetStateReply)(nil),                 // 39: fleetgrpc.GetStateReply
-	(*Event)(nil),                         // 40: fleetgrpc.Event
-	(*JobEvent)(nil),                      // 41: fleetgrpc.JobEvent
-	(*MutationReply)(nil),                 // 42: fleetgrpc.MutationReply
-	(*DeleteBuildkitCacheReply)(nil),      // 43: fleetgrpc.DeleteBuildkitCacheReply
-	(*DeleteDebCacheReply)(nil),           // 44: fleetgrpc.DeleteDebCacheReply
-	(*DeleteImageCacheReply)(nil),         // 45: fleetgrpc.DeleteImageCacheReply
-	(*GetConfigReply)(nil),                // 46: fleetgrpc.GetConfigReply
-	(*SetConfigReply)(nil),                // 47: fleetgrpc.SetConfigReply
-	(*GetArmadaReply)(nil),                // 48: fleetgrpc.GetArmadaReply
-	(*SetArmadaReply)(nil),                // 49: fleetgrpc.SetArmadaReply
-	(*ExecOut)(nil),                       // 50: fleetgrpc.ExecOut
-	(*ResolveExecCommandReply)(nil),       // 51: fleetgrpc.ResolveExecCommandReply
-	(*ResolveLogsCommandReply)(nil),       // 52: fleetgrpc.ResolveLogsCommandReply
-	(*LogLine)(nil),                       // 53: fleetgrpc.LogLine
-	(*CopyFileChunk)(nil),                 // 54: fleetgrpc.CopyFileChunk
-	(*CopyIntoReply)(nil),                 // 55: fleetgrpc.CopyIntoReply
-	(*InspectRepoReply)(nil),              // 56: fleetgrpc.InspectRepoReply
-	(*GetCoderTemplateParamsReply)(nil),   // 57: fleetgrpc.GetCoderTemplateParamsReply
-	(*GetBrowserConfigReply)(nil),         // 58: fleetgrpc.GetBrowserConfigReply
-	(*PrepareBrowserReply)(nil),           // 59: fleetgrpc.PrepareBrowserReply
+	(*TriggerLogsRequest)(nil),            // 29: fleetgrpc.TriggerLogsRequest
+	(*ForwardChunk)(nil),                  // 30: fleetgrpc.ForwardChunk
+	(*CopyFileRequest)(nil),               // 31: fleetgrpc.CopyFileRequest
+	(*CopyIntoChunk)(nil),                 // 32: fleetgrpc.CopyIntoChunk
+	(*InspectRepoRequest)(nil),            // 33: fleetgrpc.InspectRepoRequest
+	(*GetCoderTemplateParamsRequest)(nil), // 34: fleetgrpc.GetCoderTemplateParamsRequest
+	(*GetBrowserConfigRequest)(nil),       // 35: fleetgrpc.GetBrowserConfigRequest
+	(*PrepareBrowserRequest)(nil),         // 36: fleetgrpc.PrepareBrowserRequest
+	(*HelloReply)(nil),                    // 37: fleetgrpc.HelloReply
+	(*ShutdownReply)(nil),                 // 38: fleetgrpc.ShutdownReply
+	(*FleetTUIConnectedReply)(nil),        // 39: fleetgrpc.FleetTUIConnectedReply
+	(*GetStateReply)(nil),                 // 40: fleetgrpc.GetStateReply
+	(*Event)(nil),                         // 41: fleetgrpc.Event
+	(*JobEvent)(nil),                      // 42: fleetgrpc.JobEvent
+	(*MutationReply)(nil),                 // 43: fleetgrpc.MutationReply
+	(*DeleteBuildkitCacheReply)(nil),      // 44: fleetgrpc.DeleteBuildkitCacheReply
+	(*DeleteDebCacheReply)(nil),           // 45: fleetgrpc.DeleteDebCacheReply
+	(*DeleteImageCacheReply)(nil),         // 46: fleetgrpc.DeleteImageCacheReply
+	(*GetConfigReply)(nil),                // 47: fleetgrpc.GetConfigReply
+	(*SetConfigReply)(nil),                // 48: fleetgrpc.SetConfigReply
+	(*GetArmadaReply)(nil),                // 49: fleetgrpc.GetArmadaReply
+	(*SetArmadaReply)(nil),                // 50: fleetgrpc.SetArmadaReply
+	(*ExecOut)(nil),                       // 51: fleetgrpc.ExecOut
+	(*ResolveExecCommandReply)(nil),       // 52: fleetgrpc.ResolveExecCommandReply
+	(*ResolveLogsCommandReply)(nil),       // 53: fleetgrpc.ResolveLogsCommandReply
+	(*LogLine)(nil),                       // 54: fleetgrpc.LogLine
+	(*TriggerLogsReply)(nil),              // 55: fleetgrpc.TriggerLogsReply
+	(*CopyFileChunk)(nil),                 // 56: fleetgrpc.CopyFileChunk
+	(*CopyIntoReply)(nil),                 // 57: fleetgrpc.CopyIntoReply
+	(*InspectRepoReply)(nil),              // 58: fleetgrpc.InspectRepoReply
+	(*GetCoderTemplateParamsReply)(nil),   // 59: fleetgrpc.GetCoderTemplateParamsReply
+	(*GetBrowserConfigReply)(nil),         // 60: fleetgrpc.GetBrowserConfigReply
+	(*PrepareBrowserReply)(nil),           // 61: fleetgrpc.PrepareBrowserReply
 }
 var file_service_proto_depIdxs = []int32{
 	0,  // 0: fleetgrpc.FleetService.Hello:input_type -> fleetgrpc.HelloRequest
@@ -157,51 +160,53 @@ var file_service_proto_depIdxs = []int32{
 	26, // 26: fleetgrpc.FleetService.ResolveExecCommand:input_type -> fleetgrpc.ResolveExecCommandRequest
 	27, // 27: fleetgrpc.FleetService.ResolveLogsCommand:input_type -> fleetgrpc.ResolveLogsCommandRequest
 	28, // 28: fleetgrpc.FleetService.Logs:input_type -> fleetgrpc.LogsRequest
-	29, // 29: fleetgrpc.FleetService.Forward:input_type -> fleetgrpc.ForwardChunk
-	30, // 30: fleetgrpc.FleetService.CopyFile:input_type -> fleetgrpc.CopyFileRequest
-	31, // 31: fleetgrpc.FleetService.CopyInto:input_type -> fleetgrpc.CopyIntoChunk
-	32, // 32: fleetgrpc.FleetService.InspectRepo:input_type -> fleetgrpc.InspectRepoRequest
-	33, // 33: fleetgrpc.FleetService.GetCoderTemplateParams:input_type -> fleetgrpc.GetCoderTemplateParamsRequest
-	34, // 34: fleetgrpc.FleetService.GetBrowserConfig:input_type -> fleetgrpc.GetBrowserConfigRequest
-	35, // 35: fleetgrpc.FleetService.PrepareBrowser:input_type -> fleetgrpc.PrepareBrowserRequest
-	36, // 36: fleetgrpc.FleetService.Hello:output_type -> fleetgrpc.HelloReply
-	37, // 37: fleetgrpc.FleetService.Shutdown:output_type -> fleetgrpc.ShutdownReply
-	38, // 38: fleetgrpc.FleetService.FleetTUIConnected:output_type -> fleetgrpc.FleetTUIConnectedReply
-	39, // 39: fleetgrpc.FleetService.GetState:output_type -> fleetgrpc.GetStateReply
-	40, // 40: fleetgrpc.FleetService.Watch:output_type -> fleetgrpc.Event
-	41, // 41: fleetgrpc.FleetService.CreateInstance:output_type -> fleetgrpc.JobEvent
-	41, // 42: fleetgrpc.FleetService.DestroyInstance:output_type -> fleetgrpc.JobEvent
-	41, // 43: fleetgrpc.FleetService.StartInstance:output_type -> fleetgrpc.JobEvent
-	41, // 44: fleetgrpc.FleetService.StopInstance:output_type -> fleetgrpc.JobEvent
-	41, // 45: fleetgrpc.FleetService.CloneInstance:output_type -> fleetgrpc.JobEvent
-	41, // 46: fleetgrpc.FleetService.RebuildInstance:output_type -> fleetgrpc.JobEvent
-	42, // 47: fleetgrpc.FleetService.CreateFleet:output_type -> fleetgrpc.MutationReply
-	42, // 48: fleetgrpc.FleetService.DestroyFleet:output_type -> fleetgrpc.MutationReply
-	42, // 49: fleetgrpc.FleetService.SetFleetSettings:output_type -> fleetgrpc.MutationReply
-	43, // 50: fleetgrpc.FleetService.DeleteBuildkitCache:output_type -> fleetgrpc.DeleteBuildkitCacheReply
-	44, // 51: fleetgrpc.FleetService.DeleteDebCache:output_type -> fleetgrpc.DeleteDebCacheReply
-	45, // 52: fleetgrpc.FleetService.DeleteImageCache:output_type -> fleetgrpc.DeleteImageCacheReply
-	42, // 53: fleetgrpc.FleetService.SetInstanceMetadata:output_type -> fleetgrpc.MutationReply
-	42, // 54: fleetgrpc.FleetService.SetGroupLayout:output_type -> fleetgrpc.MutationReply
-	42, // 55: fleetgrpc.FleetService.DeleteGroupLayout:output_type -> fleetgrpc.MutationReply
-	42, // 56: fleetgrpc.FleetService.SetLastSeenVersion:output_type -> fleetgrpc.MutationReply
-	46, // 57: fleetgrpc.FleetService.GetConfig:output_type -> fleetgrpc.GetConfigReply
-	47, // 58: fleetgrpc.FleetService.SetConfig:output_type -> fleetgrpc.SetConfigReply
-	48, // 59: fleetgrpc.FleetService.GetArmada:output_type -> fleetgrpc.GetArmadaReply
-	49, // 60: fleetgrpc.FleetService.SetArmada:output_type -> fleetgrpc.SetArmadaReply
-	50, // 61: fleetgrpc.FleetService.Exec:output_type -> fleetgrpc.ExecOut
-	51, // 62: fleetgrpc.FleetService.ResolveExecCommand:output_type -> fleetgrpc.ResolveExecCommandReply
-	52, // 63: fleetgrpc.FleetService.ResolveLogsCommand:output_type -> fleetgrpc.ResolveLogsCommandReply
-	53, // 64: fleetgrpc.FleetService.Logs:output_type -> fleetgrpc.LogLine
-	29, // 65: fleetgrpc.FleetService.Forward:output_type -> fleetgrpc.ForwardChunk
-	54, // 66: fleetgrpc.FleetService.CopyFile:output_type -> fleetgrpc.CopyFileChunk
-	55, // 67: fleetgrpc.FleetService.CopyInto:output_type -> fleetgrpc.CopyIntoReply
-	56, // 68: fleetgrpc.FleetService.InspectRepo:output_type -> fleetgrpc.InspectRepoReply
-	57, // 69: fleetgrpc.FleetService.GetCoderTemplateParams:output_type -> fleetgrpc.GetCoderTemplateParamsReply
-	58, // 70: fleetgrpc.FleetService.GetBrowserConfig:output_type -> fleetgrpc.GetBrowserConfigReply
-	59, // 71: fleetgrpc.FleetService.PrepareBrowser:output_type -> fleetgrpc.PrepareBrowserReply
-	36, // [36:72] is the sub-list for method output_type
-	0,  // [0:36] is the sub-list for method input_type
+	29, // 29: fleetgrpc.FleetService.TriggerLogs:input_type -> fleetgrpc.TriggerLogsRequest
+	30, // 30: fleetgrpc.FleetService.Forward:input_type -> fleetgrpc.ForwardChunk
+	31, // 31: fleetgrpc.FleetService.CopyFile:input_type -> fleetgrpc.CopyFileRequest
+	32, // 32: fleetgrpc.FleetService.CopyInto:input_type -> fleetgrpc.CopyIntoChunk
+	33, // 33: fleetgrpc.FleetService.InspectRepo:input_type -> fleetgrpc.InspectRepoRequest
+	34, // 34: fleetgrpc.FleetService.GetCoderTemplateParams:input_type -> fleetgrpc.GetCoderTemplateParamsRequest
+	35, // 35: fleetgrpc.FleetService.GetBrowserConfig:input_type -> fleetgrpc.GetBrowserConfigRequest
+	36, // 36: fleetgrpc.FleetService.PrepareBrowser:input_type -> fleetgrpc.PrepareBrowserRequest
+	37, // 37: fleetgrpc.FleetService.Hello:output_type -> fleetgrpc.HelloReply
+	38, // 38: fleetgrpc.FleetService.Shutdown:output_type -> fleetgrpc.ShutdownReply
+	39, // 39: fleetgrpc.FleetService.FleetTUIConnected:output_type -> fleetgrpc.FleetTUIConnectedReply
+	40, // 40: fleetgrpc.FleetService.GetState:output_type -> fleetgrpc.GetStateReply
+	41, // 41: fleetgrpc.FleetService.Watch:output_type -> fleetgrpc.Event
+	42, // 42: fleetgrpc.FleetService.CreateInstance:output_type -> fleetgrpc.JobEvent
+	42, // 43: fleetgrpc.FleetService.DestroyInstance:output_type -> fleetgrpc.JobEvent
+	42, // 44: fleetgrpc.FleetService.StartInstance:output_type -> fleetgrpc.JobEvent
+	42, // 45: fleetgrpc.FleetService.StopInstance:output_type -> fleetgrpc.JobEvent
+	42, // 46: fleetgrpc.FleetService.CloneInstance:output_type -> fleetgrpc.JobEvent
+	42, // 47: fleetgrpc.FleetService.RebuildInstance:output_type -> fleetgrpc.JobEvent
+	43, // 48: fleetgrpc.FleetService.CreateFleet:output_type -> fleetgrpc.MutationReply
+	43, // 49: fleetgrpc.FleetService.DestroyFleet:output_type -> fleetgrpc.MutationReply
+	43, // 50: fleetgrpc.FleetService.SetFleetSettings:output_type -> fleetgrpc.MutationReply
+	44, // 51: fleetgrpc.FleetService.DeleteBuildkitCache:output_type -> fleetgrpc.DeleteBuildkitCacheReply
+	45, // 52: fleetgrpc.FleetService.DeleteDebCache:output_type -> fleetgrpc.DeleteDebCacheReply
+	46, // 53: fleetgrpc.FleetService.DeleteImageCache:output_type -> fleetgrpc.DeleteImageCacheReply
+	43, // 54: fleetgrpc.FleetService.SetInstanceMetadata:output_type -> fleetgrpc.MutationReply
+	43, // 55: fleetgrpc.FleetService.SetGroupLayout:output_type -> fleetgrpc.MutationReply
+	43, // 56: fleetgrpc.FleetService.DeleteGroupLayout:output_type -> fleetgrpc.MutationReply
+	43, // 57: fleetgrpc.FleetService.SetLastSeenVersion:output_type -> fleetgrpc.MutationReply
+	47, // 58: fleetgrpc.FleetService.GetConfig:output_type -> fleetgrpc.GetConfigReply
+	48, // 59: fleetgrpc.FleetService.SetConfig:output_type -> fleetgrpc.SetConfigReply
+	49, // 60: fleetgrpc.FleetService.GetArmada:output_type -> fleetgrpc.GetArmadaReply
+	50, // 61: fleetgrpc.FleetService.SetArmada:output_type -> fleetgrpc.SetArmadaReply
+	51, // 62: fleetgrpc.FleetService.Exec:output_type -> fleetgrpc.ExecOut
+	52, // 63: fleetgrpc.FleetService.ResolveExecCommand:output_type -> fleetgrpc.ResolveExecCommandReply
+	53, // 64: fleetgrpc.FleetService.ResolveLogsCommand:output_type -> fleetgrpc.ResolveLogsCommandReply
+	54, // 65: fleetgrpc.FleetService.Logs:output_type -> fleetgrpc.LogLine
+	55, // 66: fleetgrpc.FleetService.TriggerLogs:output_type -> fleetgrpc.TriggerLogsReply
+	30, // 67: fleetgrpc.FleetService.Forward:output_type -> fleetgrpc.ForwardChunk
+	56, // 68: fleetgrpc.FleetService.CopyFile:output_type -> fleetgrpc.CopyFileChunk
+	57, // 69: fleetgrpc.FleetService.CopyInto:output_type -> fleetgrpc.CopyIntoReply
+	58, // 70: fleetgrpc.FleetService.InspectRepo:output_type -> fleetgrpc.InspectRepoReply
+	59, // 71: fleetgrpc.FleetService.GetCoderTemplateParams:output_type -> fleetgrpc.GetCoderTemplateParamsReply
+	60, // 72: fleetgrpc.FleetService.GetBrowserConfig:output_type -> fleetgrpc.GetBrowserConfigReply
+	61, // 73: fleetgrpc.FleetService.PrepareBrowser:output_type -> fleetgrpc.PrepareBrowserReply
+	37, // [37:74] is the sub-list for method output_type
+	0,  // [0:37] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/fleetgrpc/service.proto
+++ b/fleetgrpc/service.proto
@@ -85,6 +85,12 @@ service FleetService {
   rpc ResolveLogsCommand(ResolveLogsCommandRequest) returns (ResolveLogsCommandReply);
   rpc Logs(LogsRequest) returns (stream LogLine);
 
+  // TriggerLogs returns an automation trigger's recorded event logs (the
+  // payloads of its recent firings, concatenated for viewing). The daemon owns
+  // the log files (~/.fleet/logs/<fleet>/trigger/<trigger>/), so reading them
+  // over the service works unchanged when the daemon is remote.
+  rpc TriggerLogs(TriggerLogsRequest) returns (TriggerLogsReply);
+
   // Forward is the port-forward data plane: one bidi stream per forwarded TCP
   // connection (first frame is the ForwardOpen header, the rest raw bytes).
   // The client listens locally and pipes each accepted connection through this

--- a/fleetgrpc/service_grpc.pb.go
+++ b/fleetgrpc/service_grpc.pb.go
@@ -48,6 +48,7 @@ const (
 	FleetService_ResolveExecCommand_FullMethodName     = "/fleetgrpc.FleetService/ResolveExecCommand"
 	FleetService_ResolveLogsCommand_FullMethodName     = "/fleetgrpc.FleetService/ResolveLogsCommand"
 	FleetService_Logs_FullMethodName                   = "/fleetgrpc.FleetService/Logs"
+	FleetService_TriggerLogs_FullMethodName            = "/fleetgrpc.FleetService/TriggerLogs"
 	FleetService_Forward_FullMethodName                = "/fleetgrpc.FleetService/Forward"
 	FleetService_CopyFile_FullMethodName               = "/fleetgrpc.FleetService/CopyFile"
 	FleetService_CopyInto_FullMethodName               = "/fleetgrpc.FleetService/CopyInto"
@@ -120,6 +121,11 @@ type FleetServiceClient interface {
 	ResolveExecCommand(ctx context.Context, in *ResolveExecCommandRequest, opts ...grpc.CallOption) (*ResolveExecCommandReply, error)
 	ResolveLogsCommand(ctx context.Context, in *ResolveLogsCommandRequest, opts ...grpc.CallOption) (*ResolveLogsCommandReply, error)
 	Logs(ctx context.Context, in *LogsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[LogLine], error)
+	// TriggerLogs returns an automation trigger's recorded event logs (the
+	// payloads of its recent firings, concatenated for viewing). The daemon owns
+	// the log files (~/.fleet/logs/<fleet>/trigger/<trigger>/), so reading them
+	// over the service works unchanged when the daemon is remote.
+	TriggerLogs(ctx context.Context, in *TriggerLogsRequest, opts ...grpc.CallOption) (*TriggerLogsReply, error)
 	// Forward is the port-forward data plane: one bidi stream per forwarded TCP
 	// connection (first frame is the ForwardOpen header, the rest raw bytes).
 	// The client listens locally and pipes each accepted connection through this
@@ -518,6 +524,16 @@ func (c *fleetServiceClient) Logs(ctx context.Context, in *LogsRequest, opts ...
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type FleetService_LogsClient = grpc.ServerStreamingClient[LogLine]
 
+func (c *fleetServiceClient) TriggerLogs(ctx context.Context, in *TriggerLogsRequest, opts ...grpc.CallOption) (*TriggerLogsReply, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(TriggerLogsReply)
+	err := c.cc.Invoke(ctx, FleetService_TriggerLogs_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *fleetServiceClient) Forward(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[ForwardChunk, ForwardChunk], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &FleetService_ServiceDesc.Streams[9], FleetService_Forward_FullMethodName, cOpts...)
@@ -666,6 +682,11 @@ type FleetServiceServer interface {
 	ResolveExecCommand(context.Context, *ResolveExecCommandRequest) (*ResolveExecCommandReply, error)
 	ResolveLogsCommand(context.Context, *ResolveLogsCommandRequest) (*ResolveLogsCommandReply, error)
 	Logs(*LogsRequest, grpc.ServerStreamingServer[LogLine]) error
+	// TriggerLogs returns an automation trigger's recorded event logs (the
+	// payloads of its recent firings, concatenated for viewing). The daemon owns
+	// the log files (~/.fleet/logs/<fleet>/trigger/<trigger>/), so reading them
+	// over the service works unchanged when the daemon is remote.
+	TriggerLogs(context.Context, *TriggerLogsRequest) (*TriggerLogsReply, error)
 	// Forward is the port-forward data plane: one bidi stream per forwarded TCP
 	// connection (first frame is the ForwardOpen header, the rest raw bytes).
 	// The client listens locally and pipes each accepted connection through this
@@ -785,6 +806,9 @@ func (UnimplementedFleetServiceServer) ResolveLogsCommand(context.Context, *Reso
 }
 func (UnimplementedFleetServiceServer) Logs(*LogsRequest, grpc.ServerStreamingServer[LogLine]) error {
 	return status.Errorf(codes.Unimplemented, "method Logs not implemented")
+}
+func (UnimplementedFleetServiceServer) TriggerLogs(context.Context, *TriggerLogsRequest) (*TriggerLogsReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method TriggerLogs not implemented")
 }
 func (UnimplementedFleetServiceServer) Forward(grpc.BidiStreamingServer[ForwardChunk, ForwardChunk]) error {
 	return status.Errorf(codes.Unimplemented, "method Forward not implemented")
@@ -1283,6 +1307,24 @@ func _FleetService_Logs_Handler(srv interface{}, stream grpc.ServerStream) error
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type FleetService_LogsServer = grpc.ServerStreamingServer[LogLine]
 
+func _FleetService_TriggerLogs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(TriggerLogsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FleetServiceServer).TriggerLogs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: FleetService_TriggerLogs_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FleetServiceServer).TriggerLogs(ctx, req.(*TriggerLogsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _FleetService_Forward_Handler(srv interface{}, stream grpc.ServerStream) error {
 	return srv.(FleetServiceServer).Forward(&grpc.GenericServerStream[ForwardChunk, ForwardChunk]{ServerStream: stream})
 }
@@ -1466,6 +1508,10 @@ var FleetService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ResolveLogsCommand",
 			Handler:    _FleetService_ResolveLogsCommand_Handler,
+		},
+		{
+			MethodName: "TriggerLogs",
+			Handler:    _FleetService_TriggerLogs_Handler,
 		},
 		{
 			MethodName: "InspectRepo",

--- a/internal/admiralskill/SKILL.md
+++ b/internal/admiralskill/SKILL.md
@@ -151,6 +151,10 @@ instance that runs the agent. These tools let you set that up for the user.
   `json_path`+`json_value`); `agents` names the agents it fires (each must
   exist). `fleet_trigger_update` merges fields like the agent one;
   `fleet_trigger_delete {fleet, name}` removes it.
+- `fleet_trigger_logs {fleet, trigger}` returns `{logs, count}` — the recorded
+  payloads of the trigger's recent firings (webhook body or schedule fire-time),
+  concatenated oldest-first. Use it to debug what fired (or failed to fire) an
+  automation; the daemon keeps the last 100 firings per trigger.
 
 Every write returns the fleet's resulting `{agents, triggers}`. Names are
 unique per fleet; an invalid cron, an unknown agent reference, or a duplicate
@@ -216,4 +220,5 @@ AUTOMATION  (unattended agents fired by triggers; every write returns {agents, t
   fleet_trigger_create {fleet, name, type, agents:[...], prompt?, cron? | webhook_name?+filter_type?+regex?|json_path?+json_value?}
   fleet_trigger_update {fleet, name, new_name?, type?, agents?, ...}                 # omit a field to keep it
   fleet_trigger_delete {fleet, name}
+  fleet_trigger_logs {fleet, trigger}                          # recorded firing payloads (debug what fired it)
 ```

--- a/internal/cli/automation.go
+++ b/internal/cli/automation.go
@@ -47,6 +47,22 @@ var loadAutomation = func(ctx context.Context, fleetName string) (fleet.FleetSet
 	}, nil
 }
 
+// triggerLogs fetches a trigger's recorded event logs (its recent firings'
+// payloads, concatenated) from the daemon. A package var so the command test can
+// stub the server round-trip.
+var triggerLogs = func(ctx context.Context, fleetName, triggerName string) (string, error) {
+	conn, err := fleetclient.Dial(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	reply, err := conn.Service().TriggerLogs(ctx, &fleetgrpc.TriggerLogsRequest{Fleet: fleetName, Trigger: triggerName})
+	if err != nil {
+		return "", err
+	}
+	return reply.GetLogs(), nil
+}
+
 // mutateAutomation reads the named fleet's settings, applies fn to its
 // (domain) agent/trigger lists, and writes the result back — preserving every
 // other settings field. fn returns the modified settings (the shared fleet.*

--- a/internal/cli/trigger.go
+++ b/internal/cli/trigger.go
@@ -27,6 +27,7 @@ func newTriggerCmd() *cobra.Command {
 		newTriggerCreateCmd(),
 		newTriggerEditCmd(),
 		newTriggerDeleteCmd(),
+		newTriggerLogsCmd(),
 	)
 	return cmd
 }
@@ -170,6 +171,29 @@ func newTriggerDeleteCmd() *cobra.Command {
 				return err
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Deleted trigger %q in fleet %q\n", name, fleetName)
+			return nil
+		},
+	}
+}
+
+func newTriggerLogsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "logs <fleet> <name>",
+		Short: "Show a trigger's recorded event logs",
+		Long: "Show a trigger's recorded event logs: the payloads of its recent firings\n" +
+			"(webhook body or schedule fire-time). The last 100 firings are kept.",
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fleetName, name := args[0], args[1]
+			logs, err := triggerLogs(cmd.Context(), fleetName, name)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(logs) == "" {
+				fmt.Fprintf(cmd.OutOrStdout(), "No events recorded for trigger %q in fleet %q\n", name, fleetName)
+				return nil
+			}
+			fmt.Fprint(cmd.OutOrStdout(), logs)
 			return nil
 		},
 	}

--- a/internal/cli/trigger_test.go
+++ b/internal/cli/trigger_test.go
@@ -187,6 +187,41 @@ func TestTriggerList(t *testing.T) {
 	}
 }
 
+func TestTriggerLogs(t *testing.T) {
+	orig := triggerLogs
+	t.Cleanup(func() { triggerLogs = orig })
+	var gotFleet, gotTrigger string
+	triggerLogs = func(_ context.Context, f, tr string) (string, error) {
+		gotFleet, gotTrigger = f, tr
+		return "===== event-20260623T090000Z.log =====\nhello payload\n", nil
+	}
+
+	out, err := runCLI(t, "trigger", "logs", "alpha", "nightly")
+	if err != nil {
+		t.Fatalf("logs: %v", err)
+	}
+	if gotFleet != "alpha" || gotTrigger != "nightly" {
+		t.Errorf("fetched logs for %q/%q, want alpha/nightly", gotFleet, gotTrigger)
+	}
+	if !strings.Contains(out, "hello payload") {
+		t.Errorf("output missing payload:\n%s", out)
+	}
+}
+
+func TestTriggerLogsEmpty(t *testing.T) {
+	orig := triggerLogs
+	t.Cleanup(func() { triggerLogs = orig })
+	triggerLogs = func(context.Context, string, string) (string, error) { return "", nil }
+
+	out, err := runCLI(t, "trigger", "logs", "alpha", "nightly")
+	if err != nil {
+		t.Fatalf("logs: %v", err)
+	}
+	if !strings.Contains(out, "No events recorded") {
+		t.Errorf("empty history output = %q", out)
+	}
+}
+
 func TestTriggerAliases(t *testing.T) {
 	cmds := map[string]string{}
 	for _, c := range newTriggerCmd().Commands() {

--- a/internal/server/mcp_automation.go
+++ b/internal/server/mcp_automation.go
@@ -339,3 +339,30 @@ func (s *service) mcpTriggerDelete(ctx context.Context, _ *mcp.CallToolRequest, 
 	}
 	return nil, toMCPAutomation(settings), nil
 }
+
+// --- trigger event logs ---
+
+type FleetTriggerLogsInput struct {
+	Fleet   string `json:"fleet" jsonschema:"fleet name"`
+	Trigger string `json:"trigger" jsonschema:"trigger name"`
+}
+
+// TriggerLogsOutput is a trigger's recorded event logs, concatenated for reading.
+type TriggerLogsOutput struct {
+	// Logs is every recorded firing's payload concatenated (oldest first), each
+	// preceded by a separator header; empty when the trigger has fired nothing.
+	Logs string `json:"logs"`
+	// Count is how many event logs were concatenated.
+	Count int `json:"count"`
+}
+
+func (s *service) mcpTriggerLogs(_ context.Context, _ *mcp.CallToolRequest, in FleetTriggerLogsInput) (*mcp.CallToolResult, TriggerLogsOutput, error) {
+	if in.Fleet == "" || in.Trigger == "" {
+		return nil, TriggerLogsOutput{}, errors.New("fleet and trigger are required")
+	}
+	logs, count, err := readTriggerLogs(in.Fleet, in.Trigger)
+	if err != nil {
+		return nil, TriggerLogsOutput{}, mcpErr(err)
+	}
+	return nil, TriggerLogsOutput{Logs: logs, Count: count}, nil
+}

--- a/internal/server/mcp_automation_test.go
+++ b/internal/server/mcp_automation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
@@ -192,5 +193,37 @@ func TestMCPAutomationPreservesOtherSettings(t *testing.T) {
 	}
 	if len(got.Agents) != 1 {
 		t.Errorf("agent not persisted: %+v", got.Agents)
+	}
+}
+
+// TestMCPTriggerLogs proves the fleet_trigger_logs tool returns a trigger's
+// recorded firings (read from the daemon's on-host log files).
+func TestMCPTriggerLogs(t *testing.T) {
+	cs := seedBareFleet(t) // isolates the fleet dir (HOME) the logs live under
+
+	// No firings yet → empty, count 0.
+	var empty TriggerLogsOutput
+	callJSON(t, cs, "fleet_trigger_logs", map[string]any{"fleet": "alpha", "trigger": "nightly"}, &empty)
+	if empty.Count != 0 || empty.Logs != "" {
+		t.Fatalf("empty history returned %+v", empty)
+	}
+
+	// Record a firing, then the tool reports it.
+	logTriggerEvent("alpha", &triggerEvent{
+		kind:        fleet.TriggerWebhook,
+		triggerName: "nightly",
+		firedAt:     time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		webhookName: "ci",
+		body:        []byte("event-payload"),
+	})
+	var out TriggerLogsOutput
+	callJSON(t, cs, "fleet_trigger_logs", map[string]any{"fleet": "alpha", "trigger": "nightly"}, &out)
+	if out.Count != 1 || !strings.Contains(out.Logs, "event-payload") {
+		t.Fatalf("trigger logs returned %+v", out)
+	}
+
+	// Missing args are a tool error.
+	if msg := callErr(t, cs, "fleet_trigger_logs", map[string]any{"fleet": "alpha"}); !strings.Contains(msg, "required") {
+		t.Errorf("missing-trigger error = %q", msg)
 	}
 }

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -118,7 +118,7 @@ func TestNewMCPServerRegistersAllTools(t *testing.T) {
 		"fleet_exec", "fleet_session_spawn", "fleet_session_exec", "fleet_session_read",
 		"fleet_session_list",
 		"fleet_automation_list", "fleet_agent_create", "fleet_agent_update", "fleet_agent_delete",
-		"fleet_trigger_create", "fleet_trigger_update", "fleet_trigger_delete",
+		"fleet_trigger_create", "fleet_trigger_update", "fleet_trigger_delete", "fleet_trigger_logs",
 	}
 	for _, name := range want {
 		if !got[name] {

--- a/internal/server/mcp_tools.go
+++ b/internal/server/mcp_tools.go
@@ -144,6 +144,10 @@ func registerMCPTools(srv *mcp.Server, s *service) {
 		Name:        "fleet_trigger_delete",
 		Description: "Delete an automation trigger. Returns the fleet's resulting automation config.",
 	}, s.mcpTriggerDelete)
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "fleet_trigger_logs",
+		Description: "Read an automation trigger's recorded event logs: the payloads of its recent firings (webhook body or schedule fire-time), captured on the daemon so you can debug what fired it. Returns {logs, count} with the firings concatenated, oldest first.",
+	}, s.mcpTriggerLogs)
 }
 
 // --- shared shapes ---

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -241,6 +241,17 @@ func (s *service) schedulerTick(ctx context.Context, sched *scheduler, now time.
 // webhook path; it only mutates sched.watched, so it MUST run on the scheduler
 // goroutine.
 func (s *service) fireTriggerAgents(sched *scheduler, fleetName string, trigger fleet.Trigger, agents []fleet.Agent, now time.Time, body []byte) bool {
+	// One event describes this firing; it's shared (read-only) by every agent the
+	// trigger spawns and recorded once to the trigger's on-host event log so the
+	// firing is debuggable after the instances are reaped (see trigger_logs.go).
+	ev := &triggerEvent{
+		kind:        trigger.Type,
+		triggerName: trigger.Name,
+		firedAt:     now,
+		webhookName: trigger.WebhookName,
+		body:        body,
+	}
+	logTriggerEvent(fleetName, ev)
 	fired := false
 	for _, ag := range agents {
 		instName, err := createAutomationInstance(s, fleetName, ag, now)
@@ -257,13 +268,7 @@ func (s *service) fireTriggerAgents(sched *scheduler, fleetName string, trigger 
 			systemPrompt: ag.SystemPrompt,
 			spawnedAt:    now,
 			lastActive:   now,
-			event: &triggerEvent{
-				kind:        trigger.Type,
-				triggerName: trigger.Name,
-				firedAt:     now,
-				webhookName: trigger.WebhookName,
-				body:        body,
-			},
+			event:        ev,
 		}
 		sched.watched[w.key()] = w
 		fired = true

--- a/internal/server/trigger_logs.go
+++ b/internal/server/trigger_logs.go
@@ -46,12 +46,15 @@ const triggerEventLogKeep = 100
 // not part of the automation's critical path.
 var logTriggerEvent = func(fleetName string, ev *triggerEvent) {
 	dir := state.TriggerLogsDir(fleetName, ev.triggerName)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	// 0700 dir / 0600 file: a webhook body can carry signatures or secrets, and
+	// these logs persist durably on the host (unlike the payload's previous home
+	// inside an ephemeral instance), so keep them readable only by the owner.
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		flog.Warn("automation: trigger log mkdir failed", "fleet", fleetName, "trigger", ev.triggerName, "err", err)
 		return
 	}
 	path := uniqueTriggerLogPath(dir, ev.firedAt)
-	if err := os.WriteFile(path, triggerEventLogContent(ev), 0o644); err != nil {
+	if err := os.WriteFile(path, triggerEventLogContent(ev), 0o600); err != nil {
 		flog.Warn("automation: trigger log write failed", "fleet", fleetName, "trigger", ev.triggerName, "err", err)
 		return
 	}
@@ -78,17 +81,25 @@ func triggerEventLogContent(ev *triggerEvent) []byte {
 	return []byte(b.String())
 }
 
-// uniqueTriggerLogPath returns event-<UTC timestamp>.log in dir, suffixing -N
-// when a log with that second-granular name already exists (two webhook events
-// can fire within the same second), so no firing overwrites another.
+// uniqueTriggerLogPath returns event-<UTC timestamp>.log in dir, suffixing a
+// counter when a log with that second-granular name already exists (two webhook
+// events can fire within the same second), so no firing overwrites another.
+//
+// The counter is zero-padded and uses '_' as the separator on purpose: '_'
+// (0x5F) sorts AFTER '.' (0x2E), and zero-padding makes the counter sort
+// numerically, so lexical filename order stays chronological within a second
+// (event-<ts>.log < event-<ts>_0002.log < event-<ts>_0003.log < ...). That
+// matters because eventLogNames / pruneTriggerLogs / readTriggerLogs all order
+// by name — a naive "-N" suffix would sort the 2nd firing before the 1st and
+// "-10" before "-2", reversing the pager and mis-pruning at the 100-file edge.
 func uniqueTriggerLogPath(dir string, firedAt time.Time) string {
 	base := "event-" + firedAt.UTC().Format("20060102T150405Z")
 	path := filepath.Join(dir, base+".log")
-	for i := 2; i < 100000; i++ {
+	for i := 2; i < 10000; i++ {
 		if _, err := os.Stat(path); errors.Is(err, fs.ErrNotExist) {
 			return path
 		}
-		path = filepath.Join(dir, fmt.Sprintf("%s-%d.log", base, i))
+		path = filepath.Join(dir, fmt.Sprintf("%s_%04d.log", base, i))
 	}
 	return path
 }

--- a/internal/server/trigger_logs.go
+++ b/internal/server/trigger_logs.go
@@ -1,0 +1,162 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// trigger_logs.go records and serves a per-trigger history of automation
+// firings, for debuggability. Each time a trigger fires (the schedule and
+// webhook paths both funnel through fireTriggerAgents), the daemon writes the
+// firing's event payload — the webhook request body, or the schedule fire-time — to
+//
+//	~/.fleet/logs/<fleet>/trigger/<trigger>/event-<UTC timestamp>.log
+//
+// keeping the most recent triggerEventLogKeep files. This is the SAME payload
+// that gets copied into each spawned agent's instance (see launchAutomation-
+// Command / writeAutomationEventFile), captured durably on the host so a firing
+// can be inspected after the instance is reaped — which is the whole point: it
+// makes the trigger system debuggable. The TUI's 'L' pager, the `fleet trigger
+// logs` CLI, and the fleet_trigger_logs MCP tool all read it back through the
+// TriggerLogs RPC, so it works the same whether the daemon is local or remote.
+
+// triggerEventLogKeep bounds how many event logs are retained per trigger. Older
+// ones are pruned as new firings arrive, so a busy trigger can't grow the logs
+// tree without bound.
+const triggerEventLogKeep = 100
+
+// logTriggerEvent records one trigger firing to the trigger's on-host event log
+// directory, then prunes to the newest triggerEventLogKeep files. It is a
+// package-var seam (overridden in tests) and strictly best-effort: a logging
+// failure is warned and never blocks the firing — the log is a debugging aid,
+// not part of the automation's critical path.
+var logTriggerEvent = func(fleetName string, ev *triggerEvent) {
+	dir := state.TriggerLogsDir(fleetName, ev.triggerName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		flog.Warn("automation: trigger log mkdir failed", "fleet", fleetName, "trigger", ev.triggerName, "err", err)
+		return
+	}
+	path := uniqueTriggerLogPath(dir, ev.firedAt)
+	if err := os.WriteFile(path, triggerEventLogContent(ev), 0o644); err != nil {
+		flog.Warn("automation: trigger log write failed", "fleet", fleetName, "trigger", ev.triggerName, "err", err)
+		return
+	}
+	pruneTriggerLogs(dir, triggerEventLogKeep)
+}
+
+// triggerEventLogContent renders one event log: a short header naming the firing
+// followed by its payload, so a concatenated dump is self-describing. The
+// payload mirrors exactly what the spawned agent received (triggerEvent.payload).
+func triggerEventLogContent(ev *triggerEvent) []byte {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# trigger: %s\n", ev.triggerName)
+	fmt.Fprintf(&b, "# type:    %s\n", ev.kind)
+	if ev.kind == fleet.TriggerWebhook && ev.webhookName != "" {
+		fmt.Fprintf(&b, "# webhook: %s\n", ev.webhookName)
+	}
+	fmt.Fprintf(&b, "# fired:   %s\n", ev.firedAt.UTC().Format(time.RFC3339))
+	b.WriteByte('\n')
+	payload := ev.payload()
+	b.Write(payload)
+	if len(payload) == 0 || payload[len(payload)-1] != '\n' {
+		b.WriteByte('\n')
+	}
+	return []byte(b.String())
+}
+
+// uniqueTriggerLogPath returns event-<UTC timestamp>.log in dir, suffixing -N
+// when a log with that second-granular name already exists (two webhook events
+// can fire within the same second), so no firing overwrites another.
+func uniqueTriggerLogPath(dir string, firedAt time.Time) string {
+	base := "event-" + firedAt.UTC().Format("20060102T150405Z")
+	path := filepath.Join(dir, base+".log")
+	for i := 2; i < 100000; i++ {
+		if _, err := os.Stat(path); errors.Is(err, fs.ErrNotExist) {
+			return path
+		}
+		path = filepath.Join(dir, fmt.Sprintf("%s-%d.log", base, i))
+	}
+	return path
+}
+
+// pruneTriggerLogs keeps only the newest keep event logs in dir, deleting the
+// rest. Event filenames embed a sortable UTC timestamp, so lexical order is
+// (near enough) chronological order.
+func pruneTriggerLogs(dir string, keep int) {
+	logs := eventLogNames(dir)
+	if len(logs) <= keep {
+		return
+	}
+	for _, name := range logs[:len(logs)-keep] {
+		_ = os.Remove(filepath.Join(dir, name))
+	}
+}
+
+// eventLogNames returns the event-*.log filenames in dir, sorted ascending
+// (oldest first). A missing or unreadable directory yields nil.
+func eventLogNames(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasPrefix(e.Name(), "event-") && strings.HasSuffix(e.Name(), ".log") {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// readTriggerLogs concatenates a trigger's event logs (oldest first) for
+// viewing, each preceded by a separator naming its file. It returns the text and
+// the number of logs included. A trigger that has never fired (no directory)
+// yields "" and 0 — not an error — so callers can report "no events" cleanly.
+func readTriggerLogs(fleetName, triggerName string) (string, int, error) {
+	dir := state.TriggerLogsDir(fleetName, triggerName)
+	names := eventLogNames(dir)
+	var b strings.Builder
+	included := 0
+	for _, name := range names {
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue // a log removed mid-read just drops out of the dump
+		}
+		fmt.Fprintf(&b, "===== %s =====\n", name)
+		b.Write(data)
+		if len(data) == 0 || data[len(data)-1] != '\n' {
+			b.WriteByte('\n')
+		}
+		b.WriteByte('\n')
+		included++
+	}
+	return b.String(), included, nil
+}
+
+// TriggerLogs serves an automation trigger's recorded event logs. It reads the
+// daemon-owned log files, so it works identically for a local or remote daemon.
+func (s *service) TriggerLogs(_ context.Context, req *fleetgrpc.TriggerLogsRequest) (*fleetgrpc.TriggerLogsReply, error) {
+	if req.GetFleet() == "" || req.GetTrigger() == "" {
+		return nil, status.Error(codes.InvalidArgument, "fleet and trigger are required")
+	}
+	logs, count, err := readTriggerLogs(req.GetFleet(), req.GetTrigger())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "read trigger logs: %v", err)
+	}
+	return &fleetgrpc.TriggerLogsReply{Logs: logs, Count: int32(count)}, nil
+}

--- a/internal/server/trigger_logs_test.go
+++ b/internal/server/trigger_logs_test.go
@@ -1,0 +1,174 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestLogTriggerEventWebhook writes a webhook firing and reads it back: the log
+// must carry the raw request body plus a header naming the trigger.
+func TestLogTriggerEventWebhook(t *testing.T) {
+	isolateFleetDir(t)
+	ev := &triggerEvent{
+		kind:        fleet.TriggerWebhook,
+		triggerName: "ci-hook",
+		firedAt:     time.Date(2026, 6, 23, 10, 0, 0, 0, time.UTC),
+		webhookName: "ci",
+		body:        []byte(`{"action":"opened"}`),
+	}
+	logTriggerEvent("alpha", ev)
+
+	logs, count, err := readTriggerLogs("alpha", "ci-hook")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("count = %d, want 1", count)
+	}
+	for _, want := range []string{"# trigger: ci-hook", "# type:    webhook", "# webhook: ci", `{"action":"opened"}`} {
+		if !strings.Contains(logs, want) {
+			t.Errorf("logs missing %q:\n%s", want, logs)
+		}
+	}
+}
+
+// TestLogTriggerEventSchedule records a schedule firing — its payload is the fire
+// time (schedule triggers carry no external body).
+func TestLogTriggerEventSchedule(t *testing.T) {
+	isolateFleetDir(t)
+	ev := &triggerEvent{
+		kind:        fleet.TriggerSchedule,
+		triggerName: "nightly",
+		firedAt:     time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC),
+	}
+	logTriggerEvent("alpha", ev)
+
+	logs, count, err := readTriggerLogs("alpha", "nightly")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("count = %d, want 1", count)
+	}
+	if strings.Contains(logs, "# webhook:") {
+		t.Errorf("schedule log must not carry a webhook line:\n%s", logs)
+	}
+	if !strings.Contains(logs, "2026-06-23T00:00:00Z") {
+		t.Errorf("schedule log missing fire-time payload:\n%s", logs)
+	}
+}
+
+// TestTriggerLogRotation proves the per-trigger history is capped: writing more
+// than triggerEventLogKeep firings keeps only the newest ones, dropping the
+// oldest.
+func TestTriggerLogRotation(t *testing.T) {
+	isolateFleetDir(t)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	const extra = 5
+	for i := 0; i < triggerEventLogKeep+extra; i++ {
+		logTriggerEvent("alpha", &triggerEvent{
+			kind:        fleet.TriggerSchedule,
+			triggerName: "nightly",
+			firedAt:     base.Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	dir := state.TriggerLogsDir("alpha", "nightly")
+	names := eventLogNames(dir)
+	if len(names) != triggerEventLogKeep {
+		t.Fatalf("kept %d logs, want %d", len(names), triggerEventLogKeep)
+	}
+	// The oldest `extra` firings (seconds 0..extra-1) must have been pruned; the
+	// first surviving log is the one at second `extra`.
+	oldest := "event-" + base.Format("20060102T150405Z") + ".log"
+	if _, err := os.Stat(filepath.Join(dir, oldest)); !os.IsNotExist(err) {
+		t.Errorf("oldest log %s should have been pruned (err=%v)", oldest, err)
+	}
+	firstKept := "event-" + base.Add(extra*time.Second).Format("20060102T150405Z") + ".log"
+	if names[0] != firstKept {
+		t.Errorf("first surviving log = %s, want %s", names[0], firstKept)
+	}
+}
+
+// TestUniqueTriggerLogPathNoOverwrite proves two firings in the same second each
+// get their own log file (a -N suffix) rather than clobbering one another.
+func TestUniqueTriggerLogPathNoOverwrite(t *testing.T) {
+	isolateFleetDir(t)
+	at := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		logTriggerEvent("alpha", &triggerEvent{kind: fleet.TriggerSchedule, triggerName: "burst", firedAt: at})
+	}
+	if names := eventLogNames(state.TriggerLogsDir("alpha", "burst")); len(names) != 3 {
+		t.Fatalf("same-second firings produced %d logs, want 3: %v", len(names), names)
+	}
+}
+
+// TestReadTriggerLogsEmpty: a trigger that has never fired returns empty/0, not
+// an error.
+func TestReadTriggerLogsEmpty(t *testing.T) {
+	isolateFleetDir(t)
+	logs, count, err := readTriggerLogs("alpha", "never-fired")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if logs != "" || count != 0 {
+		t.Fatalf("empty trigger returned logs=%q count=%d", logs, count)
+	}
+}
+
+// TestTriggerLogsDirNoEscape: a crafted fleet/trigger name can't escape the logs
+// tree (the sanitizer maps path separators / traversal to safe segments).
+func TestTriggerLogsDirNoEscape(t *testing.T) {
+	isolateFleetDir(t)
+	logsRoot := filepath.Join(state.FleetDir(), "logs")
+	dir := state.TriggerLogsDir("../../etc", "../../../tmp/evil")
+	if !strings.HasPrefix(filepath.Clean(dir), filepath.Clean(logsRoot)) {
+		t.Fatalf("trigger log dir escaped the logs tree: %s", dir)
+	}
+}
+
+// TestTriggerLogsRPC drives the service handler end to end.
+func TestTriggerLogsRPC(t *testing.T) {
+	isolateFleetDir(t)
+	s := newService()
+
+	// Missing args are rejected.
+	if _, err := s.TriggerLogs(context.Background(), &fleetgrpc.TriggerLogsRequest{Fleet: "alpha"}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("empty trigger: err = %v, want InvalidArgument", err)
+	}
+
+	// No firings yet → empty reply, no error.
+	reply, err := s.TriggerLogs(context.Background(), &fleetgrpc.TriggerLogsRequest{Fleet: "alpha", Trigger: "nightly"})
+	if err != nil {
+		t.Fatalf("logs (empty): %v", err)
+	}
+	if reply.GetCount() != 0 || reply.GetLogs() != "" {
+		t.Fatalf("empty reply = %+v", reply)
+	}
+
+	// After a firing, the reply carries it.
+	logTriggerEvent("alpha", &triggerEvent{
+		kind:        fleet.TriggerWebhook,
+		triggerName: "nightly",
+		firedAt:     time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		webhookName: "ci",
+		body:        []byte("payload-bytes"),
+	})
+	reply, err = s.TriggerLogs(context.Background(), &fleetgrpc.TriggerLogsRequest{Fleet: "alpha", Trigger: "nightly"})
+	if err != nil {
+		t.Fatalf("logs: %v", err)
+	}
+	if reply.GetCount() != 1 || !strings.Contains(reply.GetLogs(), "payload-bytes") {
+		t.Fatalf("reply = %+v", reply)
+	}
+}

--- a/internal/server/trigger_logs_test.go
+++ b/internal/server/trigger_logs_test.go
@@ -100,16 +100,60 @@ func TestTriggerLogRotation(t *testing.T) {
 	}
 }
 
-// TestUniqueTriggerLogPathNoOverwrite proves two firings in the same second each
-// get their own log file (a -N suffix) rather than clobbering one another.
+// TestUniqueTriggerLogPathNoOverwrite proves firings in the same second each get
+// their own log file rather than clobbering one another, AND that the on-disk
+// order matches firing order — the collision suffix must keep lexical filename
+// order chronological (eventLogNames/prune/read all sort by name).
 func TestUniqueTriggerLogPathNoOverwrite(t *testing.T) {
 	isolateFleetDir(t)
 	at := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
-	for i := 0; i < 3; i++ {
-		logTriggerEvent("alpha", &triggerEvent{kind: fleet.TriggerSchedule, triggerName: "burst", firedAt: at})
+	bodies := []string{"first-firing", "second-firing", "third-firing"}
+	for _, body := range bodies {
+		logTriggerEvent("alpha", &triggerEvent{
+			kind: fleet.TriggerWebhook, triggerName: "burst", webhookName: "ci", firedAt: at, body: []byte(body),
+		})
 	}
-	if names := eventLogNames(state.TriggerLogsDir("alpha", "burst")); len(names) != 3 {
+	dir := state.TriggerLogsDir("alpha", "burst")
+	if names := eventLogNames(dir); len(names) != 3 {
 		t.Fatalf("same-second firings produced %d logs, want 3: %v", len(names), names)
+	}
+	logs, _, err := readTriggerLogs("alpha", "burst")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// Each body must appear, in firing order.
+	prev := -1
+	for _, body := range bodies {
+		idx := strings.Index(logs, body)
+		if idx < 0 {
+			t.Fatalf("body %q missing from logs:\n%s", body, logs)
+		}
+		if idx < prev {
+			t.Fatalf("same-second logs out of firing order (%q before a prior firing):\n%s", body, logs)
+		}
+		prev = idx
+	}
+}
+
+// TestTriggerLogPerms: the durable logs (which can hold webhook secrets) are
+// owner-only — 0600 files in a 0700 trigger dir.
+func TestTriggerLogPerms(t *testing.T) {
+	isolateFleetDir(t)
+	logTriggerEvent("alpha", &triggerEvent{kind: fleet.TriggerSchedule, triggerName: "nightly", firedAt: time.Now()})
+	dir := state.TriggerLogsDir("alpha", "nightly")
+	if fi, err := os.Stat(dir); err != nil {
+		t.Fatalf("stat dir: %v", err)
+	} else if perm := fi.Mode().Perm(); perm != 0o700 {
+		t.Errorf("trigger log dir perm = %o, want 700", perm)
+	}
+	names := eventLogNames(dir)
+	if len(names) != 1 {
+		t.Fatalf("want 1 log, got %v", names)
+	}
+	if fi, err := os.Stat(filepath.Join(dir, names[0])); err != nil {
+		t.Fatalf("stat file: %v", err)
+	} else if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("trigger log file perm = %o, want 600", perm)
 	}
 }
 

--- a/internal/state/paths.go
+++ b/internal/state/paths.go
@@ -3,6 +3,7 @@ package state
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/control"
 )
@@ -29,6 +30,37 @@ func WorkspacesDir() string {
 // the path manually so all warnings end up in the same well-known place.
 func WarnPath(fleetName, instanceName string) string {
 	return filepath.Join(FleetDir(), "logs", fleetName+"-"+instanceName+".warn")
+}
+
+// TriggerLogsDir returns the host directory that holds an automation trigger's
+// recorded event logs: ~/.fleet/logs/<fleet>/trigger/<trigger>/. The daemon
+// writes one event-<timestamp>.log per firing here (keeping the most recent
+// few); the TriggerLogs RPC reads them back. Fleet and trigger names are reduced
+// to safe single path segments so a crafted name cannot escape the logs tree —
+// the writer and the reader both go through here, so they always agree on the
+// same directory.
+func TriggerLogsDir(fleetName, triggerName string) string {
+	return filepath.Join(FleetDir(), "logs", safeLogSegment(fleetName), "trigger", safeLogSegment(triggerName))
+}
+
+// safeLogSegment reduces name to one filesystem-safe path segment: it keeps
+// letters, digits, and -._, maps everything else to '_', and collapses the
+// empty / "." / ".." forms (which would escape or alias a directory) to "_".
+func safeLogSegment(name string) string {
+	out := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		case r == '-', r == '_', r == '.':
+			return r
+		default:
+			return '_'
+		}
+	}, name)
+	if out == "" || out == "." || out == ".." {
+		return "_"
+	}
+	return out
 }
 
 // BuildkitDir returns the per-fleet host directory that holds the shared

--- a/internal/state/paths.go
+++ b/internal/state/paths.go
@@ -35,7 +35,7 @@ func WarnPath(fleetName, instanceName string) string {
 // TriggerLogsDir returns the host directory that holds an automation trigger's
 // recorded event logs: ~/.fleet/logs/<fleet>/trigger/<trigger>/. The daemon
 // writes one event-<timestamp>.log per firing here (keeping the most recent
-// few); the TriggerLogs RPC reads them back. Fleet and trigger names are reduced
+// 100); the TriggerLogs RPC reads them back. Fleet and trigger names are reduced
 // to safe single path segments so a crafted name cannot escape the logs tree —
 // the writer and the reader both go through here, so they always agree on the
 // same directory.

--- a/internal/tui/automation_view.go
+++ b/internal/tui/automation_view.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
 	"slices"
 	"strings"
 
@@ -205,6 +207,49 @@ func (fleetPage *fleetPage) toggleTriggerDisabled(m *model, fleetName string, id
 		m.message = fmt.Sprintf("Enabled trigger %q", name)
 	}
 	return nil
+}
+
+// openTriggerLogs fetches a trigger's recorded event logs from the daemon and
+// opens them in `less` so the user can scroll and search (the 'L' action). The
+// logs are pulled over the service (they live on the daemon host, possibly
+// remote), written to a temp file, and paged; the temp file is removed once the
+// pager exits. An empty history or a fetch error surfaces as a status message
+// rather than launching an empty pager.
+func (fleetPage *fleetPage) openTriggerLogs(m *model, fleetName string, idx int) tea.Cmd {
+	f, ok := m.st.Fleets[fleetName]
+	if !ok {
+		return nil
+	}
+	t := triggerAt(f, idx)
+	if t == nil {
+		return nil
+	}
+	logs, err := triggerLogsRemote(fleetName, t.Name)
+	if err != nil {
+		m.message = fmt.Sprintf("Could not load trigger logs: %v", err)
+		return nil
+	}
+	if strings.TrimSpace(logs) == "" {
+		m.message = fmt.Sprintf("No events recorded for trigger %q", t.Name)
+		return nil
+	}
+	tmp, err := os.CreateTemp("", "fleet-trigger-log-*.log")
+	if err != nil {
+		m.message = fmt.Sprintf("Could not open trigger logs: %v", err)
+		return nil
+	}
+	path := tmp.Name()
+	_, writeErr := tmp.WriteString(logs)
+	closeErr := tmp.Close()
+	if writeErr != nil || closeErr != nil {
+		os.Remove(path)
+		m.message = "Could not open trigger logs: write failed"
+		return nil
+	}
+	return execProcess(exec.Command("less", path), func(err error) tea.Msg {
+		os.Remove(path)
+		return execDoneMsg{err}
+	})
 }
 
 // deleteTrigger removes the trigger at idx and persists.

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -331,6 +331,21 @@ var setFleetSettingsRemote = func(fleetName string, s fleet.FleetSettings) error
 	})
 }
 
+// triggerLogsRemote fetches a trigger's recorded event logs (its recent
+// firings' payloads, concatenated) from the daemon, for the 'L' pager.
+var triggerLogsRemote = func(fleetName, triggerName string) (string, error) {
+	var out string
+	err := mutate(func(ctx context.Context, svc fleetgrpc.FleetServiceClient) error {
+		reply, err := svc.TriggerLogs(ctx, &fleetgrpc.TriggerLogsRequest{Fleet: fleetName, Trigger: triggerName})
+		if err != nil {
+			return err
+		}
+		out = reply.GetLogs()
+		return nil
+	})
+	return out, err
+}
+
 // setInstanceMetadataRemote updates user-facing labels. A nil field means
 // "leave unchanged"; a non-nil pointer (incl. to "") sets the value.
 var setInstanceMetadataRemote = func(fleetName, instance string, displayName, color, tag *string) error {

--- a/internal/tui/keybindings.go
+++ b/internal/tui/keybindings.go
@@ -52,6 +52,17 @@ func keybindingsData() []keybindingGroup {
 			},
 		},
 		{
+			Title: "Automation (trigger / agent view)",
+			Entries: []keybindingEntry{
+				{"m", "Toggle automation / instance view"},
+				{"a", "Add trigger / agent"},
+				{"enter / e", "Edit trigger / agent"},
+				{"s", "Enable / disable trigger"},
+				{"L", "View trigger event logs"},
+				{"d", "Delete trigger / agent"},
+			},
+		},
+		{
 			Title: "Settings",
 			Entries: []keybindingEntry{
 				{"j / k", "Navigate up / down"},

--- a/internal/tui/page_fleet_keys.go
+++ b/internal/tui/page_fleet_keys.go
@@ -467,6 +467,11 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			fleetPage.rightSelected = false
 
 		case "L":
+			// On a trigger row, page its recorded event logs; otherwise the
+			// instance container/creation logs.
+			if r := fleetPage.currentRow(); r != nil && r.kind == rowTrigger {
+				return fleetPage.openTriggerLogs(m, r.fleetName, r.autoIdx)
+			}
 			_, instance := fleetPage.selectedInstance(m)
 			if instance == nil {
 				m.message = "Select an instance"
@@ -765,7 +770,7 @@ func (fleetPage *fleetPage) contextualHelpKeysBase(m *model) []string {
 
 	case rowTrigger:
 		return withArmadaHint([]string{
-			"j/k: navigate", "enter/e: edit", "s: enable/disable", "a: add trigger", "d: delete", "m: instances", "q: quit",
+			"j/k: navigate", "enter/e: edit", "s: enable/disable", "L: logs", "a: add trigger", "d: delete", "m: instances", "q: quit",
 		})
 
 	case rowAgent:

--- a/internal/tui/trigger_logs_test.go
+++ b/internal/tui/trigger_logs_test.go
@@ -1,0 +1,80 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestTriggerLogsKeyEmpty: 'L' on a trigger with no recorded firings reports
+// "no events" and launches no pager.
+func TestTriggerLogsKeyEmpty(t *testing.T) {
+	orig := triggerLogsRemote
+	t.Cleanup(func() { triggerLogsRemote = orig })
+	triggerLogsRemote = func(string, string) (string, error) { return "", nil }
+
+	m, fp := automationModelWithItems(t)
+	cursorToKind(t, fp, rowTrigger)
+	if cmd := fp.Update(m, key('L')); cmd != nil {
+		t.Fatal("an empty history must not launch a pager")
+	}
+	if !strings.Contains(m.message, "No events") {
+		t.Errorf("message = %q, want a no-events notice", m.message)
+	}
+}
+
+// TestTriggerLogsKeyError: a fetch failure surfaces as a status message, no pager.
+func TestTriggerLogsKeyError(t *testing.T) {
+	orig := triggerLogsRemote
+	t.Cleanup(func() { triggerLogsRemote = orig })
+	triggerLogsRemote = func(string, string) (string, error) { return "", errors.New("boom") }
+
+	m, fp := automationModelWithItems(t)
+	cursorToKind(t, fp, rowTrigger)
+	if cmd := fp.Update(m, key('L')); cmd != nil {
+		t.Fatal("a fetch error must not launch a pager")
+	}
+	if !strings.Contains(m.message, "boom") {
+		t.Errorf("message = %q, want the fetch error", m.message)
+	}
+}
+
+// TestTriggerLogsKeyLaunches: 'L' on a trigger with recorded firings fetches the
+// right trigger's logs and returns a pager command. TMPDIR is redirected so the
+// temp log file lands in the test's auto-cleaned dir.
+func TestTriggerLogsKeyLaunches(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	orig := triggerLogsRemote
+	t.Cleanup(func() { triggerLogsRemote = orig })
+	var gotFleet, gotTrigger string
+	triggerLogsRemote = func(f, tr string) (string, error) {
+		gotFleet, gotTrigger = f, tr
+		return "the recorded payload\n", nil
+	}
+
+	m, fp := automationModelWithItems(t)
+	cursorToKind(t, fp, rowTrigger)
+	cmd := fp.Update(m, key('L'))
+	if cmd == nil {
+		t.Fatal("recorded firings should launch a pager")
+	}
+	if gotFleet != "alpha" || gotTrigger != "nightly" {
+		t.Errorf("fetched logs for %q/%q, want alpha/nightly", gotFleet, gotTrigger)
+	}
+}
+
+// TestTriggerLogsKeyIgnoredOffTrigger: 'L' on a non-trigger row never calls the
+// trigger-logs fetch (it falls through to the instance-logs path).
+func TestTriggerLogsKeyIgnoredOffTrigger(t *testing.T) {
+	orig := triggerLogsRemote
+	t.Cleanup(func() { triggerLogsRemote = orig })
+	called := false
+	triggerLogsRemote = func(string, string) (string, error) { called = true; return "", nil }
+
+	m, fp := automationModelWithItems(t)
+	cursorToKind(t, fp, rowAutomationTriggers) // the group header, not a trigger
+	fp.Update(m, key('L'))
+	if called {
+		t.Error("L on a non-trigger row must not fetch trigger logs")
+	}
+}


### PR DESCRIPTION
## What

Makes the automation trigger system debuggable by keeping a durable, host-side log of every trigger firing's **event payload** — and exposing it through the TUI, CLI, and MCP.

Each time a trigger fires (schedule or webhook — both funnel through `fireTriggerAgents`), the daemon writes the firing's payload to:

```
~/.fleet/logs/<fleet>/trigger/<trigger>/event-<UTC timestamp>.log
```

keeping the most recent **100** firings per trigger (oldest pruned as new ones arrive). This is the *same* payload that's already copied into each spawned agent's instance at `/tmp/fleet-event-<ts>` — now captured durably on the host so a firing can be inspected after its instance has been reaped.

- **webhook** firing → log holds the raw request body
- **schedule** firing → log holds the fire-time

Each log carries a short header (`# trigger:` / `# type:` / `# webhook:` / `# fired:`) followed by the payload.

## Reading it back

All three read paths go through a new unary `TriggerLogs` RPC, so they work unchanged when the daemon is **remote**:

- **TUI** — `L` on a selected trigger row pages the concatenated logs in `less` (scroll/search). Help hint + the `?` keybindings overlay updated.
- **CLI** — `fleet trigger logs <fleet> <name>` prints the concatenated logs (pipe to a pager yourself).
- **MCP** — `fleet_trigger_logs {fleet, trigger}` returns `{logs, count}` so the admiral can debug what fired (or failed to fire) an automation.

## Safety

Writer and reader share `state.TriggerLogsDir`, which sanitizes fleet/trigger names to safe single path segments, so a crafted name can't escape the logs tree. Logging is strictly best-effort — a failure is warned and never blocks a firing.

## Tests

- `internal/server/trigger_logs_test.go` — write/read round-trip (webhook + schedule), 100-firing rotation, same-second no-overwrite, empty history, path-escape guard, and the RPC handler end to end.
- `internal/cli/trigger_test.go` — `trigger logs` command (content + empty history).
- `internal/server/mcp_automation_test.go` — `fleet_trigger_logs` tool (empty, populated, missing-arg error); `mcp_test.go` tool-count bumped.
- `internal/tui/trigger_logs_test.go` — `L` on a trigger row (empty/error/launch) and ignored off-trigger.

`go build ./...`, `go test ./...`, and `make lint` (depguard boundary) all pass; proto regenerated via `make proto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)