### PR TITLE
fix(devcontainer): resolve containerUser from the authoritative remoteUser

### DIFF
--- a/integration/common.sh
+++ b/integration/common.sh
@@ -43,6 +43,12 @@ FIXTURE_LAUNCH_SRC="${INTEGRATION_DIR}/fixture-launch"
 # launches the agent with the prompt.
 FIXTURE_AUTOMATION_SRC="${INTEGRATION_DIR}/fixture-automation"
 
+# Alternate fixture whose postCreate adds a second container user `app` (with a
+# home dir that sorts before /home/vscode). Tests opt into it via
+# setup_twouser_test to prove the containerUser resolution picks the devcontainer
+# remoteUser regardless of which user holds a tmux socket / sorts first.
+FIXTURE_TWOUSER_SRC="${INTEGRATION_DIR}/fixture-twouser"
+
 # Test scratch dir created fresh per test.
 TEST_SCRATCH_DIR="${TEST_SCRATCH_DIR:-/tmp/fleet-man-itest}"
 
@@ -224,6 +230,14 @@ setup_agent_test() {
 # verify an agent actually launches with its prompt.
 setup_automation_test() {
   FIXTURE_SRC="${FIXTURE_AUTOMATION_SRC}" setup_test
+}
+
+# setup_twouser_test prepares a clean environment whose fixture provisions a
+# second container user (`app`) alongside the vscode remoteUser, so a test can
+# verify fleet's session listing resolves the remoteUser even when another user
+# holds a tmux socket. Identical to setup_test but uses the two-user fixture.
+setup_twouser_test() {
+  FIXTURE_SRC="${FIXTURE_TWOUSER_SRC}" setup_test
 }
 
 # setup_launch_test prepares a clean environment whose fixture

--- a/integration/fixture-twouser/.devcontainer/devcontainer.json
+++ b/integration/fixture-twouser/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "name": "fleet-man two-user fixture",
+  "image": "mcr.microsoft.com/devcontainers/base:debian-12",
+  "remoteUser": "vscode",
+  "postCreateCommand": "sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends tmux && sudo useradd -m -u 4001 app"
+}

--- a/integration/tests/255_tui_session_two_users.sh
+++ b/integration/tests/255_tui_session_two_users.sh
@@ -13,12 +13,14 @@ itest_begin
 # or created sessions land on a socket the poll never reads.
 #
 # The old containerUser() guessed: first /tmp/tmux-[1-9]*/ owner, else first
-# /home/<user> owner. With /home/app sorting before /home/vscode — and app also
-# holding its own tmux socket below — that guess latches onto `app` and is cached
-# forever, so the (vscode) session fleet creates would never appear in the list.
-# The fix resolves the real remoteUser (vscode) from the devcontainer.metadata
-# label, so neither sort order nor socket timing can mislead it. This test fails
-# on the old code (session row never renders) and passes on the fix.
+# /home/<user> owner. The poison is timing: `app` brings up its tmux server and
+# the sleep below lets fleetd's poll resolve+cache the user from app's socket
+# (and, before any socket exists, the /home/app fallback that sorts ahead of
+# /home/vscode) BEFORE fleet's own vscode session socket exists. That cached
+# `app` then sticks, so the (vscode) session fleet creates is listed against
+# app's socket and never renders. The fix resolves the real remoteUser (vscode)
+# from the devcontainer.metadata label, so neither socket timing nor sort order
+# can mislead it. This test fails on the old code and passes on the fix.
 setup_twouser_test
 fleet_up alpha
 

