### PR TITLE
fix/pr-status-track-closed: keep the PR status indicator visible (purple) for closed PRs

### DIFF
--- a/fleetgrpc/runtime.pb.go
+++ b/fleetgrpc/runtime.pb.go
@@ -589,11 +589,13 @@ type PrStatus struct {
 	// repo first, then subrepos). These are the OPEN PRs when open_count > 0,
 	// otherwise the closed/merged PRs backing the purple tag.
 	Prs []*PrRef `protobuf:"bytes,7,rep,name=prs,proto3" json:"prs,omitempty"`
-	// Closed or merged PRs counted across the repos, set only when NO PR is open
-	// (open_count 0). It keeps the tag visible in purple — matching GitHub's
-	// closed/merged colour — so a finished instance stays distinguishable from one
-	// that never had a PR. Open PRs always take priority; when both exist the open
-	// status is shown and this stays 0.
+	// Closed or merged PRs, set only when NO PR is open (open_count 0). It keeps
+	// the tag visible in purple — matching GitHub's closed/merged colour — so a
+	// finished instance stays distinguishable from one that never had a PR. This
+	// counts the most-recent closed/merged PR PER repo (so it's the number of repos
+	// with a closed-but-no-open PR), unlike open_count which sums every open PR.
+	// Open PRs always take priority; when both exist the open status is shown and
+	// this stays 0.
 	ClosedCount   int32 `protobuf:"varint,8,opt,name=closed_count,json=closedCount,proto3" json:"closed_count,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/fleetgrpc/runtime.pb.go
+++ b/fleetgrpc/runtime.pb.go
@@ -201,8 +201,10 @@ func (AgentActivity) EnumDescriptor() ([]byte, []int) {
 	return file_runtime_proto_rawDescGZIP(), []int{2}
 }
 
-// PrSignal is the three-state colour shared by the auto-tag indicators:
-// green = good, yellow = in-progress/neutral, red = needs attention.
+// PrSignal is the colour shared by the auto-tag indicators: green = good,
+// yellow = in-progress/neutral, red = needs attention, purple = the PR is closed
+// or merged (kept visible so a finished instance is distinguishable from one that
+// never had a PR), matching GitHub's own closed/merged colour.
 type PrSignal int32
 
 const (
@@ -210,6 +212,7 @@ const (
 	PrSignal_PR_SIGNAL_GREEN       PrSignal = 1
 	PrSignal_PR_SIGNAL_YELLOW      PrSignal = 2
 	PrSignal_PR_SIGNAL_RED         PrSignal = 3
+	PrSignal_PR_SIGNAL_PURPLE      PrSignal = 4
 )
 
 // Enum value maps for PrSignal.
@@ -219,12 +222,14 @@ var (
 		1: "PR_SIGNAL_GREEN",
 		2: "PR_SIGNAL_YELLOW",
 		3: "PR_SIGNAL_RED",
+		4: "PR_SIGNAL_PURPLE",
 	}
 	PrSignal_value = map[string]int32{
 		"PR_SIGNAL_UNSPECIFIED": 0,
 		"PR_SIGNAL_GREEN":       1,
 		"PR_SIGNAL_YELLOW":      2,
 		"PR_SIGNAL_RED":         3,
+		"PR_SIGNAL_PURPLE":      4,
 	}
 )
 
@@ -559,12 +564,14 @@ func (x *PrRef) GetTitle() string {
 // workspace repo PLUS any nested subrepos, computed by running `gh` inside the
 // container. It drives the "auto tag" the TUI renders in the tag slot when an
 // instance has no user-set tag. It is absent (nil) when gh is missing or
-// unauthenticated inside the instance, or when no PR is open — the TUI then
-// shows no auto-tag, preserving today's behaviour.
+// unauthenticated inside the instance, or when the branch never had a PR at all.
+// When a branch's only PR(s) are closed or merged, it stays present (open_count
+// 0, closed_count > 0) so the tag persists in purple rather than vanishing.
 type PrStatus struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Open PRs counted across the workspace repo and every subrepo. The PR
-	// indicator renders "PR" for 1 and "PRxN" for N>1; 0 means no auto-tag.
+	// indicator renders "PR" for 1 and "PRxN" for N>1; 0 means no OPEN PR (the tag
+	// is then driven by closed_count, if any).
 	OpenCount int32 `protobuf:"varint,1,opt,name=open_count,json=openCount,proto3" json:"open_count,omitempty"`
 	// Colour for the [PR]/[PRxN] indicator: green when every PR is mergeable,
 	// red on any check failure or changes-requested, yellow otherwise.
@@ -577,10 +584,17 @@ type PrStatus struct {
 	// Colour for the [Checks x/x] indicator: green when all passed, red on any
 	// failure, yellow while any are still pending.
 	ChecksSignal PrSignal `protobuf:"varint,6,opt,name=checks_signal,json=checksSignal,proto3,enum=fleetgrpc.PrSignal" json:"checks_signal,omitempty"`
-	// The open PRs themselves, so the TUI can open one in a browser (or present a
+	// The PRs themselves, so the TUI can open one in a browser (or present a
 	// chooser when there is more than one). Order follows discovery (workspace
-	// repo first, then subrepos).
-	Prs           []*PrRef `protobuf:"bytes,7,rep,name=prs,proto3" json:"prs,omitempty"`
+	// repo first, then subrepos). These are the OPEN PRs when open_count > 0,
+	// otherwise the closed/merged PRs backing the purple tag.
+	Prs []*PrRef `protobuf:"bytes,7,rep,name=prs,proto3" json:"prs,omitempty"`
+	// Closed or merged PRs counted across the repos, set only when NO PR is open
+	// (open_count 0). It keeps the tag visible in purple — matching GitHub's
+	// closed/merged colour — so a finished instance stays distinguishable from one
+	// that never had a PR. Open PRs always take priority; when both exist the open
+	// status is shown and this stays 0.
+	ClosedCount   int32 `protobuf:"varint,8,opt,name=closed_count,json=closedCount,proto3" json:"closed_count,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -662,6 +676,13 @@ func (x *PrStatus) GetPrs() []*PrRef {
 		return x.Prs
 	}
 	return nil
+}
+
+func (x *PrStatus) GetClosedCount() int32 {
+	if x != nil {
+		return x.ClosedCount
+	}
+	return 0
 }
 
 // InstanceRuntime is the live view of ONE instance: everything the TUI renders
