### PR TITLE
feat(logrotate): rotate fleet.log daily at 3am, keep 100 days

### DIFF
--- a/internal/server/logrotate.go
+++ b/internal/server/logrotate.go
@@ -43,11 +43,13 @@ import (
 var (
 	// logRotateHour is the local hour-of-day (0–23) at which fleet.log is cut.
 	// The spec is 3am; overridable via FLEET_LOG_ROTATE_HOUR so a test can target
-	// the current hour.
-	logRotateHour = envIntDefault("FLEET_LOG_ROTATE_HOUR", 3)
-	// logRotateKeepDays bounds how many days of dated logs are kept. Anything
-	// older than now-keepDays is pruned after each rotation check. Overridable via
-	// FLEET_LOG_ROTATE_KEEP_DAYS for tests.
+	// the current hour. Clamped to a real hour so a fat-fingered override (e.g.
+	// 25) can't make the "before the rotation hour" gate unsatisfiable and turn
+	// every check into a rotation.
+	logRotateHour = min(max(envIntDefault("FLEET_LOG_ROTATE_HOUR", 3), 0), 23)
+	// logRotateKeepDays is how many of the most recent daily logs to keep (today
+	// inclusive). After each rotation check, logs older than that window are
+	// pruned. Overridable via FLEET_LOG_ROTATE_KEEP_DAYS for tests.
 	logRotateKeepDays = envIntDefault("FLEET_LOG_ROTATE_KEEP_DAYS", 100)
 	// logRotateInterval is how often the loop checks whether a rotation is due.
 	// A daily cut needs no fine granularity; ~15m lands the rotation within a
@@ -229,21 +231,33 @@ func pruneRotatedLogs(now time.Time) (int, error) {
 		return 0, err
 	}
 
-	// Cut at the start of the day logRotateKeepDays days back: a log dated before
-	// it is more than keepDays days old and is removed; today's just-written log
-	// (and the keepDays days behind it) is kept.
-	cutoff := startOfDay(now).AddDate(0, 0, -logRotateKeepDays)
+	// Keep the most recent logRotateKeepDays days, today inclusive: the window
+	// starts keepDays-1 days before today, so a log dated before that start is
+	// outside the window and removed. With the default 100 that retains today plus
+	// the 99 days behind it — 100 daily logs.
+	cutoff := startOfDay(now).AddDate(0, 0, -(logRotateKeepDays - 1))
 	removed := 0
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
 		}
-		day, ok := parseRotatedLogDate(e.Name())
+		name := e.Name()
+		// Reclaim a temp file orphaned by a rotation that died before its rename
+		// (the deferred cleanup never ran). Safe here: rotation is serial and the
+		// current tick's copyTruncate has already finished by the time prune runs,
+		// so any .rotate-*.log.tmp left behind is from a dead run. Mirrors how
+		// pruneBackups sweeps its own orphaned .backup-*.tmp files; without it these
+		// would accumulate forever, since the date filter below skips them.
+		if strings.HasPrefix(name, ".rotate-") && strings.HasSuffix(name, ".log.tmp") {
+			_ = os.Remove(filepath.Join(dir, name))
+			continue
+		}
+		day, ok := parseRotatedLogDate(name)
 		if !ok {
 			continue
 		}
 		if day.Before(cutoff) {
-			if err := os.Remove(filepath.Join(dir, e.Name())); err == nil {
+			if err := os.Remove(filepath.Join(dir, name)); err == nil {
 				removed++
 			}
 		}

--- a/internal/server/logrotate.go
+++ b/internal/server/logrotate.go
@@ -49,8 +49,10 @@ var (
 	logRotateHour = min(max(envIntDefault("FLEET_LOG_ROTATE_HOUR", 3), 0), 23)
 	// logRotateKeepDays is how many of the most recent daily logs to keep (today
 	// inclusive). After each rotation check, logs older than that window are
-	// pruned. Overridable via FLEET_LOG_ROTATE_KEEP_DAYS for tests.
-	logRotateKeepDays = envIntDefault("FLEET_LOG_ROTATE_KEEP_DAYS", 100)
+	// pruned. Overridable via FLEET_LOG_ROTATE_KEEP_DAYS for tests. Floored at 1
+	// so a 0 override can't push the cutoff into the future and prune the log just
+	// rotated; the smallest window keeps today alone.
+	logRotateKeepDays = max(envIntDefault("FLEET_LOG_ROTATE_KEEP_DAYS", 100), 1)
 	// logRotateInterval is how often the loop checks whether a rotation is due.
 	// A daily cut needs no fine granularity; ~15m lands the rotation within a
 	// quarter hour of 3am while keeping the check cheap. Overridable via

--- a/internal/server/logrotate.go
+++ b/internal/server/logrotate.go
@@ -1,0 +1,258 @@
+package server
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetpaths"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
+)
+
+// logrotate.go bounds the size of the shared event log. ~/.fleet/fleet.log is
+// the append-only trail every fleet process writes to (see internal/flog), and
+// nothing ever trims it, so on a long-lived host it grows without bound. This
+// loop cuts it once a day: at 3am local time it copies the current contents to
+// ~/.fleet/logs/fleetd/<date>.log, truncates the live log back to empty, and
+// drops dated logs past the retention window (the last 100 days).
+//
+// Why copytruncate and not a rename. fleet.log is appended to with O_APPEND by
+// EVERY fleet process at once — the long-lived daemon and TUI, one-shot CLIs,
+// and the detached _create/_clone children — each holding its own file
+// descriptor to the same inode for its whole lifetime, and flog opens that
+// descriptor exactly once with no reopen path. Renaming the file would leave all
+// those descriptors pointing at the renamed inode, so the daemon and TUI would
+// keep writing into the rotated file while the fresh fleet.log collected only
+// records from processes started afterwards. Truncating the inode in place keeps
+// every open descriptor valid: because all writers use O_APPEND, their next
+// write lands at the new end-of-file (offset 0) with no reopen and no
+// cross-process coordination. The cost is copytruncate's well-known race —
+// records appended in the brief window between the copy reaching EOF and the
+// truncate are dropped — which is acceptable because flog is explicitly
+// best-effort (swallow-and-continue).
+//
+// Like the backup loop it runs unconditionally (rotation must happen whether or
+// not a TUI is connected) and stops on shutdown via the context it is launched
+// with. The schedule and date naming use LOCAL time to match "3am system time";
+// daily buckets are immune to the DST double-hour that pushes the backup loop to
+// UTC.
+var (
+	// logRotateHour is the local hour-of-day (0–23) at which fleet.log is cut.
+	// The spec is 3am; overridable via FLEET_LOG_ROTATE_HOUR so a test can target
+	// the current hour.
+	logRotateHour = envIntDefault("FLEET_LOG_ROTATE_HOUR", 3)
+	// logRotateKeepDays bounds how many days of dated logs are kept. Anything
+	// older than now-keepDays is pruned after each rotation check. Overridable via
+	// FLEET_LOG_ROTATE_KEEP_DAYS for tests.
+	logRotateKeepDays = envIntDefault("FLEET_LOG_ROTATE_KEEP_DAYS", 100)
+	// logRotateInterval is how often the loop checks whether a rotation is due.
+	// A daily cut needs no fine granularity; ~15m lands the rotation within a
+	// quarter hour of 3am while keeping the check cheap. Overridable via
+	// FLEET_LOG_ROTATE_INTERVAL (a Go duration) so a test can drive the loop fast.
+	logRotateInterval = envDurationDefault("FLEET_LOG_ROTATE_INTERVAL", 15*time.Minute)
+)
+
+// envIntDefault returns the non-negative integer parsed from the named env var,
+// or def when it is unset, blank, or unparseable. Like envDurationDefault these
+// knobs exist only so tests can retarget the rotation hour / retention; the
+// daemon inherits the spawning client's environment.
+func envIntDefault(name string, def int) int {
+	if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return def
+}
+
+// fleetdLogDir is the directory holding the rotated daily logs
+// (~/.fleet/logs/fleetd). Server-only, so it lives here rather than in the
+// client-shared fleetpaths package. The parent ~/.fleet/logs already holds the
+// per-instance creation logs.
+func fleetdLogDir() string {
+	return filepath.Join(fleetpaths.Dir(), "logs", "fleetd")
+}
+
+// runLogRotateLoop rotates fleet.log when due and prunes expired dated logs on
+// logRotateInterval. It returns when ctx is cancelled. It checks once
+// immediately so a daemon that comes up after 3am on a day it has not yet
+// rotated cuts the (possibly long-overgrown) log promptly instead of waiting a
+// full interval.
+func (s *service) runLogRotateLoop(ctx context.Context) {
+	ticker := time.NewTicker(logRotateInterval)
+	defer ticker.Stop()
+	for {
+		rotateLogTick(time.Now())
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// rotateLogTick performs one rotation-if-due plus a prune. Both steps are
+// best-effort: a failure is logged and the loop continues, since a rotation miss
+// must never take the daemon down. Split from the loop so tests can drive a
+// single tick. The "rotated" info line lands as the first record of the freshly
+// truncated fleet.log, so each cut is self-marking.
+func rotateLogTick(now time.Time) {
+	switch path, rotated, err := rotateLogIfDue(now); {
+	case err != nil:
+		flog.Warn("logrotate: rotation failed", "err", err)
+	case rotated:
+		flog.Info("logrotate: rotated fleet.log", "path", path)
+	}
+	if removed, err := pruneRotatedLogs(now); err != nil {
+		flog.Warn("logrotate: prune failed", "err", err)
+	} else if removed > 0 {
+		flog.Info("logrotate: pruned expired logs", "removed", removed)
+	}
+}
+
+// rotateLogIfDue cuts fleet.log into ~/.fleet/logs/fleetd/<date>.log when a
+// rotation is due, returning the dated path and whether it rotated. A rotation
+// is due once it is at or past logRotateHour local time and today's dated log
+// does not yet exist; that filesystem-derived "already cut today" test makes the
+// rotation idempotent and gives free catch-up across daemon restarts without any
+// in-memory bookkeeping. An empty or missing fleet.log is left alone so quiet
+// days produce no empty dated files.
+func rotateLogIfDue(now time.Time) (string, bool, error) {
+	if now.Hour() < logRotateHour {
+		return "", false, nil // not yet the rotation hour today
+	}
+
+	src := flog.Path()
+	info, err := os.Stat(src)
+	if os.IsNotExist(err) {
+		return "", false, nil // nothing logged yet
+	}
+	if err != nil {
+		return "", false, err
+	}
+	if !info.Mode().IsRegular() || info.Size() == 0 {
+		return "", false, nil // nothing to rotate
+	}
+
+	// Name the dated log by the rotation date (today). The file holds everything
+	// accumulated since the previous cut, so under catch-up its name marks WHEN it
+	// was cut rather than mislabeling a multi-day backlog as a single prior day.
+	dir := fleetdLogDir()
+	dest := filepath.Join(dir, now.Format("2006-01-02")+".log")
+	if _, err := os.Stat(dest); err == nil {
+		return "", false, nil // already rotated today
+	}
+
+	// 0755 to match the existing ~/.fleet/logs directory; the event log carries no
+	// secrets (commands, names, errors), unlike the 0700 backup tree.
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", false, err
+	}
+	if err := copyTruncate(src, dest); err != nil {
+		return "", false, err
+	}
+	return dest, true, nil
+}
+
+// copyTruncate copies src's current contents to dest (via a temp file renamed
+// into place, so a reader never sees a half-written dated log) and then
+// truncates src to zero. See the file header for why this is a copytruncate
+// rather than a rename. The copy is persisted BEFORE the truncate so a failure
+// mid-rotation never loses data — fleet.log stays intact until its rotated copy
+// is safely on disk.
+func copyTruncate(src, dest string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	tmp, err := os.CreateTemp(filepath.Dir(dest), ".rotate-*.log.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	// Remove the temp file on any early return; a no-op once it is renamed away.
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := io.Copy(tmp, in); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	// Match fleet.log's own 0644 so the rotated copy is as readable as the live
+	// file (os.CreateTemp makes it 0600).
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, dest); err != nil {
+		return err
+	}
+	return os.Truncate(src, 0)
+}
+
+// parseRotatedLogDate reports whether name is a "<date>.log" rotated log,
+// returning the date parsed in local time (midnight) to line up with the
+// local-time rotation/prune clock. It is the single definition of "what counts
+// as a rotated log" shared by pruneRotatedLogs, so the prune can't drift from
+// the rotation's naming.
+func parseRotatedLogDate(name string) (time.Time, bool) {
+	s := strings.TrimSuffix(name, ".log")
+	if s == name {
+		return time.Time{}, false // no .log suffix
+	}
+	day, err := time.ParseInLocation("2006-01-02", s, time.Local)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return day, true
+}
+
+// pruneRotatedLogs removes dated logs more than logRotateKeepDays days old,
+// returning how many it deleted. A log's age is taken from its <date> filename
+// (not its mtime) so the retention boundary is exact and independent of when the
+// file was last touched, mirroring how the backup loop prunes by its <date>
+// path. Entries that are not <date>.log files are left untouched.
+func pruneRotatedLogs(now time.Time) (int, error) {
+	dir := fleetdLogDir()
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	// Cut at the start of the day logRotateKeepDays days back: a log dated before
+	// it is more than keepDays days old and is removed; today's just-written log
+	// (and the keepDays days behind it) is kept.
+	cutoff := startOfDay(now).AddDate(0, 0, -logRotateKeepDays)
+	removed := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		day, ok := parseRotatedLogDate(e.Name())
+		if !ok {
+			continue
+		}
+		if day.Before(cutoff) {
+			if err := os.Remove(filepath.Join(dir, e.Name())); err == nil {
+				removed++
+			}
+		}
+	}
+	return removed, nil
+}
+
+// startOfDay returns midnight of t's calendar day in t's own location.
+func startOfDay(t time.Time) time.Time {
+	y, m, d := t.Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, t.Location())
+}

--- a/internal/server/logrotate_test.go
+++ b/internal/server/logrotate_test.go
@@ -225,6 +225,35 @@ func TestPruneRotatedLogs(t *testing.T) {
 	}
 }
 
