### PR TITLE
fix(tui): portable placeholder sleep so session-group restore works on macOS

### DIFF
--- a/internal/tui/splitpane.go
+++ b/internal/tui/splitpane.go
@@ -202,6 +202,13 @@ func unbindDefaultSplitKeys() {
 	_ = exec.Command("tmux", "bind-key", `"`, "display-message", msg).Run()
 }
 
+// placeholderSleepSecs keeps Phase-1 placeholder panes alive until they are
+// respawned with their real session. It must be a plain seconds count:
+// `sleep infinity` is a GNU coreutils extension, and macOS/BSD sleep rejects
+// it and exits immediately — the pane then closes before the layout apply and
+// respawn phases run, breaking every group restore/switch on macOS.
+const placeholderSleepSecs = "2147483647"
+
 // splitWindowWithRetry runs `tmux split-window` with the given args,
 // retrying up to 3 times with a 250ms pause between attempts. tmux
 // occasionally fails a split mid-layout under rapid pane churn — a
@@ -581,14 +588,14 @@ func (fleetPage *fleetPage) restoreGroupCmd(m *model, fleetName string, instance
 					"split-window", "-h",
 					"-l", "70%",
 					"-P", "-F", "#{pane_id}",
-					"--", "sleep", "infinity",
+					"--", "sleep", placeholderSleepSecs,
 				}
 			} else {
 				tmuxArgs = []string{
 					"split-window", "-v",
 					"-t", lastPaneID,
 					"-P", "-F", "#{pane_id}",
-					"--", "sleep", "infinity",
+					"--", "sleep", placeholderSleepSecs,
 				}
 			}
 			paneID, err := splitWindowWithRetry(tmuxArgs)


### PR DESCRIPTION
Fixes #231

## What

Phase 1 of restoreGroupCmd creates placeholder panes with 'sleep infinity' to establish layout geometry before respawning each pane with its real session. 'sleep infinity' is a GNU coreutils extension: macOS/BSD sleep rejects it and exits immediately, so on a Mac every placeholder pane died the moment it was created. Follow-up splits then targeted dead pane IDs, select-layout had nothing to lay out, and the respawn phase found no slots. Net effect: every session-group switch or restore broke on macOS.

This swaps the placeholder to 'sleep 2147483647' (a named constant with a comment explaining why). Both GNU and BSD sleep accept a plain seconds count, and the placeholder only needs to outlive the respawn that happens moments later, so behavior on Linux is unchanged.

## Testing

- Minimal repro from #231: 'tmux split-window ... -- sleep infinity' loses the pane within a second on macOS; with the numeric sleep the pane survives. Verified on macOS (arm64), tmux 3.5a.
- Full manual pass on macOS in the TUI: two session groups (one with 2 panes, one with 1), switching via Ctrl+PageUp/PageDown lands correctly every time, pane positions and a custom resize survive round trips, rapid switching (~10 fast flips) ends in a consistent state, Ctrl+Q closes cleanly, sessions and scrollback survive.
- go build ./... clean, internal/tui tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