@@ -830,7 +851,7 @@ const file_runtime_proto_rawDesc = "" +
 	"\x05PrRef\x12\x16\n" +
 	"\x06number\x18\x01 \x01(\x05R\x06number\x12\x10\n" +
 	"\x03url\x18\x02 \x01(\tR\x03url\x12\x14\n" +
-	"\x05title\x18\x03 \x01(\tR\x05title\"\xb3\x02\n" +
+	"\x05title\x18\x03 \x01(\tR\x05title\"\xd6\x02\n" +
 	"\bPrStatus\x12\x1d\n" +
 	"\n" +
 	"open_count\x18\x01 \x01(\x05R\topenCount\x120\n" +
@@ -839,7 +860,8 @@ const file_runtime_proto_rawDesc = "" +
 	"\rchecks_passed\x18\x04 \x01(\x05R\fchecksPassed\x12!\n" +
 	"\fchecks_total\x18\x05 \x01(\x05R\vchecksTotal\x128\n" +
 	"\rchecks_signal\x18\x06 \x01(\x0e2\x13.fleetgrpc.PrSignalR\fchecksSignal\x12\"\n" +
-	"\x03prs\x18\a \x03(\v2\x10.fleetgrpc.PrRefR\x03prs\"\xd4\x04\n" +
+	"\x03prs\x18\a \x03(\v2\x10.fleetgrpc.PrRefR\x03prs\x12!\n" +
+	"\fclosed_count\x18\b \x01(\x05R\vclosedCount\"\xd4\x04\n" +
 	"\x0fInstanceRuntime\x12\x14\n" +
 	"\x05fleet\x18\x01 \x01(\tR\x05fleet\x12\x1a\n" +
 	"\binstance\x18\x02 \x01(\tR\binstance\x12?\n" +
@@ -875,12 +897,13 @@ const file_runtime_proto_rawDesc = "" +
 	"\x1aAGENT_ACTIVITY_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aAGENT_ACTIVITY_NOT_RUNNING\x10\x01\x12\x1a\n" +
 	"\x16AGENT_ACTIVITY_WORKING\x10\x02\x12\x1a\n" +
-	"\x16AGENT_ACTIVITY_WAITING\x10\x03*c\n" +
+	"\x16AGENT_ACTIVITY_WAITING\x10\x03*y\n" +
 	"\bPrSignal\x12\x19\n" +
 	"\x15PR_SIGNAL_UNSPECIFIED\x10\x00\x12\x13\n" +
 	"\x0fPR_SIGNAL_GREEN\x10\x01\x12\x14\n" +
 	"\x10PR_SIGNAL_YELLOW\x10\x02\x12\x11\n" +
-	"\rPR_SIGNAL_RED\x10\x03*\x92\x01\n" +
+	"\rPR_SIGNAL_RED\x10\x03\x12\x14\n" +
+	"\x10PR_SIGNAL_PURPLE\x10\x04*\x92\x01\n" +
 	"\rPrReviewState\x12\x1f\n" +
 	"\x1bPR_REVIEW_STATE_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18PR_REVIEW_STATE_APPROVED\x10\x01\x12%\n" +

--- a/fleetgrpc/runtime.proto
+++ b/fleetgrpc/runtime.proto
@@ -83,13 +83,16 @@ message ForwardedPort {
   optional string label = 3;
 }
 
-// PrSignal is the three-state colour shared by the auto-tag indicators:
-// green = good, yellow = in-progress/neutral, red = needs attention.
+// PrSignal is the colour shared by the auto-tag indicators: green = good,
+// yellow = in-progress/neutral, red = needs attention, purple = the PR is closed
+// or merged (kept visible so a finished instance is distinguishable from one that
+// never had a PR), matching GitHub's own closed/merged colour.
 enum PrSignal {
   PR_SIGNAL_UNSPECIFIED = 0;
   PR_SIGNAL_GREEN = 1;
   PR_SIGNAL_YELLOW = 2;
   PR_SIGNAL_RED = 3;
+  PR_SIGNAL_PURPLE = 4;
 }
 
 // PrReviewState is the aggregate review decision across an instance's open PRs,
