### PR TITLE
fix/webhook-jsonpath-reject-non-json — reject non-JSON body for json-path webhook filters with 400 (#207)

### DIFF
--- a/internal/server/webhook.go
+++ b/internal/server/webhook.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -63,11 +65,32 @@ func (s *service) serveWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fires, nameFound := collectWebhookFires(st, name, body)
+	fires, nameFound, jsonPathActive := collectWebhookFires(st, name, body)
 	if !nameFound {
 		// No trigger anywhere carries this name. Same 404 the gateway gives an
 		// unknown id, so a probe can't enumerate configured webhook names.
 		http.Error(w, "no webhook trigger with that name", http.StatusNotFound)
+		return
+	}
+
+	// A json-path filter can only evaluate a JSON body. The classic trap is
+	// GitHub's webhook default content type, application/x-www-form-urlencoded,
+	// which delivers the event as a `payload=<url-encoded-json>` form field
+	// rather than raw JSON — so json.Decode fails and the filter silently never
+	// matches (issue #207). We don't try to unwrap form encodings (their shape is
+	// sender-specific and not reliably recoverable); instead, when an active
+	// json-path trigger carries this name but the body isn't JSON, reject the
+	// delivery with 400. fleetd's response is reverse-proxied straight back to the
+	// sender, so the failure shows up in the sender's delivery dashboard (e.g.
+	// GitHub's "Recent Deliveries") instead of vanishing. Regex triggers match raw
+	// bytes and accept any body, so they are unaffected by this check.
+	//
+	// If a name carries BOTH a regex and a json-path trigger and a non-JSON body
+	// arrives, the 400 wins (nothing fires): returning 200 would hide the
+	// misconfiguration, and firing the regex trigger then returning 400 would
+	// double-fire it on the sender's retry.
+	if jsonPathActive && !bodyIsJSON(body) {
+		http.Error(w, "json-path webhook filter requires a JSON body; set the webhook content type to application/json", http.StatusBadRequest)
 		return
 	}
 
@@ -97,12 +120,14 @@ func (s *service) serveWebhook(w http.ResponseWriter, r *http.Request) {
 }
 
 // collectWebhookFires scans every fleet for webhook triggers named name and
-// returns the subset whose filter matches body, plus whether ANY trigger with
-// that name exists at all (to distinguish 404 from "matched nothing"). Firing all
+// returns the subset whose filter matches body, whether ANY trigger with that
+// name exists at all (to distinguish 404 from "matched nothing"), and whether any
+// ACTIVE (non-disabled) trigger with that name uses the json-path filter (so the
+// caller can reject a non-JSON body with 400 — see serveWebhook). Firing all
 // matches across all fleets is intentional: webhook names are per-fleet in the
 // model, so the same name can legitimately drive triggers in several fleets, and
 // the common single-match case degenerates to exactly one fire.
-func collectWebhookFires(st *state.State, name string, body []byte) (fires []webhookFire, nameFound bool) {
+func collectWebhookFires(st *state.State, name string, body []byte) (fires []webhookFire, nameFound, jsonPathActive bool) {
 	for fleetName, f := range st.Fleets {
 		if f == nil {
 			continue
@@ -115,12 +140,26 @@ func collectWebhookFires(st *state.State, name string, body []byte) (fires []web
 			if t.Disabled {
 				continue // a disabled trigger still exists (200, not 404) but never fires
 			}
+			if t.FilterType == fleet.WebhookFilterJSONPath {
+				jsonPathActive = true
+			}
 			if t.MatchesWebhook(body) {
 				fires = append(fires, webhookFire{fleet: fleetName, trigger: t, body: body})
 			}
 		}
 	}
-	return fires, nameFound
+	return fires, nameFound, jsonPathActive
+}
+
+// bodyIsJSON reports whether body decodes as a single JSON value — the same parse
+// MatchesWebhook's json-path filter performs (json.Decoder, so trailing
+// whitespace is fine and trailing junk is ignored, matching the matcher exactly).
+// It is used to reject a json-path delivery whose body isn't JSON, rather than let
+// the filter silently never match. The body is already size-bounded by the
+// MaxBytesReader in serveWebhook.
+func bodyIsJSON(body []byte) bool {
+	var v any
+	return json.NewDecoder(bytes.NewReader(body)).Decode(&v) == nil
 }
 
 // enqueueWebhookFires hands a request's matched events to the scheduler goroutine

--- a/internal/server/webhook.go
+++ b/internal/server/webhook.go
@@ -88,7 +88,14 @@ func (s *service) serveWebhook(w http.ResponseWriter, r *http.Request) {
 	// If a name carries BOTH a regex and a json-path trigger and a non-JSON body
 	// arrives, the 400 wins (nothing fires): returning 200 would hide the
 	// misconfiguration, and firing the regex trigger then returning 400 would
-	// double-fire it on the sender's retry.
+	// double-fire it on the sender's retry. Note this is keyed on the webhook NAME
+	// globally: jsonPathActive is OR'd across EVERY fleet (collectWebhookFires
+	// scans them all, since one name can drive triggers in several fleets), so a
+	// json-path trigger for this name in ANY fleet makes a non-JSON delivery 400 —
+	// even for a regex trigger of the same name in a DIFFERENT fleet. That cross-
+	// fleet blast radius is intended: a non-JSON delivery to a name any fleet
+	// treats as json-path is a misconfiguration worth surfacing loudly, not
+	// silently half-firing whichever same-named regex triggers happen to match.
 	if jsonPathActive && !bodyIsJSON(body) {
 		http.Error(w, "json-path webhook filter requires a JSON body; set the webhook content type to application/json", http.StatusBadRequest)
 		return

--- a/internal/server/webhook_remote_e2e_test.go
+++ b/internal/server/webhook_remote_e2e_test.go
@@ -216,22 +216,24 @@ func TestWebhookJSONPathDeliveryEndToEnd(t *testing.T) {
 	}
 
 	// Malformed (non-JSON) event: the most transport-sensitive case — a json-path
-	// filter must PARSE the delivered body, so a body that survives the tunnel but
-	// isn't JSON resolves no path and fires nothing, yet the name is still wired so
-	// the receiver answers 200 (not 404). This exercises the decode-failure branch
-	// end to end, which a regex filter (raw-byte match) never reaches.
+	// filter can only evaluate a JSON body, so a body that survives the tunnel but
+	// isn't JSON (e.g. GitHub's default form-urlencoded delivery) is rejected with
+	// 400 (issue #207) rather than silently never matching. The name is wired (so
+	// it's a 400, not a 404), nothing fires, and the 400 reverse-proxies back
+	// through the tunnel so the sender sees the failure. A regex filter (raw-byte
+	// match) never reaches this branch.
 	resp3, err := client.Post(base+"/deploy", "application/json",
 		strings.NewReader(`refs/heads/main not json at all`))
 	if err != nil {
 		t.Fatalf("POST malformed json-path webhook through the tunnel: %v", err)
 	}
 	resp3.Body.Close()
-	if resp3.StatusCode != http.StatusOK {
-		t.Fatalf("malformed json-path webhook POST -> %d, want 200 (name wired, body unparseable)", resp3.StatusCode)
+	if resp3.StatusCode != http.StatusBadRequest {
+		t.Fatalf("malformed json-path webhook POST -> %d, want 400 (json-path needs a JSON body)", resp3.StatusCode)
 	}
 	select {
 	case batch := <-svc.webhookFires:
-		t.Fatalf("json-path filter must not fire on an unparseable body, got %+v", batch)
+		t.Fatalf("a rejected json-path body must fire nothing, got %+v", batch)
 	case <-time.After(500 * time.Millisecond):
 		// expected: nothing enqueued
 	}

--- a/internal/server/webhook_test.go
+++ b/internal/server/webhook_test.go
@@ -311,6 +311,48 @@ func TestServeWebhook_JSONPathNonJSONRejected(t *testing.T) {
 	}
 }
 
+// TestServeWebhook_JSONPathEmptyBodyRejected covers an empty body hitting a
+// json-path trigger: bodyIsJSON("") is io.EOF -> false, so it's a 400 like any
+// other non-JSON body.
+func TestServeWebhook_JSONPathEmptyBodyRejected(t *testing.T) {
+	s := newService()
+	st := webhookState(fleet.Trigger{
+		Name: "deploy", Type: fleet.TriggerWebhook, AgentNames: []string{"a"},
+		WebhookName: "deploy", FilterType: fleet.WebhookFilterJSONPath,
+		JSONPath: "$.ref", JSONValue: "refs/heads/main",
+	})
+
+	w := postWebhook(t, s, st, "deploy", "")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for an empty body; body=%q", w.Code, w.Body.String())
+	}
+	if b := drainBatch(s); b != nil {
+		t.Fatalf("a rejected delivery must enqueue nothing, got %+v", b)
+	}
+}
+
+// TestServeWebhook_JSONPathValidJSONNoMatchAccepted is the don't-over-reject
+// boundary: a VALID JSON body whose selected value simply doesn't equal the
+// trigger's expected value is accepted (200, no fire) — only non-JSON bodies are
+// rejected with 400, never legitimate non-matching JSON deliveries.
+func TestServeWebhook_JSONPathValidJSONNoMatchAccepted(t *testing.T) {
+	s := newService()
+	st := webhookState(fleet.Trigger{
+		Name: "deploy", Type: fleet.TriggerWebhook, AgentNames: []string{"a"},
+		WebhookName: "deploy", FilterType: fleet.WebhookFilterJSONPath,
+		JSONPath: "$.ref", JSONValue: "refs/heads/main",
+	})
+
+	// Valid JSON, but $.ref is a different branch -> no match, yet still 200.
+	w := postWebhook(t, s, st, "deploy", `{"ref":"refs/heads/dev"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (valid non-matching JSON is not rejected); body=%q", w.Code, w.Body.String())
+	}
+	if b := drainBatch(s); b != nil {
+		t.Fatalf("a non-matching json-path filter must not fire, got %+v", b)
+	}
+}
+
 // TestServeWebhook_RegexFormEncodedStillFires confirms regex filters are
 // unaffected by the json-body check: a regex matches the raw bytes of even a
 // form-encoded body and fires normally (200), because the json-path string

--- a/internal/server/webhook_test.go
+++ b/internal/server/webhook_test.go
@@ -4,12 +4,20 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 )
+
+// formEncode wraps raw JSON the way GitHub's DEFAULT webhook content type
+// (application/x-www-form-urlencoded) delivers it: a single `payload=` form field
+// holding the url-encoded JSON. The result is NOT valid JSON.
+func formEncode(rawJSON string) string {
+	return "payload=" + url.QueryEscape(rawJSON)
+}
 
 // webhookState builds a state with the given webhook triggers under fleet
 // "alpha", all referencing a single agent "a".
@@ -257,6 +265,117 @@ func TestServeWebhook_SchedulerBusy503(t *testing.T) {
 	s.serveWebhook(w, req)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want 503", w.Code)
+	}
+}
+
+// TestServeWebhook_JSONPathFormEncodedRejected is the issue #207 regression: a
+// json-path trigger receiving GitHub's default form-urlencoded delivery (which is
+// not JSON) is rejected with 400 — visible in the sender's delivery dashboard —
+// rather than silently never matching. Nothing fires.
+func TestServeWebhook_JSONPathFormEncodedRejected(t *testing.T) {
+	s := newService()
+	st := webhookState(fleet.Trigger{
+		Name: "pr", Type: fleet.TriggerWebhook, AgentNames: []string{"a"},
+		WebhookName: "pr", FilterType: fleet.WebhookFilterJSONPath,
+		JSONPath: "$.pull_request.user.login", JSONValue: "BenjaminBenetti",
+	})
+
+	// The selected value WOULD match if the body were raw JSON, but GitHub
+	// delivers it form-encoded by default.
+	body := formEncode(`{"pull_request":{"user":{"login":"BenjaminBenetti"}}}`)
+	w := postWebhook(t, s, st, "pr", body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (json-path filter needs a JSON body); body=%q", w.Code, w.Body.String())
+	}
+	if b := drainBatch(s); b != nil {
+		t.Fatalf("a rejected delivery must enqueue nothing, got %+v", b)
+	}
+}
+
+// TestServeWebhook_JSONPathNonJSONRejected covers any non-JSON body (not just
+// form encoding) hitting a json-path trigger: plain text is also a 400.
+func TestServeWebhook_JSONPathNonJSONRejected(t *testing.T) {
+	s := newService()
+	st := webhookState(fleet.Trigger{
+		Name: "deploy", Type: fleet.TriggerWebhook, AgentNames: []string{"a"},
+		WebhookName: "deploy", FilterType: fleet.WebhookFilterJSONPath,
+		JSONPath: "$.ref", JSONValue: "refs/heads/main",
+	})
+
+	w := postWebhook(t, s, st, "deploy", "not json at all")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for a non-JSON body; body=%q", w.Code, w.Body.String())
+	}
+	if b := drainBatch(s); b != nil {
+		t.Fatalf("a rejected delivery must enqueue nothing, got %+v", b)
+	}
+}
+
+// TestServeWebhook_RegexFormEncodedStillFires confirms regex filters are
+// unaffected by the json-body check: a regex matches the raw bytes of even a
+// form-encoded body and fires normally (200), because the json-path string
+// "BenjaminBenetti" survives url-encoding verbatim.
+func TestServeWebhook_RegexFormEncodedStillFires(t *testing.T) {
+	s := newService()
+	st := webhookState(fleet.Trigger{
+		Name: "pr", Type: fleet.TriggerWebhook, AgentNames: []string{"a"},
+		WebhookName: "pr", FilterType: fleet.WebhookFilterRegex, Regex: "BenjaminBenetti",
+	})
+
+	body := formEncode(`{"pull_request":{"user":{"login":"BenjaminBenetti"}}}`)
+	w := postWebhook(t, s, st, "pr", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (regex accepts any body); body=%q", w.Code, w.Body.String())
+	}
+	if b := drainBatch(s); len(b) != 1 || b[0].trigger.Name != "pr" {
+		t.Fatalf("expected the regex trigger to fire, got %+v", b)
+	}
+}
+
+// TestServeWebhook_MixedRegexAndJSONPathNonJSONRejected covers the documented
+// edge case: when one webhook name carries BOTH a regex and a json-path trigger
+// and a non-JSON body arrives, the 400 wins (the regex trigger does NOT fire) so
+// the json-path misconfiguration stays visible and a retry can't double-fire.
+func TestServeWebhook_MixedRegexAndJSONPathNonJSONRejected(t *testing.T) {
+	s := newService()
+	st := webhookState(
+		fleet.Trigger{
+			Name: "rx", Type: fleet.TriggerWebhook, AgentNames: []string{"a"},
+			WebhookName: "pr", FilterType: fleet.WebhookFilterRegex, Regex: ".*",
+		},
+		fleet.Trigger{
+			Name: "jp", Type: fleet.TriggerWebhook, AgentNames: []string{"a"},
+			WebhookName: "pr", FilterType: fleet.WebhookFilterJSONPath,
+			JSONPath: "$.action", JSONValue: "opened",
+		},
+	)
+
+	w := postWebhook(t, s, st, "pr", formEncode(`{"action":"opened"}`))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 when a json-path trigger shares the name; body=%q", w.Code, w.Body.String())
+	}
+	if b := drainBatch(s); b != nil {
+		t.Fatalf("the 400 must win — nothing fires, got %+v", b)
+	}
+}
+
+// TestServeWebhook_DisabledJSONPathDoesNotReject confirms a DISABLED json-path
+// trigger doesn't arm the json-body check: a non-JSON body is accepted (200, no
+// fire) because the disabled trigger isn't active.
+func TestServeWebhook_DisabledJSONPathDoesNotReject(t *testing.T) {
+	s := newService()
+	st := webhookState(fleet.Trigger{
+		Name: "pr", Type: fleet.TriggerWebhook, AgentNames: []string{"a"},
+		WebhookName: "pr", FilterType: fleet.WebhookFilterJSONPath,
+		JSONPath: "$.action", JSONValue: "opened", Disabled: true,
+	})
+
+	w := postWebhook(t, s, st, "pr", formEncode(`{"action":"opened"}`))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (a disabled json-path trigger doesn't reject); body=%q", w.Code, w.Body.String())
+	}
+	if b := drainBatch(s); b != nil {
+		t.Fatalf("a disabled trigger must not fire, got %+v", b)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #207 — a webhook trigger using a **json-path** filter never fired even though its `json_path` selected a value equal to `json_value`, while an equivalent **regex** filter on the same endpoint fired fine.

The json-path syntax (`$.pull_request.user.login`) was never the problem — that resolves correctly. The real cause is the **webhook content type**: GitHub's webhook config defaults to `application/x-www-form-urlencoded`, which delivers the event as a `payload=<url-encoded-json>` form field instead of raw JSON. So:

- the **regex** filter matches raw bytes → `BenjaminBenetti` is still literally present in the form body → it fires;
- the **json-path** filter does `json.Decode(body)` → the `payload=` prefix isn't valid JSON → decode fails → it silently never matches.

That's the exact asymmetry in the report.

Rather than guess at sender-specific form encodings (their shape isn't reliably recoverable — only GitHub uses `payload=`), this **rejects the delivery with `400 Bad Request`** when an active json-path trigger carries the webhook name but the body isn't JSON. fleetd's 400 reverse-proxies back through the gateway, so the misconfiguration is **visible in the sender's delivery dashboard** (e.g. GitHub's "Recent Deliveries") instead of vanishing. The error tells the user what to do: set the webhook content type to `application/json`.

Regex filters match raw bytes and accept any body — they are unaffected.

### Behavior

- json-path trigger + JSON body → unchanged (matches/fires as before).
- json-path trigger + non-JSON body (form-encoded, plain text, empty) → **400**, nothing fires.
- regex trigger + any body → unchanged (fires on raw-byte match).
- A name carrying **both** a regex and a json-path trigger + non-JSON body → the 400 wins (nothing fires), so the misconfiguration stays visible and a sender retry can't double-fire the regex trigger.
- A **disabled** json-path trigger doesn't arm the check.

### Tests

- New `serveWebhook` cases: form-encoded/non-JSON body → 400 + no fire; regex still fires on a form-encoded body; mixed regex+json-path → 400 wins; disabled json-path doesn't reject.
- Updated the end-to-end tunnel test to assert the new 400 contract for a non-JSON json-path delivery (it previously encoded the buggy 200 behavior).