--- a/integration/tests/255_tui_session_two_users.sh
+++ b/integration/tests/255_tui_session_two_users.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Description: TUI session list resolves the devcontainer remoteUser even when a second container user holds a tmux socket (containerUser regression)
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+# The two-user fixture provisions an `app` user (uid 4001, /home/app) next to the
+# vscode remoteUser. tmux server sockets are per-uid (/tmp/tmux-<uid>/), so the
+# server's session poll (docker exec -u $(containerUser)) and the session-create
+# path (devcontainer exec, runs as the vscode remoteUser) MUST agree on the user
+# or created sessions land on a socket the poll never reads.
+#
+# The old containerUser() guessed: first /tmp/tmux-[1-9]*/ owner, else first
+# /home/<user> owner. With /home/app sorting before /home/vscode — and app also
+# holding its own tmux socket below — that guess latches onto `app` and is cached
+# forever, so the (vscode) session fleet creates would never appear in the list.
+# The fix resolves the real remoteUser (vscode) from the devcontainer.metadata
+# label, so neither sort order nor socket timing can mislead it. This test fails
+# on the old code (session row never renders) and passes on the fix.
+setup_twouser_test
+fleet_up alpha
+
+# The single provisioned instance's container id (same source as test 360).
+container_id=$(grep -oE '"container_id":[[:space:]]*"[^"]+"' "${HOME}/.fleet/state.json" \
+  | head -1 | grep -oE '"[^"]+"$' | tr -d '"')
+[ -n "${container_id}" ] || fail "could not read container_id from state.json"
+info "container_id = ${container_id}"
+
+info "second user (app) starts its own tmux server first — the poison"
+docker exec -u app "${container_id}" sh -c 'tmux new-session -d -s appsess sleep 600'
+
+# Let fleetd's ~1s session poll probe (and, on the old code, cache the wrong
+# user) before fleet's own session exists.
+sleep 3
+
+info "spawning TUI"
+tui_spawn
+tui_wait_for "alpha" 15
+tui_wait_for "○ idle" 60
+
+info "expanding the instance session list"
+tui_send j
+sleep 0.5
+tui_send Space
+tui_wait_for "+ new session" 15
+
+info "creating a fleet session (runs as the vscode remoteUser)"
+tui_send a
+tui_wait_for "session-name (or empty for auto)" 5
+tui_send_text "mysession"
+sleep 0.3
+tui_send Enter
+tui_wait_for "Session created" 15
+
+# The session row is sourced from fleetd's poll (docker exec -u containerUser).
+# It only renders if containerUser resolved to vscode — the session's owner — and
+# not to app. This is the regression guard.
+info "session must appear in the poll-fed list despite app's competing socket"
+tui_wait_for "○ mysession" 20
+tui_assert_contains "mysession" "fleet session invisible — containerUser resolved to the wrong user"
+
+# app's foreign session lives under app's socket; fleet lists only its
+# remoteUser's sessions, so it must not leak in.
+tui_assert_not_contains "appsess" "a second user's tmux session leaked into fleet's list"
+
+pass "session list resolves remoteUser despite a second user's tmux socket"

--- a/internal/backend/devcontainer/clone.go
+++ b/internal/backend/devcontainer/clone.go
@@ -26,6 +26,10 @@ const cloneImageLabel = "fleet.clone.image"
 const (
 	devcontainerLocalFolderLabel = "devcontainer.local_folder"
 	devcontainerConfigFileLabel  = "devcontainer.config_file"
+	// devcontainerMetadataLabel holds the JSON array of merged devcontainer
+	// metadata (image + features + devcontainer.json) the CLI stamps at up
+	// time. Its remoteUser is the user `devcontainer exec` operates as.
+	devcontainerMetadataLabel = "devcontainer.metadata"
 )
 
 // inspectedContainer holds just the fields Clone needs from
@@ -151,6 +155,53 @@ func inspectContainer(containerID string) (*inspectedContainer, error) {
 		return nil, fmt.Errorf("docker inspect returned no entries")
 	}
 	return &inspected[0], nil