@@ -117,11 +120,13 @@ message PrRef {
 // workspace repo PLUS any nested subrepos, computed by running `gh` inside the
 // container. It drives the "auto tag" the TUI renders in the tag slot when an
 // instance has no user-set tag. It is absent (nil) when gh is missing or
-// unauthenticated inside the instance, or when no PR is open — the TUI then
-// shows no auto-tag, preserving today's behaviour.
+// unauthenticated inside the instance, or when the branch never had a PR at all.
+// When a branch's only PR(s) are closed or merged, it stays present (open_count
+// 0, closed_count > 0) so the tag persists in purple rather than vanishing.
 message PrStatus {
   // Open PRs counted across the workspace repo and every subrepo. The PR
-  // indicator renders "PR" for 1 and "PRxN" for N>1; 0 means no auto-tag.
+  // indicator renders "PR" for 1 and "PRxN" for N>1; 0 means no OPEN PR (the tag
+  // is then driven by closed_count, if any).
   int32 open_count = 1;
   // Colour for the [PR]/[PRxN] indicator: green when every PR is mergeable,
   // red on any check failure or changes-requested, yellow otherwise.
@@ -134,10 +139,17 @@ message PrStatus {
   // Colour for the [Checks x/x] indicator: green when all passed, red on any
   // failure, yellow while any are still pending.
   PrSignal checks_signal = 6;
-  // The open PRs themselves, so the TUI can open one in a browser (or present a
+  // The PRs themselves, so the TUI can open one in a browser (or present a
   // chooser when there is more than one). Order follows discovery (workspace
-  // repo first, then subrepos).
+  // repo first, then subrepos). These are the OPEN PRs when open_count > 0,
+  // otherwise the closed/merged PRs backing the purple tag.
   repeated PrRef prs = 7;
+  // Closed or merged PRs counted across the repos, set only when NO PR is open
+  // (open_count 0). It keeps the tag visible in purple — matching GitHub's
+  // closed/merged colour — so a finished instance stays distinguishable from one
+  // that never had a PR. Open PRs always take priority; when both exist the open
+  // status is shown and this stays 0.
+  int32 closed_count = 8;
 }
 
 // InstanceRuntime is the live view of ONE instance: everything the TUI renders

--- a/fleetgrpc/runtime.proto
+++ b/fleetgrpc/runtime.proto
@@ -144,11 +144,13 @@ message PrStatus {
   // repo first, then subrepos). These are the OPEN PRs when open_count > 0,
   // otherwise the closed/merged PRs backing the purple tag.
   repeated PrRef prs = 7;
-  // Closed or merged PRs counted across the repos, set only when NO PR is open
-  // (open_count 0). It keeps the tag visible in purple — matching GitHub's
-  // closed/merged colour — so a finished instance stays distinguishable from one
-  // that never had a PR. Open PRs always take priority; when both exist the open
-  // status is shown and this stays 0.
+  // Closed or merged PRs, set only when NO PR is open (open_count 0). It keeps
+  // the tag visible in purple — matching GitHub's closed/merged colour — so a
+  // finished instance stays distinguishable from one that never had a PR. This
+  // counts the most-recent closed/merged PR PER repo (so it's the number of repos
+  // with a closed-but-no-open PR), unlike open_count which sums every open PR.
+  // Open PRs always take priority; when both exist the open status is shown and
+  // this stays 0.
   int32 closed_count = 8;
 }
 

--- a/internal/server/pr_status.go
+++ b/internal/server/pr_status.go
@@ -75,7 +75,10 @@ find . -maxdepth 5 -name node_modules -prune -o -name .git -prune -print 2>/dev/
     # outside the window (and silently degrade to the purple tag) on a branch
     # that's been the head of many PRs over its life.
     list=$(gh pr list --state all --head "$br" --limit 100 --json number,state --jq '.[] | "\(.state) \(.number)"' 2>/dev/null)
-    open=$(printf '%s\n' "$list" | awk '$1 == "OPEN" { print $2 }')
+    # toupper() so the shell side is as case-defensive as the Go parser's
+    # strings.ToUpper: if gh ever stopped returning uppercase states, an open PR
+    # must still be classified open (not fall through to the purple closed tag).
+    open=$(printf '%s\n' "$list" | awk 'toupper($1) == "OPEN" { print $2 }')
     if [ -n "$open" ]; then
       for num in $open; do
         gh pr view "$num" \
@@ -86,7 +89,7 @@ find . -maxdepth 5 -name node_modules -prune -o -name .git -prune -print 2>/dev/
       # any) so the indicator persists in purple instead of disappearing. The
       # highest PR number is unambiguously the newest, so pick it without relying
       # on gh's list ordering.
-      num=$(printf '%s\n' "$list" | awk '$1 != "OPEN" && $2 > max { max = $2 } END { if (max) print max }')
+      num=$(printf '%s\n' "$list" | awk 'toupper($1) != "OPEN" && $2 > max { max = $2 } END { if (max) print max }')
       if [ -n "$num" ]; then
         gh pr view "$num" --json number,state,url,title 2>/dev/null
       fi

--- a/internal/server/pr_status.go
+++ b/internal/server/pr_status.go
@@ -70,8 +70,11 @@ find . -maxdepth 5 -name node_modules -prune -o -name .git -prune -print 2>/dev/
   [ "$br" = "HEAD" ] && continue
   ( cd "$dir" || exit 0
     # One list call for the branch (gh's embedded --jq, so no standalone jq
-    # dependency): "<STATE> <number>" per PR, e.g. "OPEN 12" / "MERGED 7".
-    list=$(gh pr list --state all --head "$br" --json number,state --jq '.[] | "\(.state) \(.number)"' 2>/dev/null)
+    # dependency): "<STATE> <number>" per PR, e.g. "OPEN 12" / "MERGED 7". The
+    # explicit --limit lifts gh's default 30-row cap so an open PR can't fall
+    # outside the window (and silently degrade to the purple tag) on a branch
+    # that's been the head of many PRs over its life.
+    list=$(gh pr list --state all --head "$br" --limit 100 --json number,state --jq '.[] | "\(.state) \(.number)"' 2>/dev/null)
     open=$(printf '%s\n' "$list" | awk '$1 == "OPEN" { print $2 }')
     if [ -n "$open" ]; then
       for num in $open; do
@@ -294,6 +297,12 @@ func parsePRProbeOutput(out string) *fleetgrpc.PrStatus {
 // visible — so a finished instance is distinguishable from one that never had a
 // PR — and carries the closed PRs' refs so the tag stays clickable. Returns nil
 // when there are no closed/merged PRs either (the branch never had one).
+//
+// Note the per-repo counting: the probe emits only the single most-recent
+// closed/merged PR PER repo, so ClosedCount is the number of repos with a
+// closed-but-no-open PR (rendered "PRxN"), NOT the total closed PRs in any one
+// repo's history. This deliberately differs from open_count, which sums every
+// open PR — a branch's closed-PR history would otherwise inflate the badge.
 func closedPRStatus(closed []ghPR) *fleetgrpc.PrStatus {
 	if len(closed) == 0 {
 		return nil

--- a/internal/server/pr_status.go
+++ b/internal/server/pr_status.go
@@ -48,11 +48,13 @@ const (
 // then emits the FULL detail of each via `gh pr view <n> --json ...` — one JSON
 // object per PR. gh pr view is used (not gh pr list's --json) because gh pr
 // list's statusCheckRollup is capped at the first 100 checks, while gh pr view
-// paginates the rollup and returns every check. The objects are concatenated on
-// stdout and read back with a streaming json.Decoder, so their exact
-// whitespace/formatting doesn't matter. It prints a sentinel and exits 0 when gh
-// is absent or not logged in, so the server can distinguish "degrade quietly"
-// from a transient exec failure.
+// paginates the rollup and returns every check. When the branch has NO open PR,
+// it instead emits the most recent closed/merged PR (number/state/url/title
+// only — no check detail needed) so the tag persists in purple rather than
+// vanishing. The objects are concatenated on stdout and read back with a
+// streaming json.Decoder, so their exact whitespace/formatting doesn't matter.
+// It prints a sentinel and exits 0 when gh is absent or not logged in, so the
+// server can distinguish "degrade quietly" from a transient exec failure.
 const prProbeScript = `
 command -v gh >/dev/null 2>&1 || { printf '%s\n' "FLEET_NO_GH"; exit 0; }
 gh auth status >/dev/null 2>&1 || { printf '%s\n' "FLEET_NO_AUTH"; exit 0; }
@@ -65,10 +67,20 @@ find . -maxdepth 5 -name node_modules -prune -o -name .git -prune -print 2>/dev/
   [ -z "$br" ] && continue
   [ "$br" = "HEAD" ] && continue
   ( cd "$dir" || exit 0
-    for num in $(gh pr list --state open --head "$br" --json number --jq '.[].number' 2>/dev/null); do
-      gh pr view "$num" \
-        --json number,state,mergeStateStatus,reviewDecision,statusCheckRollup,url,title 2>/dev/null
-    done
+    open=$(gh pr list --state open --head "$br" --json number --jq '.[].number' 2>/dev/null)
+    if [ -n "$open" ]; then
+      for num in $open; do
+        gh pr view "$num" \
+          --json number,state,mergeStateStatus,reviewDecision,statusCheckRollup,url,title 2>/dev/null
+      done
+    else
+      # No open PR on this branch — surface the most recent closed/merged one (if
+      # any) so the indicator persists in purple instead of disappearing. The
+      # highest PR number is unambiguously the newest, so pick it without relying
+      # on gh's list ordering.
+      num=$(gh pr list --state all --head "$br" --json number,state --jq 'map(select(.state != "OPEN")) | sort_by(.number) | last | .number // empty' 2>/dev/null)
+      [ -n "$num" ] && gh pr view "$num" --json number,state,url,title 2>/dev/null
+    fi
   )
 done
 `
@@ -134,8 +146,9 @@ func classifyCheck(c ghCheck) checkResult {
 	}
 }
 
-// aggregatePRStatus folds the open PRs across an instance's repos into the
-// PrStatus the TUI renders. Returns nil when there are no open PRs (no auto-tag).
+// aggregatePRStatus folds the open PRs across an instance's repos into the live
+// green/yellow/red PrStatus the TUI renders. Returns nil when there are no open
+// PRs — the caller then falls back to closedPRStatus for the purple closed tag.
 func aggregatePRStatus(prs []ghPR) *fleetgrpc.PrStatus {
 	if len(prs) == 0 {
 		return nil
@@ -224,10 +237,12 @@ func aggregatePRStatus(prs []ghPR) *fleetgrpc.PrStatus {
 }
 
 // parsePRProbeOutput turns the probe's stdout — one `gh pr view --json` object
-// per open PR, concatenated — into a PrStatus. A nil result means "no auto-tag"
-// (gh unavailable, or no open PRs) and clears any prior status. The gh-missing /
-// no-auth sentinels and the empty case all map to nil. A streaming json.Decoder
-// reads successive objects regardless of their interleaving whitespace; malformed
+// per PR, concatenated — into a PrStatus. Open PRs drive the live green/yellow/red
+// tag and take priority; only when there are none does a closed/merged PR drive
+// the persistent purple tag. A nil result means "no auto-tag" (gh unavailable, or
+// the branch never had a PR) and clears any prior status. The gh-missing / no-auth
+// sentinels and the empty case all map to nil. A streaming json.Decoder reads
+// successive objects regardless of their interleaving whitespace; malformed
 // trailing noise stops the scan without discarding what parsed cleanly.
 func parsePRProbeOutput(out string) *fleetgrpc.PrStatus {
 	// Match the sentinels by PREFIX, not Contains: the script emits one as the
@@ -238,18 +253,50 @@ func parsePRProbeOutput(out string) *fleetgrpc.PrStatus {
 	if strings.HasPrefix(trimmed, prNoGHSentinel) || strings.HasPrefix(trimmed, prNoAuthSentinel) {
 		return nil
 	}
-	var prs []ghPR
+	var open, closed []ghPR
 	dec := json.NewDecoder(strings.NewReader(out))
 	for {
 		var p ghPR
 		if err := dec.Decode(&p); err != nil {
 			break // io.EOF on clean exhaustion, or unexpected noise.
 		}
-		if strings.EqualFold(p.State, "OPEN") {
-			prs = append(prs, p)
+		switch strings.ToUpper(p.State) {
+		case "OPEN":
+			open = append(open, p)
+		case "CLOSED", "MERGED":
+			closed = append(closed, p)
 		}
 	}
-	return aggregatePRStatus(prs)
+	// Open PRs win: their live status is the actionable one. Fall back to the
+	// closed/merged tag only when nothing is open.
+	if s := aggregatePRStatus(open); s != nil {
+		return s
+	}
+	return closedPRStatus(closed)
+}
+
+// closedPRStatus builds the persistent purple "PR" tag shown when a branch has no
+// open PR but DID have one that's since closed or merged. It keeps the tag
+// visible — so a finished instance is distinguishable from one that never had a
+// PR — and carries the closed PRs' refs so the tag stays clickable. Returns nil
+// when there are no closed/merged PRs either (the branch never had one).
+func closedPRStatus(closed []ghPR) *fleetgrpc.PrStatus {
+	if len(closed) == 0 {
+		return nil
+	}
+	refs := make([]*fleetgrpc.PrRef, 0, len(closed))
+	for _, pr := range closed {
+		refs = append(refs, &fleetgrpc.PrRef{
+			Number: int32(pr.Number),
+			Url:    pr.URL,
+			Title:  pr.Title,
+		})
+	}
+	return &fleetgrpc.PrStatus{
+		ClosedCount: int32(len(closed)),
+		PrSignal:    fleetgrpc.PrSignal_PR_SIGNAL_PURPLE,
+		Prs:         refs,
+	}
 }
 
 // probePRStatus runs the gh probe inside the instance and parses the result.

--- a/internal/server/pr_status.go
+++ b/internal/server/pr_status.go
@@ -51,7 +51,9 @@ const (
 // paginates the rollup and returns every check. When the branch has NO open PR,
 // it instead emits the most recent closed/merged PR (number/state/url/title
 // only — no check detail needed) so the tag persists in purple rather than
-// vanishing. The objects are concatenated on stdout and read back with a
+// vanishing. A single `gh pr list --state all` per repo covers both cases (so a
+// branch parked without an open PR costs no extra round-trip vs. the old
+// open-only query). The objects are concatenated on stdout and read back with a
 // streaming json.Decoder, so their exact whitespace/formatting doesn't matter.
 // It prints a sentinel and exits 0 when gh is absent or not logged in, so the
 // server can distinguish "degrade quietly" from a transient exec failure.
@@ -67,7 +69,10 @@ find . -maxdepth 5 -name node_modules -prune -o -name .git -prune -print 2>/dev/
   [ -z "$br" ] && continue
   [ "$br" = "HEAD" ] && continue
   ( cd "$dir" || exit 0
-    open=$(gh pr list --state open --head "$br" --json number --jq '.[].number' 2>/dev/null)
+    # One list call for the branch (gh's embedded --jq, so no standalone jq
+    # dependency): "<STATE> <number>" per PR, e.g. "OPEN 12" / "MERGED 7".
+    list=$(gh pr list --state all --head "$br" --json number,state --jq '.[] | "\(.state) \(.number)"' 2>/dev/null)
+    open=$(printf '%s\n' "$list" | awk '$1 == "OPEN" { print $2 }')
     if [ -n "$open" ]; then
       for num in $open; do
         gh pr view "$num" \
@@ -78,11 +83,20 @@ find . -maxdepth 5 -name node_modules -prune -o -name .git -prune -print 2>/dev/
       # any) so the indicator persists in purple instead of disappearing. The
       # highest PR number is unambiguously the newest, so pick it without relying
       # on gh's list ordering.
-      num=$(gh pr list --state all --head "$br" --json number,state --jq 'map(select(.state != "OPEN")) | sort_by(.number) | last | .number // empty' 2>/dev/null)
-      [ -n "$num" ] && gh pr view "$num" --json number,state,url,title 2>/dev/null
+      num=$(printf '%s\n' "$list" | awk '$1 != "OPEN" && $2 > max { max = $2 } END { if (max) print max }')
+      if [ -n "$num" ]; then
+        gh pr view "$num" --json number,state,url,title 2>/dev/null
+      fi
     fi
   )
 done
+# Always exit 0 once the scan completes: an empty result (a repo with no PRs) is a
+# valid probe outcome that should CLEAR the tag, not a transient failure. Without
+# this, a no-PR repo visited last by find leaves the loop's exit status at 1, and
+# probePRStatus would treat the whole probe as failed (ok=false) — discarding any
+# PR JSON already emitted and freezing the prior tag. A non-zero exit (ok=false,
+# keep prior) is reserved for genuine exec/timeout errors, which abort earlier.
+exit 0
 `
 
 // ghPR mirrors the subset of `gh pr list --json` fields the auto-tag needs.

--- a/internal/server/pr_status_test.go
+++ b/internal/server/pr_status_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -31,6 +33,107 @@ func TestRunProbeWithTimeout_KillsOnTimeout(t *testing.T) {
 	if elapsed := time.Since(start); elapsed > 5*time.Second {
 		t.Fatalf("timeout took %v, expected it to fire near 150ms", elapsed)
 	}
+}
+
+// stubGHScript emulates the net output of the `gh` calls prProbeScript makes:
+// `gh auth status` succeeds, `gh pr list ... --jq '<STATE> <number>'` echoes the
+// lines in $GH_FAKE_PRLIST, and `gh pr view <n>` emits a MERGED PR object.
+const stubGHScript = `#!/bin/sh
+case "$1" in
+  auth) exit 0 ;;
+  pr)
+    case "$2" in
+      list) cat "$GH_FAKE_PRLIST" 2>/dev/null ; exit 0 ;;
+      view) printf '{"number":%s,"state":"MERGED","url":"https://example.test/%s","title":"old"}\n' "$3" "$3" ; exit 0 ;;
+    esac ;;
+esac
+exit 0
+`
+
+func gitInitOnBranch(t *testing.T, dir, branch string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	env := append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.test",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.test")
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"checkout", "-q", "-b", branch},
+		{"commit", "-q", "--allow-empty", "-m", "init"},
+	} {
+		c := exec.Command("git", args...)
+		c.Dir, c.Env = dir, env
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+}
+
+// TestPRProbeScript_AlwaysExitsZero runs the real prProbeScript (with a stubbed
+// gh) over a multi-repo workspace whose repos have no open PR. It guards the QA
+// regression on issue #203: the no-PR path must exit 0 so probePRStatus treats a
+// completed probe as authoritative (clearing or setting the tag) rather than a
+// transient failure that discards stdout and freezes the prior tag. The earlier
+// `[ -n "$num" ] && gh pr view …` tail left the script's exit status at 1 when the
+// last repo find visited had no PR.
+func TestPRProbeScript_AlwaysExitsZero(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(stubGHScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	emptyList := filepath.Join(t.TempDir(), "empty")
+	closedList := filepath.Join(t.TempDir(), "closed")
+	if err := os.WriteFile(emptyList, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(closedList, []byte("MERGED 210\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	runScript := func(t *testing.T, prList string) (string, error) {
+		// Two repos (top-level + nested subrepo), each on a no-PR branch, so the
+		// last repo find traverses also has no PR — the layout that regressed.
+		ws := t.TempDir()
+		gitInitOnBranch(t, ws, "feat-x")
+		gitInitOnBranch(t, filepath.Join(ws, "nested"), "feat-y")
+		cmd := exec.Command("sh", "-c", prProbeScript)
+		cmd.Dir = ws
+		cmd.Env = append(os.Environ(),
+			"PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"),
+			"GH_FAKE_PRLIST="+prList)
+		out, err := cmd.CombinedOutput()
+		return string(out), err
+	}
+
+	t.Run("no PRs => exit 0, no output", func(t *testing.T) {
+		out, err := runScript(t, emptyList)
+		if err != nil {
+			t.Fatalf("probe script exited non-zero on a no-PR workspace: %v\noutput: %q", err, out)
+		}
+		if got := parsePRProbeOutput(out); got != nil {
+			t.Errorf("no-PR workspace parsed to %+v, want nil (clears the tag)", got)
+		}
+	})
+
+	t.Run("closed PR => exit 0, emits the merged PR", func(t *testing.T) {
+		out, err := runScript(t, closedList)
+		if err != nil {
+			t.Fatalf("probe script exited non-zero: %v\noutput: %q", err, out)
+		}
+		got := parsePRProbeOutput(out)
+		if got == nil {
+			t.Fatalf("closed-PR workspace parsed to nil, want a purple tag (out=%q)", out)
+		}
+		// One MERGED PR per repo (both repos resolve the same stub list).
+		if got.GetPrSignal() != fleetgrpc.PrSignal_PR_SIGNAL_PURPLE || got.GetClosedCount() == 0 {
+			t.Errorf("got %+v, want PURPLE with ClosedCount>0", got)
+		}
+	})
 }
 
 func TestClassifyCheck(t *testing.T) {

--- a/internal/server/pr_status_test.go
+++ b/internal/server/pr_status_test.go
@@ -36,15 +36,22 @@ func TestRunProbeWithTimeout_KillsOnTimeout(t *testing.T) {
 }
 
 // stubGHScript emulates the net output of the `gh` calls prProbeScript makes:
-// `gh auth status` succeeds, `gh pr list ... --jq '<STATE> <number>'` echoes the
-// lines in $GH_FAKE_PRLIST, and `gh pr view <n>` emits a MERGED PR object.
+// `gh auth status` succeeds and `gh pr list ... --jq '<STATE> <number>'` echoes
+// the lines in $GH_FAKE_PRLIST. `gh pr view <n>` mirrors which path called it:
+// the open path requests statusCheckRollup, so the stub reports state OPEN; the
+// closed fallback requests only number,state,url,title, so it reports MERGED.
+// That lets a test prove which branch the script's awk classification took.
 const stubGHScript = `#!/bin/sh
 case "$1" in
   auth) exit 0 ;;
   pr)
     case "$2" in
       list) cat "$GH_FAKE_PRLIST" 2>/dev/null ; exit 0 ;;
-      view) printf '{"number":%s,"state":"MERGED","url":"https://example.test/%s","title":"old"}\n' "$3" "$3" ; exit 0 ;;
+      view)
+        state=MERGED
+        case "$*" in *statusCheckRollup*) state=OPEN ;; esac
+        printf '{"number":%s,"state":"%s","url":"https://example.test/%s","title":"x"}\n' "$3" "$state" "$3"
+        exit 0 ;;
     esac ;;
 esac
 exit 0
@@ -132,6 +139,29 @@ func TestPRProbeScript_AlwaysExitsZero(t *testing.T) {
 		// One MERGED PR per repo (both repos resolve the same stub list).
 		if got.GetPrSignal() != fleetgrpc.PrSignal_PR_SIGNAL_PURPLE || got.GetClosedCount() == 0 {
 			t.Errorf("got %+v, want PURPLE with ClosedCount>0", got)
+		}
+	})
+
+	t.Run("lowercase state still classified open (toupper)", func(t *testing.T) {
+		// Defensive: if gh ever returned a non-uppercase state, the awk must still
+		// classify an open PR as open rather than letting it fall through to the
+		// purple closed fallback. The stub's `pr view` emits MERGED, so a fall-
+		// through would wrongly surface a purple tag.
+		lowerList := filepath.Join(t.TempDir(), "lower")
+		if err := os.WriteFile(lowerList, []byte("open 216\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		out, err := runScript(t, lowerList)
+		if err != nil {
+			t.Fatalf("probe script exited non-zero: %v\noutput: %q", err, out)
+		}
+		got := parsePRProbeOutput(out)
+		if got == nil || got.GetOpenCount() == 0 {
+			t.Errorf("a lowercase \"open\" PR must take the open path (full detail), "+
+				"not fall through to the purple closed fallback; got %+v (out=%q)", got, out)
+		}
+		if got.GetClosedCount() != 0 {
+			t.Errorf("lowercase open PR wrongly classified as closed: %+v", got)
 		}
 	})
 }

--- a/internal/server/pr_status_test.go
+++ b/internal/server/pr_status_test.go
@@ -307,24 +307,64 @@ func TestParsePRProbeOutput_ConcatenatedObjects(t *testing.T) {
 	}
 }
 