+// TestPruneRotatedLogsKeepsTodayAtMinWindow guards the smallest window: with
+// keepDays floored at 1, the cutoff must never reach today, so the log just
+// rotated survives while yesterday's is pruned.
+func TestPruneRotatedLogsKeepsTodayAtMinWindow(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	setRotateConfig(t, 3, 1)
+	dir := fleetdLogDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	now := time.Date(2026, 6, 24, 3, 0, 0, 0, time.Local)
+	today := now.Format("2006-01-02") + ".log"
+	yesterday := now.AddDate(0, 0, -1).Format("2006-01-02") + ".log"
+	for _, n := range []string{today, yesterday} {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", n, err)
+		}
+	}
+	if removed, err := pruneRotatedLogs(now); err != nil || removed != 1 {
+		t.Fatalf("prune: removed=%d err=%v, want 1", removed, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, today)); err != nil {
+		t.Fatalf("today's log was pruned: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, yesterday)); !os.IsNotExist(err) {
+		t.Fatalf("yesterday's log should be pruned: %v", err)
+	}
+}
+
 func TestPruneRotatedLogsNoDir(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	now := time.Date(2026, 6, 24, 3, 0, 0, 0, time.Local)

--- a/internal/server/logrotate_test.go
+++ b/internal/server/logrotate_test.go
@@ -1,0 +1,290 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
+)
+
+// seedFleetLog lays down ~/.fleet/fleet.log with content under a temp HOME and
+// returns the home dir. An empty content string still creates the file (size 0).
+func seedFleetLog(t *testing.T, content string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, ".fleet"), 0o755); err != nil {
+		t.Fatalf("mkdir .fleet: %v", err)
+	}
+	if err := os.WriteFile(flog.Path(), []byte(content), 0o644); err != nil {
+		t.Fatalf("write fleet.log: %v", err)
+	}
+	return home
+}
+
+// setRotateConfig overrides the rotation knobs (read once from env at package
+// init) for the duration of a test, restoring them after.
+func setRotateConfig(t *testing.T, hour, keepDays int) {
+	t.Helper()
+	t.Cleanup(func(h, k int) func() { return func() { logRotateHour, logRotateKeepDays = h, k } }(logRotateHour, logRotateKeepDays))
+	logRotateHour, logRotateKeepDays = hour, keepDays
+}
+
+func TestRotateLogIfDueBeforeHour(t *testing.T) {
+	seedFleetLog(t, "before-the-hour\n")
+	setRotateConfig(t, 3, 100)
+
+	// 02:59 local — not yet 3am, so nothing should happen.
+	now := time.Date(2026, 6, 24, 2, 59, 0, 0, time.Local)
+	path, rotated, err := rotateLogIfDue(now)
+	if err != nil {
+		t.Fatalf("rotateLogIfDue: %v", err)
+	}
+	if rotated || path != "" {
+		t.Fatalf("rotated before the hour: rotated=%v path=%q", rotated, path)
+	}
+	if got := readFile(t, flog.Path()); got != "before-the-hour\n" {
+		t.Fatalf("fleet.log changed: %q", got)
+	}
+	if _, err := os.Stat(fleetdLogDir()); !os.IsNotExist(err) {
+		t.Fatalf("fleetd log dir should not exist yet: %v", err)
+	}
+}
+
+func TestRotateLogIfDueRotatesAndTruncates(t *testing.T) {
+	seedFleetLog(t, "day of records\n")
+	setRotateConfig(t, 3, 100)
+
+	now := time.Date(2026, 6, 24, 3, 5, 0, 0, time.Local)
+	path, rotated, err := rotateLogIfDue(now)
+	if err != nil {
+		t.Fatalf("rotateLogIfDue: %v", err)
+	}
+	if !rotated {
+		t.Fatal("expected rotation")
+	}
+	wantPath := filepath.Join(fleetdLogDir(), "2026-06-24.log")
+	if path != wantPath {
+		t.Fatalf("dated path = %q, want %q", path, wantPath)
+	}
+	if got := readFile(t, wantPath); got != "day of records\n" {
+		t.Fatalf("dated log content = %q", got)
+	}
+	// The live log is cut back to empty so it can be appended to afresh.
+	if info, err := os.Stat(flog.Path()); err != nil || info.Size() != 0 {
+		t.Fatalf("fleet.log not truncated: size=%v err=%v", sizeOf(info), err)
+	}
+	// The dated copy inherits fleet.log's 0644, not CreateTemp's 0600.
+	if info, _ := os.Stat(wantPath); info.Mode().Perm() != 0o644 {
+		t.Fatalf("dated log perm = %v, want 0644", info.Mode().Perm())
+	}
+}
+
+func TestRotateLogIfDueIdempotentWithinDay(t *testing.T) {
+	seedFleetLog(t, "first\n")
+	setRotateConfig(t, 3, 100)
+
+	now := time.Date(2026, 6, 24, 3, 5, 0, 0, time.Local)
+	if _, rotated, err := rotateLogIfDue(now); err != nil || !rotated {
+		t.Fatalf("first rotate: rotated=%v err=%v", rotated, err)
+	}
+	// New activity accrues, and a later check the same day runs.
+	if err := os.WriteFile(flog.Path(), []byte("second\n"), 0o644); err != nil {
+		t.Fatalf("re-write fleet.log: %v", err)
+	}
+	later := time.Date(2026, 6, 24, 9, 0, 0, 0, time.Local)
+	if path, rotated, err := rotateLogIfDue(later); err != nil || rotated || path != "" {
+		t.Fatalf("second rotate should be a no-op: rotated=%v path=%q err=%v", rotated, path, err)
+	}
+	// The dated file keeps the FIRST cut and the live log keeps its new content —
+	// today's log is never clobbered mid-day.
+	if got := readFile(t, filepath.Join(fleetdLogDir(), "2026-06-24.log")); got != "first\n" {
+		t.Fatalf("dated log overwritten: %q", got)
+	}
+	if got := readFile(t, flog.Path()); got != "second\n" {
+		t.Fatalf("fleet.log clobbered: %q", got)
+	}
+}
+
+func TestRotateLogIfDueSkipsEmptyAndMissing(t *testing.T) {
+	setRotateConfig(t, 3, 100)
+	now := time.Date(2026, 6, 24, 3, 5, 0, 0, time.Local)
+
+	// Empty fleet.log → no empty dated file.
+	seedFleetLog(t, "")
+	if path, rotated, err := rotateLogIfDue(now); err != nil || rotated || path != "" {
+		t.Fatalf("empty log rotated: rotated=%v path=%q err=%v", rotated, path, err)
+	}
+	if _, err := os.Stat(fleetdLogDir()); !os.IsNotExist(err) {
+		t.Fatalf("dated dir created for empty log: %v", err)
+	}
+
+	// Missing fleet.log → no-op (remove the seeded one).
+	if err := os.Remove(flog.Path()); err != nil {
+		t.Fatalf("remove fleet.log: %v", err)
+	}
+	if path, rotated, err := rotateLogIfDue(now); err != nil || rotated || path != "" {
+		t.Fatalf("missing log rotated: rotated=%v path=%q err=%v", rotated, path, err)
+	}
+}
+
+// TestRotatePreservesSharedAppendFd is the core guarantee: a process holding an
+// O_APPEND descriptor to fleet.log keeps writing into the SAME file across a
+// rotation, because copytruncate keeps the inode. A rename would orphan the
+// descriptor onto the rotated file.
+func TestRotatePreservesSharedAppendFd(t *testing.T) {
+	seedFleetLog(t, "")
+	setRotateConfig(t, 3, 100)
+
+	// Simulate a long-lived writer (the daemon/TUI) holding fleet.log open.
+	w, err := os.OpenFile(flog.Path(), os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatalf("open fleet.log O_APPEND: %v", err)
+	}
+	defer w.Close()
+
+	if _, err := w.WriteString("before-rotate\n"); err != nil {
+		t.Fatalf("write before: %v", err)
+	}
+	now := time.Date(2026, 6, 24, 3, 5, 0, 0, time.Local)
+	if _, rotated, err := rotateLogIfDue(now); err != nil || !rotated {
+		t.Fatalf("rotate: rotated=%v err=%v", rotated, err)
+	}
+	// Same descriptor, post-rotation write — must land in the (now truncated)
+	// fleet.log, NOT the rotated dated file.
+	if _, err := w.WriteString("after-rotate\n"); err != nil {
+		t.Fatalf("write after: %v", err)
+	}
+
+	if got := readFile(t, flog.Path()); got != "after-rotate\n" {
+		t.Fatalf("live log after rotation = %q, want only the post-rotate line", got)
+	}
+	if got := readFile(t, filepath.Join(fleetdLogDir(), "2026-06-24.log")); got != "before-rotate\n" {
+		t.Fatalf("dated log = %q, want the pre-rotate line", got)
+	}
+}
+
+func TestPruneRotatedLogs(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	setRotateConfig(t, 3, 100)
+	dir := fleetdLogDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	now := time.Date(2026, 6, 24, 3, 0, 0, 0, time.Local)
+	// dayLog writes a <date>.log for now-offset days.
+	dayLog := func(daysAgo int) string {
+		name := now.AddDate(0, 0, -daysAgo).Format("2006-01-02") + ".log"
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return name
+	}
+	keep0 := dayLog(0)     // today
+	keep99 := dayLog(99)   // within window
+	keep100 := dayLog(100) // exactly at the cutoff day — kept
+	drop101 := dayLog(101) // over the limit — removed
+	drop500 := dayLog(500) // well over — removed
+	// A non-matching file must be left strictly alone.
+	other := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(other, []byte("keep me"), 0o644); err != nil {
+		t.Fatalf("write notes: %v", err)
+	}
+
+	removed, err := pruneRotatedLogs(now)
+	if err != nil {
+		t.Fatalf("pruneRotatedLogs: %v", err)
+	}
+	if removed != 2 {
+		t.Fatalf("removed = %d, want 2", removed)
+	}
+	for _, name := range []string{keep0, keep99, keep100} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Fatalf("%s should be kept: %v", name, err)
+		}
+	}
+	for _, name := range []string{drop101, drop500} {
+		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
+			t.Fatalf("%s should be removed: %v", name, err)
+		}
+	}
+	if _, err := os.Stat(other); err != nil {
+		t.Fatalf("non-log file removed: %v", err)
+	}
+}
+
+func TestPruneRotatedLogsNoDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	now := time.Date(2026, 6, 24, 3, 0, 0, 0, time.Local)
+	if removed, err := pruneRotatedLogs(now); err != nil || removed != 0 {
+		t.Fatalf("prune with no dir: removed=%d err=%v", removed, err)
+	}
+}
+
+func TestParseRotatedLogDate(t *testing.T) {
+	cases := []struct {
+		name string
+		ok   bool
+	}{
+		{"2026-06-24.log", true},
+		{"2026-01-01.log", true},
+		{"2026-06-24.log.tmp", false}, // temp file, not a finished log
+		{"fleet.log", false},          // no date
+		{"2026-13-40.log", false},     // impossible date
+		{"notes.txt", false},          // not .log
+		{".rotate-123.log.tmp", false},
+	}
+	for _, c := range cases {
+		if _, ok := parseRotatedLogDate(c.name); ok != c.ok {
+			t.Errorf("parseRotatedLogDate(%q) ok = %v, want %v", c.name, ok, c.ok)
+		}
+	}
+}
+
+func TestEnvIntDefault(t *testing.T) {
+	const key = "FLEET_TEST_INT_KNOB"
+	cases := []struct {
+		val string
+		set bool
+		def int
+		fn  int
+	}{
+		{"", false, 7, 7},   // unset → default
+		{"  ", true, 7, 7},  // blank → default
+		{"12", true, 7, 12}, // parsed
+		{"0", true, 7, 0},   // zero is valid
+		{"-3", true, 7, 7},  // negative rejected
+		{"abc", true, 7, 7}, // unparseable → default
+	}
+	for _, c := range cases {
+		if c.set {
+			t.Setenv(key, c.val)
+		} else {
+			os.Unsetenv(key)
+		}
+		if got := envIntDefault(key, c.def); got != c.fn {
+			t.Errorf("envIntDefault(%q set=%v) = %d, want %d", c.val, c.set, got, c.fn)
+		}
+	}
+}
+
+// --- small test helpers ---
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func sizeOf(info os.FileInfo) int64 {
+	if info == nil {
+		return -1
+	}
+	return info.Size()
+}

