### PR TITLE
fix(coder): stop provisioning hanging forever — stdin-EOF-safe file transfer (#223)

### DIFF
--- a/internal/agentdetect/auggie_provisioner.go
+++ b/internal/agentdetect/auggie_provisioner.go
@@ -1,6 +1,7 @@
 package agentdetect
 
 import (
+	"bytes"
 	"fmt"
 	"path"
 	"strings"
@@ -132,14 +133,12 @@ func (p *AuggieProvisioner) readSettings(settingsPath string) ([]byte, error) {
 }
 
 // writeSettings writes content to settingsPath atomically (same-directory tmp
-// then rename, handled by the inline writer, which also mkdir's the parent).
-// Inline (base64-in-argv) rather than stdin-streamed so it cannot hang on the
-// coder backend (issue #223).
+// then rename, plus a parent mkdir — both guaranteed by the CopyFile transport).
+// It streams via CopyFile rather than an inline (base64-in-argv) write because
+// the merged settings.json is unbounded: a user's pre-existing file can exceed
+// the inline writer's ARG_MAX-derived cap. CopyFile is both uncapped and
+// stdin-EOF-safe on every backend including coder (issue #223). The fixed-size
+// hook script keeps using the inline writer.
 func (p *AuggieProvisioner) writeSettings(settingsPath string, content []byte) error {
-	argv, err := backend.InlineWriteScript(settingsPath, content, 0o644)
-	if err != nil {
-		return err
-	}
-	_, err = p.exec.Run(argv, nil)
-	return err
+	return p.exec.CopyFile(bytes.NewReader(content), settingsPath, 0o644)
 }

--- a/internal/agentdetect/auggie_provisioner.go
+++ b/internal/agentdetect/auggie_provisioner.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path"
 	"strings"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 )
 
 // ===========================================
@@ -52,14 +54,15 @@ func NewAuggieProvisioner(exec ContainerExecutor) *AuggieProvisioner {
 // caller which step did not complete; the caller may surface them as
 // warnings rather than aborting container creation.
 func (p *AuggieProvisioner) Provision() error {
-	scriptPath, err := p.resolveScriptPath()
+	home, err := p.resolveHome()
 	if err != nil {
-		return fmt.Errorf("resolve script path: %w", err)
+		return fmt.Errorf("resolve home: %w", err)
 	}
+	scriptPath := path.Join(home, AuggieScriptSuffix)
 	if err := p.dropHookScript(scriptPath); err != nil {
 		return fmt.Errorf("install hook script: %w", err)
 	}
-	if err := p.injectSettings(scriptPath); err != nil {
+	if err := p.injectSettings(home, scriptPath); err != nil {
 		return fmt.Errorf("edit settings.json: %w", err)
 	}
 	return nil
@@ -69,10 +72,13 @@ func (p *AuggieProvisioner) Provision() error {
 // Private helpers
 // ===========================================
 
-// resolveScriptPath asks the container for $HOME and joins it with
-// AuggieScriptSuffix to produce the absolute path the hook script will
-// be dropped at and that settings.json will reference.
-func (p *AuggieProvisioner) resolveScriptPath() (string, error) {
+// settingsSuffix is the home-relative path of auggie's settings file.
+const auggieSettingsSuffix = ".augment/settings.json"
+
+// resolveHome asks the container for $HOME. The hook script and settings.json
+// both live under it, and their absolute paths are baked into the in-container
+// commands (and into settings.json's hook command field).
+func (p *AuggieProvisioner) resolveHome() (string, error) {
 	out, err := p.exec.Run([]string{"sh", "-c", "echo \"$HOME\""}, nil)
 	if err != nil {
 		return "", err
@@ -81,28 +87,28 @@ func (p *AuggieProvisioner) resolveScriptPath() (string, error) {
 	if home == "" {
 		return "", fmt.Errorf("container reported empty $HOME")
 	}
-	return path.Join(home, AuggieScriptSuffix), nil
+	return home, nil
 }
 
-// dropHookScript writes the embedded hook script bytes to scriptPath
-// and sets the executable bit, mkdir-ing the parent first. All three
-// operations are bundled into one shell invocation to minimise
-// round-trips to the container exec layer.
+// dropHookScript writes the embedded hook script bytes to scriptPath and sets
+// the executable bit, via an inline (base64-in-argv) write rather than streaming
+// over stdin — a stdin-reading `cat > file` hangs forever on the coder backend
+// (issue #223). The write mkdir's the parent and is atomic.
 func (p *AuggieProvisioner) dropHookScript(scriptPath string) error {
-	parentDir := path.Dir(scriptPath)
-	script := fmt.Sprintf(
-		`mkdir -p %q && cat > %q && chmod +x %q`,
-		parentDir, scriptPath, scriptPath,
-	)
-	_, err := p.exec.Run([]string{"sh", "-c", script}, AuggieHookScript)
+	argv, err := backend.InlineWriteScript(scriptPath, AuggieHookScript, 0o755)
+	if err != nil {
+		return err
+	}
+	_, err = p.exec.Run(argv, nil)
 	return err
 }
 
 // injectSettings reads the current ~/.augment/settings.json (or treats
 // it as absent), passes it through InjectAuggieHooks, and writes the
 // result back atomically.
-func (p *AuggieProvisioner) injectSettings(scriptPath string) error {
-	current, err := p.readSettings()
+func (p *AuggieProvisioner) injectSettings(home, scriptPath string) error {
+	settingsPath := path.Join(home, auggieSettingsSuffix)
+	current, err := p.readSettings(settingsPath)
 	if err != nil {
 		return fmt.Errorf("read: %w", err)
 	}
@@ -110,27 +116,30 @@ func (p *AuggieProvisioner) injectSettings(scriptPath string) error {
 	if err != nil {
 		return fmt.Errorf("compute: %w", err)
 	}
-	if err := p.writeSettings(updated); err != nil {
+	if err := p.writeSettings(settingsPath, updated); err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
 	return nil
 }
 
-// readSettings cats ~/.augment/settings.json. A missing file produces
-// empty bytes (treated by InjectAuggieHooks as "the file does not
-// exist"), not an error.
-func (p *AuggieProvisioner) readSettings() ([]byte, error) {
-	const script = `if [ -f "$HOME/.augment/settings.json" ]; then cat "$HOME/.augment/settings.json"; fi`
+// readSettings cats settingsPath. A missing file produces empty bytes (treated
+// by InjectAuggieHooks as "the file does not exist"), not an error. The read
+// produces output and exits, so it has no stdin-EOF dependency.
+func (p *AuggieProvisioner) readSettings(settingsPath string) ([]byte, error) {
+	q := backend.ShellQuote(settingsPath)
+	script := fmt.Sprintf(`if [ -f %s ]; then cat %s; fi`, q, q)
 	return p.exec.Run([]string{"sh", "-c", script}, nil)
 }
 
-// writeSettings writes content to ~/.augment/settings.json atomically:
-// same-directory tmp file then rename. mkdir of ~/.augment handles the
-// first-time case where auggie has never been run in this container.
-func (p *AuggieProvisioner) writeSettings(content []byte) error {
-	const script = `mkdir -p "$HOME/.augment" && ` +
-		`cat > "$HOME/.augment/settings.json.tmp" && ` +
-		`mv "$HOME/.augment/settings.json.tmp" "$HOME/.augment/settings.json"`
-	_, err := p.exec.Run([]string{"sh", "-c", script}, content)
+// writeSettings writes content to settingsPath atomically (same-directory tmp
+// then rename, handled by the inline writer, which also mkdir's the parent).
+// Inline (base64-in-argv) rather than stdin-streamed so it cannot hang on the
+// coder backend (issue #223).
+func (p *AuggieProvisioner) writeSettings(settingsPath string, content []byte) error {
+	argv, err := backend.InlineWriteScript(settingsPath, content, 0o644)
+	if err != nil {
+		return err
+	}
+	_, err = p.exec.Run(argv, nil)
 	return err
 }

--- a/internal/agentdetect/auggie_provisioner_test.go
+++ b/internal/agentdetect/auggie_provisioner_test.go
@@ -35,7 +35,7 @@ func TestAuggieProvision_FreshContainer(t *testing.T) {
 	}
 
 	// The hook script payload must be the embedded auggie bytes.
-	if !bytes.Equal(exec.calls[1].stdin, AuggieHookScript) {
+	if !bytes.Equal(inlineWritten(exec.calls[1]), AuggieHookScript) {
 		t.Errorf("drop-script stdin does not match embedded AuggieHookScript")
 	}
 
@@ -55,7 +55,7 @@ func TestAuggieProvision_FreshContainer(t *testing.T) {
 
 	// The written settings.json must register every managed event,
 	// each pointing at the resolved script path.
-	written := exec.calls[3].stdin
+	written := inlineWritten(exec.calls[3])
 	hooks := parseHooks(t, written)
 	for _, event := range auggieManagedEvents {
 		group := fleetManAuggieGroup(t, hooks, event.name)
@@ -81,7 +81,7 @@ func TestAuggieProvision_PreservesExistingSettings(t *testing.T) {
 	if err := NewAuggieProvisioner(exec).Provision(); err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
-	written := string(exec.calls[3].stdin)
+	written := string(inlineWritten(exec.calls[3]))
 	if !strings.Contains(written, `"model"`) || !strings.Contains(written, "/u/audit.sh") {
 		t.Errorf("user content dropped from output:\n%s", written)
 	}
@@ -101,7 +101,7 @@ func TestAuggieProvision_Idempotent(t *testing.T) {
 	if err := NewAuggieProvisioner(first).Provision(); err != nil {
 		t.Fatalf("first Provision: %v", err)
 	}
-	firstWritten := first.calls[3].stdin
+	firstWritten := inlineWritten(first.calls[3])
 
 	second := &fakeExec{
 		responses: []fakeResponse{
@@ -114,8 +114,9 @@ func TestAuggieProvision_Idempotent(t *testing.T) {
 	if err := NewAuggieProvisioner(second).Provision(); err != nil {
 		t.Fatalf("second Provision: %v", err)
 	}
-	if !bytes.Equal(firstWritten, second.calls[3].stdin) {
-		t.Errorf("not idempotent\nfirst:  %s\nsecond: %s", firstWritten, second.calls[3].stdin)
+	secondWritten := inlineWritten(second.calls[3])
+	if !bytes.Equal(firstWritten, secondWritten) {
+		t.Errorf("not idempotent\nfirst:  %s\nsecond: %s", firstWritten, secondWritten)
 	}
 }
 

--- a/internal/agentdetect/auggie_provisioner_test.go
+++ b/internal/agentdetect/auggie_provisioner_test.go
@@ -17,17 +17,18 @@ func TestAuggieProvision_FreshContainer(t *testing.T) {
 			{stdout: []byte(homeStdout), err: nil}, // query home
 			{stdout: nil, err: nil},                // drop script
 			{stdout: nil, err: nil},                // read settings (empty)
-			{stdout: nil, err: nil},                // write settings
 		},
 	}
 	if err := NewAuggieProvisioner(exec).Provision(); err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
 
-	if len(exec.calls) != 4 {
-		t.Fatalf("expected 4 exec calls, got %d", len(exec.calls))
+	// The settings write now streams through CopyFile, so only three Run calls
+	// remain (home, drop, read) plus one recorded copy.
+	if len(exec.calls) != 3 {
+		t.Fatalf("expected 3 exec calls, got %d", len(exec.calls))
 	}
-	wantKinds := []string{"query-home", "drop-script", "read-settings", "write-settings"}
+	wantKinds := []string{"query-home", "drop-script", "read-settings"}
 	for i, want := range wantKinds {
 		if got := callKind(exec.calls[i]); got != want {
 			t.Errorf("call %d kind = %q, want %q", i, got, want)
@@ -45,17 +46,21 @@ func TestAuggieProvision_FreshContainer(t *testing.T) {
 		t.Errorf("drop-script missing resolved path %q:\n%s", expectedScriptPath, dropBody)
 	}
 
-	// Read and write must target ~/.augment/settings.json, not ~/.claude.
+	// Read (Run) and write (CopyFile) must target ~/.augment/settings.json, not
+	// ~/.claude.
 	if body := exec.calls[2].args[2]; !strings.Contains(body, ".augment/settings.json") {
 		t.Errorf("read does not target ~/.augment/settings.json:\n%s", body)
 	}
-	if body := exec.calls[3].args[2]; !strings.Contains(body, ".augment/settings.json") {
-		t.Errorf("write does not target ~/.augment/settings.json:\n%s", body)
+	if len(exec.copies) != 1 {
+		t.Fatalf("expected 1 settings CopyFile, got %d", len(exec.copies))
+	}
+	if p := exec.copies[0].path; !strings.Contains(p, ".augment/settings.json") {
+		t.Errorf("write does not target ~/.augment/settings.json: %q", p)
 	}
 
 	// The written settings.json must register every managed event,
 	// each pointing at the resolved script path.
-	written := inlineWritten(exec.calls[3])
+	written := exec.copies[0].content
 	hooks := parseHooks(t, written)
 	for _, event := range auggieManagedEvents {
 		group := fleetManAuggieGroup(t, hooks, event.name)
@@ -75,13 +80,12 @@ func TestAuggieProvision_PreservesExistingSettings(t *testing.T) {
 			{stdout: []byte(homeStdout), err: nil},
 			{stdout: nil, err: nil},
 			{stdout: existing, err: nil},
-			{stdout: nil, err: nil},
 		},
 	}
 	if err := NewAuggieProvisioner(exec).Provision(); err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
-	written := string(inlineWritten(exec.calls[3]))
+	written := string(exec.copies[0].content)
 	if !strings.Contains(written, `"model"`) || !strings.Contains(written, "/u/audit.sh") {
 		t.Errorf("user content dropped from output:\n%s", written)
 	}
@@ -95,26 +99,24 @@ func TestAuggieProvision_Idempotent(t *testing.T) {
 			{stdout: []byte(homeStdout), err: nil},
 			{stdout: nil, err: nil},
 			{stdout: nil, err: nil},
-			{stdout: nil, err: nil},
 		},
 	}
 	if err := NewAuggieProvisioner(first).Provision(); err != nil {
 		t.Fatalf("first Provision: %v", err)
 	}
-	firstWritten := inlineWritten(first.calls[3])
+	firstWritten := first.copies[0].content
 
 	second := &fakeExec{
 		responses: []fakeResponse{
 			{stdout: []byte(homeStdout), err: nil},
 			{stdout: nil, err: nil},
 			{stdout: firstWritten, err: nil},
-			{stdout: nil, err: nil},
 		},
 	}
 	if err := NewAuggieProvisioner(second).Provision(); err != nil {
 		t.Fatalf("second Provision: %v", err)
 	}
-	secondWritten := inlineWritten(second.calls[3])
+	secondWritten := second.copies[0].content
 	if !bytes.Equal(firstWritten, secondWritten) {
 		t.Errorf("not idempotent\nfirst:  %s\nsecond: %s", firstWritten, secondWritten)
 	}

--- a/internal/agentdetect/backend_executor.go
+++ b/internal/agentdetect/backend_executor.go
@@ -3,6 +3,7 @@ package agentdetect
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
@@ -61,4 +62,11 @@ func (b *BackendExecutor) Run(args []string, stdin []byte) ([]byte, error) {
 		return nil, err
 	}
 	return stdout.Bytes(), nil
+}
+
+// CopyFile delegates to the backend's stdin-EOF-safe file transfer, anchored at
+// the same workspace dir. It is the uncapped counterpart to an inline write,
+// used for payloads (the merged settings.json) that may exceed the inline cap.
+func (b *BackendExecutor) CopyFile(src io.Reader, remotePath string, mode int) error {
+	return b.backend.CopyFile(b.workspaceDir, src, remotePath, mode)
 }

--- a/internal/agentdetect/claude_integration_test.go
+++ b/internal/agentdetect/claude_integration_test.go
@@ -3,6 +3,7 @@ package agentdetect
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -44,6 +45,21 @@ func (l *localExecutor) Run(args []string, stdin []byte) ([]byte, error) {
 		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
 	}
 	return stdout.Bytes(), nil
+}
+
+// CopyFile satisfies ContainerExecutor for the settings write. Since this
+// executor targets the host filesystem (with HOME redirected to a temp dir), it
+// writes the bytes straight to remotePath, mkdir'ing the parent — mirroring the
+// atomic-write contract the production CopyFile transports provide.
+func (l *localExecutor) CopyFile(src io.Reader, remotePath string, mode int) error {
+	data, err := io.ReadAll(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(remotePath), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(remotePath, data, os.FileMode(mode))
 }
 
 // ===========================================

--- a/internal/agentdetect/claude_provisioner.go
+++ b/internal/agentdetect/claude_provisioner.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path"
 	"strings"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 )
 
 // ===========================================
@@ -66,14 +68,15 @@ func NewClaudeProvisioner(exec ContainerExecutor) *ClaudeProvisioner {
 // path into settings.json keeps Claude Code's hook command field
 // independent of any shell expansion behaviour.
 func (p *ClaudeProvisioner) Provision() error {
-	scriptPath, err := p.resolveScriptPath()
+	home, err := p.resolveHome()
 	if err != nil {
-		return fmt.Errorf("resolve script path: %w", err)
+		return fmt.Errorf("resolve home: %w", err)
 	}
+	scriptPath := path.Join(home, FleetManScriptSuffix)
 	if err := p.dropHookScript(scriptPath); err != nil {
 		return fmt.Errorf("install hook script: %w", err)
 	}
-	if err := p.injectSettings(scriptPath); err != nil {
+	if err := p.injectSettings(home, scriptPath); err != nil {
 		return fmt.Errorf("edit settings.json: %w", err)
 	}
 	return nil
@@ -83,10 +86,14 @@ func (p *ClaudeProvisioner) Provision() error {
 // Private helpers
 // ===========================================
 
-// resolveScriptPath asks the container for $HOME and joins it with
-// FleetManScriptSuffix to produce the absolute path the hook script
-// will be dropped at and that settings.json will reference.
-func (p *ClaudeProvisioner) resolveScriptPath() (string, error) {
+// settingsSuffix is the home-relative path of Claude Code's settings file.
+const settingsSuffix = ".claude/settings.json"
+
+// resolveHome asks the container for $HOME. The hook script and settings.json
+// both live under it, and their absolute paths are baked into the in-container
+// commands (and into settings.json's hook command field) so nothing depends on
+// later shell expansion.
+func (p *ClaudeProvisioner) resolveHome() (string, error) {
 	out, err := p.exec.Run([]string{"sh", "-c", "echo \"$HOME\""}, nil)
 	if err != nil {
 		return "", err
@@ -95,31 +102,29 @@ func (p *ClaudeProvisioner) resolveScriptPath() (string, error) {
 	if home == "" {
 		return "", fmt.Errorf("container reported empty $HOME")
 	}
-	return path.Join(home, FleetManScriptSuffix), nil
+	return home, nil
 }
 
-// dropHookScript writes the embedded hook script bytes to scriptPath
-// and sets the executable bit. mkdir of the parent directory
-// guarantees the path exists even on a fresh container that has
-// never had ~/.fleet/scripts before.
-//
-// All three operations are bundled into a single shell invocation
-// to minimise round-trips to the container exec layer.
+// dropHookScript writes the embedded hook script bytes to scriptPath and sets
+// the executable bit. It uses an inline (base64-in-argv) write rather than
+// streaming the bytes over stdin: a stdin-reading `cat > file` hangs forever on
+// the coder backend, whose transport never delivers the stdin EOF (issue #223).
+// The write mkdir's the parent and is atomic.
 func (p *ClaudeProvisioner) dropHookScript(scriptPath string) error {
-	parentDir := path.Dir(scriptPath)
-	script := fmt.Sprintf(
-		`mkdir -p %q && cat > %q && chmod +x %q`,
-		parentDir, scriptPath, scriptPath,
-	)
-	_, err := p.exec.Run([]string{"sh", "-c", script}, ClaudeHookScript)
+	argv, err := backend.InlineWriteScript(scriptPath, ClaudeHookScript, 0o755)
+	if err != nil {
+		return err
+	}
+	_, err = p.exec.Run(argv, nil)
 	return err
 }
 
 // injectSettings reads the current settings.json (or treats it as
 // absent), passes it through InjectFleetManHooks, and writes the
 // result back atomically.
-func (p *ClaudeProvisioner) injectSettings(scriptPath string) error {
-	current, err := p.readSettings()
+func (p *ClaudeProvisioner) injectSettings(home, scriptPath string) error {
+	settingsPath := path.Join(home, settingsSuffix)
+	current, err := p.readSettings(settingsPath)
 	if err != nil {
 		return fmt.Errorf("read: %w", err)
 	}
@@ -127,30 +132,32 @@ func (p *ClaudeProvisioner) injectSettings(scriptPath string) error {
 	if err != nil {
 		return fmt.Errorf("compute: %w", err)
 	}
-	if err := p.writeSettings(updated); err != nil {
+	if err := p.writeSettings(settingsPath, updated); err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
 	return nil
 }
 
-// readSettings cats ~/.claude/settings.json. A missing file
-// produces empty bytes (treated by InjectFleetManHooks as "the file
-// does not exist"), not an error — distinguishing "missing" from
-// "present and empty" inside a shell pipeline is not worth the
-// complexity since both yield the same downstream behaviour.
-func (p *ClaudeProvisioner) readSettings() ([]byte, error) {
-	const script = `if [ -f "$HOME/.claude/settings.json" ]; then cat "$HOME/.claude/settings.json"; fi`
+// readSettings cats settingsPath. A missing file produces empty bytes (treated
+// by InjectFleetManHooks as "the file does not exist"), not an error —
+// distinguishing "missing" from "present and empty" inside a shell pipeline is
+// not worth the complexity since both yield the same downstream behaviour. The
+// read produces output and exits, so it has no stdin-EOF dependency.
+func (p *ClaudeProvisioner) readSettings(settingsPath string) ([]byte, error) {
+	q := backend.ShellQuote(settingsPath)
+	script := fmt.Sprintf(`if [ -f %s ]; then cat %s; fi`, q, q)
 	return p.exec.Run([]string{"sh", "-c", script}, nil)
 }
 
-// writeSettings writes content to ~/.claude/settings.json
-// atomically: same-directory tmp file then rename. mkdir of
-// ~/.claude handles the first-time case where Claude Code has
-// never been run in this container.
-func (p *ClaudeProvisioner) writeSettings(content []byte) error {
-	const script = `mkdir -p "$HOME/.claude" && ` +
-		`cat > "$HOME/.claude/settings.json.tmp" && ` +
-		`mv "$HOME/.claude/settings.json.tmp" "$HOME/.claude/settings.json"`
-	_, err := p.exec.Run([]string{"sh", "-c", script}, content)
+// writeSettings writes content to settingsPath atomically (same-directory tmp
+// then rename, handled by the inline writer, which also mkdir's the parent for
+// the first-time case). Inline (base64-in-argv) rather than stdin-streamed so it
+// cannot hang on the coder backend (issue #223).
+func (p *ClaudeProvisioner) writeSettings(settingsPath string, content []byte) error {
+	argv, err := backend.InlineWriteScript(settingsPath, content, 0o644)
+	if err != nil {
+		return err
+	}
+	_, err = p.exec.Run(argv, nil)
 	return err
 }

--- a/internal/agentdetect/claude_provisioner.go
+++ b/internal/agentdetect/claude_provisioner.go
@@ -1,6 +1,7 @@
 package agentdetect
 
 import (
+	"bytes"
 	"fmt"
 	"path"
 	"strings"
@@ -150,14 +151,14 @@ func (p *ClaudeProvisioner) readSettings(settingsPath string) ([]byte, error) {
 }
 
 // writeSettings writes content to settingsPath atomically (same-directory tmp
-// then rename, handled by the inline writer, which also mkdir's the parent for
-// the first-time case). Inline (base64-in-argv) rather than stdin-streamed so it
-// cannot hang on the coder backend (issue #223).
+// then rename, plus a parent mkdir for the first-time case — both guaranteed by
+// the CopyFile transport). It streams via CopyFile rather than an inline
+// (base64-in-argv) write because the merged settings.json is the one unbounded
+// payload here: a user's pre-existing file can be arbitrarily large, and the
+// inline writer hard-errors above its ARG_MAX-derived cap. CopyFile is both
+// uncapped and stdin-EOF-safe on every backend including coder (issue #223), so
+// it carries a large settings.json without the hang the inline path was added to
+// avoid. The fixed-size hook script keeps using the inline writer.
 func (p *ClaudeProvisioner) writeSettings(settingsPath string, content []byte) error {
-	argv, err := backend.InlineWriteScript(settingsPath, content, 0o644)
-	if err != nil {
-		return err
-	}
-	_, err = p.exec.Run(argv, nil)
-	return err
+	return p.exec.CopyFile(bytes.NewReader(content), settingsPath, 0o644)
 }

--- a/internal/agentdetect/claude_provisioner_test.go
+++ b/internal/agentdetect/claude_provisioner_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 )
@@ -25,6 +26,14 @@ type fakeResponse struct {
 	err    error
 }
 
+// copyCall captures one CopyFile invocation (the settings write, now streamed
+// through the backend's uncapped CopyFile rather than an inline Run).
+type copyCall struct {
+	path    string
+	content []byte
+	mode    int
+}
+
 // fakeExec is a ContainerExecutor that records calls and returns
 // pre-seeded responses in order. Tests use it to assert both that
 // the provisioner issued the expected sequence of shell
@@ -32,6 +41,8 @@ type fakeResponse struct {
 type fakeExec struct {
 	calls     []fakeCall
 	responses []fakeResponse
+	copies    []copyCall // recorded CopyFile invocations (settings writes)
+	copyErr   error      // error CopyFile returns, for the write-failure paths
 }
 
 // Run satisfies ContainerExecutor.
@@ -44,13 +55,22 @@ func (f *fakeExec) Run(args []string, stdin []byte) ([]byte, error) {
 	return resp.stdout, resp.err
 }
 
-// callKind classifies a recorded call by inspecting its shell
-// payload — this lets tests assert "the third call wrote
+// CopyFile satisfies ContainerExecutor, recording the streamed payload so tests
+// can assert on the written settings.json without an inline base64 decode.
+func (f *fakeExec) CopyFile(src io.Reader, remotePath string, mode int) error {
+	data, _ := io.ReadAll(src)
+	f.copies = append(f.copies, copyCall{path: remotePath, content: data, mode: mode})
+	return f.copyErr
+}
+
+// callKind classifies a recorded Run call by inspecting its shell
+// payload — this lets tests assert "the third call read
 // settings.json" without depending on the exact wording of the
-// shell snippet. The script and settings writes are now inline
-// (base64-in-argv) writes rather than stdin-streamed `cat >`s, so
-// they are recognised by the in-container `base64 -d` decode plus
-// whether the target path is settings.json.
+// shell snippet. The hook script drop is an inline (base64-in-argv)
+// write, recognised by its in-container `base64 -d` decode; the
+// settings WRITE no longer appears here at all (it streams through
+// CopyFile, asserted via fakeExec.copies). The write-settings case
+// is retained only to label any stray inline settings write.
 func callKind(call fakeCall) string {
 	if len(call.args) < 3 {
 		return "unknown"
@@ -112,21 +132,28 @@ func TestProvision_FreshContainer(t *testing.T) {
 			{stdout: []byte(homeStdout), err: nil}, // query home
 			{stdout: nil, err: nil},                // drop script
 			{stdout: nil, err: nil},                // read settings (empty file)
-			{stdout: nil, err: nil},                // write settings
 		},
 	}
 	if err := NewClaudeProvisioner(exec).Provision(); err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
 
-	if len(exec.calls) != 4 {
-		t.Fatalf("expected 4 exec calls, got %d", len(exec.calls))
+	// The settings write now streams through CopyFile, so only three Run calls
+	// remain (home, drop, read) plus one recorded copy.
+	if len(exec.calls) != 3 {
+		t.Fatalf("expected 3 exec calls, got %d", len(exec.calls))
 	}
-	wantKinds := []string{"query-home", "drop-script", "read-settings", "write-settings"}
+	wantKinds := []string{"query-home", "drop-script", "read-settings"}
 	for i, want := range wantKinds {
 		if got := callKind(exec.calls[i]); got != want {
 			t.Errorf("call %d kind = %q, want %q", i, got, want)
 		}
+	}
+	if len(exec.copies) != 1 {
+		t.Fatalf("expected 1 settings CopyFile, got %d", len(exec.copies))
+	}
+	if want := "/home/test/" + settingsSuffix; exec.copies[0].path != want {
+		t.Errorf("settings written to %q, want %q", exec.copies[0].path, want)
 	}
 
 	// The hook script payload sent over stdin must match the
@@ -145,7 +172,7 @@ func TestProvision_FreshContainer(t *testing.T) {
 
 	// The written settings.json must contain our hook command path
 	// for every managed event, using the resolved absolute path.
-	written := string(inlineWritten(exec.calls[3]))
+	written := string(exec.copies[0].content)
 	for _, event := range fleetManManagedEvents {
 		marker := expectedScriptPath + " " + event
 		if !strings.Contains(written, marker) {
@@ -165,14 +192,13 @@ func TestProvision_PreservesExistingSettings(t *testing.T) {
 			{stdout: []byte(homeStdout), err: nil},
 			{stdout: nil, err: nil},
 			{stdout: existing, err: nil},
-			{stdout: nil, err: nil},
 		},
 	}
 	if err := NewClaudeProvisioner(exec).Provision(); err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
 
-	written := string(inlineWritten(exec.calls[3]))
+	written := string(exec.copies[0].content)
 	if !strings.Contains(written, `"theme"`) || !strings.Contains(written, `"dark"`) {
 		t.Errorf("user theme key dropped from output:\n%s", written)
 	}
@@ -191,26 +217,24 @@ func TestProvision_Idempotent(t *testing.T) {
 			{stdout: []byte(homeStdout), err: nil},
 			{stdout: nil, err: nil},
 			{stdout: nil, err: nil},
-			{stdout: nil, err: nil},
 		},
 	}
 	if err := NewClaudeProvisioner(first).Provision(); err != nil {
 		t.Fatalf("first Provision: %v", err)
 	}
-	firstWritten := inlineWritten(first.calls[3])
+	firstWritten := first.copies[0].content
 
 	second := &fakeExec{
 		responses: []fakeResponse{
 			{stdout: []byte(homeStdout), err: nil},
 			{stdout: nil, err: nil},
 			{stdout: firstWritten, err: nil},
-			{stdout: nil, err: nil},
 		},
 	}
 	if err := NewClaudeProvisioner(second).Provision(); err != nil {
 		t.Fatalf("second Provision: %v", err)
 	}
-	secondWritten := inlineWritten(second.calls[3])
+	secondWritten := second.copies[0].content
 
 	if !bytes.Equal(firstWritten, secondWritten) {
 		t.Errorf("not idempotent\nfirst:  %s\nsecond: %s", firstWritten, secondWritten)
@@ -382,11 +406,11 @@ func TestProvision_MalformedExistingSettingsSurfaces(t *testing.T) {
 // compute succeed, a write error bubbles up with phase context.
 func TestProvision_WriteFailureSurfaces(t *testing.T) {
 	exec := &fakeExec{
+		copyErr: errors.New("disk full"), // the settings write now fails via CopyFile
 		responses: []fakeResponse{
 			{stdout: []byte(homeStdout), err: nil},
 			{stdout: nil, err: nil},
 			{stdout: nil, err: nil},
-			{stdout: nil, err: errors.New("disk full")},
 		},
 	}
 	err := NewClaudeProvisioner(exec).Provision()

--- a/internal/agentdetect/claude_provisioner_test.go
+++ b/internal/agentdetect/claude_provisioner_test.go
@@ -2,6 +2,7 @@ package agentdetect
 
 import (
 	"bytes"
+	"encoding/base64"
 	"errors"
 	"strings"
 	"testing"
@@ -46,7 +47,10 @@ func (f *fakeExec) Run(args []string, stdin []byte) ([]byte, error) {
 // callKind classifies a recorded call by inspecting its shell
 // payload — this lets tests assert "the third call wrote
 // settings.json" without depending on the exact wording of the
-// shell snippet.
+// shell snippet. The script and settings writes are now inline
+// (base64-in-argv) writes rather than stdin-streamed `cat >`s, so
+// they are recognised by the in-container `base64 -d` decode plus
+// whether the target path is settings.json.
 func callKind(call fakeCall) string {
 	if len(call.args) < 3 {
 		return "unknown"
@@ -55,14 +59,39 @@ func callKind(call fakeCall) string {
 	switch {
 	case strings.Contains(body, "echo") && strings.Contains(body, "$HOME"):
 		return "query-home"
-	case strings.Contains(body, "chmod +x"):
-		return "drop-script"
 	case strings.Contains(body, "if [ -f") && strings.Contains(body, "settings.json"):
 		return "read-settings"
-	case strings.Contains(body, "settings.json.tmp") && strings.Contains(body, "mv"):
+	case strings.Contains(body, "base64 -d") && strings.Contains(body, "settings.json"):
 		return "write-settings"
+	case strings.Contains(body, "base64 -d"):
+		return "drop-script"
 	}
 	return "unknown"
+}
+
+// inlineWritten extracts and decodes the payload an inline (base64-in-argv)
+// write embeds in its shell body (between `printf %s '` and `'`), so tests can
+// assert on the bytes the provisioner wrote without a stdin pipe.
+func inlineWritten(call fakeCall) []byte {
+	if len(call.args) < 3 {
+		return nil
+	}
+	const pre = "printf %s '"
+	body := call.args[2]
+	i := strings.Index(body, pre)
+	if i < 0 {
+		return nil
+	}
+	rest := body[i+len(pre):]
+	j := strings.Index(rest, "'")
+	if j < 0 {
+		return nil
+	}
+	data, err := base64.StdEncoding.DecodeString(rest[:j])
+	if err != nil {
+		return nil
+	}
+	return data
 }
 
 // homeStdout is the canned response to the queryHome call — used by
@@ -102,7 +131,7 @@ func TestProvision_FreshContainer(t *testing.T) {
 
 	// The hook script payload sent over stdin must match the
 	// embedded bytes — proves the wrong file isn't being shipped.
-	if !bytes.Equal(exec.calls[1].stdin, ClaudeHookScript) {
+	if !bytes.Equal(inlineWritten(exec.calls[1]), ClaudeHookScript) {
 		t.Errorf("drop-script stdin does not match embedded ClaudeHookScript")
 	}
 
@@ -116,7 +145,7 @@ func TestProvision_FreshContainer(t *testing.T) {
 
 	// The written settings.json must contain our hook command path
 	// for every managed event, using the resolved absolute path.
-	written := string(exec.calls[3].stdin)
+	written := string(inlineWritten(exec.calls[3]))
 	for _, event := range fleetManManagedEvents {
 		marker := expectedScriptPath + " " + event
 		if !strings.Contains(written, marker) {
@@ -143,7 +172,7 @@ func TestProvision_PreservesExistingSettings(t *testing.T) {
 		t.Fatalf("Provision: %v", err)
 	}
 
-	written := string(exec.calls[3].stdin)
+	written := string(inlineWritten(exec.calls[3]))
 	if !strings.Contains(written, `"theme"`) || !strings.Contains(written, `"dark"`) {
 		t.Errorf("user theme key dropped from output:\n%s", written)
 	}
@@ -168,7 +197,7 @@ func TestProvision_Idempotent(t *testing.T) {
 	if err := NewClaudeProvisioner(first).Provision(); err != nil {
 		t.Fatalf("first Provision: %v", err)
 	}
-	firstWritten := first.calls[3].stdin
+	firstWritten := inlineWritten(first.calls[3])
 
 	second := &fakeExec{
 		responses: []fakeResponse{
@@ -181,7 +210,7 @@ func TestProvision_Idempotent(t *testing.T) {
 	if err := NewClaudeProvisioner(second).Provision(); err != nil {
 		t.Fatalf("second Provision: %v", err)
 	}
-	secondWritten := second.calls[3].stdin
+	secondWritten := inlineWritten(second.calls[3])
 
 	if !bytes.Equal(firstWritten, secondWritten) {
 		t.Errorf("not idempotent\nfirst:  %s\nsecond: %s", firstWritten, secondWritten)
@@ -258,7 +287,7 @@ func TestProvision_HomeQueryFailureAborts(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when home query fails, got nil")
 	}
-	if !strings.Contains(err.Error(), "resolve script path") {
+	if !strings.Contains(err.Error(), "resolve home") {
 		t.Errorf("error not phase-tagged: %v", err)
 	}
 	if len(exec.calls) != 1 {

--- a/internal/agentdetect/container_executor.go
+++ b/internal/agentdetect/container_executor.go
@@ -1,5 +1,7 @@
 package agentdetect
 
+import "io"
+
 // ===========================================
 // ContainerExecutor abstraction
 // ===========================================
@@ -14,6 +16,13 @@ package agentdetect
 // exit or transport error is returned as err with stderr included
 // in the wrapped message so the caller has something diagnostic to
 // surface to the user.
+//
+// CopyFile writes src to remotePath with the given mode using the
+// backend's stdin-EOF-safe file transfer (atomic, parent-creating).
+// Unlike an inline base64-in-argv write it carries no size cap, so the
+// provisioner uses it for the unbounded read-merge-rewrite of the
+// user's settings.json; small fixed payloads still go inline.
 type ContainerExecutor interface {
 	Run(args []string, stdin []byte) ([]byte, error)
+	CopyFile(src io.Reader, remotePath string, mode int) error
 }

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -1,6 +1,9 @@
 package backend
 
-import "os/exec"
+import (
+	"io"
+	"os/exec"
+)
 
 // Backend defines the strategy interface for container runtimes.
 // Implementations handle provisioning, lifecycle, execution,
@@ -91,6 +94,25 @@ type Backend interface {
 	// where logging every command would flood the event log. Behaviour is
 	// otherwise identical to ExecCommand.
 	ExecCommandQuiet(workspaceDir string, command []string) *Cmd
+
+	// CopyFile streams src INTO the instance, writing it to remotePath with the
+	// given mode. It is the single strategy seam for host→instance file transfer:
+	// callers (the fleet-launch binary stager, the `fleet copy` server handler)
+	// invoke it without caring which transport a backend uses. The write is
+	// atomic (same-directory temp + rename), creates remotePath's parent, and
+	// assumes that parent is writable by the exec user (a caller needing a
+	// privileged destination copies to a writable staging path and moves it into
+	// place separately).
+	//
+	// Crucially, an implementation MUST NOT rely on the remote command reading
+	// stdin to EOF: the coder backend's SSH transport never half-closes a remote
+	// command's stdin, so a `cat > file` there hangs forever. devcontainer (local
+	// docker exec) and codespaces (OpenSSH, no PTY) stream over stdin via
+	// StreamWriteScript; coder transfers out-of-band with scp.
+	//
+	// This is the INTO direction (host → instance); it is unrelated to the
+	// fleetgrpc CopyFile RPC, which streams a file OUT of an instance.
+	CopyFile(workspaceDir string, src io.Reader, remotePath string, mode int) error
 
 	// Stats returns CPU and memory usage for the given container IDs.
 	Stats(containerIDs []string) (map[string]*ContainerStats, error)

--- a/internal/backend/coder/coder_copy.go
+++ b/internal/backend/coder/coder_copy.go
@@ -57,6 +57,15 @@ func remoteStageName(remotePath string) string {
 // CopyTimeout rather than a caller context — Backend.CopyFile takes no context,
 // so a client that aborts an in-flight `fleet copy` cannot cancel the scp before
 // that timeout; the bound keeps an abandoned copy from leaking indefinitely.
+//
+// remotePath should be ABSOLUTE. Every caller in the staging path passes one
+// (the binary stages to /tmp, the automation event file to /tmp). A relative
+// remotePath resolves against scp's / `coder ssh`'s login dir (home) on coder —
+// which differs from the workspace folder a devcontainer/codespaces write would
+// use, and from the path the `fleet copy` handler reports — so a `fleet copy`
+// with an empty/relative dest lands in an undefined spot on coder. That path is
+// part of the still-to-be-validated coder `fleet copy` support; the #223 fix
+// (binary + automation staging) is unaffected because it is always absolute.
 func (coderBackend *CoderBackend) CopyFile(workspaceDir string, src io.Reader, remotePath string, mode int) error {
 	if _, err := exec.LookPath("scp"); err != nil {
 		return fmt.Errorf("copy into %q: scp not found on host (required for coder file transfer): %w", remotePath, err)
@@ -80,6 +89,13 @@ func (coderBackend *CoderBackend) CopyFile(workspaceDir string, src io.Reader, r
 
 	ctx, cancel := context.WithTimeout(context.Background(), backend.CopyTimeout)
 	defer cancel()
+	// The remote operand (target:remoteTmp) is intentionally NOT shell-quoted,
+	// unlike the mkdir/install/cleanup execs around it: scp's default SFTP
+	// transfer (OpenSSH 9.0+) takes the post-colon path LITERALLY, so a `'..'`
+	// wrapper would become part of the filename. (Quoting is only right for the
+	// pre-9.0 legacy protocol, where a remote shell expands the path — which this
+	// code never opts into via -O.) remoteTmp derives from remotePath, so the
+	// staging-path callers (always /tmp) carry no spaces regardless.
 	scp := exec.CommandContext(ctx, "scp",
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=/dev/null",

--- a/internal/backend/coder/coder_copy.go
+++ b/internal/backend/coder/coder_copy.go
@@ -1,0 +1,139 @@
+package coder
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// coderPrepTimeout bounds the small stdin-free helper execs (mkdir, chmod+mv,
+// cleanup) that bracket the scp transfer. They read no stdin, so they cannot hit
+// the coder stdin-EOF hang; the deadline only guards against a stuck tunnel.
+const coderPrepTimeout = 30 * time.Second
+
+// coderCopySeq makes the remote staging name unique within this process so two
+// concurrent CopyFile calls to the same remotePath never collide on it.
+var coderCopySeq atomic.Uint64
+
+// remoteStageName returns a hidden, per-call-unique sibling of remotePath to scp
+// into before the atomic rename — the out-of-band analogue of the in-shell
+// `$$`-suffixed temp the stdin-streaming backends use.
+func remoteStageName(remotePath string) string {
+	var b [6]byte
+	_, _ = rand.Read(b[:])
+	return fmt.Sprintf("%s.fleet-scp.%d.%x", remotePath, coderCopySeq.Add(1), b)
+}
+
+// CopyFile transfers src INTO the coder workspace (its nested devcontainer) at
+// remotePath. It cannot stream over `coder ssh` stdin like the other backends:
+// the coder agent's SSH server (gliderlabs/ssh) never half-closes a remote
+// command's stdin, so a `cat > file` reading to EOF hangs forever (issue #223).
+//
+// Instead it uses scp, whose length-framed protocol needs no stdin EOF,
+// tunnelled over `coder ssh --stdio` as an OpenSSH ProxyCommand — the transport
+// coder documents for scp/rsync, which lands the file inside the nested
+// devcontainer agent. Sequence:
+//
+//  1. materialise src to a host file (an *os.File source is used directly);
+//  2. mkdir -p the destination's parent (scp will not create it);
+//  3. scp the host file to a sibling temp next to remotePath;
+//  4. chmod + atomic rename into place via a normal exec (stdin-free, hang-proof).
+//
+// scp defaults to the SFTP subsystem, which the coder agent provides; if a
+// particular template's nested agent lacks it the transfer fails cleanly (the
+// caller treats binary staging as best-effort) rather than hanging.
+//
+// Requirements & limitations: `scp` must be on the host PATH and be an
+// OpenSSH-compatible build (the `-o ProxyCommand` syntax is OpenSSH-specific;
+// e.g. Dropbear's scp would reject it). The scp deadline is the standalone
+// CopyTimeout rather than a caller context — Backend.CopyFile takes no context,
+// so a client that aborts an in-flight `fleet copy` cannot cancel the scp before
+// that timeout; the bound keeps an abandoned copy from leaking indefinitely.
+func (coderBackend *CoderBackend) CopyFile(workspaceDir string, src io.Reader, remotePath string, mode int) error {
+	if _, err := exec.LookPath("scp"); err != nil {
+		return fmt.Errorf("copy into %q: scp not found on host (required for coder file transfer): %w", remotePath, err)
+	}
+
+	localPath, cleanup, err := localFileForCopy(src)
+	if err != nil {
+		return fmt.Errorf("copy into %q: stage source: %w", remotePath, err)
+	}
+	defer cleanup()
+
+	name := coderWorkspaceName(workspaceDir)
+	target := coderBackend.resolveSSHTarget(name)
+	remoteTmp := remoteStageName(remotePath)
+
+	// scp cannot create the destination directory; make sure it exists first.
+	mkdir := fmt.Sprintf(`mkdir -p "$(dirname %s)"`, backend.ShellQuote(remotePath))
+	if out, err := coderBackend.ExecCommand(workspaceDir, []string{"sh", "-c", mkdir}).CombinedOutputWithTimeout(coderPrepTimeout); err != nil {
+		return fmt.Errorf("copy into %q: prepare dir: %w (%s)", remotePath, err, strings.TrimSpace(string(out)))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), backend.CopyTimeout)
+	defer cancel()
+	scp := exec.CommandContext(ctx, "scp",
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "LogLevel=ERROR",
+		"-o", "ProxyCommand=coder ssh --stdio %h",
+		localPath, target+":"+remoteTmp,
+	)
+	if out, err := scp.CombinedOutput(); err != nil {
+		// scp may have written a partial remote temp before failing.
+		coderBackend.removeRemote(workspaceDir, remoteTmp)
+		return fmt.Errorf("copy into %q: scp: %w (%s)", remotePath, err, strings.TrimSpace(string(out)))
+	}
+
+	// chmod to the requested mode then atomically rename into place. Neither
+	// command reads stdin, so they are immune to the coder stdin-EOF hang.
+	install := fmt.Sprintf(`set -e; chmod %o %[2]s; mv -f %[2]s %[3]s`,
+		mode, backend.ShellQuote(remoteTmp), backend.ShellQuote(remotePath))
+	if out, err := coderBackend.ExecCommand(workspaceDir, []string{"sh", "-c", install}).CombinedOutputWithTimeout(coderPrepTimeout); err != nil {
+		// The rename did not complete; don't leave the staged temp behind.
+		coderBackend.removeRemote(workspaceDir, remoteTmp)
+		return fmt.Errorf("copy into %q: install: %w (%s)", remotePath, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// removeRemote best-effort deletes a leftover staging file inside the workspace
+// after a failed transfer, so repeated failures don't accumulate orphans.
+func (coderBackend *CoderBackend) removeRemote(workspaceDir, path string) {
+	rm := fmt.Sprintf(`rm -f %s`, backend.ShellQuote(path))
+	_, _ = coderBackend.ExecCommand(workspaceDir, []string{"sh", "-c", rm}).CombinedOutputWithTimeout(coderPrepTimeout)
+}
+
+// localFileForCopy yields a host filesystem path for src that scp can read. When
+// src is already an *os.File (e.g. the open fleet binary) its path is used
+// directly with a no-op cleanup; any other reader is buffered into a temp file
+// the caller must remove via the returned cleanup.
+func localFileForCopy(src io.Reader) (path string, cleanup func(), err error) {
+	noop := func() {}
+	if f, ok := src.(*os.File); ok && f.Name() != "" {
+		return f.Name(), noop, nil
+	}
+	tmp, err := os.CreateTemp("", "fleet-copy-*")
+	if err != nil {
+		return "", noop, err
+	}
+	remove := func() { _ = os.Remove(tmp.Name()) }
+	if _, err := io.Copy(tmp, src); err != nil {
+		_ = tmp.Close()
+		remove()
+		return "", noop, err
+	}
+	if err := tmp.Close(); err != nil {
+		remove()
+		return "", noop, err
+	}
+	return tmp.Name(), remove, nil
+}

--- a/internal/backend/coder/coder_copy.go
+++ b/internal/backend/coder/coder_copy.go
@@ -19,6 +19,13 @@ import (
 // the coder stdin-EOF hang; the deadline only guards against a stuck tunnel.
 const coderPrepTimeout = 30 * time.Second
 
+// coderScpWaitDelay is the grace period after the scp deadline fires (when
+// CommandContext kills scp) before Go force-closes the inherited stdout/stderr
+// pipe and lets cmd.Wait() return — so a hung tunnel can't keep the call blocked
+// past CopyTimeout. Generous relative to backend.Cmd's own 3s WaitDelay because
+// scp's nested `coder ssh --stdio` teardown can be slower than a local exec.
+const coderScpWaitDelay = 10 * time.Second
+
 // coderCopySeq makes the remote staging name unique within this process so two
 // concurrent CopyFile calls never collide on it.
 var coderCopySeq atomic.Uint64
@@ -124,6 +131,14 @@ func (coderBackend *CoderBackend) CopyFile(workspaceDir string, src io.Reader, r
 		"-o", "ProxyCommand=coder ssh --stdio %h",
 		localPath, target+":"+remoteTmp,
 	)
+	// Make the ctx deadline real. On timeout, CommandContext kills only scp; its
+	// ssh / `coder ssh --stdio` children inherit the stdout/stderr pipe, so
+	// without WaitDelay cmd.Wait() (inside CombinedOutput) would block on the
+	// output-copy goroutine until those children close it — a stuck tunnel could
+	// hang past CopyTimeout, the exact failure class this file removes. WaitDelay
+	// force-closes the pipe shortly after the kill, mirroring
+	// CombinedOutputWithTimeout's own WaitDelay.
+	scp.WaitDelay = coderScpWaitDelay
 	if out, err := scp.CombinedOutput(); err != nil {
 		// scp may have written a partial remote temp before failing.
 		coderBackend.removeRemote(workspaceDir, remoteTmp)

--- a/internal/backend/coder/coder_copy.go
+++ b/internal/backend/coder/coder_copy.go
@@ -20,16 +20,27 @@ import (
 const coderPrepTimeout = 30 * time.Second
 
 // coderCopySeq makes the remote staging name unique within this process so two
-// concurrent CopyFile calls to the same remotePath never collide on it.
+// concurrent CopyFile calls never collide on it.
 var coderCopySeq atomic.Uint64
 
-// remoteStageName returns a hidden, per-call-unique sibling of remotePath to scp
-// into before the atomic rename — the out-of-band analogue of the in-shell
-// `$$`-suffixed temp the stdin-streaming backends use.
-func remoteStageName(remotePath string) string {
+// coderStageDir is the fixed directory CopyFile scp's into before the install
+// rename. It is deliberately NOT a sibling of remotePath: the scp remote operand
+// is the one path in this file that cannot be ShellQuote'd (see the scp call),
+// and remotePath's parent can legitimately contain spaces — a `fleet copy` dest
+// directory is only `test -d`-probed, not character-restricted. Staging instead
+// in /tmp, whose name carries no shell metacharacters, keeps that operand safe
+// under both scp transports without quoting. /tmp is writable on every backend
+// (the binary and automation-event staging paths already rely on it).
+const coderStageDir = "/tmp"
+
+// remoteStageName returns a hidden, per-call-unique path in coderStageDir to scp
+// into before the install rename — the out-of-band analogue of the in-shell
+// `$$`-suffixed temp the stdin-streaming backends use. Its characters are
+// restricted to [0-9a-f.] so the unquoted scp operand is transport-safe.
+func remoteStageName() string {
 	var b [6]byte
 	_, _ = rand.Read(b[:])
-	return fmt.Sprintf("%s.fleet-scp.%d.%x", remotePath, coderCopySeq.Add(1), b)
+	return fmt.Sprintf("%s/.fleet-scp.%d.%x", coderStageDir, coderCopySeq.Add(1), b)
 }
 
 // CopyFile transfers src INTO the coder workspace (its nested devcontainer) at
@@ -44,8 +55,15 @@ func remoteStageName(remotePath string) string {
 //
 //  1. materialise src to a host file (an *os.File source is used directly);
 //  2. mkdir -p the destination's parent (scp will not create it);
-//  3. scp the host file to a sibling temp next to remotePath;
-//  4. chmod + atomic rename into place via a normal exec (stdin-free, hang-proof).
+//  3. scp the host file to a fixed metacharacter-free temp in /tmp;
+//  4. chmod + rename it into place via a normal exec (stdin-free, hang-proof).
+//
+// The rename in step 4 (not the scp in step 3) targets remotePath, so a `fleet
+// copy` destination that contains spaces is handled by the ShellQuote'd `mv` —
+// the scp operand never sees it. Because the temp lives in /tmp rather than
+// beside remotePath, that `mv` may cross filesystems (a copy+unlink, not an
+// atomic rename) when remotePath is outside /tmp; that is acceptable for the
+// best-effort staging this serves and matches no concurrent-reader expectation.
 //
 // scp defaults to the SFTP subsystem, which the coder agent provides; if a
 // particular template's nested agent lacks it the transfer fails cleanly (the
@@ -79,7 +97,7 @@ func (coderBackend *CoderBackend) CopyFile(workspaceDir string, src io.Reader, r
 
 	name := coderWorkspaceName(workspaceDir)
 	target := coderBackend.resolveSSHTarget(name)
-	remoteTmp := remoteStageName(remotePath)
+	remoteTmp := remoteStageName()
 
 	// scp cannot create the destination directory; make sure it exists first.
 	mkdir := fmt.Sprintf(`mkdir -p "$(dirname %s)"`, backend.ShellQuote(remotePath))
@@ -90,12 +108,15 @@ func (coderBackend *CoderBackend) CopyFile(workspaceDir string, src io.Reader, r
 	ctx, cancel := context.WithTimeout(context.Background(), backend.CopyTimeout)
 	defer cancel()
 	// The remote operand (target:remoteTmp) is intentionally NOT shell-quoted,
-	// unlike the mkdir/install/cleanup execs around it: scp's default SFTP
-	// transfer (OpenSSH 9.0+) takes the post-colon path LITERALLY, so a `'..'`
-	// wrapper would become part of the filename. (Quoting is only right for the
-	// pre-9.0 legacy protocol, where a remote shell expands the path — which this
-	// code never opts into via -O.) remoteTmp derives from remotePath, so the
-	// staging-path callers (always /tmp) carry no spaces regardless.
+	// unlike the mkdir/install/cleanup execs around it. The two scp transports
+	// disagree on how to read it: the default SFTP transfer (OpenSSH 9.0+) takes
+	// the post-colon path LITERALLY, so a `'..'` wrapper would become part of the
+	// filename, while the legacy pre-9.0 protocol shell-expands it (where quoting
+	// would be required). No single quoting choice is right for both — so instead
+	// remoteTmp is constructed to need none: it lives in /tmp with only [0-9a-f.]
+	// characters (see remoteStageName), which is safe verbatim under either
+	// transport. The spacey final path is reached by the ShellQuote'd `mv` below,
+	// never by scp.
 	scp := exec.CommandContext(ctx, "scp",
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=/dev/null",

--- a/internal/backend/coder/coder_copy_test.go
+++ b/internal/backend/coder/coder_copy_test.go
@@ -8,18 +8,21 @@ import (
 	"testing"
 )
 
-// TestRemoteStageNameUnique confirms the remote scp staging name is a hidden
-// sibling of the destination and differs across calls, so concurrent copies to
-// the same path don't collide (the bug a fixed ".fleet-scp" suffix would cause).
+// TestRemoteStageNameUnique confirms the remote scp staging name lives in the
+// fixed metacharacter-free /tmp dir (so the unquoted scp operand is transport-
+// safe regardless of the destination), differs across calls (so concurrent
+// copies don't collide), and carries no shell metacharacters.
 func TestRemoteStageNameUnique(t *testing.T) {
-	const dst = "/usr/bin/fleet"
-	a, b := remoteStageName(dst), remoteStageName(dst)
+	a, b := remoteStageName(), remoteStageName()
 	if a == b {
 		t.Fatalf("stage names collide: %q", a)
 	}
 	for _, n := range []string{a, b} {
-		if !strings.HasPrefix(n, dst+".fleet-scp.") {
-			t.Errorf("stage name %q is not a hidden sibling of %q", n, dst)
+		if !strings.HasPrefix(n, coderStageDir+"/.fleet-scp.") {
+			t.Errorf("stage name %q is not in the fixed staging dir %q", n, coderStageDir)
+		}
+		if strings.ContainsAny(n, " \t'\"$`\\*?(){}[]") {
+			t.Errorf("stage name %q contains a shell metacharacter (unsafe as an unquoted scp operand)", n)
 		}
 	}
 }

--- a/internal/backend/coder/coder_copy_test.go
+++ b/internal/backend/coder/coder_copy_test.go
@@ -1,0 +1,75 @@
+package coder
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRemoteStageNameUnique confirms the remote scp staging name is a hidden
+// sibling of the destination and differs across calls, so concurrent copies to
+// the same path don't collide (the bug a fixed ".fleet-scp" suffix would cause).
+func TestRemoteStageNameUnique(t *testing.T) {
+	const dst = "/usr/bin/fleet"
+	a, b := remoteStageName(dst), remoteStageName(dst)
+	if a == b {
+		t.Fatalf("stage names collide: %q", a)
+	}
+	for _, n := range []string{a, b} {
+		if !strings.HasPrefix(n, dst+".fleet-scp.") {
+			t.Errorf("stage name %q is not a hidden sibling of %q", n, dst)
+		}
+	}
+}
+
+// TestLocalFileForCopyOsFile confirms an *os.File source is scp'd directly (its
+// path reused, no buffering copy) so staging the already-on-disk fleet binary
+// doesn't pay an extra full-size temp write.
+func TestLocalFileForCopyOsFile(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "bin")
+	if err := os.WriteFile(src, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	path, cleanup, err := localFileForCopy(f)
+	if err != nil {
+		t.Fatalf("localFileForCopy: %v", err)
+	}
+	defer cleanup()
+	if path != src {
+		t.Fatalf("path = %q, want the source path %q (no buffering)", path, src)
+	}
+	// Cleanup for the direct path is a no-op: the source must survive it.
+	cleanup()
+	if _, err := os.Stat(src); err != nil {
+		t.Fatalf("direct-path cleanup removed the source: %v", err)
+	}
+}
+
+// TestLocalFileForCopyReader confirms a non-file reader is buffered to a host
+// temp whose bytes match, and that cleanup removes it.
+func TestLocalFileForCopyReader(t *testing.T) {
+	content := []byte("buffer me\x00please")
+	path, cleanup, err := localFileForCopy(bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("localFileForCopy: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read temp: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("buffered content = %q, want %q", got, content)
+	}
+	cleanup()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("cleanup did not remove temp %q (err %v)", path, err)
+	}
+}

--- a/internal/backend/codespaces/codespaces_backend.go
+++ b/internal/backend/codespaces/codespaces_backend.go
@@ -210,6 +210,22 @@ func (codespacesBackend *CodespacesBackend) rawExec(workspaceDir string, command
 	return codespacesBackend.sshCommand(name, command, true)
 }
 
+// CopyFile streams src into the codespace over stdin. It deliberately builds a
+// NON-PTY ssh command (allocPTY=false): the PTY that ExecCommand allocates for
+// interactive work runs a line discipline that mangles raw binary (a 0x04 byte
+// reads as EOF, truncating the file). Without a PTY the channel is a clean
+// 8-bit pipe, and OpenSSH/gh half-close stdin on EOF, so the StreamWriteScript
+// `cat > tmp` terminates and the bytes survive intact.
+func (codespacesBackend *CodespacesBackend) CopyFile(workspaceDir string, src io.Reader, remotePath string, mode int) error {
+	name := codespacesBackend.resolveCodespaceName(workspaceDir)
+	cmd := backend.NewCmd(codespacesBackend.sshCommand(name, backend.StreamWriteScript(remotePath, mode), false), nil)
+	cmd.Stdin = src
+	if out, err := cmd.CombinedOutputWithTimeout(backend.CopyTimeout); err != nil {
+		return fmt.Errorf("copy into %q: %w (%s)", remotePath, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
 // ===========================================
 // Monitoring
 // ===========================================

--- a/internal/backend/copy_file.go
+++ b/internal/backend/copy_file.go
@@ -1,0 +1,104 @@
+package backend
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// copy_file.go holds the transport-agnostic helpers behind the Backend.CopyFile
+// strategy and the small-file inline writer. They exist because a remote command
+// that reads stdin until EOF (e.g. `cat > file`) hangs forever on transports
+// that do not half-close a remote command's stdin — notably `coder ssh`, whose
+// agent SSH server never delivers the stdin EOF. Two stdin-EOF-free techniques
+// live here:
+//
+//   - WriteFileInline / InlineWriteScript embed the payload in the command as
+//     base64 (decoded in-container), so no stdin is involved at all. Use it for
+//     SMALL files; the whole command line is bounded by the host ARG_MAX.
+//
+//   - StreamWriteScript is the classic stdin-streamed write (`cat > tmp`) used by
+//     backends whose transport DOES deliver stdin EOF (devcontainer's local
+//     docker exec, codespaces' OpenSSH). The coder backend cannot use it and
+//     ships its own scp-based CopyFile instead.
+
+// CopyTimeout bounds a single CopyFile transport so a wedged copy can never stall
+// instance provisioning (which is otherwise best-effort but has no deadline of
+// its own). Generous enough for a multi-tens-of-MB binary over a slow tunnel.
+const CopyTimeout = 5 * time.Minute
+
+// maxInlineRaw caps the raw payload an inline (base64-in-argv) write accepts.
+// The base64 expansion (+~33%) plus the surrounding script must fit comfortably
+// under the host ARG_MAX (as low as 128KB on some systems), so the cap is kept
+// well below that. Every inline caller (fleet.rc, agent hook scripts and
+// settings.json) is a few KB, so this is never hit in practice; it exists to
+// fail loudly rather than silently exceed ARG_MAX if a payload ever grows.
+const maxInlineRaw = 64 * 1024
+
+// ShellQuote wraps value in single quotes with embedded single quotes escaped
+// via the '\” idiom, so any path is safe to drop into a /bin/sh command
+// literal. Exported so backend implementations (e.g. coder's scp install step)
+// share one quoting routine; kept here rather than imported from
+// internal/dotfiles to avoid that package's transitive state dependency.
+func ShellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
+// InlineWriteScript returns a /bin/sh command (as argv: {"sh","-c",body}) that
+// writes content to remotePath with the given mode, WITHOUT reading stdin: the
+// payload travels base64-encoded inside the command itself and is decoded in the
+// container. The write is atomic (same-dir temp + rename) and creates the parent
+// directory. Returns an error when content exceeds maxInlineRaw — callers with
+// large payloads must use the streaming Backend.CopyFile instead.
+//
+// `printf %s '<b64>'` is a shell builtin, so the base64 blob never becomes its
+// own argv entry (no extra ARG_MAX pressure beyond the single `sh -c` literal),
+// and base64's alphabet contains no single quote, so the blob is safe to embed
+// single-quoted verbatim.
+func InlineWriteScript(remotePath string, content []byte, mode int) ([]string, error) {
+	if len(content) > maxInlineRaw {
+		return nil, fmt.Errorf("inline write of %q: payload %d bytes exceeds inline cap %d (use CopyFile)", remotePath, len(content), maxInlineRaw)
+	}
+	b64 := base64.StdEncoding.EncodeToString(content)
+	qPath := ShellQuote(remotePath)
+	// $$ (the sh PID) keeps the temp unique against a concurrent writer in the
+	// same directory; set -e aborts before the rename if any step fails.
+	body := fmt.Sprintf(
+		`set -e; d=$(dirname %[1]s); mkdir -p "$d"; t="$d/.fleet-inline.$$"; printf %%s '%[2]s' | base64 -d > "$t"; chmod %[3]o "$t"; mv -f "$t" %[1]s`,
+		qPath, b64, mode,
+	)
+	return []string{"sh", "-c", body}, nil
+}
+
+// WriteFileInline runs InlineWriteScript against the backend's exec surface with
+// a deadline, returning a wrapped error (including any container stderr) on
+// failure. It is the one-call front door for staging a small in-memory file into
+// an instance in a way that works on every backend, including coder.
+func WriteFileInline(b Backend, workspaceDir, remotePath string, content []byte, mode int) error {
+	argv, err := InlineWriteScript(remotePath, content, mode)
+	if err != nil {
+		return err
+	}
+	out, err := b.ExecCommand(workspaceDir, argv).CombinedOutputWithTimeout(CopyTimeout)
+	if err != nil {
+		return fmt.Errorf("inline write %q: %w (%s)", remotePath, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// StreamWriteScript returns a /bin/sh command (as argv: {"sh","-c",body}) that
+// reads file content from STDIN and writes it to remotePath with the given mode.
+// The write is atomic (same-dir temp + rename) and creates the parent directory.
+//
+// This is the stdin-streamed counterpart used by CopyFile on backends whose
+// transport delivers stdin EOF. It must NOT be used on the coder backend, whose
+// `cat` would block forever waiting for an EOF that never arrives.
+func StreamWriteScript(remotePath string, mode int) []string {
+	qPath := ShellQuote(remotePath)
+	body := fmt.Sprintf(
+		`set -e; d=$(dirname %[1]s); mkdir -p "$d"; t="$d/.fleet-copy.$$"; cat > "$t"; chmod %[2]o "$t"; mv -f "$t" %[1]s`,
+		qPath, mode,
+	)
+	return []string{"sh", "-c", body}
+}

--- a/internal/backend/copy_file.go
+++ b/internal/backend/copy_file.go
@@ -63,9 +63,12 @@ func InlineWriteScript(remotePath string, content []byte, mode int) ([]string, e
 	b64 := base64.StdEncoding.EncodeToString(content)
 	qPath := ShellQuote(remotePath)
 	// $$ (the sh PID) keeps the temp unique against a concurrent writer in the
-	// same directory; set -e aborts before the rename if any step fails.
+	// same directory; set -e aborts before the rename if any step fails, and the
+	// EXIT trap removes the temp on that abort so a failed write leaves no orphan
+	// in the dest dir. On success the temp is already renamed away, so the trap's
+	// rm is a harmless no-op.
 	body := fmt.Sprintf(
-		`set -e; d=$(dirname %[1]s); mkdir -p "$d"; t="$d/.fleet-inline.$$"; printf %%s '%[2]s' | base64 -d > "$t"; chmod %[3]o "$t"; mv -f "$t" %[1]s`,
+		`set -e; d=$(dirname %[1]s); mkdir -p "$d"; t="$d/.fleet-inline.$$"; trap 'rm -f "$t"' EXIT; printf %%s '%[2]s' | base64 -d > "$t"; chmod %[3]o "$t"; mv -f "$t" %[1]s`,
 		qPath, b64, mode,
 	)
 	return []string{"sh", "-c", body}, nil
@@ -96,8 +99,11 @@ func WriteFileInline(b Backend, workspaceDir, remotePath string, content []byte,
 // `cat` would block forever waiting for an EOF that never arrives.
 func StreamWriteScript(remotePath string, mode int) []string {
 	qPath := ShellQuote(remotePath)
+	// The EXIT trap removes the temp if any step fails before the rename (set -e),
+	// so an interrupted stream leaves no orphan .fleet-copy.$$ in the dest dir; on
+	// success the temp is already renamed away and the rm is a no-op.
 	body := fmt.Sprintf(
-		`set -e; d=$(dirname %[1]s); mkdir -p "$d"; t="$d/.fleet-copy.$$"; cat > "$t"; chmod %[2]o "$t"; mv -f "$t" %[1]s`,
+		`set -e; d=$(dirname %[1]s); mkdir -p "$d"; t="$d/.fleet-copy.$$"; trap 'rm -f "$t"' EXIT; cat > "$t"; chmod %[2]o "$t"; mv -f "$t" %[1]s`,
 		qPath, mode,
 	)
 	return []string{"sh", "-c", body}

--- a/internal/backend/copy_file_test.go
+++ b/internal/backend/copy_file_test.go
@@ -1,0 +1,120 @@
+package backend
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestInlineWriteScriptRoundTrip runs the generated inline-write command in a
+// real /bin/sh and confirms the base64-in-argv payload round-trips to disk with
+// the requested mode, mkdir-ing a missing parent — the path that lets the coder
+// backend stage files without streaming stdin. Binary bytes (NUL, 0x01) prove
+// the transport is 8-bit clean.
+func TestInlineWriteScriptRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "missing", "fleet.rc")
+	content := []byte("hello\nfleet\x00binary\x01bytes")
+
+	argv, err := InlineWriteScript(target, content, 0o640)
+	if err != nil {
+		t.Fatalf("InlineWriteScript: %v", err)
+	}
+	if out, err := exec.Command(argv[0], argv[1:]...).CombinedOutput(); err != nil {
+		t.Fatalf("run inline write: %v (%s)", err, out)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("content = %q, want %q", got, content)
+	}
+	if fi, _ := os.Stat(target); fi.Mode().Perm() != 0o640 {
+		t.Fatalf("mode = %o, want 0640", fi.Mode().Perm())
+	}
+	// The atomic temp must not be left behind.
+	entries, _ := os.ReadDir(filepath.Dir(target))
+	for _, e := range entries {
+		if e.Name() != "fleet.rc" {
+			t.Errorf("unexpected leftover %q in target dir", e.Name())
+		}
+	}
+}
+
+// TestInlineWriteScriptSizeGuard confirms an oversized payload is rejected
+// (callers must use the streaming CopyFile) rather than silently overflowing
+// the host ARG_MAX.
+func TestInlineWriteScriptSizeGuard(t *testing.T) {
+	if _, err := InlineWriteScript("/x", make([]byte, maxInlineRaw+1), 0o644); err == nil {
+		t.Fatal("expected error for oversized inline payload, got nil")
+	}
+	if _, err := InlineWriteScript("/x", make([]byte, maxInlineRaw), 0o644); err != nil {
+		t.Fatalf("payload at the cap should be accepted: %v", err)
+	}
+}
+
+// TestStreamWriteScriptRoundTrip runs the generated stdin-streamed write command
+// in a real /bin/sh and confirms the stdin payload round-trips with the
+// requested mode, mkdir-ing a missing parent.
+func TestStreamWriteScriptRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "missing", "out.bin")
+	content := []byte("streamed\x00content")
+
+	argv := StreamWriteScript(target, 0o600)
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.Stdin = bytes.NewReader(content)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run stream write: %v (%s)", err, out)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("content = %q, want %q", got, content)
+	}
+	if fi, _ := os.Stat(target); fi.Mode().Perm() != 0o600 {
+		t.Fatalf("mode = %o, want 0600", fi.Mode().Perm())
+	}
+}
+
+// TestWriteScriptsQuotePathsSafely confirms a path with a single quote (and
+// other shell metacharacters) is handled verbatim by both writers, so a hostile
+// or merely awkward path can't break out of the command literal.
+func TestWriteScriptsQuotePathsSafely(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "a'b $x ;rm.txt")
+	content := []byte("safe")
+
+	argv, err := InlineWriteScript(target, content, 0o644)
+	if err != nil {
+		t.Fatalf("InlineWriteScript: %v", err)
+	}
+	if out, err := exec.Command(argv[0], argv[1:]...).CombinedOutput(); err != nil {
+		t.Fatalf("run inline write: %v (%s)", err, out)
+	}
+	if got, _ := os.ReadFile(target); !bytes.Equal(got, content) {
+		t.Fatalf("inline: content = %q, want %q", got, content)
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	cases := map[string]string{
+		"plain":     "'plain'",
+		"a'b":       `'a'\''b'`,
+		"/usr/bin":  "'/usr/bin'",
+		"":          "''",
+		"two words": "'two words'",
+	}
+	for in, want := range cases {
+		if got := ShellQuote(in); got != want {
+			t.Errorf("ShellQuote(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/backend/devcontainer/devcontainer_backend.go
+++ b/internal/backend/devcontainer/devcontainer_backend.go
@@ -352,6 +352,18 @@ func (devcontainerBackend *DevcontainerBackend) rawExec(workspaceDir string, com
 	return exec.Command("devcontainer", args...)
 }
 
+// CopyFile streams src into the container over stdin. `devcontainer exec` runs
+// `docker exec` without a PTY over a clean binary channel that delivers stdin
+// EOF, so the StreamWriteScript `cat > tmp` reliably terminates here.
+func (devcontainerBackend *DevcontainerBackend) CopyFile(workspaceDir string, src io.Reader, remotePath string, mode int) error {
+	cmd := devcontainerBackend.ExecCommand(workspaceDir, backend.StreamWriteScript(remotePath, mode))
+	cmd.Stdin = src
+	if out, err := cmd.CombinedOutputWithTimeout(backend.CopyTimeout); err != nil {
+		return fmt.Errorf("copy into %q: %w (%s)", remotePath, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
 // pruneStaleContainers force-removes any docker container labelled
 // `devcontainer.local_folder=<workspaceDir>`. Called from Up() so that
 // reusing an instance name (same wsDir on disk) never silently rebinds

--- a/internal/fleetlaunch/fleetlaunch.go
+++ b/internal/fleetlaunch/fleetlaunch.go
@@ -11,6 +11,7 @@
 package fleetlaunch
 
 import (
+	"crypto/rand"
 	"fmt"
 	"os"
 	"strings"
@@ -115,10 +116,17 @@ fi`, RemotePath, RemotePath)
 	}
 }
 
-// stagePath is the user-writable path the binary is transferred to before being
-// installed into the privileged RemotePath. /tmp is writable without sudo on
-// every backend, so CopyFile (which is itself sudo-free) can always land it here.
-const stagePath = "/tmp/.fleet-launch-stage"
+// stageBinaryPath returns a per-call-unique, user-writable path the binary is
+// transferred to before being installed into the privileged RemotePath. /tmp is
+// writable without sudo on every backend, so CopyFile (which is itself sudo-free)
+// can always land it here. The random suffix keeps two concurrent stagers from
+// clobbering each other's staging file between CopyFile and the install mv,
+// matching the per-call uniqueness used elsewhere in the staging path.
+func stageBinaryPath() string {
+	var b [6]byte
+	_, _ = rand.Read(b[:])
+	return fmt.Sprintf("/tmp/.fleet-launch-stage.%x", b[:])
+}
 
 // copyBinary transfers the running fleet binary into the container at RemotePath
 // in two stdin-EOF-safe steps:
@@ -148,6 +156,7 @@ func copyBinary(instanceBackend backend.Backend, workspaceDir string) error {
 	}
 	defer bin.Close()
 
+	stagePath := stageBinaryPath()
 	if err := instanceBackend.CopyFile(workspaceDir, bin, stagePath, 0o755); err != nil {
 		return fmt.Errorf("stage fleet binary: %w", err)
 	}

--- a/internal/fleetlaunch/fleetlaunch.go
+++ b/internal/fleetlaunch/fleetlaunch.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync/atomic"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/backend"
 	"github.com/BenjaminBenetti/fleet-man/internal/version"
@@ -116,16 +117,21 @@ fi`, RemotePath, RemotePath)
 	}
 }
 
+// stageSeq makes stageBinaryPath unique even if crypto/rand.Read fails (leaving
+// the byte buffer zeroed), so two concurrent stagers can never collide — the same
+// belt-and-suspenders the coder backend's remoteStageName uses.
+var stageSeq atomic.Uint64
+
 // stageBinaryPath returns a per-call-unique, user-writable path the binary is
 // transferred to before being installed into the privileged RemotePath. /tmp is
 // writable without sudo on every backend, so CopyFile (which is itself sudo-free)
-// can always land it here. The random suffix keeps two concurrent stagers from
-// clobbering each other's staging file between CopyFile and the install mv,
+// can always land it here. The seq+random suffix keeps two concurrent stagers
+// from clobbering each other's staging file between CopyFile and the install mv,
 // matching the per-call uniqueness used elsewhere in the staging path.
 func stageBinaryPath() string {
 	var b [6]byte
 	_, _ = rand.Read(b[:])
-	return fmt.Sprintf("/tmp/.fleet-launch-stage.%x", b[:])
+	return fmt.Sprintf("/tmp/.fleet-launch-stage.%d.%x", stageSeq.Add(1), b[:])
 }
 
 // copyBinary transfers the running fleet binary into the container at RemotePath
@@ -170,6 +176,12 @@ else
 fi`, RemotePath, stagePath, remoteDir)
 
 	if out, err := instanceBackend.ExecCommand(workspaceDir, []string{"sh", "-c", install}).CombinedOutputWithTimeout(backend.CopyTimeout); err != nil {
+		// CopyFile landed the binary but the install didn't move it (e.g. /usr/bin
+		// not writable and `sudo -n` denied). Remove the staged copy best-effort so
+		// repeated provision attempts don't pile up /tmp/.fleet-launch-stage.*
+		// orphans — each gets a fresh random name. Mirrors coder.removeRemote.
+		rm := fmt.Sprintf("rm -f %s", backend.ShellQuote(stagePath))
+		_, _ = instanceBackend.ExecCommand(workspaceDir, []string{"sh", "-c", rm}).CombinedOutputWithTimeout(backend.CopyTimeout)
 		return fmt.Errorf("install fleet binary: %w (%s)", err, strings.TrimSpace(string(out)))
 	}
 	return nil

--- a/internal/fleetlaunch/fleetlaunch.go
+++ b/internal/fleetlaunch/fleetlaunch.go
@@ -115,19 +115,28 @@ fi`, RemotePath, RemotePath)
 	}
 }
 
-// copyBinary streams the running fleet binary into the container at
-// RemotePath. It unlinks the old file first rather than truncating it:
-// a process the caller has just signalled may still have the old
-// binary mmap'd, and overwriting a mapped executable surfaces as
-// ETXTBSY. Unlink-then-create allocates a fresh inode so the running
-// process keeps its old copy and the new file is written cleanly.
+// stagePath is the user-writable path the binary is transferred to before being
+// installed into the privileged RemotePath. /tmp is writable without sudo on
+// every backend, so CopyFile (which is itself sudo-free) can always land it here.
+const stagePath = "/tmp/.fleet-launch-stage"
+
+// copyBinary transfers the running fleet binary into the container at RemotePath
+// in two stdin-EOF-safe steps:
 //
-// /usr/bin is typically not writable by a devcontainer's default user,
-// so the script probes the directory once and either writes directly or
-// re-runs through `sudo -n` (passwordless, matching the pattern used by
-// privoxy and tmux installers elsewhere). The branch is decided BEFORE
-// stdin is consumed so the binary bytes flow down exactly one of the
-// two paths — important because a pipe can only be read once.
+//   - CopyFile streams it to a user-writable staging path. CopyFile is the
+//     backend strategy seam, so this works on every backend including coder
+//     (whose `coder ssh` transport hangs a stdin-reading `cat`); the host-side
+//     conditional that used to branch on transport is gone.
+//
+//   - a small exec installs it into RemotePath. /usr/bin is typically not
+//     writable by a devcontainer's default user, so the script probes the
+//     directory and either moves directly or re-runs through `sudo -n`
+//     (passwordless, matching the privoxy/tmux installers elsewhere). It unlinks
+//     the old file before the move: a process the caller just signalled may
+//     still have the old binary mmap'd, and overwriting a mapped executable
+//     surfaces as ETXTBSY — rm-then-mv allocates a fresh inode so the running
+//     process keeps its old copy. The install reads no stdin, so it cannot hang
+//     on any backend.
 func copyBinary(instanceBackend backend.Backend, workspaceDir string) error {
 	self, err := os.Executable()
 	if err != nil {
@@ -139,18 +148,20 @@ func copyBinary(instanceBackend backend.Backend, workspaceDir string) error {
 	}
 	defer bin.Close()
 
-	script := fmt.Sprintf(`
-write='rm -f %s && cat > %s && chmod +x %s'
-if [ -w %s ]; then
+	if err := instanceBackend.CopyFile(workspaceDir, bin, stagePath, 0o755); err != nil {
+		return fmt.Errorf("stage fleet binary: %w", err)
+	}
+
+	install := fmt.Sprintf(`
+write='rm -f %[1]s && mv -f %[2]s %[1]s && chmod +x %[1]s'
+if [ -w %[3]s ]; then
   sh -c "$write"
 else
   sudo -n sh -c "$write"
-fi`, RemotePath, RemotePath, RemotePath, remoteDir)
+fi`, RemotePath, stagePath, remoteDir)
 
-	cmd := instanceBackend.ExecCommand(workspaceDir, []string{"sh", "-c", script})
-	cmd.Stdin = bin
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("copy fleet binary: %w (%s)", err, strings.TrimSpace(string(out)))
+	if out, err := instanceBackend.ExecCommand(workspaceDir, []string{"sh", "-c", install}).CombinedOutputWithTimeout(backend.CopyTimeout); err != nil {
+		return fmt.Errorf("install fleet binary: %w (%s)", err, strings.TrimSpace(string(out)))
 	}
 	return nil
 }

--- a/internal/fleetlaunch/fleetlaunch_test.go
+++ b/internal/fleetlaunch/fleetlaunch_test.go
@@ -1,0 +1,132 @@
+package fleetlaunch
+
+import (
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/backend"
+)
+
+// recordingBackend is a backend.Backend that records the CopyFile transfer and
+// the exec scripts run against it, succeeding every exec by shelling out to
+// `true`. Only the methods the fleet-launch staging path touches do anything;
+// the rest satisfy the interface.
+type recordingBackend struct {
+	copiedTo    string
+	copiedBytes int
+	copyMode    int
+	execScripts []string
+}
+
+func (b *recordingBackend) CopyFile(workspaceDir string, src io.Reader, remotePath string, mode int) error {
+	data, _ := io.ReadAll(src)
+	b.copiedBytes = len(data)
+	b.copiedTo = remotePath
+	b.copyMode = mode
+	return nil
+}
+
+func (b *recordingBackend) ExecCommand(workspaceDir string, command []string) *backend.Cmd {
+	if len(command) == 3 {
+		b.execScripts = append(b.execScripts, command[2])
+	}
+	return backend.NewCmd(exec.Command("true"), nil)
+}
+
+func (b *recordingBackend) ExecCommandQuiet(workspaceDir string, command []string) *backend.Cmd {
+	return b.ExecCommand(workspaceDir, command)
+}
+
+// --- interface filler: unused by the staging path ---
+
+func (b *recordingBackend) Up(string, []backend.Mount) (*backend.UpResult, error) { return nil, nil }
+func (b *recordingBackend) SupportsCustomMounts() bool                            { return false }
+func (b *recordingBackend) Clone(string, string, []backend.Mount) (*backend.UpResult, error) {
+	return nil, nil
+}
+func (b *recordingBackend) SupportsClone() bool { return false }
+func (b *recordingBackend) Rebuild(string, string, []backend.Mount) (*backend.UpResult, error) {
+	return nil, nil
+}
+func (b *recordingBackend) SupportsRebuild() bool       { return false }
+func (b *recordingBackend) Down(string) error           { return nil }
+func (b *recordingBackend) Stop(string) error           { return nil }
+func (b *recordingBackend) Start(string) error          { return nil }
+func (b *recordingBackend) Exec(string, []string) error { return nil }
+func (b *recordingBackend) Stats([]string) (map[string]*backend.ContainerStats, error) {
+	return nil, nil
+}
+func (b *recordingBackend) Logs(string, bool) error            { return nil }
+func (b *recordingBackend) LogsCommand(string, bool) *exec.Cmd { return nil }
+func (b *recordingBackend) CaptureAllSessions(string) backend.AllSessions {
+	return backend.AllSessions{}
+}
+func (b *recordingBackend) ListSessions(string) string                    { return "" }
+func (b *recordingBackend) AgentToolProbe(string) (string, bool)          { return "", false }
+func (b *recordingBackend) RunScript(string, string) (string, error)      { return "", nil }
+func (b *recordingBackend) EditorURI(string, string) (string, bool)       { return "", false }
+func (b *recordingBackend) PortForwardCommand(string, int, int) *exec.Cmd { return nil }
+func (b *recordingBackend) ForwardStdioCommand(string, int) (*exec.Cmd, bool) {
+	return nil, false
+}
+func (b *recordingBackend) ResolveHostname(string) (string, bool) { return "", false }
+func (b *recordingBackend) Status(string) backend.LiveStatus      { return backend.LiveStatusUnknown }
+
+// TestCopyBinaryStagesViaCopyFileThenInstalls asserts the binary staging now
+// goes through the backend's stdin-EOF-safe CopyFile (to a writable temp) and
+// then installs into RemotePath with a stdin-free move — never a `cat >` that
+// would hang on the coder backend.
+func TestCopyBinaryStagesViaCopyFileThenInstalls(t *testing.T) {
+	b := &recordingBackend{}
+	if err := copyBinary(b, "/ws"); err != nil {
+		t.Fatalf("copyBinary: %v", err)
+	}
+
+	if b.copiedTo != stagePath {
+		t.Errorf("staged to %q, want %q", b.copiedTo, stagePath)
+	}
+	if b.copyMode != 0o755 {
+		t.Errorf("stage mode = %o, want 0755", b.copyMode)
+	}
+	if b.copiedBytes == 0 {
+		t.Error("no bytes streamed to CopyFile")
+	}
+	if len(b.execScripts) != 1 {
+		t.Fatalf("expected 1 install exec, got %d: %v", len(b.execScripts), b.execScripts)
+	}
+	install := b.execScripts[0]
+	if !strings.Contains(install, stagePath) || !strings.Contains(install, RemotePath) {
+		t.Errorf("install script missing stage/remote paths:\n%s", install)
+	}
+	if strings.Contains(install, "cat >") {
+		t.Errorf("install must not stream over stdin (hangs on coder):\n%s", install)
+	}
+	if !strings.Contains(install, "sudo -n") {
+		t.Errorf("install lost the sudo fallback for a non-writable /usr/bin:\n%s", install)
+	}
+}
+
+// TestEnsureFleetRCWritesInlineThenWiresBashrc asserts the rc write is an inline
+// (base64-in-argv) write — not a stdin `cat >` — and that the .bashrc wire still
+// runs afterward.
+func TestEnsureFleetRCWritesInlineThenWiresBashrc(t *testing.T) {
+	b := &recordingBackend{}
+	if err := EnsureFleetRC(b, "/ws", "/home/vscode", "inst-1"); err != nil {
+		t.Fatalf("EnsureFleetRC: %v", err)
+	}
+	if len(b.execScripts) != 2 {
+		t.Fatalf("expected 2 execs (inline write, bashrc wire), got %d", len(b.execScripts))
+	}
+	write := b.execScripts[0]
+	if !strings.Contains(write, "base64 -d") || !strings.Contains(write, "/home/vscode/.fleet/fleet.rc") {
+		t.Errorf("rc write is not an inline base64 write to the rc path:\n%s", write)
+	}
+	if strings.Contains(write, "cat >") {
+		t.Errorf("rc write must not stream over stdin (hangs on coder):\n%s", write)
+	}
+	if wire := b.execScripts[1]; !strings.Contains(wire, ".bashrc") {
+		t.Errorf("second exec should wire .bashrc:\n%s", wire)
+	}
+}

--- a/internal/fleetlaunch/fleetlaunch_test.go
+++ b/internal/fleetlaunch/fleetlaunch_test.go
@@ -18,6 +18,7 @@ type recordingBackend struct {
 	copiedBytes int
 	copyMode    int
 	execScripts []string
+	failExec    bool // when set, every exec exits non-zero (drives error paths)
 }
 
 func (b *recordingBackend) CopyFile(workspaceDir string, src io.Reader, remotePath string, mode int) error {
@@ -32,7 +33,11 @@ func (b *recordingBackend) ExecCommand(workspaceDir string, command []string) *b
 	if len(command) == 3 {
 		b.execScripts = append(b.execScripts, command[2])
 	}
-	return backend.NewCmd(exec.Command("true"), nil)
+	bin := "true"
+	if b.failExec {
+		bin = "false"
+	}
+	return backend.NewCmd(exec.Command(bin), nil)
 }
 
 func (b *recordingBackend) ExecCommandQuiet(workspaceDir string, command []string) *backend.Cmd {
@@ -105,6 +110,23 @@ func TestCopyBinaryStagesViaCopyFileThenInstalls(t *testing.T) {
 	}
 	if !strings.Contains(install, "sudo -n") {
 		t.Errorf("install lost the sudo fallback for a non-writable /usr/bin:\n%s", install)
+	}
+}
+
+// TestCopyBinaryCleansStageOnInstallFailure asserts that when the install exec
+// fails (e.g. /usr/bin not writable and sudo -n denied) the staged /tmp copy is
+// removed best-effort, so retried provisions don't accumulate orphans.
+func TestCopyBinaryCleansStageOnInstallFailure(t *testing.T) {
+	b := &recordingBackend{failExec: true}
+	if err := copyBinary(b, "/ws"); err == nil {
+		t.Fatal("expected the failing install to surface as an error")
+	}
+	if len(b.execScripts) != 2 {
+		t.Fatalf("expected install + cleanup execs, got %d: %v", len(b.execScripts), b.execScripts)
+	}
+	cleanup := b.execScripts[1]
+	if !strings.Contains(cleanup, "rm -f") || !strings.Contains(cleanup, b.copiedTo) {
+		t.Errorf("cleanup must rm the staged temp %q:\n%s", b.copiedTo, cleanup)
 	}
 }
 

--- a/internal/fleetlaunch/fleetlaunch_test.go
+++ b/internal/fleetlaunch/fleetlaunch_test.go
@@ -84,8 +84,8 @@ func TestCopyBinaryStagesViaCopyFileThenInstalls(t *testing.T) {
 		t.Fatalf("copyBinary: %v", err)
 	}
 
-	if b.copiedTo != stagePath {
-		t.Errorf("staged to %q, want %q", b.copiedTo, stagePath)
+	if !strings.HasPrefix(b.copiedTo, "/tmp/.fleet-launch-stage.") {
+		t.Errorf("staged to %q, want a unique /tmp/.fleet-launch-stage.* path", b.copiedTo)
 	}
 	if b.copyMode != 0o755 {
 		t.Errorf("stage mode = %o, want 0755", b.copyMode)
@@ -97,8 +97,8 @@ func TestCopyBinaryStagesViaCopyFileThenInstalls(t *testing.T) {
 		t.Fatalf("expected 1 install exec, got %d: %v", len(b.execScripts), b.execScripts)
 	}
 	install := b.execScripts[0]
-	if !strings.Contains(install, stagePath) || !strings.Contains(install, RemotePath) {
-		t.Errorf("install script missing stage/remote paths:\n%s", install)
+	if !strings.Contains(install, b.copiedTo) || !strings.Contains(install, RemotePath) {
+		t.Errorf("install script missing the staged/remote paths:\n%s", install)
 	}
 	if strings.Contains(install, "cat >") {
 		t.Errorf("install must not stream over stdin (hangs on coder):\n%s", install)

--- a/internal/fleetlaunch/fleetrc.go
+++ b/internal/fleetlaunch/fleetrc.go
@@ -74,14 +74,13 @@ func EnsureFleetRC(instanceBackend backend.Backend, workspaceDir, homeDir, insta
 	target := rcDir + "/" + rcFilename
 	bashrc := homeDir + "/.bashrc"
 
-	// 1. Write the rc. mkdir -p is idempotent; cat streams the embedded
-	// content over stdin so the body never has to be shell-quoted into
-	// the script literal.
-	write := fmt.Sprintf(`mkdir -p %s && cat > %s`, rcDir, target)
-	cmd := instanceBackend.ExecCommand(workspaceDir, []string{"sh", "-c", write})
-	cmd.Stdin = strings.NewReader(renderFleetRC(instanceName))
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("write fleet.rc: %w (%s)", err, strings.TrimSpace(string(out)))
+	// 1. Write the rc. WriteFileInline embeds the (small) content base64-encoded
+	// in the command itself and decodes it in-container, so nothing is streamed
+	// over stdin — a plain `cat > file` would hang forever on the coder backend,
+	// whose transport never delivers the stdin EOF (issue #223). It also mkdir's
+	// the parent and writes atomically.
+	if err := backend.WriteFileInline(instanceBackend, workspaceDir, target, []byte(renderFleetRC(instanceName)), 0o644); err != nil {
+		return fmt.Errorf("write fleet.rc: %w", err)
 	}
 
 	// 2. Wire the rc into .bashrc — touch first so a missing file

--- a/internal/server/automation_event_test.go
+++ b/internal/server/automation_event_test.go
@@ -2,8 +2,8 @@ package server
 
 import (
 	"bytes"
+	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -90,16 +90,21 @@ func TestAutomationEventPath(t *testing.T) {
 	}
 }
 
-// TestWriteAutomationEventFile drives the real base64-over-stdin write by stubbing
-// the copy exec seam to run the same argv locally — so a payload of arbitrary
-// bytes round-trips through `base64 -d` exactly as it would inside a container.
+// TestWriteAutomationEventFile drives the real write by stubbing the CopyFile
+// strategy seam to write to a host file — so a payload of arbitrary bytes
+// round-trips exactly as it would inside a container, now over the stdin-EOF-safe
+// CopyFile path rather than a base64-over-stdin pipe that hung on coder.
 func TestWriteAutomationEventFile(t *testing.T) {
 	dir := t.TempDir()
-	orig := copyIntoExecCommand
-	copyIntoExecCommand = func(_ *fleet.Instance, argv []string) *exec.Cmd {
-		return exec.Command(argv[0], argv[1:]...)
+	orig := copyFileInto
+	copyFileInto = func(_ *fleet.Instance, src io.Reader, remotePath string, mode int) error {
+		data, err := io.ReadAll(src)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(remotePath, data, os.FileMode(mode))
 	}
-	t.Cleanup(func() { copyIntoExecCommand = orig })
+	t.Cleanup(func() { copyFileInto = orig })
 
 	cases := map[string][]byte{
 		"binary": {0x00, 0x01, 'h', 'i', 0xff, '\n', 0x04},

--- a/internal/server/copy.go
+++ b/internal/server/copy.go
@@ -4,15 +4,12 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
-	"crypto/rand"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
@@ -28,19 +25,22 @@ import (
 // in-instance `fc` shorthand): CopyFile streams a file OUT of an instance to the
 // client, CopyInto streams a file INTO an instance from the client.
 //
-// Both move bytes through the backend with a single container exec and a `tar`
-// pipe, so the file's metadata (mode, size) and bytes ride one consistent
-// stream with no shell quoting (argv goes straight to exec) and no stat/cat
-// race. OUT runs `tar -chf -` to stdout (-h dereferences a symlinked source so
-// the client receives the real content); IN runs `tar -xf -` from stdin into
-// the destination directory, preserving the file mode.
+// OUT runs `tar -chf -` to stdout (-h dereferences a symlinked source so the
+// client receives the real content) and reads the stream until the remote
+// process exits — a remote→host close the transport always delivers, so it works
+// on every backend.
 //
-// Backend caveat (shared by both directions, pre-existing): the codespaces
-// backend allocates a PTY for exec, whose line discipline mangles binary tar —
-// on stdin (IN) a 0x04 byte reads as EOF, truncating the upload. The strict size
-// check below turns such a truncation into a clean InvalidArgument rather than a
-// silent partial write. devcontainer (the default) and coder exec without a PTY
-// and over a clean binary channel, so both directions work there.
+// IN (single file) buffers the upload to a host temp — validating the declared
+// size exactly so a truncated/oversized stream fails before anything is written
+// — then hands it to the backend's CopyFile, the strategy seam that picks a
+// stdin-EOF-safe transport per backend. This is deliberate: a host→remote
+// `tar -xf -` reading stdin to EOF hangs forever on the coder backend, whose
+// `coder ssh` transport never half-closes the remote command's stdin (issue
+// #223); CopyFile streams over stdin on devcontainer/codespaces and transfers
+// out-of-band with scp on coder. IN (directory, copyDirInto) still streams a tar
+// to `tar -xf -` and so remains subject to that stdin-EOF limitation on coder —
+// it is already refused on codespaces (whose exec PTY mangles binary tar) and is
+// a tracked follow-up for coder.
 
 // copyChunkSize is the data-frame payload size. Comfortably under gRPC's 4MB
 // default message cap while keeping per-frame overhead negligible.
@@ -296,12 +296,13 @@ var copyIntoExecCommand = func(inst *fleet.Instance, argv []string) *exec.Cmd {
 
 // CopyInto streams the file in the client's chunks INTO the instance. The first
 // chunk carries the open header (instance, dest, name, mode, size); the rest
-// carry data. The server resolves dest inside the container, extracts a one-file
-// tar (built here from the streamed bytes) with `tar -xf - -C <dir>` under a
-// temporary name, then renames it into place — so a truncated or oversized
-// stream (the declared size is a hard cap) fails the RPC without ever clobbering
-// an existing destination, the same atomicity the download direction has. Only
-// single regular files; the mode is preserved.
+// carry data. The server resolves dest inside the container, buffers the stream
+// to a host temp validated against the declared size (a hard cap), then hands it
+// to the backend's CopyFile — which writes it atomically (temp + rename), so a
+// truncated or oversized stream fails the RPC without ever clobbering an existing
+// destination, the same atomicity the download direction has. Only single
+// regular files; the mode is preserved. (A directory upload routes to
+// copyDirInto.)
 func (s *service) CopyInto(stream grpc.ClientStreamingServer[fleetgrpc.CopyIntoChunk, fleetgrpc.CopyIntoReply]) (err error) {
 	start := time.Now()
 	first, err := stream.Recv()
@@ -353,76 +354,88 @@ func (s *service) CopyInto(stream grpc.ClientStreamingServer[fleetgrpc.CopyIntoC
 		mode = 0o644
 	}
 
-	// Extract under a hidden temporary name and rename into place only on a clean
-	// finish, so a half-written upload never replaces a previous good file.
-	tempName := copyIntoTempName()
-
-	cmd := copyIntoExecCommand(inst, []string{"tar", "-xf", "-", "-C", finalDir})
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	stdin, err := cmd.StdinPipe()
+	// Buffer the upload to a host temp, validating the declared size exactly, so a
+	// truncated or oversized stream fails the RPC BEFORE anything is written into
+	// the instance (preserving any existing destination, the same atomicity the
+	// tar path had). Then hand the validated file to the backend's CopyFile, which
+	// transfers it with a transport that does not depend on stdin EOF — so it
+	// works on the coder backend, whose `coder ssh` never delivers the stdin EOF a
+	// `tar -xf -` waits for — and publishes it atomically (same-dir temp + rename).
+	hostTmp, written, err := drainCopyIntoToHostFile(stream, open.GetSize())
 	if err != nil {
-		return status.Errorf(codes.Internal, "pipe: %v", err)
+		return err
 	}
-	if err := cmd.Start(); err != nil {
-		return status.Errorf(codes.Internal, "start copy: %v", err)
+	defer func() { _ = hostTmp.Close(); _ = os.Remove(hostTmp.Name()) }()
+
+	finalPath := finalName
+	if finalDir != "." {
+		finalPath = path.Join(finalDir, finalName)
 	}
-
-	ctx := stream.Context()
-	finished := make(chan struct{})
-	// On client disconnect, kill tar AND close stdin so a write blocked on a full
-	// pipe unblocks (the inverse of CopyFile, where the active side is stdout).
-	go func() {
-		select {
-		case <-ctx.Done():
-			_ = cmd.Process.Kill()
-			_ = stdin.Close()
-		case <-finished:
-		}
-	}()
-
-	writeErr := writeCopyIntoTar(stdin, stream, tempName, mode, open.GetSize())
-	// EOF to tar. A no-op if the killer already closed it; harmless after a
-	// write error (tar already saw a short archive).
-	_ = stdin.Close()
-	waitErr := cmd.Wait()
-	close(finished)
-
-	tarMsg := strings.TrimSpace(stderr.String())
-	if writeErr != nil || waitErr != nil {
-		// Never leave the temp file behind on a failed upload.
-		s.removeContainerFile(inst, finalDir, tempName)
-		if writeErr != nil {
-			// A size mismatch is the client's fault and already a clean status.
-			if status.Code(writeErr) == codes.InvalidArgument {
-				return writeErr
-			}
-			// Otherwise the write likely hit EPIPE because tar died first — tar's
-			// own stderr (e.g. a missing directory) is the real cause.
-			if tarMsg != "" {
-				return status.Errorf(codes.Internal, "write %q to %s/%s: %s", finalName, open.GetFleet(), open.GetInstance(), tarMsg)
-			}
-			return writeErr
-		}
-		if tarMsg != "" {
-			return status.Errorf(codes.Internal, "write %q to %s/%s: %s", finalName, open.GetFleet(), open.GetInstance(), tarMsg)
-		}
-		return status.Errorf(codes.Internal, "write %q to %s/%s: %v", finalName, open.GetFleet(), open.GetInstance(), waitErr)
+	if err := copyFileInto(inst, hostTmp, finalPath, int(mode)); err != nil {
+		return status.Errorf(codes.Internal, "write %q to %s/%s: %v", finalName, open.GetFleet(), open.GetInstance(), err)
 	}
 
-	// Publish the fully-written file with an atomic rename.
-	if err := s.moveContainerFile(inst, finalDir, tempName, finalName); err != nil {
-		s.removeContainerFile(inst, finalDir, tempName)
-		return status.Errorf(codes.Internal, "finalize %q in %s/%s: %v", finalName, open.GetFleet(), open.GetInstance(), err)
-	}
-
-	finalPath := path.Join(finalDir, finalName)
-	if !path.IsAbs(finalPath) {
+	reportedPath := finalPath
+	if !path.IsAbs(reportedPath) {
 		// A relative dest resolved against the workspace folder (the exec cwd);
 		// report the absolute path the file actually landed at.
-		finalPath = path.Join(inst.WorkspaceDir, finalDir, finalName)
+		reportedPath = path.Join(inst.WorkspaceDir, finalDir, finalName)
 	}
-	return stream.SendAndClose(&fleetgrpc.CopyIntoReply{Path: finalPath, Written: open.GetSize()})
+	return stream.SendAndClose(&fleetgrpc.CopyIntoReply{Path: reportedPath, Written: written})
+}
+
+// copyFileInto is the seam from the CopyInto handler to the backend's stdin-EOF-
+// safe file transfer. A package var so tests can stub the whole backend layer
+// (mirroring copyIntoExecCommand).
+var copyFileInto = func(inst *fleet.Instance, src io.Reader, remotePath string, mode int) error {
+	return backendutil.NewForInstance(inst, false).CopyFile(inst.WorkspaceDir, src, remotePath, mode)
+}
+
+// drainCopyIntoToHostFile streams the client's data chunks into a host temp file,
+// enforcing the declared size exactly: a stream that ends short or overruns is an
+// InvalidArgument (so a truncated upload never lands as a silent partial file),
+// and any other failure is Internal. On success it returns the temp file
+// rewound to the start (ready to be read by CopyFile) and the byte count; the
+// caller owns closing and removing it.
+func drainCopyIntoToHostFile(stream copyIntoChunkReceiver, size int64) (*os.File, int64, error) {
+	f, err := os.CreateTemp("", "fleetcopyin-*")
+	if err != nil {
+		return nil, 0, status.Errorf(codes.Internal, "stage upload: %v", err)
+	}
+	fail := func(c codes.Code, format string, a ...any) (*os.File, int64, error) {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return nil, 0, status.Errorf(c, format, a...)
+	}
+
+	var written int64
+	for {
+		chunk, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fail(codes.Internal, "recv: %v", err)
+		}
+		data := chunk.GetData()
+		if len(data) == 0 {
+			continue
+		}
+		written += int64(len(data))
+		if written > size {
+			return fail(codes.InvalidArgument, "copy into: stream exceeds declared size %d", size)
+		}
+		if _, err := f.Write(data); err != nil {
+			return fail(codes.Internal, "stage upload: %v", err)
+		}
+	}
+	if written != size {
+		return fail(codes.InvalidArgument, "copy into: stream ended early — got %d of %d bytes", written, size)
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return fail(codes.Internal, "stage upload: %v", err)
+	}
+	return f, written, nil
 }
 
 // copyDirInto extracts the client's tar of directory contents into the instance.
@@ -434,6 +447,14 @@ func (s *service) CopyInto(stream grpc.ClientStreamingServer[fleetgrpc.CopyIntoC
 func (s *service) copyDirInto(inst *fleet.Instance, open *fleetgrpc.CopyIntoOpen, stream grpc.ClientStreamingServer[fleetgrpc.CopyIntoChunk, fleetgrpc.CopyIntoReply]) error {
 	if inst.Backend == fleet.BackendCodespaces {
 		return status.Errorf(codes.FailedPrecondition, "copying a directory is not supported on the codespaces backend")
+	}
+	// The dir path still pipes a tar to a stdin-reading `tar -xf -`, which hangs
+	// forever on coder (its `coder ssh` never delivers the stdin EOF — issue
+	// #223). Refuse it cleanly rather than wedging the RPC; the single-file path
+	// goes through CopyFile and is unaffected. A CopyFile-based recursive extract
+	// is a tracked follow-up.
+	if inst.Backend == fleet.BackendCoder {
+		return status.Errorf(codes.FailedPrecondition, "copying a directory is not yet supported on the coder backend")
 	}
 	if err := validateCopyName(open.GetName()); err != nil {
 		return err
@@ -553,43 +574,6 @@ func pumpCopyIntoData(w io.Writer, stream copyIntoChunkReceiver) (int64, error) 
 	}
 }
 
-// copyIntoSeq makes the temp name below unique within this process regardless of
-// the RNG, so two concurrent uploads into one directory never collide even if
-// crypto/rand degrades (a failed Read would otherwise leave the bytes zeroed).
-var copyIntoSeq atomic.Uint64
-
-// copyIntoTempName returns a hidden, unique basename to extract an upload into
-// before the atomic rename onto its real destination.
-func copyIntoTempName() string {
-	var b [8]byte
-	_, _ = rand.Read(b[:])
-	return fmt.Sprintf(".fleetcopy-%d-%x", copyIntoSeq.Add(1), b[:])
-}
-
-// moveContainerFile renames from→to within dir inside the instance — the atomic
-// publish step that replaces any existing destination only once the upload is
-// fully written.
-func (s *service) moveContainerFile(inst *fleet.Instance, dir, from, to string) error {
-	// `--` so a destination basename beginning with '-' is treated as a path,
-	// not an mv flag.
-	cmd := copyIntoExecCommand(inst, []string{"mv", "-f", "--", path.Join(dir, from), path.Join(dir, to)})
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		if msg := strings.TrimSpace(stderr.String()); msg != "" {
-			return fmt.Errorf("%s", msg)
-		}
-		return err
-	}
-	return nil
-}
-
-// removeContainerFile best-effort deletes a leftover temp file inside the
-// instance after a failed upload.
-func (s *service) removeContainerFile(inst *fleet.Instance, dir, name string) {
-	_ = copyIntoExecCommand(inst, []string{"rm", "-f", "--", path.Join(dir, name)}).Run()
-}
-
 // resolveCopyIntoDest resolves the destination dir + final basename inside the
 // container, scp-style: an empty dest (or a dest that is an existing directory)
 // keeps the source name; otherwise dest is the full target path. A trailing
@@ -625,62 +609,23 @@ func (s *service) probeContainerDir(inst *fleet.Instance, dir string) bool {
 }
 
 // copyIntoChunkReceiver is the read half of the CopyInto stream — abstracted so
-// writeCopyIntoTar is unit-testable without a real gRPC stream.
+// drainCopyIntoToHostFile (single file) and pumpCopyIntoData (directory) are
+// unit-testable without a real gRPC stream.
 type copyIntoChunkReceiver interface {
 	Recv() (*fleetgrpc.CopyIntoChunk, error)
 }
 
-// writeCopyIntoTar drains the client's data chunks into w as a single-file tar
-// archive named name with the given mode. It enforces size exactly: a stream
-// that ends short or overruns is an InvalidArgument (so a truncated upload never
-// lands as a silent partial file), and any other write failure surfaces verbatim.
-func writeCopyIntoTar(w io.Writer, stream copyIntoChunkReceiver, name string, mode os.FileMode, size int64) error {
-	tw := tar.NewWriter(w)
-	if err := tw.WriteHeader(&tar.Header{
-		Name:     name,
-		Mode:     int64(mode.Perm()),
-		Size:     size,
-		Typeflag: tar.TypeReg,
-	}); err != nil {
-		return status.Errorf(codes.Internal, "tar header: %v", err)
-	}
-
-	var written int64
-	for {
-		chunk, err := stream.Recv()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return status.Errorf(codes.Internal, "recv: %v", err)
-		}
-		data := chunk.GetData()
-		if len(data) == 0 {
-			continue
-		}
-		written += int64(len(data))
-		if written > size {
-			return status.Errorf(codes.InvalidArgument, "copy into: stream exceeds declared size %d", size)
-		}
-		if _, err := tw.Write(data); err != nil {
-			return status.Errorf(codes.Internal, "tar write: %v", err)
-		}
-	}
-	if written != size {
-		return status.Errorf(codes.InvalidArgument, "copy into: stream ended early — got %d of %d bytes", written, size)
-	}
-	if err := tw.Close(); err != nil {
-		return status.Errorf(codes.Internal, "tar close: %v", err)
-	}
-	return nil
-}
-
-// validateCopyName rejects a basename that is empty, a path-traversal token, or
-// contains a separator — a single-file copy must never create or escape into
-// subdirectories from the name alone.
+// validateCopyName rejects a basename that is empty, a path-traversal token,
+// contains a separator, or carries a control character — a single-file copy must
+// never create or escape into subdirectories from the name alone, and a newline
+// or NUL would corrupt the coder backend's scp transfer (its legacy-protocol
+// fallback frames records by newline, so an embedded one breaks the stream).
 func validateCopyName(name string) error {
 	if name == "" || name == "." || name == ".." || strings.ContainsRune(name, '/') {
 		return status.Errorf(codes.InvalidArgument, "invalid file name %q", name)
+	}
+	if strings.ContainsAny(name, "\n\r\x00") {
+		return status.Errorf(codes.InvalidArgument, "file name %q contains a control character", name)
 	}
 	return nil
 }

--- a/internal/server/copy.go
+++ b/internal/server/copy.go
@@ -397,6 +397,14 @@ var copyFileInto = func(inst *fleet.Instance, src io.Reader, remotePath string, 
 // and any other failure is Internal. On success it returns the temp file
 // rewound to the start (ready to be read by CopyFile) and the byte count; the
 // caller owns closing and removing it.
+//
+// Unlike the old tar path (which streamed straight through to the instance), the
+// whole upload is buffered to disk first — that is what makes the exact-size
+// check possible before anything is written into the instance, and it lets the
+// coder backend scp the file without a second copy. The temp lives in os.TempDir
+// (honoring $TMPDIR), so a very large `fleet copy` needs host scratch space
+// there; point $TMPDIR at a roomy filesystem if the default /tmp is small or
+// RAM-backed.
 func drainCopyIntoToHostFile(stream copyIntoChunkReceiver, size int64) (*os.File, int64, error) {
 	f, err := os.CreateTemp("", "fleetcopyin-*")
 	if err != nil {

--- a/internal/server/copyinto_test.go
+++ b/internal/server/copyinto_test.go
@@ -37,41 +37,37 @@ func dataChunk(b string) *fleetgrpc.CopyIntoChunk {
 	return &fleetgrpc.CopyIntoChunk{Msg: &fleetgrpc.CopyIntoChunk_Data{Data: []byte(b)}}
 }
 
-func TestWriteCopyIntoTarRoundTrip(t *testing.T) {
-	var buf bytes.Buffer
+func TestDrainCopyIntoToHostFileRoundTrip(t *testing.T) {
 	rcv := &fakeChunkReceiver{chunks: []*fleetgrpc.CopyIntoChunk{dataChunk("hello "), dataChunk("world")}}
-	if err := writeCopyIntoTar(&buf, rcv, "tool", 0o755, 11); err != nil {
-		t.Fatalf("writeCopyIntoTar: %v", err)
-	}
-	tr := tar.NewReader(&buf)
-	hdr, err := tr.Next()
+	f, written, err := drainCopyIntoToHostFile(rcv, 11)
 	if err != nil {
-		t.Fatalf("tar Next: %v", err)
+		t.Fatalf("drainCopyIntoToHostFile: %v", err)
 	}
-	if hdr.Name != "tool" || hdr.Mode != 0o755 || hdr.Size != 11 {
-		t.Fatalf("header = name=%q mode=%o size=%d, want tool 0755 11", hdr.Name, hdr.Mode, hdr.Size)
+	defer func() { f.Close(); os.Remove(f.Name()) }()
+	if written != 11 {
+		t.Fatalf("written = %d, want 11", written)
 	}
-	body, _ := io.ReadAll(tr)
+	body, _ := io.ReadAll(f)
 	if string(body) != "hello world" {
 		t.Fatalf("body = %q, want hello world", body)
 	}
 }
 
-func TestWriteCopyIntoTarSizeMismatch(t *testing.T) {
+func TestDrainCopyIntoToHostFileSizeMismatch(t *testing.T) {
 	// Stream ends short of the declared size.
 	short := &fakeChunkReceiver{chunks: []*fleetgrpc.CopyIntoChunk{dataChunk("hi")}}
-	if err := writeCopyIntoTar(io.Discard, short, "f", 0o644, 10); status.Code(err) != codes.InvalidArgument {
+	if _, _, err := drainCopyIntoToHostFile(short, 10); status.Code(err) != codes.InvalidArgument {
 		t.Fatalf("short stream: want InvalidArgument, got %v", err)
 	}
 	// Stream overruns the declared size.
 	over := &fakeChunkReceiver{chunks: []*fleetgrpc.CopyIntoChunk{dataChunk("too much data")}}
-	if err := writeCopyIntoTar(io.Discard, over, "f", 0o644, 4); status.Code(err) != codes.InvalidArgument {
+	if _, _, err := drainCopyIntoToHostFile(over, 4); status.Code(err) != codes.InvalidArgument {
 		t.Fatalf("over stream: want InvalidArgument, got %v", err)
 	}
 }
 
 func TestValidateCopyName(t *testing.T) {
-	for _, bad := range []string{"", ".", "..", "a/b", "/abs", "sub/file"} {
+	for _, bad := range []string{"", ".", "..", "a/b", "/abs", "sub/file", "a\nb", "a\rb", "a\x00b"} {
 		if err := validateCopyName(bad); status.Code(err) != codes.InvalidArgument {
 			t.Errorf("validateCopyName(%q): want InvalidArgument, got %v", bad, err)
 		}
@@ -95,6 +91,33 @@ func stubCopyIntoExec(t *testing.T) {
 		return cmd
 	}
 	t.Cleanup(func() { copyIntoExecCommand = orig })
+}
+
+// stubCopyFileInto stands in for the backend's CopyFile: it writes the streamed
+// bytes to the resolved path on the host (relative paths resolve against the
+// instance's WorkspaceDir, the exec cwd), so a real temp dir models the
+// container filesystem without a backend.
+func stubCopyFileInto(t *testing.T) {
+	t.Helper()
+	orig := copyFileInto
+	copyFileInto = func(inst *fleet.Instance, src io.Reader, remotePath string, mode int) error {
+		p := remotePath
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(inst.WorkspaceDir, remotePath)
+		}
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			return err
+		}
+		data, err := io.ReadAll(src)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(p, data, os.FileMode(mode)); err != nil {
+			return err
+		}
+		return os.Chmod(p, os.FileMode(mode))
+	}
+	t.Cleanup(func() { copyFileInto = orig })
 }
 
 func seedCopyIntoInstance(t *testing.T, ws string) {
@@ -201,6 +224,31 @@ func TestCopyIntoDirCodespacesGate(t *testing.T) {
 	}
 }
 
+// TestCopyIntoDirCoderGate confirms the IN dir path is refused on coder rather
+// than hanging on its stdin-EOF-bound `tar -xf -`.
+func TestCopyIntoDirCoderGate(t *testing.T) {
+	isolateFleetDir(t)
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"alpha": {Name: "alpha", Instances: []*fleet.Instance{
+			{Name: "i1", Backend: fleet.BackendCoder, WorkspaceDir: t.TempDir(), ContainerID: "ws.agent", Status: fleet.StatusRunning},
+		}},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+	stream, err := client.CopyInto(context.Background())
+	if err != nil {
+		t.Fatalf("CopyInto: %v", err)
+	}
+	_, err = sendCopyInto(t, stream,
+		&fleetgrpc.CopyIntoOpen{Fleet: "alpha", Instance: "i1", Name: "proj", IsDir: true}, "")
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("coder dir IN: want FailedPrecondition, got %v", err)
+	}
+}
+
 // TestCopyFileDirCodespacesGate confirms the OUT dir path is refused on
 // codespaces (reached once the `test -d` probe — stubbed onto the host — sees a
 // real directory).
@@ -252,6 +300,7 @@ func TestCopyIntoWritesFileToDir(t *testing.T) {
 	}
 	seedCopyIntoInstance(t, ws)
 	stubCopyIntoExec(t)
+	stubCopyFileInto(t)
 
 	_, client, cleanup := newTestServer(t)
 	defer cleanup()
@@ -288,6 +337,7 @@ func TestCopyIntoEmptyDestUsesWorkspace(t *testing.T) {
 	ws := t.TempDir()
 	seedCopyIntoInstance(t, ws)
 	stubCopyIntoExec(t)
+	stubCopyFileInto(t)
 
 	_, client, cleanup := newTestServer(t)
 	defer cleanup()

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -3,7 +3,6 @@ package server
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
@@ -622,22 +621,15 @@ func appendEventPrompt(prompt string, e *triggerEvent, path string) string {
 	return prompt + "\n\n---\n" + note
 }
 
-// writeAutomationEventFile writes data to path inside the instance. It reuses the
-// fleet-copy exec seam (copyIntoExecCommand) and streams the payload as base64
-// over STDIN, decoded in-container — so a payload of any size avoids the argv
-// length limit a shell-embedded write would hit, arbitrary bytes survive intact,
-// and the base64 text stays clean over the codespaces backend's exec PTY (which
-// mangles raw binary). A package var so tests can stub the exec.
+// writeAutomationEventFile writes data to path inside the instance via the
+// backend's CopyFile strategy seam (copyFileInto) — the same stdin-EOF-safe
+// transfer the fleet-copy handler uses. An earlier base64-over-stdin write hung
+// forever on the coder backend, whose `coder ssh` never delivers the stdin EOF a
+// `base64 -d` waits for (issue #223); routing through CopyFile streams over a
+// clean channel on devcontainer/codespaces and transfers out-of-band with scp on
+// coder, for a payload of any size. A package var so tests can stub it.
 var writeAutomationEventFile = func(inst *fleet.Instance, path string, data []byte) error {
-	cmd := copyIntoExecCommand(inst, []string{"sh", "-c", "base64 -d > " + dotfiles.ShQuote(path)})
-	cmd.Stdin = strings.NewReader(base64.StdEncoding.EncodeToString(data))
-	if out, err := cmd.CombinedOutput(); err != nil {
-		if msg := strings.TrimSpace(string(out)); msg != "" {
-			return fmt.Errorf("%w: %s", err, msg)
-		}
-		return err
-	}
-	return nil
+	return copyFileInto(inst, bytes.NewReader(data), path, 0o644)
 }
 
 // buildAgentLaunchScript builds the in-container snippet that brings up the agent


### PR DESCRIPTION
Fixes #223.

## Root cause
Coder instances sat in `creating` forever (no error). Any provisioning command that **reads stdin to EOF** — `cat > file`, `tar -xf -`, `base64 -d` — never terminates over `coder ssh`, because the coder agent's SSH server (gliderlabs/ssh) never half-closes a remote command's stdin. The first such step in `finishProvision` (the `fleet.rc` write, or the binary copy when sudo is available) blocked `CombinedOutput()` forever, so `markInstanceRunning` was never reached. devcontainer (local `docker exec`) and codespaces (OpenSSH) deliver stdin EOF, so only coder hung.

## Approach — `Backend.CopyFile` strategy seam
A new interface method lets callers transfer a file into an instance without caring about the transport:

| backend | transport |
|---|---|
| devcontainer | `cat`-over-stdin (local docker exec delivers EOF) |
| codespaces | `cat`-over-stdin via a **non-PTY** exec (its normal exec PTY mangles binary — fixes a latent bug too) |
| coder | `scp` over `coder ssh --stdio` (length-framed, EOF-independent), then atomic `mv`+`chmod` |

Wired into the two callers, with no backend branching at the call site:
- **Binary staging** (`fleetlaunch`): `CopyFile` to a writable `/tmp` path, then a stdin-free `mv` install into `/usr/bin` (keeps the sudo/ETXTBSY handling).
- **`fleet copy`** (`server.CopyInto`, single file): buffers the upload to a host temp with exact-size validation, then `CopyFile` → `fc` now works on coder.

**Small in-memory files** (`fleet.rc`, Claude/auggie hook scripts + `settings.json`) move to **base64-in-argv** (`InlineWriteScript`) — stdin-free and uniform across backends. All staging execs gained a **timeout backstop** so no future stdin-reader can wedge create again.

Also fixes the same stdin-EOF hang in the automation event-file write (`writeAutomationEventFile` → `CopyFile`), refuses **directory** `fleet copy` on coder cleanly (`FailedPrecondition`) instead of hanging, and rejects control characters in copy filenames so they can't corrupt the scp transfer.

## Tests
- Real-`/bin/sh` round-trips for the inline/stream writers (binary bytes + nasty quoted paths), size guard, `ShellQuote`.
- Coder buffering helper + unique-stage-name test.
- Fake-backend test proving `copyBinary` stages-then-installs without `cat >`, and `EnsureFleetRC` writes inline.
- `CopyInto`/automation suites updated to the new seam; coder dir-copy gate test.
- Full non-TUI suite + `go vet` green.

## Adversarial review
Ran a multi-agent review (5 dimensions → per-finding verification). All 7 confirmed findings addressed: non-unique coder temp (race), `writeAutomationEventFile` hang, orphaned-temp cleanup, coder dir-copy hang→clean refusal, control-char filenames; OpenSSH-scp requirement and the missing cancellation-context documented.

## Known limitations / follow-ups
- The **coder scp path can't be exercised here** (no coder instance) — best-effort + 5-min timeout means a wrong guess degrades to "not staged", never a hang. **Needs validation on a real coder workspace.**
- `CopyFile`-based **recursive (directory)** copy on coder (currently refused).
- Threading a cancellation **context** into `Backend.CopyFile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)