### PR TITLE
fix(tui): stop a session group swallowing a sibling whose ID is a prefix

### DIFF
--- a/integration/tests/265_tui_session_group_prefix.sh
+++ b/integration/tests/265_tui_session_group_prefix.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Description: Opening a session group does not pull in a sibling group whose ID is a string prefix (dog vs dog-2)
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+# Repro for the "dog shows panes from both dog and dog-2" bug. The TUI names a
+# group's sessions <instance>~<groupID> (root) and <instance>~<groupID>~<hex>
+# (panes). Group operations used to filter membership with a raw
+# strings.HasPrefix(name, "<instance>~<groupID>"), so the prefix "alpha~dog"
+# also matched the sibling group "alpha~dog-2" (and its panes). Opening "dog"
+# then split a pane for every "dog" AND "dog-2" session — the reported symptom.
+#
+# This test creates "dog" and "dog-2", opens "dog", and asserts exactly one
+# shell pane appears (2 panes total incl. the TUI). On the buggy code "dog-2"
+# leaks in as a second shell pane (3 total) and the assertion fails.
+setup_test
+fleet_up alpha
+
+info "spawning TUI"
+tui_spawn
+
+info "waiting for TUI to hydrate before any keypress"
+tui_wait_for "alpha" 15
+tui_wait_for "○ idle" 60
+
+info "moving cursor to alpha instance row and expanding its session list"
+tui_send j
+sleep 0.5
+tui_send Space
+tui_wait_for "+ new session" 15
+
+# --- create session "dog" ---
+info "creating session 'dog'"
+tui_send a
+tui_wait_for "session-name (or empty for auto)" 5
+tui_send_text "dog"
+sleep 0.3
+tui_send Enter
+tui_wait_for "Session created" 15
+tui_wait_for "○ dog" 15
+
+# --- create sibling session "dog-2" (cursor is still on the instance row) ---
+info "creating sibling session 'dog-2'"
+tui_send a
+tui_wait_for "session-name (or empty for auto)" 5
+tui_send_text "dog-2"
+sleep 0.3
+tui_send Enter
+tui_wait_for "Session created" 15
+# Wait for the dog-2 row AND for the server's ~1s poll to surface it in the
+# runtime — opening "dog" reads that runtime session list, so both sessions
+# must be live there for the bug (if present) to manifest.
+tui_wait_for "○ dog-2" 15
+sleep 2
+
+# --- open the "dog" group ---
+# Rows under the expanded instance are sorted by group ID: "dog" then "dog-2".
+# From the instance row a single 'j' lands on "dog".
+info "opening the 'dog' group"
+tui_send j
+sleep 0.5
+tui_send Enter
+
+# The split opens asynchronously; wait for it to appear.
+info "waiting for the dog split pane to open"
+opened=0
+deadline=$(( $(date +%s) + $(_scale_timeout 20) ))
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  [ "$(tui_pane_count)" -ge 2 ] && { opened=1; break; }
+  sleep 0.25
+done
+[ "${opened}" -eq 1 ] || fail "the 'dog' group never opened a split pane"
+
+# restoreGroupCmd creates every pane synchronously, so the count settles fast.
+# Give a leaked dog-2 pane time to materialize before asserting the final count.
+sleep 3
+panes="$(tui_pane_count)"
+assert_equals 2 "${panes}" \
+  "opening 'dog' produced ${panes} panes; expected 2 (TUI + dog) — the 'dog-2' group leaked in via a prefix-matched group restore"
+
+# Belt-and-suspenders: a leaked pane is titled with the dog-2 session name.
+titles="$(tmux list-panes -t "${TUI_SESSION}" -F '#{pane_title}' 2>/dev/null || true)"
+assert_not_contains "${titles}" "dog-2" \
+  "the dog-2 session leaked into the dog group's split panes (titles: ${titles})"
+
+pass "opening a session group ignores a sibling group whose ID is a prefix"

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -444,12 +444,12 @@ func (m *model) migrateRenamedSession(msg sessionRenamedMsg) {
 				bindHostSplitKeys(msg.ref.Key(), msg.newGroupID)
 			}
 		}