-func TestParsePRProbeOutput_EmptyAndClosed(t *testing.T) {
-	// No open PRs => the script emits nothing => nil. A closed PR (filtered by
-	// state) also contributes nothing.
+func TestParsePRProbeOutput_Empty(t *testing.T) {
+	// No PRs at all => the script emits nothing => nil (the branch never had a PR).
 	if got := parsePRProbeOutput(""); got != nil {
 		t.Errorf("empty output = %+v, want nil", got)
 	}
-	closed := `{"number":1,"state":"CLOSED","mergeStateStatus":"CLEAN","statusCheckRollup":[]}`
-	if got := parsePRProbeOutput(closed); got != nil {
-		t.Errorf("closed-only output = %+v, want nil (no open PRs)", got)
-	}
+}
 
-	// A closed object followed by a genuinely open one => one open PR.
-	out := closed + "\n" + `{"number":2,"state":"OPEN","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}` + "\n"
-	got := parsePRProbeOutput(out)
+func TestParsePRProbeOutput_ClosedPersistsPurple(t *testing.T) {
+	// A branch whose only PR is closed/merged keeps a persistent purple tag (issue
+	// #203) rather than vanishing — open_count 0, closed_count > 0, the closed PR
+	// kept as a ref so the tag stays clickable.
+	for _, tc := range []struct {
+		name, state string
+	}{
+		{"closed", "CLOSED"},
+		{"merged", "MERGED"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := `{"number":1,"state":"` + tc.state + `","url":"https://example.test/pr/1","title":"old work"}`
+			got := parsePRProbeOutput(out)
+			if got == nil {
+				t.Fatalf("%s-only output = nil, want a purple tag", tc.state)
+			}
+			if got.GetOpenCount() != 0 {
+				t.Errorf("OpenCount = %d, want 0", got.GetOpenCount())
+			}
+			if got.GetClosedCount() != 1 {
+				t.Errorf("ClosedCount = %d, want 1", got.GetClosedCount())
+			}
+			if got.GetPrSignal() != fleetgrpc.PrSignal_PR_SIGNAL_PURPLE {
+				t.Errorf("PrSignal = %v, want PURPLE", got.GetPrSignal())
+			}
+			if n := len(got.GetPrs()); n != 1 {
+				t.Fatalf("len(Prs) = %d, want 1 (kept clickable)", n)
+			}
+			if got.GetPrs()[0].GetNumber() != 1 {
+				t.Errorf("Prs[0].Number = %d, want 1", got.GetPrs()[0].GetNumber())
+			}
+		})
+	}
+}
+
+func TestParsePRProbeOutput_OpenWinsOverClosed(t *testing.T) {
+	// An open PR (workspace repo) and a closed one (a subrepo) => the open status
+	// wins; the closed one neither shows nor inflates closed_count.
+	closed := `{"number":1,"state":"CLOSED","url":"https://example.test/pr/1","title":"old"}`
+	open := `{"number":2,"state":"OPEN","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}`
+	got := parsePRProbeOutput(closed + "\n" + open + "\n")
 	if got == nil {
 		t.Fatalf("parsePRProbeOutput returned nil, want one open PR")
 	}
 	if got.GetOpenCount() != 1 {
 		t.Errorf("OpenCount = %d, want 1", got.GetOpenCount())
+	}
+	if got.GetClosedCount() != 0 {
+		t.Errorf("ClosedCount = %d, want 0 (open takes priority)", got.GetClosedCount())
+	}
+	if got.GetPrSignal() != fleetgrpc.PrSignal_PR_SIGNAL_GREEN {
+		t.Errorf("PrSignal = %v, want GREEN (the open PR)", got.GetPrSignal())
 	}
 }

