### PR TITLE
feat(tui): tabs in panes — tmux windows as a per-pane tab bar

### DIFF
--- a/internal/tui/dotfiles.go
+++ b/internal/tui/dotfiles.go
@@ -86,19 +86,48 @@ func ShellCommandForSession(config *configutil.Config, session string, cols, row
 		tmuxSize = fmt.Sprintf(` -x %d -y %d`, cols, rows-1)
 		resizeHook = ` \; set -g aggressive-resize on \; set -g window-size latest`
 	}
+	// Tabs (issue #168): tmux windows inside the inner session act as
+	// per-pane tabs. The status line is the tab bar, rendered across the
+	// top of the pane with one entry per window; tmux's default
+	// MouseDown1Status binding makes each entry click-to-switch, and the
+	// default prefix keys (c / n / p / 0-9) create and cycle tabs.
+	//
+	// tabToggle hides the bar while a session has a single window and
+	// shows it otherwise. It runs once at attach time and again from the
+	// window-linked/unlinked hooks on every window create/kill. The hooks
+	// are global on the container's shared tmux server, so they are
+	// guarded by the session-scoped @fleet_tab_autohide marker: nested
+	// panes auto-hide (the TUI provides all other UI) while full-screen
+	// attaches keep the bar always on because status-right also carries
+	// the detach hint there.
+	tabToggle := `if -F '#{&&:#{@fleet_tab_autohide},#{==:#{session_windows},1}}' 'set status off' 'set status on'`
+	tabBarConf := ` \; set -g status-position top` +
+		` \; set -g status-style 'bg=default,fg=colour245'` +
+		` \; set -g window-status-format ' #I:#W '` +
+		` \; set -g window-status-current-format '#[fg=colour39,bold] #I:#W #[default]'` +
+		` \; set-hook -g window-linked "` + tabToggle + `"` +
+		` \; set-hook -g window-unlinked "` + tabToggle + `"`
 	// When nested inside a host tmux (split pane mode), use Ctrl+X as
 	// the inner prefix so it doesn't conflict with the outer Ctrl+B.
 	// Pane navigation (h/j/k/l) is handled by the outer tmux, so the
 	// inner tmux only needs prefix and session keys.
-	prefixConf := ""
+	modeConf := ""
 	statusRight := ` ctrl+q/ctrl+o: detach `
 	if nested {
 		// In nested mode, Ctrl+Q/O are handled by the outer tmux
 		// (they close all split panes). The inner tmux only needs
 		// the prefix override and session navigation. The status bar
-		// is hidden because the outer tmux provides all the UI.
-		prefixConf = ` \; set -g prefix C-x \; bind-key C-x send-prefix \; set -g status off`
+		// doubles as the tab bar and is hidden while the session has a
+		// single window (the outer tmux provides all other UI).
+		modeConf = ` \; set -g prefix C-x \; bind-key C-x send-prefix` +
+			` \; set status-left '' \; set status-right ' ctrl+x c: new tab '` +
+			` \; set @fleet_tab_autohide 1 \; ` + tabToggle
 		statusRight = ""
+	} else {
+		// Full-screen mode keeps the bar always on: it carries the
+		// detach hint and doubles as the tab bar. -u resets a
+		// status-left cleared by an earlier nested attach.
+		modeConf = ` \; set @fleet_tab_autohide 0 \; set status on \; set -u status-left`
 	}
 	// Session navigation: Ctrl+PageUp/Down are handled by the outer
 	// tmux to cycle session groups. prefix+T creates a new session