-		if fleetPage.split.ref == msg.ref && strings.HasPrefix(fleetPage.split.session, oldPrefix) {
+		if fleetPage.split.ref == msg.ref && sessionInGroup(sanitized, fleetPage.split.session, msg.oldGroupID) {
 			fleetPage.split.session = newPrefix + fleetPage.split.session[len(oldPrefix):]
 		}
 		if last, ok := m.sessionStore.LastActive(msg.ref); ok && last.groupID == msg.oldGroupID {
 			last.groupID = msg.newGroupID
-			if strings.HasPrefix(last.sessionName, oldPrefix) {
+			if sessionInGroup(sanitized, last.sessionName, msg.oldGroupID) {
 				last.sessionName = newPrefix + last.sessionName[len(oldPrefix):]
 			}
 			m.sessionStore.SetLastActive(msg.ref, last)
@@ -484,9 +484,10 @@ func (m *model) migrateSavedGroup(ref InstanceRef, oldGroupID, newGroupID, oldPr
 	if !ok {
 		return
 	}
+	sanitized := SanitizeSessionName(ref.Instance)
 	sessions := make([]string, len(sg.Sessions))
 	for i, name := range sg.Sessions {
-		if strings.HasPrefix(name, oldPrefix) {
+		if sessionInGroup(sanitized, name, oldGroupID) {
 			sessions[i] = newPrefix + name[len(oldPrefix):]
 		} else {
 			sessions[i] = name

--- a/internal/tui/group_prefix_test.go
+++ b/internal/tui/group_prefix_test.go
@@ -1,0 +1,184 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// These tests pin down the group-boundary bug: a session group's ID can be a
+// string prefix of a sibling group's ID (the user creates "dog" then "dog-2"),
+// and every group operation that filtered membership with a raw
+// strings.HasPrefix(name, "<inst>~<gid>") wrongly swallowed the sibling. The
+// reported symptom was opening "dog" showing the panes of both "dog" and
+// "dog-2"; the same flaw also made deleting/renaming "dog" hit "dog-2".
+
+// fourSessions is the live session list for an instance "alpha" that has two
+// sibling groups, "dog" and "dog-2", each with one extra split pane — exactly
+// the ps-output shape from the bug report.
+var fourSessions = []tmuxSession{
+	{Name: "alpha~dog"},
+	{Name: "alpha~dog~ff00"},
+	{Name: "alpha~dog-2"},
+	{Name: "alpha~dog-2~1177"},
+}
+
+func TestSessionInGroupBoundary(t *testing.T) {
+	cases := []struct {
+		name    string
+		session string
+		groupID string
+		want    bool
+	}{
+		{"root matches own group", "alpha~dog", "dog", true},
+		{"pane matches own group", "alpha~dog~ff00", "dog", true},
+		{"sibling root not in shorter group", "alpha~dog-2", "dog", false},
+		{"sibling pane not in shorter group", "alpha~dog-2~1177", "dog", false},
+		{"longer group owns its own root", "alpha~dog-2", "dog-2", true},
+		{"longer group owns its own pane", "alpha~dog-2~1177", "dog-2", true},
+		{"shorter root not in longer group", "alpha~dog", "dog-2", false},
+		{"other instance never matches", "beta~dog", "dog", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sessionInGroup("alpha", tc.session, tc.groupID); got != tc.want {
+				t.Fatalf("sessionInGroup(alpha, %q, %q) = %v, want %v", tc.session, tc.groupID, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRestoreSessionNamesExcludesSiblingPrefixGroup is the direct unit-level
+// repro of the visible bug: restoring "dog" must produce panes only for "dog",
+// never the "dog-2" sessions whose names start with "alpha~dog".
+func TestRestoreSessionNamesExcludesSiblingPrefixGroup(t *testing.T) {
+	discovered := "alpha~dog\nalpha~dog~ff00\nalpha~dog-2\nalpha~dog-2~1177\n"
+
+	got := restoreSessionNames(discovered, "dog", nil, nil, "alpha")
+	want := []string{"alpha~dog", "alpha~dog~ff00"}
+	if len(got) != len(want) {
+		t.Fatalf("restored %d sessions %#v, want %d %#v", len(got), got, len(want), want)
+	}
+	for _, name := range got {
+		if strings.HasPrefix(name, "alpha~dog-2") {
+			t.Fatalf("sibling group session leaked into the restore: %q (full set %#v)", name, got)
+		}
+	}
+}
+
+func TestSessionStillExistsBoundary(t *testing.T) {
+	cases := []struct {
+		name string
+		last lastSession
+		sess []tmuxSession
+		want bool
+	}{
+		{
+			name: "dead group not kept alive by a sibling prefix group",
+			last: lastSession{sessionName: "alpha~dog", groupID: "dog"},
+			sess: []tmuxSession{{Name: "alpha~dog-2"}, {Name: "alpha~dog-2~1177"}},
+			want: false,
+		},
+		{
+			name: "group alive via a surviving pane after the root is killed",
+			last: lastSession{sessionName: "alpha~dog", groupID: "dog"},
+			sess: []tmuxSession{{Name: "alpha~dog~ff00"}},
+			want: true,
+		},
+		{
+			name: "group alive when its own root is present",
+			last: lastSession{sessionName: "alpha~dog", groupID: "dog"},
+			sess: fourSessions,
+			want: true,
+		},
+		{
+			name: "ad-hoc bare session kept by exact-name fallthrough",
+			last: lastSession{sessionName: "foo", groupID: "foo"},
+			sess: []tmuxSession{{Name: "foo"}},
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sessionStillExists("alpha", tc.last, tc.sess); got != tc.want {
+				t.Fatalf("sessionStillExists = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// stubGroupSessionList makes runInstanceCommand answer a `tmux list-sessions`
+// with the four-session sibling fixture and records every other tmux script the
+// command runs, so a test can assert which sessions a group op touched.
+func stubGroupSessionList(t *testing.T) *[]string {
+	t.Helper()
+	orig := runInstanceCommand
+	t.Cleanup(func() { runInstanceCommand = orig })
+
+	ran := &[]string{}
+	runInstanceCommand = func(_, _ string, argv []string) (string, int, error) {
+		script := argv[len(argv)-1]
+		if strings.Contains(script, "list-sessions") {
+			return "alpha~dog\nalpha~dog~ff00\nalpha~dog-2\nalpha~dog-2~1177\n", 0, nil
+		}
+		*ran = append(*ran, script)
+		return "", 0, nil
+	}
+	return ran
+}
+
+// TestDeleteGroupSessionsCmdExcludesSiblingPrefixGroup proves the data-loss
+// variant of the bug is gone: deleting "dog" kills only the "dog" sessions and
+// leaves "dog-2" untouched.
+func TestDeleteGroupSessionsCmdExcludesSiblingPrefixGroup(t *testing.T) {
+	ran := stubGroupSessionList(t)
+
+	cmd := deleteGroupSessionsCmd(InstanceRef{Fleet: "f", Instance: "alpha"}, "alpha", "dog")
+	msg, ok := cmd().(sessionDeletedMsg)
+	if !ok {
+		t.Fatalf("expected sessionDeletedMsg")
+	}
+	if msg.err != nil {
+		t.Fatalf("unexpected error: %v", msg.err)
+	}
+
+	joined := strings.Join(*ran, "\n")
+	for _, want := range []string{shQuote("alpha~dog"), shQuote("alpha~dog~ff00")} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected %s to be killed; scripts: %v", want, *ran)
+		}
+	}
+	for _, forbidden := range []string{shQuote("alpha~dog-2"), shQuote("alpha~dog-2~1177")} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("sibling group session %s was wrongly killed; scripts: %v", forbidden, *ran)
+		}
+	}
+}
+
+// TestRenameGroupCmdExcludesSiblingPrefixGroup proves renaming "dog" reprefixes
+// only the "dog" sessions and never touches "dog-2".
+func TestRenameGroupCmdExcludesSiblingPrefixGroup(t *testing.T) {
+	ran := stubGroupSessionList(t)
+
+	cmd := renameGroupCmd(InstanceRef{Fleet: "f", Instance: "alpha"}, "alpha", "dog", "renamed")
+	msg, ok := cmd().(sessionRenamedMsg)
+	if !ok {
+		t.Fatalf("expected sessionRenamedMsg")
+	}
+	if msg.err != nil {
+		t.Fatalf("unexpected error: %v", msg.err)
+	}
+
+	joined := strings.Join(*ran, "\n")
+	// dog's root and pane get reprefixed to the new group ID.
+	for _, want := range []string{shQuote("alpha~dog"), shQuote("alpha~renamed"), shQuote("alpha~renamed~ff00")} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected %s in a rename; scripts: %v", want, *ran)
+		}
+	}
+	// dog-2 must not be a rename source.
+	for _, forbidden := range []string{shQuote("alpha~dog-2"), shQuote("alpha~dog-2~1177")} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("sibling group session %s was wrongly renamed; scripts: %v", forbidden, *ran)
+		}
+	}
+}

--- a/internal/tui/groups.go
+++ b/internal/tui/groups.go
@@ -129,9 +129,11 @@ func NewGroupPaneSessionName(sanitizedInstance, groupID string) string {
 // apply, but a re-apply (or a leftover from a prior failed apply) falls back to
 // a random id so the root never collides forever on `tmux new-session` — the
 // reported "stuck, a restart doesn't help" bug, since the session lives in the
-// container. It deliberately does NOT auto-suffix (dev-2): that would prefix-
-// match a sibling group ("dev") in the prefix-based group ops (open/rename/
-// delete) — readable names for re-applies need boundary-aware matching first.
+// container. It falls back to a random id rather than an auto-suffixed readable
+// name (dev-2): a random id is the minimal collision-free choice and keeps this
+// path simple. (The group ops now match on the group boundary — sessionInGroup,
+// not a raw string prefix — so an auto-suffixed sibling would no longer be
+// swallowed; readable auto-suffixing is therefore a safe possible future change.)
 func groupIDFor(sanitizedInstance, desired string, existing []tmuxSession) string {
 	for _, s := range existing {
 		if gid, ok := parseGroupID(sanitizedInstance, s.Name); ok && gid == desired {

--- a/internal/tui/groups.go
+++ b/internal/tui/groups.go
@@ -222,6 +222,23 @@ func isGroupedSession(sanitizedInstance, sessionName string) bool {
 	return ok
 }
 
+// sessionInGroup reports whether sessionName belongs to group groupID of the
+// given instance: its root (<inst>~<gid>) or one of its panes
+// (<inst>~<gid>~<suffix>).
+//
+// This is the boundary-aware membership test every group operation
+// (open/restore/rename/delete) must use. The naive alternative —
+// strings.HasPrefix(name, <inst>~<gid>) — also matches a sibling group whose
+// ID merely has this group's ID as a string prefix: group "dog" swallows
+// "dog-2" and "dog-2~ff00", which is exactly the reported bug where opening
+// "dog" shows the panes of both "dog" and "dog-2". parseGroupID splits on the
+// group separator, so it draws the group boundary correctly where a raw string
+// prefix does not.
+func sessionInGroup(sanitizedInstance, sessionName, groupID string) bool {
+	gid, ok := parseGroupID(sanitizedInstance, sessionName)
+	return ok && gid == groupID
+}
+
 // splitBindGroupID returns the group ID that is safe to pass to
 // `fleet shell --group` when rebinding the outer tmux split keys after
 // attaching to sessionName. It mirrors the isGroupedSession guard the

--- a/internal/tui/groups_test.go
+++ b/internal/tui/groups_test.go
@@ -322,7 +322,7 @@ func TestRestoreSessionNamesRecreatesAllWhenGroupFullyDead(t *testing.T) {
 
 	got := restoreSessionNames(
 		"",
-		"alpha~abc123",
+		"abc123",
 		sg.Sessions,
 		&sg,
 		"alpha",
@@ -353,7 +353,7 @@ func TestRestoreSessionNamesDropsDeadSessionsWhenGroupAlive(t *testing.T) {
 
 	got := restoreSessionNames(
 		"alpha~abc123\n",
-		"alpha~abc123",
+		"abc123",
 		sg.Sessions,
 		&sg,
 		"alpha",
@@ -381,7 +381,7 @@ func TestRestoreSessionNamesMergesSnapshotWithLiveGroup(t *testing.T) {
 
 	got := restoreSessionNames(
 		"alpha~abc123\nalpha~abc123~3421\nalpha~other\n",
-		"alpha~abc123",
+		"abc123",
 		nil,
 		&sg,
 		"alpha",

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -313,7 +313,10 @@ func renameGroupCmd(ref InstanceRef, sanitizedInstance, oldGroupID, newGroupID s
 		var lastErr error
 		for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
 			name := strings.TrimSpace(line)
-			if name == "" || !strings.HasPrefix(name, oldPrefix) {
+			// Boundary-aware: only rename sessions actually in oldGroupID, so a
+			// sibling group whose ID has oldGroupID as a prefix (e.g. "dog-2"
+			// vs "dog") is left untouched.
+			if name == "" || !sessionInGroup(sanitizedInstance, name, oldGroupID) {
 				continue
 			}
 			renamed := newPrefix + name[len(oldPrefix):]
@@ -354,7 +357,10 @@ func deleteGroupSessionsCmd(ref InstanceRef, sanitizedInstance, groupID string) 
 		var lastErr error
 		for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
 			name := strings.TrimSpace(line)
-			if name == "" || !strings.HasPrefix(name, prefix) {
+			// Boundary-aware: only kill sessions actually in groupID. A raw
+			// prefix match would also kill a sibling group whose ID has this
+			// one as a prefix (deleting "dog" would wrongly kill "dog-2").
+			if name == "" || !sessionInGroup(sanitizedInstance, name, groupID) {
 				continue
 			}
 			script := fmt.Sprintf(`tmux kill-session -t %s 2>/dev/null`, shQuote(name))
@@ -375,14 +381,21 @@ func deleteGroupSessionsCmd(ref InstanceRef, sanitizedInstance, groupID string) 
 
 // sessionStillExists checks whether a lastSession reference is still valid
 // against the current list of discovered tmux sessions.
-func sessionStillExists(last lastSession, sessions []tmuxSession) bool {
+//
+// For a real group the match is boundary-aware (sessionInGroup): the group is
+// alive if any of its sessions survives. The old test —
+// strings.Contains(name, "~"+groupID) — was both too loose (group "dog" stayed
+// "alive" because "alpha~dog-2" contains "~dog") and too tight (a pseudo-group
+// whose ID is a bare ad-hoc name like "foo" never matched, since "foo" has no
+// "~foo" substring). When the grouped match finds nothing we fall through to an
+// exact session-name check, which keeps that ad-hoc-session case working.
+func sessionStillExists(sanitizedInstance string, last lastSession, sessions []tmuxSession) bool {
 	if last.groupID != "" {
 		for _, session := range sessions {
-			if strings.Contains(session.Name, groupSep+last.groupID) {
+			if sessionInGroup(sanitizedInstance, session.Name, last.groupID) {
 				return true
 			}
 		}
-		return false
 	}
 	for _, session := range sessions {
 		if session.Name == last.sessionName {

--- a/internal/tui/sessionstore.go
+++ b/internal/tui/sessionstore.go
@@ -198,7 +198,7 @@ func (s *SessionStore) PruneStaleLastActive() {
 			delete(s.lastActive, ref)
 			continue
 		}
-		if !sessionStillExists(last, d.sessions) {
+		if !sessionStillExists(SanitizeSessionName(ref.Instance), last, d.sessions) {
 			delete(s.lastActive, ref)
 		}
 	}

--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -372,8 +372,7 @@ func derivePersistableSnapshot(activeGroup ActiveGroup, panes []paneByPosition, 
 		if p.title == "" {
 			return savedGroup{}, false
 		}
-		parsedGID, ok := parseGroupID(sanitized, p.title)
-		if !ok || parsedGID != groupID {
+		if !sessionInGroup(sanitized, p.title, groupID) {
 			return savedGroup{}, false
 		}
 		if seen[p.title] {
@@ -402,7 +401,7 @@ func snapshotMatchesRuntime(snapshot savedGroup, liveSessions []tmuxSession) boo
 	sanitized := SanitizeSessionName(snapshot.InstanceName)
 	live := make(map[string]bool)
 	for _, s := range liveSessions {
-		if gid, ok := parseGroupID(sanitized, s.Name); ok && gid == snapshot.GroupID {
+		if sessionInGroup(sanitized, s.Name, snapshot.GroupID) {
 			live[s.Name] = true
 		}
 	}

--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -492,12 +492,11 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 	instanceName := instance.Name
 	qualifiedName := fleetName + "/" + instanceName
 	sanitized := SanitizeSessionName(instanceName)
-	prefix := sanitized + groupSep + groupID
 
 	// The live session list comes from the server runtime (it polls tmux for all
 	// running instances), captured here on the Update goroutine and passed into
 	// the closure as newline-delimited names — the same shape the old `tmux
-	// list-sessions` exec produced, which restoreSessionNames filters by prefix.
+	// list-sessions` exec produced, which restoreSessionNames filters by group.
 	var runtimeNames []string
 	for _, s := range m.runtimeSessions(InstanceRef{Fleet: fleetName, Instance: instanceName}) {
 		runtimeNames = append(runtimeNames, s.Name)
@@ -552,7 +551,7 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 			return splitPaneMsg{restoreSeq: restoreSeq, err: fmt.Errorf("os.Executable: %w", err)}
 		}
 
-		sessions := restoreSessionNames(sessionList, prefix, savedOrder, savedSnapshot, sanitized)
+		sessions := restoreSessionNames(sessionList, groupID, savedOrder, savedSnapshot, sanitized)
 		if len(sessions) == 0 {
 			if _, ok := fleetPage.savedGroups[key]; !ok {
 				return splitPaneMsg{restoreSeq: restoreSeq, err: fmt.Errorf("no sessions found for group %s", groupID)}
@@ -681,13 +680,16 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 	}
 }
 
-func restoreSessionNames(discovered, prefix string, savedOrder []string, savedSnapshot *savedGroup, sanitized string) []string {
-	// Build a set of live sessions for validation.
+func restoreSessionNames(discovered, groupID string, savedOrder []string, savedSnapshot *savedGroup, sanitized string) []string {
+	// Build a set of live sessions for validation. Membership is
+	// boundary-aware (sessionInGroup, not a raw string prefix) so a sibling
+	// group whose ID has this group's ID as a prefix — e.g. "dog-2" when
+	// restoring "dog" — does not leak its sessions in as extra panes.
 	live := make(map[string]bool)
 	var liveOrder []string
 	for _, line := range strings.Split(strings.TrimSpace(discovered), "\n") {
 		name := strings.TrimSpace(line)
-		if name != "" && strings.HasPrefix(name, prefix) {
+		if name != "" && sessionInGroup(sanitized, name, groupID) {
 			live[name] = true
 			liveOrder = append(liveOrder, name)
 		}


### PR DESCRIPTION
## Problem

Creating two sessions where one name is a string prefix of the other — e.g. `dog` and `dog-2` — made opening `dog` show the panes of **both** `dog` and `dog-2`. From the bug report's `ps` output, a single outer-tmux window held panes attached to `…~dog`, `…~dog~fd96`, `…~dog-2`, and `…~dog-2~1177` — two groups mixed into one.

## Root cause

A group's tmux sessions are named `<instance>~<groupID>` (root) and `<instance>~<groupID>~<hex>` (panes). Group operations filtered membership with a raw `strings.HasPrefix(name, "<instance>~<groupID>")`. Because `alpha~dog` is a string prefix of `alpha~dog-2`, the group `dog` matched `dog-2`'s sessions. `parseGroupID` already splits on the group separator and draws the boundary correctly — the prefix filters just didn't use it. (The `groupIDFor` comment already flagged this exact hazard.)

## Fix

Add `sessionInGroup(sanitizedInstance, sessionName, groupID)` (built on `parseGroupID`) and route every group-membership filter through it:

- **`restoreSessionNames`** — the visible "open/restore shows both groups' panes" bug.
- **`deleteGroupSessionsCmd` / `renameGroupCmd`** — these were *data-loss / corruption*: deleting `dog` also killed `dog-2`; renaming `dog` also renamed `dog-2`.
- **`sessionStillExists`** — a dead group stayed "alive" because a sibling's name contained `~<groupID>`. The rewrite also fixes the inverse (a bare ad-hoc session whose pseudo-group ID has no `~` now matches via an exact-name fallthrough).
- **`migrateRenamedSession` / `migrateSavedGroup`** reprefix guards in `app.go`.

No change to session creation, `groupIDFor`, preset scripts, or the #158 multi-TUI snapshot logic — only the membership predicate is corrected, so the recent session fixes (#160, #165, #211, #212) are preserved.

## Tests

- **`internal/tui/group_prefix_test.go`** — unit coverage for the `dog`/`dog-2` boundary across `sessionInGroup`, `restoreSessionNames`, `sessionStillExists`, `deleteGroupSessionsCmd`, `renameGroupCmd`.
- **`integration/tests/265_tui_session_group_prefix.sh`** — end-to-end: create `dog` + `dog-2`, open `dog`, assert exactly one split pane (TUI + dog) and that no pane is titled with `dog-2`. Fails on the old code (3 panes), passes on the fix.

Existing `restoreSessionNames` tests (incl. the #158 cases) were updated to pass the group ID rather than the prebuilt prefix and still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)