### PR TITLE
fix(tui): stop session create failing forever with bare "exit code 1"

### DIFF
--- a/internal/tui/dialog_session.go
+++ b/internal/tui/dialog_session.go
@@ -123,24 +123,26 @@ func (fleetPage *fleetPage) saveCreateSession(m *model) tea.Cmd {
 	// A template was Tab-selected: mint the whole group — one session per
 	// pane, the resolved name as the group ID — and run each pane's command.
 	if preset != nil {
-		// The group root is named after the preset, so re-applying a preset (or
-		// a leftover from a prior failed apply) would collide on new-session and
-		// fail forever. Suffix to a free name (dev → dev-2) so the root is always
-		// creatable; load the runtime session list first so the check sees what's
-		// actually live.
-		ensureSessionsLoaded(m, ref)
-		name = uniqueGroupName(sanitized, name, m.sessionStore.Sessions(ref))
-		fullName = GroupSessionName(sanitized, name)
+		// Mint the group under a FRESH RANDOM id (like a split group), not the
+		// preset name. A preset-derived root name re-collides forever on
+		// new-session once that group exists — the reported "stuck, restart
+		// doesn't help" bug, since the session lives in the container. A random
+		// id never collides on re-apply, and (unlike a readable suffix such as
+		// dev-2) can't prefix-match a sibling group in the prefix-based group ops
+		// (open/rename/delete). Readable/typed layout-group names need
+		// boundary-aware matching first — that's the deferred P1 prefix work.
+		groupID := randomHex(3)
+		fullName = GroupSessionName(sanitized, groupID)
 
 		sessions := make([]string, 0, preset.PaneCount())
 		sessions = append(sessions, fullName)
 		for i := 1; i < preset.PaneCount(); i++ {
-			sessions = append(sessions, NewGroupPaneSessionName(sanitized, name))
+			sessions = append(sessions, NewGroupPaneSessionName(sanitized, groupID))
 		}
 		fleetPage.mode = viewNormal
 		fleetPage.blurDialogFields()
-		m.message = fmt.Sprintf("Creating session %s from %s...", name, preset.Name)
-		return createSessionGroupFromPresetCmd(ref, name, sessions, *preset)
+		m.message = fmt.Sprintf("Creating session from %s...", preset.Name)
+		return createSessionGroupFromPresetCmd(ref, groupID, sessions, *preset)
 	}
 
 	fleetPage.mode = viewNormal

--- a/internal/tui/dialog_session.go
+++ b/internal/tui/dialog_session.go
@@ -123,6 +123,15 @@ func (fleetPage *fleetPage) saveCreateSession(m *model) tea.Cmd {
 	// A template was Tab-selected: mint the whole group — one session per
 	// pane, the resolved name as the group ID — and run each pane's command.
 	if preset != nil {
+		// The group root is named after the preset, so re-applying a preset (or
+		// a leftover from a prior failed apply) would collide on new-session and
+		// fail forever. Suffix to a free name (dev → dev-2) so the root is always
+		// creatable; load the runtime session list first so the check sees what's
+		// actually live.
+		ensureSessionsLoaded(m, ref)
+		name = uniqueGroupName(sanitized, name, m.sessionStore.Sessions(ref))
+		fullName = GroupSessionName(sanitized, name)
+
 		sessions := make([]string, 0, preset.PaneCount())
 		sessions = append(sessions, fullName)
 		for i := 1; i < preset.PaneCount(); i++ {

--- a/internal/tui/dialog_session.go
+++ b/internal/tui/dialog_session.go
@@ -123,15 +123,17 @@ func (fleetPage *fleetPage) saveCreateSession(m *model) tea.Cmd {
 	// A template was Tab-selected: mint the whole group — one session per
 	// pane, the resolved name as the group ID — and run each pane's command.
 	if preset != nil {
-		// Mint the group under a FRESH RANDOM id (like a split group), not the
-		// preset name. A preset-derived root name re-collides forever on
-		// new-session once that group exists — the reported "stuck, restart
-		// doesn't help" bug, since the session lives in the container. A random
-		// id never collides on re-apply, and (unlike a readable suffix such as
-		// dev-2) can't prefix-match a sibling group in the prefix-based group ops
-		// (open/rename/delete). Readable/typed layout-group names need
-		// boundary-aware matching first — that's the deferred P1 prefix work.
-		groupID := randomHex(3)
+		// Keep the readable preset/typed name as the group id when it's free,
+		// else fall back to a fresh random id. A preset-derived root name
+		// re-collides forever on new-session once that group exists — the
+		// reported "stuck, restart doesn't help" bug, since the session lives in
+		// the container. Falling back to random (rather than auto-suffixing to
+		// dev-2) avoids minting a sibling whose name a prefix-based group op would
+		// match against "dev"; readable names for re-applies need boundary-aware
+		// matching first — the deferred P1 prefix work. Load the runtime list so
+		// the free check sees what's actually live.
+		ensureSessionsLoaded(m, ref)
+		groupID := groupIDFor(sanitized, name, m.sessionStore.Sessions(ref))
 		fullName = GroupSessionName(sanitized, groupID)
 
 		sessions := make([]string, 0, preset.PaneCount())
@@ -141,7 +143,7 @@ func (fleetPage *fleetPage) saveCreateSession(m *model) tea.Cmd {
 		}
 		fleetPage.mode = viewNormal
 		fleetPage.blurDialogFields()
-		m.message = fmt.Sprintf("Creating session from %s...", preset.Name)
+		m.message = fmt.Sprintf("Creating session %s from %s...", groupID, preset.Name)
 		return createSessionGroupFromPresetCmd(ref, groupID, sessions, *preset)
 	}
 

--- a/internal/tui/groups.go
+++ b/internal/tui/groups.go
@@ -123,6 +123,24 @@ func NewGroupPaneSessionName(sanitizedInstance, groupID string) string {
 	return GroupSessionName(sanitizedInstance, groupID) + groupSep + randomHex(2)
 }
 
+// groupIDFor returns desired when no live group in the instance already uses it,
+// otherwise a fresh random id. Layout presets create their root under the
+// readable preset/typed name; honoring it keeps the group named that on first
+// apply, but a re-apply (or a leftover from a prior failed apply) falls back to
+// a random id so the root never collides forever on `tmux new-session` — the
+// reported "stuck, a restart doesn't help" bug, since the session lives in the
+// container. It deliberately does NOT auto-suffix (dev-2): that would prefix-
+// match a sibling group ("dev") in the prefix-based group ops (open/rename/
+// delete) — readable names for re-applies need boundary-aware matching first.
+func groupIDFor(sanitizedInstance, desired string, existing []tmuxSession) string {
+	for _, s := range existing {
+		if gid, ok := parseGroupID(sanitizedInstance, s.Name); ok && gid == desired {
+			return randomHex(3)
+		}
+	}
+	return desired
+}
+
 // ResolveSessionName maps a user-supplied session name to its canonical
 // grouped form for the given instance. Names that already follow the
 // convention pass through unchanged; anything else becomes the root

--- a/internal/tui/groups.go
+++ b/internal/tui/groups.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -122,31 +121,6 @@ func NewGroupRootSessionName(sanitizedInstance string) string {
 // an existing group: <instance>~<groupID>~<hex>.
 func NewGroupPaneSessionName(sanitizedInstance, groupID string) string {
 	return GroupSessionName(sanitizedInstance, groupID) + groupSep + randomHex(2)
-}
-
-// uniqueGroupName returns desired, or desired-2/-3/… when a group with that ID
-// already lives in the instance. Layout presets create their root under a FIXED,
-// preset-derived name; without this, re-applying a preset (or a leftover from a
-// prior failed apply) would collide on `tmux new-session` and fail forever with
-// "duplicate session". Suffixing keeps the readable preset name in the common
-// case while guaranteeing the root is free — mirroring uniquePresetName and the
-// auto-increment the single-session path intends.
-func uniqueGroupName(sanitizedInstance, desired string, existing []tmuxSession) string {
-	taken := make(map[string]bool, len(existing))
-	for _, s := range existing {
-		if gid, ok := parseGroupID(sanitizedInstance, s.Name); ok {
-			taken[gid] = true
-		}
-	}
-	if !taken[desired] {
-		return desired
-	}
-	for n := 2; ; n++ {
-		candidate := fmt.Sprintf("%s-%d", desired, n)
-		if !taken[candidate] {
-			return candidate
-		}
-	}
 }
 
 // ResolveSessionName maps a user-supplied session name to its canonical

--- a/internal/tui/groups.go
+++ b/internal/tui/groups.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -121,6 +122,31 @@ func NewGroupRootSessionName(sanitizedInstance string) string {
 // an existing group: <instance>~<groupID>~<hex>.
 func NewGroupPaneSessionName(sanitizedInstance, groupID string) string {
 	return GroupSessionName(sanitizedInstance, groupID) + groupSep + randomHex(2)
+}
+
+// uniqueGroupName returns desired, or desired-2/-3/… when a group with that ID
+// already lives in the instance. Layout presets create their root under a FIXED,
+// preset-derived name; without this, re-applying a preset (or a leftover from a
+// prior failed apply) would collide on `tmux new-session` and fail forever with
+// "duplicate session". Suffixing keeps the readable preset name in the common
+// case while guaranteeing the root is free — mirroring uniquePresetName and the
+// auto-increment the single-session path intends.
+func uniqueGroupName(sanitizedInstance, desired string, existing []tmuxSession) string {
+	taken := make(map[string]bool, len(existing))
+	for _, s := range existing {
+		if gid, ok := parseGroupID(sanitizedInstance, s.Name); ok {
+			taken[gid] = true
+		}
+	}
+	if !taken[desired] {
+		return desired
+	}
+	for n := 2; ; n++ {
+		candidate := fmt.Sprintf("%s-%d", desired, n)
+		if !taken[candidate] {
+			return candidate
+		}
+	}
 }
 
 // ResolveSessionName maps a user-supplied session name to its canonical

--- a/internal/tui/layout_preset_test.go
+++ b/internal/tui/layout_preset_test.go
@@ -70,6 +70,31 @@ func TestBuildPresetSessionScriptSinglePaneNoCleanup(t *testing.T) {
 	}
 }
 
+func TestGroupIDFor(t *testing.T) {
+	existing := []tmuxSession{
+		{Name: "inst~dev"},      // root of a live group "dev"
+		{Name: "inst~dev~a1b2"}, // a pane of the same group
+		{Name: "other"},         // ungrouped, ignored
+	}
+	// A free name is honored verbatim so the group reads as the preset/typed name.
+	if got := groupIDFor("inst", "fromtpl", existing); got != "fromtpl" {
+		t.Fatalf("got %q, want fromtpl (free name honored)", got)
+	}
+	// A taken name falls back to a random 6-char hex id — NOT a "dev-2" suffix
+	// (which would prefix-match the live "dev" group in prefix-based group ops).
+	got := groupIDFor("inst", "dev", existing)
+	if got == "dev" || got == "dev-2" {
+		t.Fatalf("got %q, want a random fallback id", got)
+	}
+	if len(got) != 6 {
+		t.Fatalf("fallback %q is not a 3-byte hex id", got)
+	}
+	// A different instance's sessions never count against this instance.
+	if got := groupIDFor("inst", "dev", []tmuxSession{{Name: "elsewhere~dev"}}); got != "dev" {
+		t.Fatalf("got %q, want dev (other instance ignored)", got)
+	}
+}
+
 func TestCyclePresetTemplateWrapsThroughNone(t *testing.T) {
 	page := newFleetPage()
 	page.newSession.presets = []fleet.LayoutPreset{

--- a/internal/tui/layout_preset_test.go
+++ b/internal/tui/layout_preset_test.go
@@ -12,11 +12,16 @@ func TestBuildPresetSessionScript(t *testing.T) {
 		[]string{"inst~dev", "inst~dev~a1"},
 		[]string{"npm run dev", ""},
 	)
-	if !strings.Contains(script, `tmux new-session -d -s 'inst~dev' 2>/dev/null`) {
+	// 2>&1 (not 2>/dev/null): a "duplicate session" reason must survive so the
+	// TUI can show it instead of a bare "exit status 1".
+	if !strings.Contains(script, `tmux new-session -d -s 'inst~dev' 2>&1`) {
 		t.Fatalf("missing root new-session: %s", script)
 	}
-	if !strings.Contains(script, `tmux new-session -d -s 'inst~dev~a1' 2>/dev/null`) {
+	if !strings.Contains(script, `tmux new-session -d -s 'inst~dev~a1' 2>&1`) {
 		t.Fatalf("missing pane new-session: %s", script)
+	}
+	if strings.Contains(script, "2>/dev/null tmux new-session") || strings.Contains(script, `new-session -d -s 'inst~dev' 2>/dev/null`) {
+		t.Fatalf("new-session still swallows stderr: %s", script)
 	}
 	// The first pane's command is typed literally (-l) after a "--" flag
 	// terminator (so a leading-dash command isn't parsed as a flag) then
@@ -29,13 +34,58 @@ func TestBuildPresetSessionScript(t *testing.T) {
 		t.Fatalf("missing Enter send-keys: %s", script)
 	}
 	// The empty second command must not produce a send-keys for that pane.
-	if strings.Contains(script, `'=inst~dev~a1:'`) {
+	if strings.Contains(script, `send-keys -t '=inst~dev~a1:'`) {
 		t.Fatalf("plain-shell pane got a send-keys: %s", script)
 	}
-	// Steps are &&-chained so a name collision aborts instead of minting a
+	// Steps are &&-chained so a later failure aborts instead of minting a
 	// partial group.
 	if !strings.Contains(script, "&&") {
 		t.Fatalf("steps not chained: %s", script)
+	}
+	// The root is created on its own and gated with `|| exit 1`, so a collision
+	// on the EXISTING root exits before the cleanup — a pre-existing session is
+	// never killed.
+	if !strings.Contains(script, `tmux new-session -d -s 'inst~dev' 2>&1 || exit 1`) {
+		t.Fatalf("root not gated with || exit 1: %s", script)
+	}
+	// A failure after the root exists tears down every session this run made,
+	// so a partial chain can't strand a root that collides forever on retry.
+	if !strings.Contains(script, `tmux kill-session -t '=inst~dev:' 2>/dev/null`) ||
+		!strings.Contains(script, `tmux kill-session -t '=inst~dev~a1:' 2>/dev/null`) {
+		t.Fatalf("missing partial-failure cleanup: %s", script)
+	}
+}
+
+// A single-pane plain-shell preset has nothing to run after the root, so it is
+// just the bare guarded new-session — no cleanup block (there is nothing to tear
+// down) and no stray `|| exit 1`/kill scaffolding.
+func TestBuildPresetSessionScriptSinglePaneNoCleanup(t *testing.T) {
+	script := buildPresetSessionScript([]string{"inst~dev"}, []string{""})
+	if !strings.Contains(script, `tmux new-session -d -s 'inst~dev' 2>&1`) {
+		t.Fatalf("missing root new-session: %s", script)
+	}
+	if strings.Contains(script, "kill-session") || strings.Contains(script, "exit 1") {
+		t.Fatalf("single bare session should have no cleanup scaffolding: %s", script)
+	}
+}
+
+func TestUniqueGroupName(t *testing.T) {
+	existing := []tmuxSession{
+		{Name: "inst~dev"},      // root of a live group "dev"
+		{Name: "inst~dev~a1b2"}, // a pane of the same group
+		{Name: "inst~dev-2"},    // a previously-suffixed group
+		{Name: "other"},         // ungrouped, ignored
+	}
+	if got := uniqueGroupName("inst", "dev", existing); got != "dev-3" {
+		t.Fatalf("got %q, want dev-3", got)
+	}
+	if got := uniqueGroupName("inst", "fresh", existing); got != "fresh" {
+		t.Fatalf("got %q, want fresh (unused name passes through)", got)
+	}
+	// A different instance's sessions never count against this instance.
+	other := []tmuxSession{{Name: "elsewhere~dev"}}
+	if got := uniqueGroupName("inst", "dev", other); got != "dev" {
+		t.Fatalf("got %q, want dev (other instance ignored)", got)
 	}
 }
 

--- a/internal/tui/layout_preset_test.go
+++ b/internal/tui/layout_preset_test.go
@@ -70,26 +70,6 @@ func TestBuildPresetSessionScriptSinglePaneNoCleanup(t *testing.T) {
 	}
 }
 
-func TestUniqueGroupName(t *testing.T) {
-	existing := []tmuxSession{
-		{Name: "inst~dev"},      // root of a live group "dev"
-		{Name: "inst~dev~a1b2"}, // a pane of the same group
-		{Name: "inst~dev-2"},    // a previously-suffixed group
-		{Name: "other"},         // ungrouped, ignored
-	}
-	if got := uniqueGroupName("inst", "dev", existing); got != "dev-3" {
-		t.Fatalf("got %q, want dev-3", got)
-	}
-	if got := uniqueGroupName("inst", "fresh", existing); got != "fresh" {
-		t.Fatalf("got %q, want fresh (unused name passes through)", got)
-	}
-	// A different instance's sessions never count against this instance.
-	other := []tmuxSession{{Name: "elsewhere~dev"}}
-	if got := uniqueGroupName("inst", "dev", other); got != "dev" {
-		t.Fatalf("got %q, want dev (other instance ignored)", got)
-	}
-}
-
 func TestCyclePresetTemplateWrapsThroughNone(t *testing.T) {
 	page := newFleetPage()
 	page.newSession.presets = []fleet.LayoutPreset{

--- a/internal/tui/layout_preset_test.go
+++ b/internal/tui/layout_preset_test.go
@@ -26,11 +26,12 @@ func TestBuildPresetSessionScript(t *testing.T) {
 	// The first pane's command is typed literally (-l) after a "--" flag
 	// terminator (so a leading-dash command isn't parsed as a flag) then
 	// submitted; the exact (=, colon-terminated) session target prevents tmux
-	// prefix-matching from hitting inst~dev~a1.
-	if !strings.Contains(script, `tmux send-keys -t '=inst~dev:' -l -- 'npm run dev'`) {
+	// prefix-matching from hitting inst~dev~a1. send-keys also merges stderr so a
+	// failure HERE (not just at new-session) surfaces its reason, not "exit 1".
+	if !strings.Contains(script, `tmux send-keys -t '=inst~dev:' -l -- 'npm run dev' 2>&1`) {
 		t.Fatalf("missing literal send-keys: %s", script)
 	}
-	if !strings.Contains(script, `tmux send-keys -t '=inst~dev:' Enter`) {
+	if !strings.Contains(script, `tmux send-keys -t '=inst~dev:' Enter 2>&1`) {
 		t.Fatalf("missing Enter send-keys: %s", script)
 	}
 	// The empty second command must not produce a send-keys for that pane.

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -199,10 +199,10 @@ type presetSessionsCreatedMsg struct {
 // already exists), the script exits immediately and the cleanup never runs, so a
 // pre-existing session is left untouched — never killed. Only once the root is
 // ours does the rest run; if any later step fails, the cleanup tears down the
-// root plus its panes. The caller picked the root name with uniqueGroupName, so
-// the whole "<inst>~<group>~*" namespace was free to begin with — the kills can
-// only hit sessions this run made, never a live group — and a partial chain
-// can't strand a root that would collide forever on retry. Every tmux step uses
+// root plus its panes. The caller mints the root under a fresh random group id,
+// so the whole "<inst>~<group>~*" namespace is this run's — the kills can only
+// hit sessions this run made, never a live group — and a partial chain can't
+// strand a root that would collide forever on retry. Every tmux step uses
 // 2>&1 so a failure at ANY step (not just new-session) keeps its reason (e.g.
 // "duplicate session: NAME") for runSessionScript to surface, instead of a bare
 // "exit status 1".

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -115,19 +115,34 @@ func ensureSessionsLoaded(m *model, ref InstanceRef) {
 // create scripts merge tmux's stderr into stdout (2>&1) so a captured reason
 // (e.g. "duplicate session: NAME") rides along here instead of being lost to a
 // bare "exit status 1" — the single biggest diagnosability win for the TUI,
-// which otherwise swallowed why a session failed to create.
+// which otherwise swallowed why a session failed to create. Only the LAST
+// non-empty line is surfaced: that's the actual failing command's message,
+// dropping any TmuxEnsureInstalled "==> Installing tmux..." preamble (while
+// still surfacing a real "ERROR: failed to install tmux", which is the last
+// line in that case).
 func runSessionScript(ref InstanceRef, script string) (string, error) {
 	out, code, err := runInstanceCommand(ref.Fleet, ref.Instance, []string{"sh", "-c", script})
 	if err != nil {
 		return out, err
 	}
 	if code != 0 {
-		if reason := strings.TrimSpace(out); reason != "" {
+		if reason := lastNonEmptyLine(out); reason != "" {
 			return out, fmt.Errorf("exit status %d: %s", code, reason)
 		}
 		return out, fmt.Errorf("exit status %d", code)
 	}
 	return out, nil
+}
+
+// lastNonEmptyLine returns the last non-blank line of s (trimmed), or "".
+func lastNonEmptyLine(s string) string {
+	lines := strings.Split(s, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if t := strings.TrimSpace(lines[i]); t != "" {
+			return t
+		}
+	}
+	return ""
 }
 
 // sessionCreatedMsg is sent after creating a new tmux session.
@@ -199,10 +214,11 @@ type presetSessionsCreatedMsg struct {
 // already exists), the script exits immediately and the cleanup never runs, so a
 // pre-existing session is left untouched — never killed. Only once the root is
 // ours does the rest run; if any later step fails, the cleanup tears down the
-// root plus its panes. The caller mints the root under a fresh random group id,
-// so the whole "<inst>~<group>~*" namespace is this run's — the kills can only
-// hit sessions this run made, never a live group — and a partial chain can't
-// strand a root that would collide forever on retry. Every tmux step uses
+// root plus its panes by EXACT "=name:" target. The caller picked a group id
+// that was free (groupIDFor), so nothing pre-existed under "<inst>~<group>~*" —
+// the kills can only hit sessions this run made, never a live group — and a
+// partial chain can't strand a root that would collide forever on retry. Every
+// tmux step uses
 // 2>&1 so a failure at ANY step (not just new-session) keeps its reason (e.g.
 // "duplicate session: NAME") for runSessionScript to surface, instead of a bare
 // "exit status 1".

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -117,9 +117,10 @@ func ensureSessionsLoaded(m *model, ref InstanceRef) {
 // bare "exit status 1" — the single biggest diagnosability win for the TUI,
 // which otherwise swallowed why a session failed to create. Only the LAST
 // non-empty line is surfaced: that's the actual failing command's message,
-// dropping any TmuxEnsureInstalled "==> Installing tmux..." preamble (while
-// still surfacing a real "ERROR: failed to install tmux", which is the last
-// line in that case).
+// dropping any TmuxEnsureInstalled "==> Installing tmux..." preamble. (If the
+// install itself fails, TmuxEnsureInstalled falls through to `tmux new-session`,
+// which then fails with e.g. "tmux: not found" — that becomes the last line, so
+// a missing-tmux failure still reads usefully.)
 func runSessionScript(ref InstanceRef, script string) (string, error) {
 	out, code, err := runInstanceCommand(ref.Fleet, ref.Instance, []string{"sh", "-c", script})
 	if err != nil {

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -198,12 +198,14 @@ type presetSessionsCreatedMsg struct {
 // The root is created first and on its own: if THAT fails (e.g. the group name
 // already exists), the script exits immediately and the cleanup never runs, so a
 // pre-existing session is left untouched — never killed. Only once the root is
-// ours does the rest run; if any later step fails, the cleanup tears down every
-// session this run created (the root plus the random-suffixed panes — all names
-// unique to this attempt), so a partial chain can't strand a root that would
-// collide forever on retry. 2>&1 keeps tmux's failure reason (e.g. "duplicate
-// session: NAME") so runSessionScript can surface it instead of a bare "exit
-// status 1".
+// ours does the rest run; if any later step fails, the cleanup tears down the
+// root plus its panes. The caller picked the root name with uniqueGroupName, so
+// the whole "<inst>~<group>~*" namespace was free to begin with — the kills can
+// only hit sessions this run made, never a live group — and a partial chain
+// can't strand a root that would collide forever on retry. Every tmux step uses
+// 2>&1 so a failure at ANY step (not just new-session) keeps its reason (e.g.
+// "duplicate session: NAME") for runSessionScript to surface, instead of a bare
+// "exit status 1".
 //
 // send-keys targets use "=<name>:" — exact session match (the group's pane names
 // extend the root name, so prefix matching would be ambiguous) and the trailing
@@ -221,8 +223,8 @@ func buildPresetSessionScript(sessions []string, commands []string) string {
 	sendKeys := func(name, command string) []string {
 		target := shQuote("=" + name + ":")
 		return []string{
-			fmt.Sprintf("tmux send-keys -t %s -l -- %s", target, shQuote(command)),
-			fmt.Sprintf("tmux send-keys -t %s Enter", target),
+			fmt.Sprintf("tmux send-keys -t %s -l -- %s 2>&1", target, shQuote(command)),
+			fmt.Sprintf("tmux send-keys -t %s Enter 2>&1", target),
 		}
 	}
 

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -111,13 +111,20 @@ func ensureSessionsLoaded(m *model, ref InstanceRef) {
 
 // runSessionScript runs a shell one-liner inside ref's container and folds a
 // non-zero exit into the returned error — matching the semantics of the old
-// local cmd.Run()/cmd.Output() call sites these commands were built on.
+// local cmd.Run()/cmd.Output() call sites these commands were built on. The
+// create scripts merge tmux's stderr into stdout (2>&1) so a captured reason
+// (e.g. "duplicate session: NAME") rides along here instead of being lost to a
+// bare "exit status 1" — the single biggest diagnosability win for the TUI,
+// which otherwise swallowed why a session failed to create.
 func runSessionScript(ref InstanceRef, script string) (string, error) {
 	out, code, err := runInstanceCommand(ref.Fleet, ref.Instance, []string{"sh", "-c", script})
 	if err != nil {
 		return out, err
 	}
 	if code != 0 {
+		if reason := strings.TrimSpace(out); reason != "" {
+			return out, fmt.Errorf("exit status %d: %s", code, reason)
+		}
 		return out, fmt.Errorf("exit status %d", code)
 	}
 	return out, nil
@@ -157,7 +164,10 @@ type sessionDeletedMsg struct {
 // path) and then creates a detached session inside the container.
 func createSessionCmd(ref InstanceRef, sessionName string) tea.Cmd {
 	return func() tea.Msg {
-		script := tmuxEnsureInstalled + fmt.Sprintf(`tmux new-session -d -s %s 2>/dev/null`, shQuote(sessionName))
+		// 2>&1 (not 2>/dev/null): on a name collision tmux exits 1 with
+		// "duplicate session: NAME" on stderr — keep it so runSessionScript can
+		// surface the reason instead of a bare "exit status 1".
+		script := tmuxEnsureInstalled + fmt.Sprintf(`tmux new-session -d -s %s 2>&1`, shQuote(sessionName))
 		if _, err := runSessionScript(ref, script); err != nil {
 			return sessionCreatedMsg{ref: ref, err: err}
 		}
@@ -178,30 +188,69 @@ type presetSessionsCreatedMsg struct {
 
 // buildPresetSessionScript builds the in-container one-liner that mints a
 // preset's tmux sessions and types each pane's startup command into its
-// session. Steps are chained with && so a failure (e.g. a name collision on
-// the first new-session) stops the script instead of minting a partial group
-// silently. send-keys targets use "=<name>:" — exact session match (the
-// group's pane names extend the root name, so prefix matching would be
-// ambiguous) and the trailing ":" makes it a session target; a bare "=<name>"
-// fails target-pane parsing ("can't find pane") on tmux 3.x. -l sends the
-// command literally so key names inside it (e.g. "Enter") are not interpreted,
-// and the "--" terminates send-keys' own flag parsing so a command beginning
-// with "-" (e.g. "-rf ...") is not mistaken for a flag (which would fail the
-// step and abort the whole && chain).
+// session.
+//
+// Shape:
+//
+//	tmux new-session -d -s ROOT 2>&1 || exit 1
+//	{ <root send-keys> && <pane new-sessions + send-keys> } || { <kill them all>; exit 1 }
+//
+// The root is created first and on its own: if THAT fails (e.g. the group name
+// already exists), the script exits immediately and the cleanup never runs, so a
+// pre-existing session is left untouched — never killed. Only once the root is
+// ours does the rest run; if any later step fails, the cleanup tears down every
+// session this run created (the root plus the random-suffixed panes — all names
+// unique to this attempt), so a partial chain can't strand a root that would
+// collide forever on retry. 2>&1 keeps tmux's failure reason (e.g. "duplicate
+// session: NAME") so runSessionScript can surface it instead of a bare "exit
+// status 1".
+//
+// send-keys targets use "=<name>:" — exact session match (the group's pane names
+// extend the root name, so prefix matching would be ambiguous) and the trailing
+// ":" makes it a session target; a bare "=<name>" fails target-pane parsing
+// ("can't find pane") on tmux 3.x. -l sends the command literally so key names
+// inside it (e.g. "Enter") are not interpreted, and the "--" terminates
+// send-keys' own flag parsing so a command beginning with "-" (e.g. "-rf ...")
+// is not mistaken for a flag.
 func buildPresetSessionScript(sessions []string, commands []string) string {
-	var b strings.Builder
-	b.WriteString(tmuxEnsureInstalled)
-	for i, name := range sessions {
-		if i > 0 {
-			b.WriteString(" && ")
-		}
-		fmt.Fprintf(&b, `tmux new-session -d -s %s 2>/dev/null`, shQuote(name))
-		if i < len(commands) && commands[i] != "" {
-			target := shQuote("=" + name + ":")
-			fmt.Fprintf(&b, ` && tmux send-keys -t %s -l -- %s && tmux send-keys -t %s Enter`,
-				target, shQuote(commands[i]), target)
+	if len(sessions) == 0 {
+		return ""
+	}
+	root := sessions[0]
+
+	sendKeys := func(name, command string) []string {
+		target := shQuote("=" + name + ":")
+		return []string{
+			fmt.Sprintf("tmux send-keys -t %s -l -- %s", target, shQuote(command)),
+			fmt.Sprintf("tmux send-keys -t %s Enter", target),
 		}
 	}
+
+	// Steps that run only after the root session exists.
+	var inner []string
+	if len(commands) > 0 && commands[0] != "" {
+		inner = append(inner, sendKeys(root, commands[0])...)
+	}
+	for i := 1; i < len(sessions); i++ {
+		inner = append(inner, fmt.Sprintf(`tmux new-session -d -s %s 2>&1`, shQuote(sessions[i])))
+		if i < len(commands) && commands[i] != "" {
+			inner = append(inner, sendKeys(sessions[i], commands[i])...)
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString(tmuxEnsureInstalled)
+	fmt.Fprintf(&b, `tmux new-session -d -s %s 2>&1`, shQuote(root))
+	if len(inner) == 0 {
+		return b.String()
+	}
+
+	kills := make([]string, 0, len(sessions))
+	for _, name := range sessions {
+		kills = append(kills, fmt.Sprintf("tmux kill-session -t %s 2>/dev/null", shQuote("="+name+":")))
+	}
+	fmt.Fprintf(&b, " || exit 1\n{ %s; } || { %s; exit 1; }",
+		strings.Join(inner, " && "), strings.Join(kills, "; "))
 	return b.String()
 }
 

--- a/internal/tui/sessions_test.go
+++ b/internal/tui/sessions_test.go
@@ -25,6 +25,24 @@ func TestRunSessionScriptSurfacesReason(t *testing.T) {
 	}
 }
 
+// The TmuxEnsureInstalled "==> Installing tmux..." preamble (now on stdout via
+// 2>&1) must not bury the real reason: only the last non-empty line is surfaced.
+func TestRunSessionScriptDropsInstallPreamble(t *testing.T) {
+	orig := runInstanceCommand
+	defer func() { runInstanceCommand = orig }()
+
+	runInstanceCommand = func(_, _ string, _ []string) (string, int, error) {
+		return "==> Installing tmux...\nduplicate session: inst~dev\n", 1, nil
+	}
+	_, err := runSessionScript(InstanceRef{Fleet: "f", Instance: "inst"}, "ignored")
+	if err == nil || !strings.Contains(err.Error(), "duplicate session: inst~dev") {
+		t.Fatalf("reason not surfaced: %v", err)
+	}
+	if strings.Contains(err.Error(), "Installing tmux") {
+		t.Fatalf("install preamble leaked into error: %v", err)
+	}
+}
+
 // With no captured output the error is still the plain exit code (e.g. rename /
 // delete scripts that keep 2>/dev/null), not "exit status 1: ".
 func TestRunSessionScriptBareExitWhenSilent(t *testing.T) {

--- a/internal/tui/sessions_test.go
+++ b/internal/tui/sessions_test.go
@@ -1,0 +1,56 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// runSessionScript must fold a non-zero tmux exit into an error that CARRIES the
+// captured reason (create scripts merge stderr via 2>&1), so the TUI shows
+// "duplicate session: NAME" instead of a bare "exit status 1".
+func TestRunSessionScriptSurfacesReason(t *testing.T) {
+	orig := runInstanceCommand
+	defer func() { runInstanceCommand = orig }()
+
+	runInstanceCommand = func(_, _ string, _ []string) (string, int, error) {
+		return "duplicate session: inst~dev\n", 1, nil
+	}
+	_, err := runSessionScript(InstanceRef{Fleet: "f", Instance: "inst"}, "ignored")
+	if err == nil {
+		t.Fatal("expected an error on non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "duplicate session: inst~dev") {
+		t.Fatalf("error dropped the reason: %v", err)
+	}
+}
+
+// With no captured output the error is still the plain exit code (e.g. rename /
+// delete scripts that keep 2>/dev/null), not "exit status 1: ".
+func TestRunSessionScriptBareExitWhenSilent(t *testing.T) {
+	orig := runInstanceCommand
+	defer func() { runInstanceCommand = orig }()
+
+	runInstanceCommand = func(_, _ string, _ []string) (string, int, error) {
+		return "", 1, nil
+	}
+	_, err := runSessionScript(InstanceRef{Fleet: "f", Instance: "inst"}, "ignored")
+	if err == nil || err.Error() != "exit status 1" {
+		t.Fatalf("got %v, want bare \"exit status 1\"", err)
+	}
+}
+
+// A transport/start failure (err != nil) is returned verbatim, untouched by the
+// exit-code folding.
+func TestRunSessionScriptPropagatesTransportError(t *testing.T) {
+	orig := runInstanceCommand
+	defer func() { runInstanceCommand = orig }()
+
+	boom := errors.New("dial: connection refused")
+	runInstanceCommand = func(_, _ string, _ []string) (string, int, error) {
+		return "", 0, boom
+	}
+	if _, err := runSessionScript(InstanceRef{Fleet: "f", Instance: "inst"}, "ignored"); !errors.Is(err, boom) {
+		t.Fatalf("got %v, want the transport error", err)
+	}
+}


### PR DESCRIPTION
## Problem

Creating a tmux session from the TUI could fail with an opaque **`Error Creating Session: Exit code 1`**. For **layout presets** the failure was *persistent* — it stuck around, and (unlike the single-session case) **restarting fleetd did not clear it**.

## Root cause

- **The reason was swallowed.** Every TUI create ran `tmux new-session ... 2>/dev/null`. On a name collision tmux exits 1 with `duplicate session: NAME` on stderr — `2>/dev/null` threw that away, leaving only a bare `exit status 1`. (The CLI/MCP paths never suppressed it, which is why only the TUI was undiagnosable.)
- **Layouts collide on a fixed name with no cleanup.** A layout's group root is named after the preset (`<inst>~<presetName>`), and `buildPresetSessionScript` chained panes with `&&`. If any step failed, the root it already created was left behind — and the error handler did no cleanup. Because the name is fixed and tmux sessions live in the **container** (not fleetd), every retry re-collided on the identical name *forever*; a daemon restart couldn't help.

Single-session creates dodged permanence because their auto-name varies; layout names don't.

## Fix (P0 only)

1. **Surface the reason** — create `new-session` *and* `send-keys` steps use `2>&1`, and `runSessionScript` folds the captured output's **last non-empty line** into the error (dropping any `==> Installing tmux...` preamble). The status line now shows `duplicate session: <name>` instead of `exit status 1`.
2. **No more permanent collision** — `groupIDFor` keeps the readable preset/typed group name **when its group id is free**, and falls back to a **fresh random id** only when that group already exists. So a first apply reads as `dev` (test `290` types `fromtpl` and asserts `alpha~fromtpl` — preserved), while a re-apply / leftover mints a random id and succeeds instead of colliding forever. A random fallback (rather than `dev-2`) also avoids minting a name that prefix-matches a sibling group in the prefix-based group ops.
3. **Transactional preset script** — the root is created on its own with `|| exit 1` (so a **pre-existing** root is never touched), then the rest runs in a group that, on any failure, kills exactly the sessions *this run* created (by exact `=name:` target). No stranded root; no killing a live group.

## Testing

- Unit: `TestBuildPresetSessionScript` (+ single-pane no-cleanup), `TestGroupIDFor`, `TestRunSessionScript*` (reason surfaced / install-preamble dropped / bare exit / transport-error passthrough).
- Verified the **real generated script** against live tmux 3.3a (isolated socket): clean create; duplicate fails loud *and preserves the existing root*; mid-chain failure tears down only this run's root.
- `go build ./...` + full non-integration `go test` green; CI green (unit + 7 integration shards incl. `290_tui_layout_preset`); automated QA 7/7.

## Scope

P0 only. **Deferred to P1** (owner's call):
1. `nextSessionName` always returns `session-2` (matches a bare `session-` prefix against grouped cache names).
2. Self-correcting container-user probe (create runs as the devcontainer `remoteUser`; the poller pins a possibly-different user for the daemon's lifetime).
3. **Boundary-aware group matching** — the group ops match membership by raw prefix (`HasPrefix(name, "<inst>~<gid>")`), so readable layout-group names can't safely survive a re-apply (hence the random-id fallback here). Fixing this would also let re-applied presets keep readable names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)