@@ -152,7 +181,7 @@ func ShellCommandForSession(config *configutil.Config, session string, cols, row
 		` \; unbind -n MouseDown2Pane`
 	clipboardFeatures := ` \; set -as terminal-features ',*:clipboard'`
 	inner := setup + tmuxEnsureInstalled + sizefix + sshAgentFix + hookClear + fmt.Sprintf(
-		`exec tmux -u new-session -A -s %s`+tmuxSize+` \; set -g mouse on`+clipboardConf+mouseBindings+detachKeys+statusConf+prefixConf+sessionKeys+resizeHook+clipboardFeatures,
+		`exec tmux -u new-session -A -s %s`+tmuxSize+` \; set -g mouse on`+clipboardConf+mouseBindings+detachKeys+tabBarConf+statusConf+modeConf+sessionKeys+resizeHook+clipboardFeatures,
 		shQuote(session),
 	)
 	return []string{"sh", "-c", inner}

--- a/internal/tui/dotfiles.go
+++ b/internal/tui/dotfiles.go
@@ -95,18 +95,21 @@ func ShellCommandForSession(config *configutil.Config, session string, cols, row
 	// tabToggle hides the bar while a session has a single window and
 	// shows it otherwise. It runs once at attach time and again from the
 	// window-linked/unlinked hooks on every window create/kill. The hooks
-	// are global on the container's shared tmux server, so they are
-	// guarded by the session-scoped @fleet_tab_autohide marker: nested
-	// panes auto-hide (the TUI provides all other UI) while full-screen
+	// and the status options are session-scoped so they never touch a
+	// user's own tmux sessions on the container's shared server (or
+	// clobber their global hooks); only the window-status formats are
+	// global, as window options have no session scope. The session-scoped
+	// @fleet_tab_autohide marker distinguishes the modes: nested panes
+	// auto-hide (the TUI provides all other UI) while full-screen
 	// attaches keep the bar always on because status-right also carries
 	// the detach hint there.
 	tabToggle := `if -F '#{&&:#{@fleet_tab_autohide},#{==:#{session_windows},1}}' 'set status off' 'set status on'`
-	tabBarConf := ` \; set -g status-position top` +
-		` \; set -g status-style 'bg=default,fg=colour245'` +
+	tabBarConf := ` \; set status-position top` +
+		` \; set status-style 'bg=default,fg=colour245'` +
 		` \; set -g window-status-format ' #I:#W '` +
 		` \; set -g window-status-current-format '#[fg=colour39,bold] #I:#W #[default]'` +
-		` \; set-hook -g window-linked "` + tabToggle + `"` +
-		` \; set-hook -g window-unlinked "` + tabToggle + `"`
+		` \; set-hook window-linked "` + tabToggle + `"` +
+		` \; set-hook window-unlinked "` + tabToggle + `"`
 	// When nested inside a host tmux (split pane mode), use Ctrl+X as
 	// the inner prefix so it doesn't conflict with the outer Ctrl+B.
 	// Pane navigation (h/j/k/l) is handled by the outer tmux, so the

--- a/internal/tui/dotfiles.go
+++ b/internal/tui/dotfiles.go
@@ -119,18 +119,24 @@ func ShellCommandForSession(config *configutil.Config, session string, cols, row
 	if nested {
 		// In nested mode, Ctrl+Q/O are handled by the outer tmux
 		// (they close all split panes). The inner tmux only needs
-		// the prefix override and session navigation. The status bar
+		// the prefix override and session navigation. The prefix is
+		// session-scoped so full-screen attaches and a user's own
+		// sessions on the shared server keep the default Ctrl+B
+		// (bind-key tables are inherently global; prefix+C-x =
+		// send-prefix is inert under other prefixes). The status bar
 		// doubles as the tab bar and is hidden while the session has a
 		// single window (the outer tmux provides all other UI).
-		modeConf = ` \; set -g prefix C-x \; bind-key C-x send-prefix` +
+		modeConf = ` \; set prefix C-x \; bind-key C-x send-prefix` +
 			` \; set status-left '' \; set status-right ' ctrl+x c: new tab '` +
 			` \; set @fleet_tab_autohide 1 \; ` + tabToggle
 		statusRight = ""
 	} else {
 		// Full-screen mode keeps the bar always on: it carries the
-		// detach hint and doubles as the tab bar. -u resets a
-		// status-left cleared by an earlier nested attach.
-		modeConf = ` \; set @fleet_tab_autohide 0 \; set status on \; set -u status-left`
+		// detach hint and doubles as the tab bar. -u resets the
+		// prefix and status-left a prior nested attach overrode, so
+		// the documented full-screen keys (ctrl+b …) hold regardless
+		// of attach order.
+		modeConf = ` \; set @fleet_tab_autohide 0 \; set status on \; set -u status-left \; set -u prefix`
 	}
 	// Session navigation: Ctrl+PageUp/Down are handled by the outer
 	// tmux to cycle session groups. prefix+T creates a new session

--- a/internal/tui/dotfiles_test.go
+++ b/internal/tui/dotfiles_test.go
@@ -244,10 +244,10 @@ func TestShellCommandTabBar(t *testing.T) {
 	for _, nested := range []bool{true, false} {
 		script := shellCommand(config, "agent-1", 80, 24, nested)[2]
 		for _, want := range []string{
-			"set -g status-position top",
+			"set status-position top",
 			"set -g window-status-format ' #I:#W '",
-			`set-hook -g window-linked "` + toggle + `"`,
-			`set-hook -g window-unlinked "` + toggle + `"`,
+			`set-hook window-linked "` + toggle + `"`,
+			`set-hook window-unlinked "` + toggle + `"`,
 		} {
 			if !strings.Contains(script, want) {
 				t.Errorf("nested=%v script missing %q: %s", nested, want, script)

--- a/internal/tui/dotfiles_test.go
+++ b/internal/tui/dotfiles_test.go
@@ -231,9 +231,53 @@ func TestShellCommandNestedNoInnerPaneKeys(t *testing.T) {
 	if !strings.Contains(script, "set -g prefix C-x") {
 		t.Errorf("nested script missing prefix override: %s", script)
 	}
-	// Status bar should be hidden in nested mode.
-	if !strings.Contains(script, "set -g status off") {
-		t.Errorf("nested script should hide status bar: %s", script)
+	// The status bar doubles as the tab bar and auto-hides while the
+	// session has a single window.
+	if !strings.Contains(script, "set @fleet_tab_autohide 1") {
+		t.Errorf("nested script missing tab auto-hide marker: %s", script)
+	}
+}
+
+func TestShellCommandTabBar(t *testing.T) {
+	config := state.DefaultConfig()
+	toggle := `if -F '#{&&:#{@fleet_tab_autohide},#{==:#{session_windows},1}}' 'set status off' 'set status on'`
+	for _, nested := range []bool{true, false} {
+		script := shellCommand(config, "agent-1", 80, 24, nested)[2]
+		for _, want := range []string{
+			"set -g status-position top",
+			"set -g window-status-format ' #I:#W '",
+			`set-hook -g window-linked "` + toggle + `"`,
+			`set-hook -g window-unlinked "` + toggle + `"`,
+		} {
+			if !strings.Contains(script, want) {
+				t.Errorf("nested=%v script missing %q: %s", nested, want, script)
+			}
+		}
+	}
+}
+
+func TestShellCommandTabBarNested(t *testing.T) {
+	config := state.DefaultConfig()
+	script := shellCommand(config, "agent-1", 80, 24, true)[2]
+	// Auto-hide on, and the initial toggle runs at attach so a reattach
+	// to a multi-window session shows the bar immediately.
+	if !strings.Contains(script, `set @fleet_tab_autohide 1 \; if -F`) {
+		t.Errorf("nested script missing attach-time tab toggle: %s", script)
+	}
+	if !strings.Contains(script, "ctrl+x c: new tab") {
+		t.Errorf("nested script missing new-tab hint: %s", script)
+	}
+}
+
+func TestShellCommandTabBarFullScreen(t *testing.T) {
+	config := state.DefaultConfig()
+	script := shellCommand(config, "agent-1", 80, 24, false)[2]
+	// Full-screen keeps the bar always on (it carries the detach hint).
+	if !strings.Contains(script, `set @fleet_tab_autohide 0 \; set status on`) {
+		t.Errorf("full-screen script should force status on: %s", script)
+	}
+	if !strings.Contains(script, "ctrl+q/ctrl+o: detach") {
+		t.Errorf("full-screen script missing detach hint: %s", script)
 	}
 }
 

--- a/internal/tui/dotfiles_test.go
+++ b/internal/tui/dotfiles_test.go
@@ -227,9 +227,11 @@ func TestShellCommandNestedNoInnerPaneKeys(t *testing.T) {
 	if strings.Contains(script, "bind-key k select-pane") {
 		t.Errorf("nested script should not have k keybinding (pane nav is on outer tmux): %s", script)
 	}
-	// Should still have the prefix override for inner tmux.
-	if !strings.Contains(script, "set -g prefix C-x") {
-		t.Errorf("nested script missing prefix override: %s", script)
+	// Should still have the prefix override for inner tmux,
+	// session-scoped so it doesn't leak to full-screen attaches or a
+	// user's own sessions on the shared server.
+	if !strings.Contains(script, `set prefix C-x`) || strings.Contains(script, "set -g prefix") {
+		t.Errorf("nested script should set session-scoped prefix: %s", script)
 	}
 	// The status bar doubles as the tab bar and auto-hides while the
 	// session has a single window.
@@ -279,6 +281,11 @@ func TestShellCommandTabBarFullScreen(t *testing.T) {
 	if !strings.Contains(script, "ctrl+q/ctrl+o: detach") {
 		t.Errorf("full-screen script missing detach hint: %s", script)
 	}
+	// A prior nested attach session-scopes prefix C-x; full-screen must
+	// reset it so the documented ctrl+b keys hold regardless of order.
+	if !strings.Contains(script, `set -u prefix`) {
+		t.Errorf("full-screen script should reset session prefix: %s", script)
+	}
 }
 
 func TestShellCommandNestedVimKeysDisabled(t *testing.T) {
@@ -298,7 +305,7 @@ func TestShellCommandNestedVimKeysDisabled(t *testing.T) {
 		t.Errorf("nested script should not have vim keys help text: %s", script)
 	}
 	// Should still have the prefix override
-	if !strings.Contains(script, "set -g prefix C-x") {
+	if !strings.Contains(script, "set prefix C-x") {
 		t.Errorf("nested script missing prefix override: %s", script)
 	}
 }

--- a/internal/tui/keybindings.go
+++ b/internal/tui/keybindings.go
@@ -76,6 +76,9 @@ func keybindingsData() []keybindingGroup {
 			Entries: []keybindingEntry{
 				{"ctrl+x", "Prefix key (nested)"},
 				{"ctrl+PageUp/Down", "Cycle sessions"},
+				{"prefix + c", "New tab in pane"},
+				{"prefix + n / p", "Next / previous tab"},
+				{"prefix + 0-9", "Jump to tab"},
 				{"prefix + T", "New tmux session"},
 				{"ctrl+q / ctrl+o", "Detach from session"},
 				{"j / k (vim mode)", "Select pane down / up"},

--- a/internal/tui/page_fleet_rows.go
+++ b/internal/tui/page_fleet_rows.go
@@ -55,6 +55,13 @@ func (fleetPage *fleetPage) buildRows(m *model) {
 					for _, g := range m.sessionStore.Groups(ref) {
 						liveGroups[g.GroupID] = true
 						rootName := g.Sessions[0].Name
+						// Tab badge only for single-session rows: a
+						// multi-pane group already carries the panes
+						// suffix, and its per-pane tab counts differ.
+						tabCount := 0
+						if len(g.Sessions) == 1 {
+							tabCount = g.Sessions[0].Windows
+						}
 						fleetPage.rows = append(fleetPage.rows, row{
 							kind:        rowSession,
 							fleetName:   name,
@@ -62,6 +69,7 @@ func (fleetPage *fleetPage) buildRows(m *model) {
 							sessionName: rootName,
 							groupID:     g.GroupID,
 							groupSize:   len(g.Sessions),
+							tabCount:    tabCount,
 						})
 					}
 					fleetPage.appendSavedGroupRows(name, instance, liveGroups)

--- a/internal/tui/page_fleet_test.go
+++ b/internal/tui/page_fleet_test.go
@@ -205,6 +205,47 @@ func TestBuildRowsShowsSavedGroupWithoutLiveSessions(t *testing.T) {
 	}
 }
 
+func TestBuildRowsTabCount(t *testing.T) {
+	inst := &fleet.Instance{Name: "alpha", Status: fleet.StatusRunning, ContainerID: "abc"}
+	fp := newFleetPage()
+	m := &model{
+		st: &state.State{
+			Fleets: map[string]*fleet.Fleet{
+				"repo": {Name: "repo", Instances: []*fleet.Instance{inst}},
+			},
+		},
+		sessionStore: func() *SessionStore {
+			s := NewSessionStore()
+			ref := InstanceRef{Fleet: "repo", Instance: "alpha"}
+			s.SetExpanded(ref, true)
+			s.SetDiscovery(ref, []tmuxSession{
+				{Name: "alpha~solo", Windows: 3},
+				{Name: "alpha~grp", Windows: 2},
+				{Name: "alpha~grp~ff00", Windows: 1},
+			})
+			return s
+		}(),
+		fleetPage: fp,
+	}
+
+	fp.buildRows(m)
+
+	got := map[string]int{}
+	for _, r := range fp.rows {
+		if r.kind == rowSession {
+			got[r.groupID] = r.tabCount
+		}
+	}
+	// Single-session row carries its window count as the tab badge.
+	if got["solo"] != 3 {
+		t.Errorf("solo tabCount = %d, want 3", got["solo"])
+	}
+	// Multi-pane groups show a panes suffix instead — no tab badge.
+	if got["grp"] != 0 {
+		t.Errorf("group tabCount = %d, want 0", got["grp"])
+	}
+}
+
 func tagTestModel(fp *fleetPage, inst *fleet.Instance, expanded bool) *model {
 	store := NewSessionStore()
 	if expanded {

--- a/internal/tui/page_fleet_view.go
+++ b/internal/tui/page_fleet_view.go
@@ -246,13 +246,17 @@ func (fleetPage *fleetPage) viewFleetList(m *model) string {
 				icon = "●"
 				style = sessionActiveStyle
 			}
+			tabSuffix := ""
+			if r.tabCount > 1 {
+				tabSuffix = fmt.Sprintf(" (%d tabs)", r.tabCount)
+			}
 			var label string
 			if r.groupSize > 1 {
 				label = fmt.Sprintf("%s %s (%d panes)", icon, r.groupID, r.groupSize)
 			} else if r.groupID != "" && isGroupedSession(SanitizeSessionName(r.instance.Name), r.sessionName) {
-				label = fmt.Sprintf("%s %s", icon, r.groupID)
+				label = fmt.Sprintf("%s %s%s", icon, r.groupID, tabSuffix)
 			} else {
-				label = fmt.Sprintf("%s %s", icon, r.sessionName)
+				label = fmt.Sprintf("%s %s%s", icon, r.sessionName, tabSuffix)
 			}
 			if isSelected {
 				style = selectedStyle

--- a/internal/tui/rows.go
+++ b/internal/tui/rows.go
@@ -37,6 +37,7 @@ type row struct {
 	sessionName string // set when kind == rowSession or rowNewSession
 	groupID     string // set for grouped session rows
 	groupSize   int    // number of sessions in the group (for display)
+	tabCount    int    // tmux windows in a single-session row (for display)
 	// autoIdx indexes the fleet's Settings.Triggers (rowTrigger) or
 	// Settings.Agents (rowAgent) — the automation item this row renders/edits.
 	autoIdx int


### PR DESCRIPTION
Closes #168.

## What

Per-pane tabs in the fleet TUI, exactly as mocked in the issue: a clickable tab strip across the top of each session pane, keyboard shortcuts to create/cycle tabs, independent per pane.

## How — the moon shot turned out to be a config change

Each TUI pane is a host-tmux split pane attached (via `fleet shell`) to a full tmux **session** inside the container. Tmux **windows** inside that session are the tabs — and the inner tmux status line, which fleet previously hid in split mode (`set -g status off`), is the tab bar. No terminal emulation, no new rendering, no data-plane round trips:

- **Tab bar** = inner status line at `status-position top`, styled to the TUI palette (`styles.go` greys + colour39 accent), one entry per window.
- **Click-to-switch** = tmux's default `MouseDown1Status` binding; mouse passthrough already works (it's how drag-copy inside panes works today).
- **Keys** = tmux defaults, now visible and documented: `ctrl+x c` new tab, `ctrl+x n`/`p` cycle, `ctrl+x 0-9` jump (split mode; `ctrl+b` prefix full-screen). These technically "worked" before — into an invisible window with zero indication. The keybindings overlay lists them now.
- **Auto-hide** (split mode): `window-linked`/`window-unlinked` hooks hide the bar while a session has a single window, so the common one-tab case keeps full pane height — matching the issue mockup. The hooks are global on the container's shared tmux server, so a session-scoped `@fleet_tab_autohide` marker keeps them from hiding the bar on full-screen attaches, where it stays always-on and carries the existing detach hint.
- **Switching is instant** — window select/create is local to the container's tmux server; no ~2-3s exec round trip, nothing per-keystroke.
- Tabs persist across detach/reattach/TUI restarts for free (they live in the inner session).
- Session rows in the fleet list now show an `(N tabs)` badge sourced from the already-polled `#{session_windows}` count (previously plumbed but unused).

## Verified

Ran the exact emitted attach scripts (both modes) in an isolated nested two-server tmux harness (outer host layer + inner layer, isolated sockets):

- split mode: bar hidden at 1 window → appears at top with `0:bash 1:vim` + `ctrl+x c: new tab` hint on second window → hides again after kill
- full-screen: bar always on with session name + detach hint
- mode transition (same session attached split then full-screen): autohide flips, `status-left` restored
- `MouseDown1Status select-window -t=` confirmed present in default bindings (actual clicking not injectable headlessly)
- `go test ./...` green, `golangci-lint` 0 issues

## Known limitations (documented, deliberate v1 scope)

- Screen capture, agent-activity detection, and MCP `fleet_session_exec`/`read` target a session's *active* window — an agent running in a background tab is invisible to them until you switch back. Extending the capture/poll scripts per-window is a natural follow-up if this bites.
- Layout presets snapshot outer pane geometry only; a session's tab set isn't captured.
- *Concurrent* mixed-mode attaches to the same session (a TUI split pane and a full-screen `fleet shell` at once) get last-attach-wins semantics for the session-scoped prefix / auto-hide / status options — tmux options have no per-client scope. Sequential transitions are handled; concurrent same-mode attaches (multi-TUI) are consistent by construction. If it ever bites, `client-attached`/`client-detached` hooks re-running the mode chain are the escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