--- a/internal/server/logrotate_test.go
+++ b/internal/server/logrotate_test.go
@@ -184,8 +184,8 @@ func TestPruneRotatedLogs(t *testing.T) {
 		return name
 	}
 	keep0 := dayLog(0)     // today
-	keep99 := dayLog(99)   // within window
-	keep100 := dayLog(100) // exactly at the cutoff day — kept
+	keep99 := dayLog(99)   // oldest still inside the 100-day window
+	drop100 := dayLog(100) // just outside the window — removed
 	drop101 := dayLog(101) // over the limit — removed
 	drop500 := dayLog(500) // well over — removed
 	// A non-matching file must be left strictly alone.
@@ -193,26 +193,35 @@ func TestPruneRotatedLogs(t *testing.T) {
 	if err := os.WriteFile(other, []byte("keep me"), 0o644); err != nil {
 		t.Fatalf("write notes: %v", err)
 	}
+	// A crash-orphaned rotation temp must be reclaimed (but not counted as a
+	// removed dated log).
+	orphan := filepath.Join(dir, ".rotate-987654.log.tmp")
+	if err := os.WriteFile(orphan, []byte("half-written"), 0o600); err != nil {
+		t.Fatalf("write orphan tmp: %v", err)
+	}
 
 	removed, err := pruneRotatedLogs(now)
 	if err != nil {
 		t.Fatalf("pruneRotatedLogs: %v", err)
 	}
-	if removed != 2 {
-		t.Fatalf("removed = %d, want 2", removed)
+	if removed != 3 {
+		t.Fatalf("removed = %d, want 3", removed)
 	}
-	for _, name := range []string{keep0, keep99, keep100} {
+	for _, name := range []string{keep0, keep99} {
 		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
 			t.Fatalf("%s should be kept: %v", name, err)
 		}
 	}
-	for _, name := range []string{drop101, drop500} {
+	for _, name := range []string{drop100, drop101, drop500} {
 		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
 			t.Fatalf("%s should be removed: %v", name, err)
 		}
 	}
 	if _, err := os.Stat(other); err != nil {
 		t.Fatalf("non-log file removed: %v", err)
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("orphaned rotate tmp not reclaimed: %v", err)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -147,6 +147,13 @@ func Serve(ctx context.Context) error {
 	// files instead of racing them.
 	go svc.runBackupLoop(hubCtx)
 
+	// Log rotation loop: at 3am local it cuts the shared event log
+	// (~/.fleet/fleet.log) into ~/.fleet/logs/fleetd/<date>.log and prunes dated
+	// logs past the retention window, so the append-only trail every fleet process
+	// writes to can't grow without bound. Unconditional and stops on shutdown via
+	// hubCtx, like the backup loop above.
+	go svc.runLogRotateLoop(hubCtx)
+
 	// Tunnel-facing servers fed by the gateway tunnel demux (no extra port/socket):
 	//   - gRPC: the SAME FleetService as the local unix socket, but gated by the
 	//     MCP bearer token (the local socket stays auth-less). Tunneled whenever


### PR DESCRIPTION
## Problem

`~/.fleet/fleet.log` is the append-only event trail every fleet process writes to (see `internal/flog`), and nothing ever trimmed it. On a long-lived host it grows without bound.

## Change

A new server-side background loop (`internal/server/logrotate.go`) cuts the log once a day:

- At **3am local time** it copies the current `fleet.log` contents into `~/.fleet/logs/fleetd/<date>.log`, truncates the live log back to empty, and **prunes dated logs older than 100 days**.
- Launched alongside the backup loop in `Serve()`; unconditional, stops on shutdown via `hubCtx`.

### Why copytruncate, not rename

`fleet.log` is appended to with `O_APPEND` by **every fleet process at once** — the long-lived daemon and TUI, one-shot CLIs, and detached `_create`/`_clone` children — each holding its own descriptor to the same inode for its whole lifetime, and `flog` opens that descriptor exactly once with **no reopen path**. A rename would orphan all those descriptors onto the rotated file, so the daemon and TUI would keep writing into yesterday's log while the fresh `fleet.log` only collected records from newly-started processes. Truncating the inode in place keeps every descriptor valid: because all writers use `O_APPEND`, their next write lands at the new end-of-file with no reopen and no coordination. The narrow copytruncate race (records written between the copy reaching EOF and the truncate) is acceptable — `flog` is explicitly best-effort.

### Behaviour notes

- **Due-ness is filesystem-derived** (past the hour *and* today's dated log absent), so rotation is idempotent and catches up across daemon restarts with no in-memory bookkeeping.
- Empty/missing `fleet.log` is left alone — quiet days produce no empty dated files.
- Schedule, naming, and pruning use **local time** to match "3am system time" (daily buckets are immune to the DST double-hour that pushes the backup loop to UTC).
- Dated copy preserves `fleet.log`'s `0644`.
- Test seams via env: `FLEET_LOG_ROTATE_HOUR`, `FLEET_LOG_ROTATE_KEEP_DAYS`, `FLEET_LOG_ROTATE_INTERVAL`.

## Tests

`internal/server/logrotate_test.go` covers: before-hour no-op, rotate-creates-dated-file + truncates (+ perms), same-day idempotency (never clobbers today's log), empty/missing skip, **the shared `O_APPEND` fd continuing into the truncated log after rotation** (the core guarantee a rename would break), date-window pruning, date parsing, and the env helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)