### PR TITLE
fix/pr-status-skip-default-branch: exclude the default branch from PR status indicator (#217)

### DIFF
--- a/internal/server/pr_status.go
+++ b/internal/server/pr_status.go
@@ -44,7 +44,9 @@ const (
 
 // prProbeScript runs inside the container with the workspace folder as its cwd
 // (the backend's ExecCommand resolves that). For the workspace repo and every
-// nested subrepo it finds the open PRs on the current branch (gh pr list) and
+// nested subrepo it first skips the repo when its checked-out branch is that
+// repo's own default branch (the trunk has no in-flight PR to track; issue #217),
+// then finds the open PRs on the current branch (gh pr list) and
 // then emits the FULL detail of each via `gh pr view <n> --json ...` — one JSON
 // object per PR. gh pr view is used (not gh pr list's --json) because gh pr
 // list's statusCheckRollup is capped at the first 100 checks, while gh pr view
@@ -69,6 +71,18 @@ find . -maxdepth 5 -name node_modules -prune -o -name .git -prune -print 2>/dev/
   [ -z "$br" ] && continue
   [ "$br" = "HEAD" ] && continue
   ( cd "$dir" || exit 0
+    # Skip the repo's DEFAULT branch (usually main): it is the trunk, not in-flight
+    # work, yet it may have been the HEAD of PRs into other branches over its life.
+    # Surfacing those long-closed PRs put a bogus purple "closed PR" tag on an
+    # instance merely parked on main (issue #217). Resolved PER-REPO so a nested
+    # subrepo is judged against its OWN default branch. Prefer the local origin/HEAD
+    # ref (set by git clone, no API round-trip); fall back to gh only when it isn't
+    # configured. On any failure "default" is empty and we DON'T skip — degrading to
+    # the prior (over-eager) behaviour rather than risk hiding a real PR.
+    default=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)
+    default=${default#origin/}
+    [ -z "$default" ] && default=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null)
+    [ -n "$default" ] && [ "$br" = "$default" ] && exit 0
     # One list call for the branch (gh's embedded --jq, so no standalone jq
     # dependency): "<STATE> <number>" per PR, e.g. "OPEN 12" / "MERGED 7". The
     # explicit --limit lifts gh's default 30-row cap so an open PR can't fall

--- a/internal/server/pr_status_test.go
+++ b/internal/server/pr_status_test.go
@@ -62,6 +62,18 @@ esac
 exit 0
 `
 
+// setSymbolicRef writes a symbolic ref in dir (e.g. refs/remotes/origin/HEAD ->
+// refs/remotes/origin/main, the marker `git clone` writes). git stores it as-is,
+// so no real remote or fetch is needed to emulate a freshly-cloned repo.
+func setSymbolicRef(t *testing.T, dir, name, target string) {
+	t.Helper()
+	c := exec.Command("git", "symbolic-ref", name, target)
+	c.Dir = dir
+	if out, err := c.CombinedOutput(); err != nil {
+		t.Fatalf("git symbolic-ref %s %s: %v\n%s", name, target, err, out)
+	}
+}
+
 func gitInitOnBranch(t *testing.T, dir, branch string) {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -247,6 +259,85 @@ func TestPRProbeScript_SkipsDefaultBranch(t *testing.T) {
 		if got.GetClosedCount() != 1 {
 			t.Errorf("ClosedCount = %d, want 1 (subrepo on its default branch skipped); out=%q",
 				got.GetClosedCount(), out)
+		}
+	})
+}
+
+// TestPRProbeScript_SkipsDefaultBranch_LocalOriginHead covers the production-
+// dominant arm of the issue-#217 skip: a cloned repo has refs/remotes/origin/HEAD
+// set, so the probe resolves the default branch from that LOCAL ref without a gh
+// round-trip. The gh stub here fails `repo view`, so the fallback can't supply a
+// default — any skip must come from the local ref alone. This guards the
+// `git symbolic-ref --short` output shape plus the `${default#origin/}` strip,
+// which the no-remote tests above never exercise (they fall through to gh).
+func TestPRProbeScript_SkipsDefaultBranch_LocalOriginHead(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	// gh stub whose `repo view` FAILS: the default-branch fallback is unavailable,
+	// so a skip proves the local origin/HEAD ref drove it. `pr list` still reports a
+	// merged PR, so a repo that is NOT skipped surfaces a (wrong) purple tag.
+	const ghNoRepoView = `#!/bin/sh
+case "$1" in
+  auth) exit 0 ;;
+  repo) exit 1 ;;
+  pr)
+    case "$2" in
+      list) cat "$GH_FAKE_PRLIST" 2>/dev/null ; exit 0 ;;
+      view) printf '{"number":%s,"state":"MERGED","url":"https://example.test/%s","title":"x"}\n' "$3" "$3" ; exit 0 ;;
+    esac ;;
+esac
+exit 0
+`
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(ghNoRepoView), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	closedList := filepath.Join(t.TempDir(), "closed")
+	if err := os.WriteFile(closedList, []byte("MERGED 210\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// run builds a repo on `main` and runs the real probe; when withOriginHead is
+	// set it first writes origin/HEAD -> origin/main, emulating a fresh clone.
+	run := func(t *testing.T, withOriginHead bool) string {
+		t.Helper()
+		ws := t.TempDir()
+		gitInitOnBranch(t, ws, "main")
+		if withOriginHead {
+			setSymbolicRef(t, ws, "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+		}
+		cmd := exec.Command("sh", "-c", prProbeScript)
+		cmd.Dir = ws
+		cmd.Env = append(os.Environ(),
+			"PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"),
+			"GH_FAKE_PRLIST="+closedList)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("probe script exited non-zero: %v\noutput: %q", err, out)
+		}
+		return string(out)
+	}
+
+	t.Run("local origin/HEAD alone drives the skip", func(t *testing.T) {
+		out := run(t, true)
+		if got := parsePRProbeOutput(out); got != nil {
+			t.Errorf("default branch resolved via local origin/HEAD parsed to %+v, want nil — "+
+				"the local ref must drive the skip with no gh fallback; out=%q", got, out)
+		}
+	})
+
+	t.Run("negative control: no origin/HEAD and no gh fallback => not skipped", func(t *testing.T) {
+		// Same repo on main, but without the local ref: the lookup misses AND the gh
+		// fallback fails, so the default branch is NOT recognised and its closed PR
+		// surfaces. This proves the skip above came from the local ref, not elsewhere.
+		out := run(t, false)
+		got := parsePRProbeOutput(out)
+		if got == nil {
+			t.Fatalf("with no default-branch signal the repo should not be skipped, want a purple tag; out=%q", out)
+		}
+		if got.GetPrSignal() != fleetgrpc.PrSignal_PR_SIGNAL_PURPLE {
+			t.Errorf("got %+v, want PURPLE (repo not skipped)", got)
 		}
 	})
 }

--- a/internal/server/pr_status_test.go
+++ b/internal/server/pr_status_test.go
@@ -41,9 +41,14 @@ func TestRunProbeWithTimeout_KillsOnTimeout(t *testing.T) {
 // the open path requests statusCheckRollup, so the stub reports state OPEN; the
 // closed fallback requests only number,state,url,title, so it reports MERGED.
 // That lets a test prove which branch the script's awk classification took.
+// `gh repo view --json defaultBranchRef --jq ...` reports $GH_FAKE_DEFAULT_BRANCH
+// (default "main"), the default-branch determination's gh fallback — the test
+// repos have no origin remote, so the script's local origin/HEAD lookup misses and
+// this fallback is what the issue-#217 skip is exercised through.
 const stubGHScript = `#!/bin/sh
 case "$1" in
   auth) exit 0 ;;
+  repo) printf '%s\n' "${GH_FAKE_DEFAULT_BRANCH:-main}" ; exit 0 ;;
   pr)
     case "$2" in
       list) cat "$GH_FAKE_PRLIST" 2>/dev/null ; exit 0 ;;
@@ -162,6 +167,86 @@ func TestPRProbeScript_AlwaysExitsZero(t *testing.T) {
 		}
 		if got.GetClosedCount() != 0 {
 			t.Errorf("lowercase open PR wrongly classified as closed: %+v", got)
+		}
+	})
+}
+
+// TestPRProbeScript_SkipsDefaultBranch guards issue #217: a repo whose CURRENT
+// branch is its default branch (usually main) must be excluded from the probe
+// entirely. The default branch may have been the HEAD of PRs into other branches
+// over its life; surfacing those long-closed PRs put a bogus purple "closed PR"
+// tag on an instance merely parked on main. The skip is PER-REPO, so a nested
+// subrepo is judged against its own default branch.
+func TestPRProbeScript_SkipsDefaultBranch(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(stubGHScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Every repo the stub reports has a single MERGED PR — so anything NOT skipped
+	// surfaces a purple closed tag, and the skip is observable by its absence.
+	closedList := filepath.Join(t.TempDir(), "closed")
+	if err := os.WriteFile(closedList, []byte("MERGED 210\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// run executes the real probe over a freshly-built workspace; init lays out the
+	// repos (relative dir -> branch) and defaultBranch is what the gh stub reports.
+	run := func(t *testing.T, repos map[string]string, defaultBranch string) string {
+		t.Helper()
+		ws := t.TempDir()
+		for rel, branch := range repos {
+			dir := ws
+			if rel != "." {
+				dir = filepath.Join(ws, rel)
+			}
+			gitInitOnBranch(t, dir, branch)
+		}
+		cmd := exec.Command("sh", "-c", prProbeScript)
+		cmd.Dir = ws
+		cmd.Env = append(os.Environ(),
+			"PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"),
+			"GH_FAKE_PRLIST="+closedList,
+			"GH_FAKE_DEFAULT_BRANCH="+defaultBranch)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("probe script exited non-zero: %v\noutput: %q", err, out)
+		}
+		return string(out)
+	}
+
+	t.Run("on default branch => skipped, no tag", func(t *testing.T) {
+		out := run(t, map[string]string{".": "main"}, "main")
+		if got := parsePRProbeOutput(out); got != nil {
+			t.Errorf("instance parked on the default branch parsed to %+v, want nil (no tag); out=%q", got, out)
+		}
+	})
+
+	t.Run("on feature branch => closed PR still surfaces", func(t *testing.T) {
+		out := run(t, map[string]string{".": "feature"}, "main")
+		got := parsePRProbeOutput(out)
+		if got == nil {
+			t.Fatalf("feature branch with a closed PR parsed to nil, want a purple tag; out=%q", out)
+		}
+		if got.GetPrSignal() != fleetgrpc.PrSignal_PR_SIGNAL_PURPLE {
+			t.Errorf("got %+v, want PURPLE", got)
+		}
+	})
+
+	t.Run("per-repo: subrepo on default skipped, top-level feature kept", func(t *testing.T) {
+		// Top-level on a feature branch (kept) + a subrepo on the default branch
+		// (skipped). Only the top-level emits, so exactly one repo's closed PR
+		// shows — proving the default-branch test is applied per-repo, not globally.
+		out := run(t, map[string]string{".": "feature", "nested": "main"}, "main")
+		got := parsePRProbeOutput(out)
+		if got == nil {
+			t.Fatalf("top-level feature branch parsed to nil, want a purple tag; out=%q", out)
+		}
+		if got.GetClosedCount() != 1 {
+			t.Errorf("ClosedCount = %d, want 1 (subrepo on its default branch skipped); out=%q",
+				got.GetClosedCount(), out)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Fixes #217. The PR status auto-tag was showing a bogus purple "closed PR" indicator on instances merely parked on a repo's default branch (usually `main`).

The probe (`internal/server/pr_status.go`) lists PRs by `--head <current-branch>` for the workspace repo and every nested subrepo. When the checked-out branch is the repo's default branch, any PR that ever used that branch as its *HEAD* into another branch matches. This was harmless until PR #215 added the persistent purple closed/merged tag — now those long-closed PRs surface a false indicator on an instance just sitting on the trunk.

The fix skips a repo when its checked-out branch is that repo's own default branch:

- **Per-repo** determination, so nested subrepos are judged against their *own* default (as the ticket calls out).
- Prefers the local `origin/HEAD` ref (set by `git clone`, **no API round-trip**), falling back to `gh repo view --json defaultBranchRef` only when `origin/HEAD` isn't configured.
- On any failure the skip is a no-op — degrading to the prior behaviour rather than risk hiding a real PR.

The default branch is the trunk; it has no in-flight PR to track, so it's excluded entirely (open and closed).

A new `TestPRProbeScript_SkipsDefaultBranch` exercises the real probe script against a stubbed `gh` + real git repos, covering the on-default (skipped), on-feature (kept), and mixed per-repo subrepo cases.