+}
+
+// remoteUserFromMetadata returns the devcontainer remoteUser recorded in the
+// container's devcontainer.metadata label, or "" when the container has no such
+// label / it carries no user. Pure `docker inspect`, so it is cheap enough for
+// the session poll path.
+func remoteUserFromMetadata(containerID string) string {
+	inspected, err := inspectContainer(containerID)
+	if err != nil || inspected.Config.Labels == nil {
+		return ""
+	}
+	return remoteUserFromMetadataJSON(inspected.Config.Labels[devcontainerMetadataLabel])
+}
+
+// remoteUserFromMetadataJSON extracts the effective remoteUser from a
+// devcontainer.metadata label value — the JSON array of merged metadata entries
+// (base image, then each feature, then the user's devcontainer.json last).
+// Scalars merge by array order with later entries winning, so the effective
+// user is the LAST non-empty remoteUser; absent any remoteUser it falls back to
+// the last non-empty containerUser (what the CLI itself defaults exec to).
+// Returns "" for an empty/unparseable label or one that names neither.
+func remoteUserFromMetadataJSON(raw string) string {
+	if strings.TrimSpace(raw) == "" {
+		return ""
+	}
+	var entries []struct {
+		RemoteUser    string `json:"remoteUser"`
+		ContainerUser string `json:"containerUser"`
+	}
+	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+		return ""
+	}
+	user := ""
+	for _, e := range entries {
+		if e.RemoteUser != "" {
+			user = e.RemoteUser
+		}
+	}
+	if user != "" {
+		return user
+	}
+	for _, e := range entries {
+		if e.ContainerUser != "" {
+			user = e.ContainerUser
+		}
+	}
+	return user
 }
 
 // rebaseConfigFileLabel computes the destination's