--- a/internal/tui/auto_tag.go
+++ b/internal/tui/auto_tag.go
@@ -64,10 +64,16 @@ func (m *model) instanceAutoTag(fleetName, instance string, selected bool) strin
 	}
 	segments := make([]segment, 0, 3)
 
-	// PR indicator: "PR" for a single open PR, "PRxN" for N>1.
+	// PR indicator: "PR" for a single PR, "PRxN" for N>1. Counts open PRs, or the
+	// closed/merged ones when none are open (the purple tag), so the badge matches
+	// the chooser either way.
+	count := ps.GetOpenCount()
+	if count == 0 {
+		count = ps.GetClosedCount()
+	}
 	label := "PR"
-	if n := ps.GetOpenCount(); n > 1 {
-		label = fmt.Sprintf("PRx%d", n)
+	if count > 1 {
+		label = fmt.Sprintf("PRx%d", count)
 	}
 	segments = append(segments, segment{label, prSignalStyle(ps.GetPrSignal())})
 

--- a/internal/tui/auto_tag.go
+++ b/internal/tui/auto_tag.go
@@ -21,6 +21,8 @@ func prSignalStyle(sig fleetgrpc.PrSignal) lipgloss.Style {
 		return prGreenStyle
 	case fleetgrpc.PrSignal_PR_SIGNAL_RED:
 		return prRedStyle
+	case fleetgrpc.PrSignal_PR_SIGNAL_PURPLE:
+		return prPurpleStyle
 	default:
 		return prYellowStyle
 	}
@@ -40,16 +42,19 @@ func prChecksStyle(sig fleetgrpc.PrSignal) lipgloss.Style {
 }
 
 // instanceAutoTag renders the auto tag for an instance, or "" when there is
-// nothing to show — gh is unavailable inside the instance, no PR is open, or the
-// status hasn't been probed yet. The format is "[PR|PRxN] [Rejected | Accepted |
-// Pending] [Checks x/x]", each element coloured and shown only when it applies.
+// nothing to show — gh is unavailable inside the instance, the branch never had a
+// PR, or the status hasn't been probed yet. The format is "[PR|PRxN] [Rejected |
+// Accepted | Pending] [Checks x/x]", each element coloured and shown only when it
+// applies. When the only PR(s) are closed or merged, it shrinks to a single
+// purple "PR" badge (no review/checks) that persists so a finished instance stays
+// distinguishable from one that never had a PR.
 //
 // When selected (horizontally, via →/l), the whole tag is drawn as one chunk in
 // the pink selection colour wrapped in [ ], so it reads as a single navigable
 // unit rather than three separately-coloured indicators.
 func (m *model) instanceAutoTag(fleetName, instance string, selected bool) string {
 	ps := m.runtime[rtKey(fleetName, instance)].GetPrStatus()
-	if ps == nil || ps.GetOpenCount() == 0 {
+	if ps == nil || (ps.GetOpenCount() == 0 && ps.GetClosedCount() == 0) {
 		return ""
 	}
 

--- a/internal/tui/auto_tag_nav.go
+++ b/internal/tui/auto_tag_nav.go
@@ -14,15 +14,15 @@ import (
 // instance's PR status (→/l) and opening the PR in a browser (enter, or a
 // click), with a chooser dialog when more than one PR is open.
 
-// instancePRRefs returns the open PRs backing an instance's auto tag (nil when
-// there is no PR status).
+// instancePRRefs returns the PRs backing an instance's auto tag — the open PRs,
+// or the closed/merged ones when none are open (nil when there is no PR status).
 func (m *model) instancePRRefs(fleetName, instance string) []*fleetgrpc.PrRef {
 	return m.runtime[rtKey(fleetName, instance)].GetPrStatus().GetPrs()
 }
 
-// rowInlinePRRefs returns the open PRs for a row that carries the inline PR
-// status (the first child row of an expanded, untagged instance), or nil. This
-// is where the auto tag lives now, so it is the unit the cursor selects.
+// rowInlinePRRefs returns the PRs for a row that carries the inline PR status
+// (the first child row of an expanded, untagged instance), or nil. This is where
+// the auto tag lives now, so it is the unit the cursor selects.
 func (m *model) rowInlinePRRefs(r row) []*fleetgrpc.PrRef {
 	if !r.prStatusInline || r.instance == nil {
 		return nil
@@ -70,7 +70,7 @@ func openPRRefCmd(m *model, ref *fleetgrpc.PrRef) tea.Cmd {
 // ===========================================
 
 // choosePRState backs the "which PR?" dialog shown when an instance has more
-// than one open PR.
+// than one PR (open, or closed/merged).
 type choosePRState struct {
 	refs   []*fleetgrpc.PrRef
 	cursor int
@@ -106,8 +106,8 @@ func (fleetPage *fleetPage) updateChoosePR(m *model, msg tea.Msg) tea.Cmd {
 	return nil
 }
 
-// renderChoosePRDialog draws the chooser: one row per open PR (number, title,
-// url), with the selected row highlighted.
+// renderChoosePRDialog draws the chooser: one row per PR (number, title, url),
+// with the selected row highlighted.
 func (fleetPage *fleetPage) renderChoosePRDialog(m *model) string {
 	var b strings.Builder
 	b.WriteString(dialogTitle.Render("Open which PR?"))

--- a/internal/tui/auto_tag_test.go
+++ b/internal/tui/auto_tag_test.go
@@ -73,6 +73,28 @@ func TestInstanceAutoTag_ClosedPurple(t *testing.T) {
 	}
 }
 
+func TestInstanceAutoTag_MultipleClosedPurple(t *testing.T) {
+	// Two closed/merged PRs (e.g. workspace repo + a subrepo) render "PRx2" in
+	// purple, matching the open "PRxN" convention and the multi-PR chooser.
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning}
+	ps := &fleetgrpc.PrStatus{
+		ClosedCount: 2,
+		PrSignal:    fleetgrpc.PrSignal_PR_SIGNAL_PURPLE,
+		Prs: []*fleetgrpc.PrRef{
+			{Number: 7, Url: "https://example.test/pr/7"},
+			{Number: 8, Url: "https://example.test/pr/8"},
+		},
+	}
+	m := autoTagModel(newFleetPage(), inst, true, ps)
+	got := m.instanceAutoTag("alpha", "agent-1", false)
+	if !strings.Contains(got, "PRx2") {
+		t.Errorf("two closed PRs should render PRx2, got %q", got)
+	}
+	if !strings.Contains(got, prPurpleStyle.Render("PRx2")) {
+		t.Errorf("PRx2 badge %q not rendered in the purple style", got)
+	}
+}
+
 func TestPrSignalStylePurple(t *testing.T) {
 	if prSignalStyle(fleetgrpc.PrSignal_PR_SIGNAL_PURPLE).GetForeground() != prPurpleStyle.GetForeground() {
 		t.Errorf("a closed/merged PR should render in purple")

--- a/internal/tui/auto_tag_test.go
+++ b/internal/tui/auto_tag_test.go
@@ -47,6 +47,38 @@ func TestInstanceAutoTag_NoStatus(t *testing.T) {
 	}
 }
 
+func TestInstanceAutoTag_ClosedPurple(t *testing.T) {
+	// A branch whose only PR is closed/merged keeps a persistent purple "PR" badge
+	// (issue #203): open_count 0 but closed_count > 0. It shows just "PR" — no
+	// review/checks — in the purple style, and stays distinct from "no PR ever".
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning}
+	ps := &fleetgrpc.PrStatus{
+		ClosedCount: 1,
+		PrSignal:    fleetgrpc.PrSignal_PR_SIGNAL_PURPLE,
+		Prs:         []*fleetgrpc.PrRef{{Number: 7, Url: "https://example.test/pr/7", Title: "done"}},
+	}
+	m := autoTagModel(newFleetPage(), inst, true, ps)
+	got := m.instanceAutoTag("alpha", "agent-1", false)
+	if !strings.Contains(got, "PR") {
+		t.Fatalf("closed PR tag %q missing PR badge", got)
+	}
+	for _, unwanted := range []string{"Accepted", "Rejected", "Pending", "Checks", "PRx"} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("closed PR tag should be a bare PR badge, got %q (has %q)", got, unwanted)
+		}
+	}
+	// The badge renders in the purple style.
+	if !strings.Contains(got, prPurpleStyle.Render("PR")) {
+		t.Errorf("closed PR badge %q not rendered in the purple style", got)
+	}
+}
+
+func TestPrSignalStylePurple(t *testing.T) {
+	if prSignalStyle(fleetgrpc.PrSignal_PR_SIGNAL_PURPLE).GetForeground() != prPurpleStyle.GetForeground() {
+		t.Errorf("a closed/merged PR should render in purple")
+	}
+}
+
 func TestPrChecksStyleGraysPending(t *testing.T) {
 	// Pending checks are de-emphasised to grey; pass/fail keep green/red.
 	if prChecksStyle(fleetgrpc.PrSignal_PR_SIGNAL_YELLOW).GetForeground() != prGrayStyle.GetForeground() {
@@ -240,6 +272,34 @@ func TestViewFleetListRendersAutoTag(t *testing.T) {
 		if !strings.Contains(view, want) {
 			t.Fatalf("view missing %q:\n%s", want, view)
 		}
+	}
+}
+
+func TestViewFleetListRendersClosedPurpleTag(t *testing.T) {
+	// End-to-end: a closed-only PrStatus still marks the first child row inline and
+	// surfaces the purple PR badge in the rendered list (issue #203) — the indicator
+	// no longer vanishes when the PR closes.
+	inst := &fleet.Instance{Name: "agent-1", Status: fleet.StatusRunning}
+	ps := &fleetgrpc.PrStatus{
+		ClosedCount: 1,
+		PrSignal:    fleetgrpc.PrSignal_PR_SIGNAL_PURPLE,
+		Prs:         []*fleetgrpc.PrRef{{Number: 7, Url: "https://example.test/pr/7", Title: "done"}},
+	}
+	fp := newFleetPage()
+	m := autoTagModel(fp, inst, true, ps)
+	fp.buildRows(m)
+
+	inlineMarked := false
+	for _, r := range fp.rows {
+		if r.prStatusInline {
+			inlineMarked = true
+		}
+	}
+	if !inlineMarked {
+		t.Fatalf("closed PR should still mark an inline-PR-status row: %#v", fp.rows)
+	}
+	if view := fp.viewFleetList(m); !strings.Contains(view, "PR") {
+		t.Fatalf("rendered list missing the persistent closed PR badge:\n%s", view)
 	}
 }
 

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -75,6 +75,12 @@ var (
 	prGrayStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("240"))
 
+	// Purple marks a closed/merged PR, matching GitHub's own colour. The tag is
+	// kept visible (rather than vanishing) so a finished instance is
+	// distinguishable from one that never had a PR.
+	prPurpleStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("99"))
+
 	// Agent tool indicator
 	agentWorkingStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("42")).


### PR DESCRIPTION
## Summary

Closes #203. The auto-tag PR indicator vanished the instant a PR closed or merged, making a finished instance indistinguishable from one that never had a PR. Now a branch whose only PR(s) are **closed or merged** keeps a persistent **purple `PR` badge** — matching GitHub's own closed/merged colour — so you can tell "this PR is done" from "no PR was ever opened". The badge stays clickable and opens the closed PR.

## What changed

- **Probe (`internal/server/pr_status.go`)** — when a branch has no open PR, the `gh` probe now falls back to the most recent closed/merged PR for that branch (picked by highest PR number, so it doesn't rely on `gh`'s list ordering). It only fetches `number,state,url,title` for closed PRs (no check detail needed).
- **Parser** — `parsePRProbeOutput` buckets decoded PRs into open vs closed/merged. **Open PRs always take priority**; the new `closedPRStatus()` builds the purple tag only when nothing is open. A branch that never had a PR still yields `nil` (no tag), exactly as before.
- **Proto** — new `PR_SIGNAL_PURPLE = 4` and `PrStatus.closed_count = 8` (field 8 was free; backward-compatible additions).
- **TUI (`internal/tui/auto_tag.go`, `styles.go`)** — `prSignalStyle` maps purple to a new `prPurpleStyle` (256-colour `99`); the render gate now keeps the tag when `closed_count > 0`. A closed-only status renders a bare purple `PR` (no review/checks segments). The existing row-gating and click-to-open navigation work unchanged because they key off the tag being non-empty and off `Prs`, which is populated with the closed ref.

Open-PR behaviour (green/yellow/red, review, checks, multi-PR) is untouched.