--- a/internal/backend/devcontainer/containeruser_test.go
+++ b/internal/backend/devcontainer/containeruser_test.go
@@ -1,0 +1,40 @@
+package devcontainer
+
+import "testing"
+
+func TestRemoteUserFromMetadataJSON(t *testing.T) {
+	// Trimmed from a real devcontainer.metadata label: remoteUser is declared
+	// on one feature entry, the user's own config (last) declares none.
+	realLabel := `[ {"id":"ghcr.io/devcontainers/features/common-utils:2"},` +
+		` {"id":"ghcr.io/devcontainers/features/node:1"},` +
+		` {"customizations":{"vscode":{"extensions":["ms-dotnettools.csharp"]}},"remoteUser":"vscode"},` +
+		` {"id":"ghcr.io/devcontainers/features/github-cli:1"},` +
+		` {"postCreateCommand":"./.devcontainer/postCreate.sh","customizations":{"vscode":{"extensions":["anthropic.claude-code"]}}} ]`
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"real label", realLabel, "vscode"},
+		{"empty", "", ""},
+		{"whitespace", "   ", ""},
+		{"malformed", "[ not json", ""},
+		{"no users", `[{"id":"a"},{"id":"b"}]`, ""},
+		{"single remoteUser", `[{"remoteUser":"node"}]`, "node"},
+		// Later array entries override earlier ones (devcontainer.json is last).
+		{"last remoteUser wins", `[{"remoteUser":"vscode"},{"remoteUser":"root"}]`, "root"},
+		// containerUser is the fallback when no entry names a remoteUser.
+		{"containerUser fallback", `[{"containerUser":"app"}]`, "app"},
+		{"remoteUser beats containerUser", `[{"containerUser":"app","remoteUser":"vscode"}]`, "vscode"},
+		{"last containerUser wins", `[{"containerUser":"app"},{"containerUser":"dev"}]`, "dev"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := remoteUserFromMetadataJSON(tt.raw); got != tt.want {
+				t.Errorf("remoteUserFromMetadataJSON() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/backend/devcontainer/containeruser_test.go
+++ b/internal/backend/devcontainer/containeruser_test.go
@@ -38,3 +38,20 @@ func TestRemoteUserFromMetadataJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestLooksLikeUsername(t *testing.T) {
+	valid := []string{"vscode", "root", "app", "node-dev", "user_1", "ubuntu"}
+	for _, s := range valid {
+		if !looksLikeUsername(s) {
+			t.Errorf("looksLikeUsername(%q) = false, want true", s)
+		}
+	}
+	// Empty, whitespace (banner noise), and unsubstituted templates must be
+	// rejected so they never get cached and routed to `docker exec -u`.
+	invalid := []string{"", "  ", "two words", "name\twith\ttab", "${localEnv:USER}", "${containerEnv:FOO}", "line1\nvscode"}
+	for _, s := range invalid {
+		if looksLikeUsername(s) {
+			t.Errorf("looksLikeUsername(%q) = true, want false", s)
+		}
+	}
+}

--- a/internal/backend/devcontainer/devcontainer_backend.go
+++ b/internal/backend/devcontainer/devcontainer_backend.go
@@ -22,12 +22,21 @@ type DevcontainerBackend struct {
 	verbose bool
 
 	userCache   map[string]string
+	userMissAt  map[string]time.Time // last failed user resolution, to throttle re-resolves
 	userCacheMu sync.Mutex
 }
 
+// userResolveRetryInterval throttles re-resolving a container whose user
+// couldn't be determined, so a persistently-unresolvable container can't make
+// the per-second poll re-spawn the resolution subprocesses every tick.
+const userResolveRetryInterval = 15 * time.Second
+
 // New creates a new DevcontainerBackend.
 func New(opts ...Option) *DevcontainerBackend {
-	devcontainerBackend := &DevcontainerBackend{userCache: make(map[string]string)}
+	devcontainerBackend := &DevcontainerBackend{
+		userCache:  make(map[string]string),
+		userMissAt: make(map[string]time.Time),
+	}
 	for _, opt := range opts {
 		opt(devcontainerBackend)
 	}
@@ -39,26 +48,36 @@ func New(opts ...Option) *DevcontainerBackend {
 // they operate on the SAME tmux server as the `devcontainer exec` paths
 // (create/attach). That user is the devcontainer remoteUser — see
 // resolveContainerUser. The answer is cached to avoid re-resolving on every
-// poll. Only a non-empty answer is cached: an empty result (a just-started or
-// gone container, or a transient probe failure) must be re-resolved next call
-// so it self-heals. Caching "" would, now that the backend is reused across
-// poll ticks, pin every later exec to the wrong user forever.
+// poll. Only a non-empty answer is cached permanently: an empty result (a
+// just-started or gone container, or a transient probe failure) must be
+// re-resolved later so it self-heals, but re-resolution is throttled to
+// userResolveRetryInterval so a stuck container can't re-spawn the resolution
+// subprocesses every tick. Caching "" permanently would, now that the backend
+// is reused across poll ticks, pin every later exec to the wrong user forever.
 func (devcontainerBackend *DevcontainerBackend) containerUser(containerID string) string {
 	devcontainerBackend.userCacheMu.Lock()
 	if cached, ok := devcontainerBackend.userCache[containerID]; ok {
 		devcontainerBackend.userCacheMu.Unlock()
 		return cached
 	}
+	if missAt, ok := devcontainerBackend.userMissAt[containerID]; ok && time.Since(missAt) < userResolveRetryInterval {
+		devcontainerBackend.userCacheMu.Unlock()
+		return ""
+	}
 	devcontainerBackend.userCacheMu.Unlock()
 
 	user := devcontainerBackend.resolveContainerUser(containerID)
 
-	// Cache only a real answer; leave a miss uncached so the next poll re-probes.
+	devcontainerBackend.userCacheMu.Lock()
 	if user != "" {
-		devcontainerBackend.userCacheMu.Lock()
+		// Cache a real answer permanently; clear any prior miss.
 		devcontainerBackend.userCache[containerID] = user
-		devcontainerBackend.userCacheMu.Unlock()
+		delete(devcontainerBackend.userMissAt, containerID)
+	} else {
+		// Record the miss so the next ticks back off instead of re-resolving.
+		devcontainerBackend.userMissAt[containerID] = time.Now()
 	}
+	devcontainerBackend.userCacheMu.Unlock()
 	return user
 }
 
@@ -76,14 +95,26 @@ func (devcontainerBackend *DevcontainerBackend) containerUser(containerID string
 //     call, cached by the caller, never on the steady-state path. The env probe
 //     is disabled so the username is the only thing on stdout.
 //  3. the legacy ownership heuristic — last resort only.
+//
+// The authoritative answers are sanity-checked: a metadata remoteUser that isn't
+// a usable runtime username (e.g. an unsubstituted "${localEnv:USER}") is
+// rejected so it can't be cached and route every `docker exec -u` to a user that
+// doesn't exist — re-creating the very bug this resolves.
 func (devcontainerBackend *DevcontainerBackend) resolveContainerUser(containerID string) string {
-	if user := remoteUserFromMetadata(containerID); user != "" {
+	if user := remoteUserFromMetadata(containerID); looksLikeUsername(user) {
 		return user
 	}
-	if user := devcontainerBackend.remoteUserViaExec(containerID); user != "" {
+	if user := devcontainerBackend.remoteUserViaExec(containerID); looksLikeUsername(user) {
 		return user
 	}
 	return containerUserHeuristic(containerID)
+}
+
+// looksLikeUsername reports whether s is a plausible single-token Unix username:
+// non-empty, no whitespace, and free of shell-expansion leftovers like an
+// unsubstituted ${...} that a metadata template may carry.
+func looksLikeUsername(s string) bool {
+	return s != "" && !strings.ContainsAny(s, " \t\r\n") && !strings.Contains(s, "${")
 }
 
 // remoteUserViaExec asks the devcontainer CLI who it execs as. --default-user-env-probe
@@ -100,17 +131,14 @@ func (devcontainerBackend *DevcontainerBackend) remoteUserViaExec(containerID st
 	if err != nil {
 		return ""
 	}
-	// Take the last line and reject anything with whitespace: a username is a
-	// single token, so banner noise from a sourced profile can't masquerade as one.
+	// Take the last line: with --default-user-env-probe none the username is the
+	// only stdout, but this is belt-and-suspenders against a stray banner line.
+	// resolveContainerUser validates the token via looksLikeUsername.
 	out = bytes.TrimSpace(out)
 	if i := bytes.LastIndexByte(out, '\n'); i >= 0 {
 		out = bytes.TrimSpace(out[i+1:])
 	}
-	user := string(out)
-	if user == "" || strings.ContainsAny(user, " \t") {
-		return ""
-	}
-	return user
+	return string(out)
 }
 
 // containerUserHeuristic is the legacy last-resort guess: the owner of an active

--- a/internal/backend/devcontainer/devcontainer_backend.go
+++ b/internal/backend/devcontainer/devcontainer_backend.go
@@ -34,13 +34,15 @@ func New(opts ...Option) *DevcontainerBackend {
 	return devcontainerBackend
 }
 
-// containerUser returns the non-root user inside the container, caching
-// the result to avoid a docker exec round-trip on every poll. Only a
-// non-empty answer is cached: an empty probe (a just-started container with
-// no tmux socket and no /home/<user> yet, or a transient exec failure) must be
-// re-probed next call so it self-heals. Caching "" would, now that the backend
-// is reused across poll ticks, pin every later exec to root forever and hide
-// the real user's tmux sessions.
+// containerUser returns the user fleet's direct `docker exec -u` paths
+// (ListSessions, CaptureAllSessions, RunScript, AgentToolProbe) must act as so
+// they operate on the SAME tmux server as the `devcontainer exec` paths
+// (create/attach). That user is the devcontainer remoteUser — see
+// resolveContainerUser. The answer is cached to avoid re-resolving on every
+// poll. Only a non-empty answer is cached: an empty result (a just-started or
+// gone container, or a transient probe failure) must be re-resolved next call
+// so it self-heals. Caching "" would, now that the backend is reused across
+// poll ticks, pin every later exec to the wrong user forever.
 func (devcontainerBackend *DevcontainerBackend) containerUser(containerID string) string {
 	devcontainerBackend.userCacheMu.Lock()
 	if cached, ok := devcontainerBackend.userCache[containerID]; ok {
@@ -49,22 +51,7 @@ func (devcontainerBackend *DevcontainerBackend) containerUser(containerID string
 	}
 	devcontainerBackend.userCacheMu.Unlock()
 
-	// Pick the owner of an active tmux server socket directory.
-	// tmux creates /tmp/tmux-$UID/ for each user that runs a server,
-	// so this is the canonical signal for "which user holds fleet's
-	// sessions". The [1-9]* glob skips /tmp/tmux-0/ — a stale dir
-	// some images leave behind from a root-side init poke at tmux —
-	// because fleet's sessions never live under root. Fall back to
-	// the first /home/<user>/ owner when no tmux socket exists yet
-	// (brand-new container, first poll before any session).
-	cmd := exec.Command("docker", "exec", containerID, "sh", "-c",
-		`for d in /tmp/tmux-[1-9]*/; do [ -d "$d" ] && stat -c %U "$d" 2>/dev/null && exit; done; `+
-			`for d in /home/*/; do [ -d "$d" ] && stat -c %U "$d" 2>/dev/null && exit; done`)
-	out, err := cmd.Output()
-	user := ""
-	if err == nil {
-		user = strings.TrimSpace(string(out))
-	}
+	user := devcontainerBackend.resolveContainerUser(containerID)
 
 	// Cache only a real answer; leave a miss uncached so the next poll re-probes.
 	if user != "" {
@@ -73,6 +60,73 @@ func (devcontainerBackend *DevcontainerBackend) containerUser(containerID string
 		devcontainerBackend.userCacheMu.Unlock()
 	}
 	return user
+}
+
+// resolveContainerUser determines who `devcontainer exec` operates as — the
+// devcontainer remoteUser — so the direct `docker exec -u` paths run as the
+// same user and share its tmux server. Resolving the authoritative user (rather
+// than guessing it from socket ownership) is what keeps create and list from
+// landing on different per-uid tmux sockets. Tries, cheapest-and-surest first:
+//
+//  1. remoteUser from the container's `devcontainer.metadata` label — the value
+//     the CLI itself stamped at `up` time. Pure `docker inspect`, no Node, so it
+//     is safe on the per-second poll path (and runs only on a cache miss).
+//  2. `devcontainer exec ... id -un` — ground truth, asked of the CLI directly,
+//     for the rare container whose metadata carries no remoteUser. One Node
+//     call, cached by the caller, never on the steady-state path. The env probe
+//     is disabled so the username is the only thing on stdout.
+//  3. the legacy ownership heuristic — last resort only.
+func (devcontainerBackend *DevcontainerBackend) resolveContainerUser(containerID string) string {
+	if user := remoteUserFromMetadata(containerID); user != "" {
+		return user
+	}
+	if user := devcontainerBackend.remoteUserViaExec(containerID); user != "" {
+		return user
+	}
+	return containerUserHeuristic(containerID)
+}
+
+// remoteUserViaExec asks the devcontainer CLI who it execs as. --default-user-env-probe
+// none skips the login-shell env capture (faster, and keeps a noisy ~/.bashrc
+// off stdout so the username is all that comes back).
+func (devcontainerBackend *DevcontainerBackend) remoteUserViaExec(containerID string) string {
+	workspaceDir := workspaceFolderForContainer(containerID)
+	if workspaceDir == "" {
+		return ""
+	}
+	out, err := exec.Command("devcontainer",
+		"exec", "--default-user-env-probe", "none", "--workspace-folder", workspaceDir,
+		"id", "-un").Output()
+	if err != nil {
+		return ""
+	}
+	// Take the last line and reject anything with whitespace: a username is a
+	// single token, so banner noise from a sourced profile can't masquerade as one.
+	out = bytes.TrimSpace(out)
+	if i := bytes.LastIndexByte(out, '\n'); i >= 0 {
+		out = bytes.TrimSpace(out[i+1:])
+	}
+	user := string(out)
+	if user == "" || strings.ContainsAny(user, " \t") {
+		return ""
+	}
+	return user
+}
+
+// containerUserHeuristic is the legacy last-resort guess: the owner of an active
+// non-root tmux socket dir, else the first /home/<user>. It is fragile — a
+// non-fleet user that happens to hold a tmux socket (e.g. an image's `app` user
+// running its own tmux) poisons it, which is exactly why the authoritative
+// remoteUser lookups in resolveContainerUser run first. tmux creates
+// /tmp/tmux-$UID/ per user; the [1-9]* glob skips /tmp/tmux-0/ (root).
+func containerUserHeuristic(containerID string) string {
+	out, err := exec.Command("docker", "exec", containerID, "sh", "-c",
+		`for d in /tmp/tmux-[1-9]*/; do [ -d "$d" ] && stat -c %U "$d" 2>/dev/null && exit; done; `+
+			`for d in /home/*/; do [ -d "$d" ] && stat -c %U "$d" 2>/dev/null && exit; done`).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // Up provisions a devcontainer for the given workspace folder.


### PR DESCRIPTION
## The bug

In a fleet, tmux **sessions can't be opened** — the TUI reports "session created" but nothing shows up, and automation agents fail to launch (`tmux: Permission denied`, `~/.augment` write `exit 1`).

Root cause: fleet creates/attaches tmux sessions via `devcontainer exec` (which runs as the devcontainer **`remoteUser`**), but lists/captures/automation-launches them via `docker exec -u $(containerUser)`. `containerUser()` *guessed* the user from `/tmp/tmux-[1-9]*/` socket ownership — and that guess is wrong whenever a **non-fleet user holds a tmux socket**.

Confirmed live: the affected container had two tmux sockets —

```
/tmp/tmux-1000  ->  vscode   ← fleet's sessions live here
/tmp/tmux-1654  ->  app      ← image's own user, empty
```

`devcontainer exec` runs as `vscode`, so sessions land in `/tmp/tmux-1000`. But `containerUser()` latched onto `app` (its socket existed at the first probe; the answer is cached permanently), so the poll ran `docker exec -u app`, read `/tmp/tmux-1654` (empty), and showed nothing. tmux sockets are **per-uid**, so create and list landing on different users never see each other.

## The fix

Make `containerUser()` **authoritative** instead of a guess: resolve the user `devcontainer exec` itself uses, so both transports share one tmux server. The fast `docker exec` transport (poller CPU fix #182) is untouched — only *which user* it targets changes. Resolution is cached by containerID, cheapest-and-surest first:

1. **`remoteUser` from the `devcontainer.metadata` container label** — pure `docker inspect`, **no Node**, safe on the ~1s poll path (runs only on a cache miss). Effective user = last non-empty `remoteUser` in the merged-metadata array, falling back to last `containerUser`.
2. **`devcontainer exec --default-user-env-probe none id -un`** — ground truth for a container whose metadata names no user (one cached Node call, never on the steady-state path; env probe disabled so the username is all that's on stdout).
3. **the legacy socket/home-ownership heuristic** — last resort only.

Also fixes the inverse case the old heuristic mishandled: a `remoteUser: root` container, where the old comment's "fleet's sessions never live under root" assumption was simply false (create as root → `/tmp/tmux-0/`, which the heuristic explicitly skipped).

## Why not the alternatives

- *Swap create/attach onto `docker exec -u containerUser`* — would drag the interactive shells onto a transport that loses the login-shell PATH, the auto-TTY, and the workspace cwd `devcontainer exec` gives for free (behind ~15 call sites). Big blast radius, real regression surface.
- *Put `devcontainer exec` on the list path* — reintroduces the Node cold-start CPU burn that #182 deliberately removed.

This keeps both transports as-is and just makes them agree on the user.

## Test

`TestRemoteUserFromMetadataJSON` covers the parse against a real label sample plus edge cases (last-wins merge, `containerUser` fallback, malformed/empty). Full `go build ./...` + backend/server/agentdetect suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)