### PR TITLE
fix(devcontainer): mount the Docker VM's SSH agent path on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ Variables fleet **reads** (set them to configure behavior):
 | `FLEET_SERVER` | `host:port` | Drive a remote daemon over plain TCP (no gateway). |
 | `FLEET_DEVCONTAINER_BUILDKIT` | `auto` (default), `never` | BuildKit mode for Fleet-managed devcontainers. See [Devcontainer BuildKit](#devcontainer-buildkit). |
 | `FLEET_DEVCONTAINER_UPDATE_REMOTE_USER_UID` | `default`, `never`, `on`, `off` | Remote-user UID/GID rewrite mode. See [Devcontainer UID Rewrite](#devcontainer-uid-rewrite). |
+| `FLEET_SSH_AGENT_SOCK` | path, `off`, or `none` | Override the bind source for SSH agent forwarding into instances (`off`/`none` disables it). On macOS the default is Docker Desktop's VM-side `/run/host-services/ssh-auth.sock` (OrbStack and `colima --ssh-agent` are path-compatible); set this if your Docker backend exposes the agent elsewhere (default Colima, Podman machine, Rancher Desktop). |
 | `CODER_URL` | URL | Coder deployment URL (Coder backend). |
 | `CODER_SESSION_TOKEN` | token | Coder API token (Coder backend). |
 | `CODER_CONFIG_DIR` | path | Override the Coder CLI config dir. |

--- a/internal/backend/devcontainer/clone.go
+++ b/internal/backend/devcontainer/clone.go
@@ -301,7 +301,7 @@ func buildCloneRunArgs(imageTag, destWorkspaceDir, workspaceTarget string, inspe
 		args = append(args, "--network", mode)
 	}
 
-	if sock := hostSSHAuthSock(); sock != "" {
+	if sock := sshAgentMountSource(); sock != "" {
 		args = append(args, "--mount", "type=bind,source="+sock+",target="+containerSSHSocketPath)
 	}
 

--- a/internal/backend/devcontainer/devcontainer_test.go
+++ b/internal/backend/devcontainer/devcontainer_test.go
@@ -162,6 +162,7 @@ func TestDevcontainerUpArgsUpdateRemoteUserUID(t *testing.T) {
 func TestRunUserCommandsArgs(t *testing.T) {
 	t.Run("without ssh agent", func(t *testing.T) {
 		t.Setenv("SSH_AUTH_SOCK", "")
+		t.Setenv(sshAgentSockOverrideEnv, "")
 		got := runUserCommandsArgs("/ws/alpha")
 		want := []string{"run-user-commands", "--workspace-folder", "/ws/alpha"}
 		if !slices.Equal(got, want) {
@@ -170,7 +171,7 @@ func TestRunUserCommandsArgs(t *testing.T) {
 	})
 
 	t.Run("with ssh agent threads remote-env", func(t *testing.T) {
-		t.Setenv("SSH_AUTH_SOCK", "/tmp/agent.sock")
+		liveAgentSocket(t)
 		got := runUserCommandsArgs("/ws/alpha")
 		want := []string{
 			"run-user-commands", "--workspace-folder", "/ws/alpha",

--- a/internal/backend/devcontainer/ssh.go
+++ b/internal/backend/devcontainer/ssh.go
@@ -90,10 +90,12 @@ func sshUpArgs() []string {
 }
 
 // sshExecArgs returns additional devcontainer exec arguments to set
-// SSH_AUTH_SOCK inside the container. Returns nil if SSH_AUTH_SOCK
-// is not set on the host.
+// SSH_AUTH_SOCK inside the container. It uses the same gate as the mount
+// (sshAgentMountSource) so exec sessions export the variable exactly when
+// the socket is actually mounted — e.g. FLEET_SSH_AGENT_SOCK=off suppresses
+// both, and an override path with no host agent enables both.
 func sshExecArgs() []string {
-	if os.Getenv("SSH_AUTH_SOCK") == "" {
+	if sshAgentMountSource() == "" {
 		return nil
 	}
 	return []string{

--- a/internal/backend/devcontainer/ssh.go
+++ b/internal/backend/devcontainer/ssh.go
@@ -1,11 +1,21 @@
 package devcontainer
 
-import "os"
+import (
+	"os"
+	"runtime"
+)
 
 // containerSSHSocketPath is the target path for the SSH agent socket inside
 // managed containers. Uses /run instead of /tmp because some devcontainer
 // features (e.g. docker-in-docker) mount a tmpfs on /tmp that shadows bind mounts.
 const containerSSHSocketPath = "/run/ssh-agent.sock"
+
+// dockerDesktopSSHAuthSock is the fixed path at which Docker Desktop (and
+// OrbStack, which is path-compatible) exposes the host's SSH agent inside its
+// Linux VM. On macOS the host's real SSH_AUTH_SOCK (a launchd socket under
+// /private/tmp) is not visible to the VM, so bind-mounting it fails with
+// "bind source path does not exist" — this VM-side path must be used instead.
+const dockerDesktopSSHAuthSock = "/run/host-services/ssh-auth.sock"
 
 // hostSSHAuthSock returns the host's SSH_AUTH_SOCK path if the environment
 // variable is set and the socket exists. Returns empty string otherwise.
@@ -31,6 +41,12 @@ func sshUpArgs() []string {
 	sock := hostSSHAuthSock()
 	if sock == "" {
 		return nil
+	}
+	// The macOS agent socket only exists on the mac side; the Docker VM
+	// exposes the agent at its own fixed path. The host check above still
+	// gates on an agent actually running.
+	if runtime.GOOS == "darwin" {
+		sock = dockerDesktopSSHAuthSock
 	}
 	return []string{
 		"--mount", "type=bind,source=" + sock + ",target=" + containerSSHSocketPath,

--- a/internal/backend/devcontainer/ssh.go
+++ b/internal/backend/devcontainer/ssh.go
@@ -11,11 +11,22 @@ import (
 const containerSSHSocketPath = "/run/ssh-agent.sock"
 
 // dockerDesktopSSHAuthSock is the fixed path at which Docker Desktop (and
-// OrbStack, which is path-compatible) exposes the host's SSH agent inside its
-// Linux VM. On macOS the host's real SSH_AUTH_SOCK (a launchd socket under
-// /private/tmp) is not visible to the VM, so bind-mounting it fails with
-// "bind source path does not exist" — this VM-side path must be used instead.
+// OrbStack, which is path-compatible; likewise `colima --ssh-agent`) exposes
+// the host's SSH agent inside its Linux VM. On macOS the host's real
+// SSH_AUTH_SOCK (a launchd socket under /private/tmp) is not visible to the
+// VM, so bind-mounting it fails with "bind source path does not exist" — this
+// VM-side path must be used instead. Two caveats, both escapable via
+// FLEET_SSH_AGENT_SOCK: default Colima, Podman machine, and Rancher Desktop
+// don't provide this path; and it forwards the agent Docker Desktop itself
+// sees (the default launchd one), which may differ from a custom
+// SSH_AUTH_SOCK agent such as 1Password's.
 const dockerDesktopSSHAuthSock = "/run/host-services/ssh-auth.sock"
+
+// sshAgentSockOverrideEnv overrides the bind source used for SSH agent
+// forwarding into instances: a path replaces the computed source verbatim
+// (no host-side existence check — the path may only exist inside the Docker
+// VM), and "off" or "none" disables the agent mount entirely.
+const sshAgentSockOverrideEnv = "FLEET_SSH_AGENT_SOCK"
 
 // hostSSHAuthSock returns the host's SSH_AUTH_SOCK path if the environment
 // variable is set and the socket exists. Returns empty string otherwise.
@@ -34,19 +45,43 @@ func hostSSHAuthSock() string {
 	return sock
 }
 
+// sshAgentMountSource returns the bind source to use for the SSH agent
+// socket mount, or "" when agent forwarding should be skipped. Shared by
+// devcontainer up and clone so every container-creation path applies the
+// same gate, darwin remap, and override.
+func sshAgentMountSource() string {
+	return sshAgentMountSourceFor(os.Getenv(sshAgentSockOverrideEnv), hostSSHAuthSock(), runtime.GOOS)
+}
+
+// sshAgentMountSourceFor is the pure core of sshAgentMountSource, split out
+// so both the linux and darwin branches are testable on any platform.
+func sshAgentMountSourceFor(override, hostSock, goos string) string {
+	switch override {
+	case "off", "none":
+		return ""
+	case "":
+	default:
+		return override
+	}
+	if hostSock == "" {
+		return ""
+	}
+	// The macOS agent socket only exists on the mac side; the Docker VM
+	// exposes the agent at its own fixed path. The hostSock gate still
+	// requires an agent to actually be running.
+	if goos == "darwin" {
+		return dockerDesktopSSHAuthSock
+	}
+	return hostSock
+}
+
 // sshUpArgs returns additional devcontainer up arguments to bind-mount the
 // host SSH agent socket and set SSH_AUTH_SOCK inside the container.
 // Returns nil if SSH agent forwarding is not available.
 func sshUpArgs() []string {
-	sock := hostSSHAuthSock()
+	sock := sshAgentMountSource()
 	if sock == "" {
 		return nil
-	}
-	// The macOS agent socket only exists on the mac side; the Docker VM
-	// exposes the agent at its own fixed path. The host check above still
-	// gates on an agent actually running.
-	if runtime.GOOS == "darwin" {
-		sock = dockerDesktopSSHAuthSock
 	}
 	return []string{
 		"--mount", "type=bind,source=" + sock + ",target=" + containerSSHSocketPath,

--- a/internal/backend/devcontainer/ssh_test.go
+++ b/internal/backend/devcontainer/ssh_test.go
@@ -132,13 +132,29 @@ func TestSSHUpArgs_OverrideOff(t *testing.T) {
 
 func TestSSHUpArgs_NoSocket(t *testing.T) {
 	t.Setenv("SSH_AUTH_SOCK", "")
+	t.Setenv(sshAgentSockOverrideEnv, "")
 	if args := sshUpArgs(); args != nil {
 		t.Errorf("expected nil, got %v", args)
 	}
 }
 
-func TestSSHExecArgs_WithEnvVar(t *testing.T) {
-	t.Setenv("SSH_AUTH_SOCK", "/some/path")
+// liveAgentSocket binds a real unix socket and points SSH_AUTH_SOCK at it,
+// with the override cleared — sshExecArgs shares sshUpArgs's gate, which
+// stats the socket, so a bare env var is no longer enough.
+func liveAgentSocket(t *testing.T) {
+	t.Helper()
+	sockPath := shortSocketPath(t)
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	t.Setenv("SSH_AUTH_SOCK", sockPath)
+	t.Setenv(sshAgentSockOverrideEnv, "")
+}
+
+func TestSSHExecArgs_WithAgent(t *testing.T) {
+	liveAgentSocket(t)
 	args := sshExecArgs()
 	if len(args) != 2 {
 		t.Fatalf("expected 2 args, got %d: %v", len(args), args)
@@ -152,15 +168,24 @@ func TestSSHExecArgs_WithEnvVar(t *testing.T) {
 	}
 }
 
-func TestSSHExecArgs_NoEnvVar(t *testing.T) {
+func TestSSHExecArgs_NoAgent(t *testing.T) {
 	t.Setenv("SSH_AUTH_SOCK", "")
+	t.Setenv(sshAgentSockOverrideEnv, "")
 	if args := sshExecArgs(); args != nil {
 		t.Errorf("expected nil, got %v", args)
 	}
 }
 
+func TestSSHExecArgs_OverrideOff(t *testing.T) {
+	liveAgentSocket(t)
+	t.Setenv(sshAgentSockOverrideEnv, "off")
+	if args := sshExecArgs(); args != nil {
+		t.Errorf("expected nil with %s=off, got %v", sshAgentSockOverrideEnv, args)
+	}
+}
+
 func TestExecArgs_WithSSH(t *testing.T) {
-	t.Setenv("SSH_AUTH_SOCK", "/some/path")
+	liveAgentSocket(t)
 	args := execArgs("/workspace", []string{"bash"})
 	expected := []string{
 		"exec", "--workspace-folder", "/workspace",
@@ -179,6 +204,7 @@ func TestExecArgs_WithSSH(t *testing.T) {
 
 func TestExecArgs_WithoutSSH(t *testing.T) {
 	t.Setenv("SSH_AUTH_SOCK", "")
+	t.Setenv(sshAgentSockOverrideEnv, "")
 	args := execArgs("/workspace", []string{"bash"})
 	expected := []string{"exec", "--workspace-folder", "/workspace", "bash"}
 	if len(args) != len(expected) {

--- a/internal/backend/devcontainer/ssh_test.go
+++ b/internal/backend/devcontainer/ssh_test.go
@@ -61,6 +61,29 @@ func TestHostSSHAuthSock_ValidSocket(t *testing.T) {
 	}
 }
 
+func TestSSHAgentMountSourceFor(t *testing.T) {
+	cases := []struct {
+		name, override, hostSock, goos, want string
+	}{
+		{"linux uses host socket", "", "/tmp/agent.sock", "linux", "/tmp/agent.sock"},
+		{"darwin remaps to docker vm path", "", "/private/tmp/launchd/Listeners", "darwin", dockerDesktopSSHAuthSock},
+		{"no agent, no mount", "", "", "linux", ""},
+		{"no agent on darwin, no mount", "", "", "darwin", ""},
+		{"override wins without host agent", "/vm/custom.sock", "", "darwin", "/vm/custom.sock"},
+		{"override wins over remap", "/vm/custom.sock", "/tmp/agent.sock", "darwin", "/vm/custom.sock"},
+		{"off disables", "off", "/tmp/agent.sock", "linux", ""},
+		{"none disables", "none", "/tmp/agent.sock", "darwin", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sshAgentMountSourceFor(tc.override, tc.hostSock, tc.goos); got != tc.want {
+				t.Errorf("sshAgentMountSourceFor(%q, %q, %q) = %q, want %q",
+					tc.override, tc.hostSock, tc.goos, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSSHUpArgs_WithValidSocket(t *testing.T) {
 	sockPath := shortSocketPath(t)
 	ln, err := net.Listen("unix", sockPath)
@@ -70,6 +93,7 @@ func TestSSHUpArgs_WithValidSocket(t *testing.T) {
 	defer ln.Close()
 
 	t.Setenv("SSH_AUTH_SOCK", sockPath)
+	t.Setenv(sshAgentSockOverrideEnv, "")
 	args := sshUpArgs()
 	if len(args) != 4 {
 		t.Fatalf("expected 4 args, got %d: %v", len(args), args)
@@ -77,10 +101,7 @@ func TestSSHUpArgs_WithValidSocket(t *testing.T) {
 	if args[0] != "--mount" {
 		t.Errorf("args[0] = %q, want --mount", args[0])
 	}
-	wantSource := sockPath
-	if runtime.GOOS == "darwin" {
-		wantSource = dockerDesktopSSHAuthSock
-	}
+	wantSource := sshAgentMountSourceFor("", sockPath, runtime.GOOS)
 	wantMount := "type=bind,source=" + wantSource + ",target=" + containerSSHSocketPath
 	if args[1] != wantMount {
 		t.Errorf("args[1] = %q, want %q", args[1], wantMount)
@@ -91,6 +112,21 @@ func TestSSHUpArgs_WithValidSocket(t *testing.T) {
 	wantEnv := "SSH_AUTH_SOCK=" + containerSSHSocketPath
 	if args[3] != wantEnv {
 		t.Errorf("args[3] = %q, want %q", args[3], wantEnv)
+	}
+}
+
+func TestSSHUpArgs_OverrideOff(t *testing.T) {
+	sockPath := shortSocketPath(t)
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	t.Setenv("SSH_AUTH_SOCK", sockPath)
+	t.Setenv(sshAgentSockOverrideEnv, "off")
+	if args := sshUpArgs(); args != nil {
+		t.Errorf("expected nil with %s=off, got %v", sshAgentSockOverrideEnv, args)
 	}
 }
 

--- a/internal/backend/devcontainer/ssh_test.go
+++ b/internal/backend/devcontainer/ssh_test.go
@@ -4,8 +4,22 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
+
+// shortSocketPath returns a socket path short enough to bind. t.TempDir()
+// on macOS lives under /var/folders/... and, with the test name appended,
+// exceeds the platform's 104-byte sun_path limit.
+func shortSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "fmssh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return filepath.Join(dir, "agent.sock")
+}
 
 func TestHostSSHAuthSock_Unset(t *testing.T) {
 	t.Setenv("SSH_AUTH_SOCK", "")
@@ -34,7 +48,7 @@ func TestHostSSHAuthSock_RegularFile(t *testing.T) {
 }
 
 func TestHostSSHAuthSock_ValidSocket(t *testing.T) {
-	sockPath := filepath.Join(t.TempDir(), "agent.sock")
+	sockPath := shortSocketPath(t)
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
 		t.Fatal(err)
@@ -48,7 +62,7 @@ func TestHostSSHAuthSock_ValidSocket(t *testing.T) {
 }
 
 func TestSSHUpArgs_WithValidSocket(t *testing.T) {
-	sockPath := filepath.Join(t.TempDir(), "agent.sock")
+	sockPath := shortSocketPath(t)
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
 		t.Fatal(err)
@@ -63,7 +77,11 @@ func TestSSHUpArgs_WithValidSocket(t *testing.T) {
 	if args[0] != "--mount" {
 		t.Errorf("args[0] = %q, want --mount", args[0])
 	}
-	wantMount := "type=bind,source=" + sockPath + ",target=" + containerSSHSocketPath
+	wantSource := sockPath
+	if runtime.GOOS == "darwin" {
+		wantSource = dockerDesktopSSHAuthSock
+	}
+	wantMount := "type=bind,source=" + wantSource + ",target=" + containerSSHSocketPath
 	if args[1] != wantMount {
 		t.Errorf("args[1] = %q, want %q", args[1], wantMount)
 	}


### PR DESCRIPTION
Fixes #234

## What

sshUpArgs bind-mounts the host's $SSH_AUTH_SOCK into new containers. On macOS that is a launchd socket under /private/tmp/com.apple.launchd.*/, which exists on the mac side but is invisible to Docker Desktop's Linux VM, so 'devcontainer up' fails with "bind source path does not exist" and instance creation never succeeds on a Mac.

Docker Desktop exposes the host's SSH agent inside the VM at a fixed path, /run/host-services/ssh-auth.sock (OrbStack is path-compatible). On darwin this change keeps the existing "is an agent actually running" gate on $SSH_AUTH_SOCK, but uses the VM-side path as the bind source. Linux behavior is unchanged.

Also fixes two ssh_test.go cases that failed on macOS independent of this bug: they bound unix sockets at t.TempDir() paths, which on macOS live under /var/folders/... and exceed the platform's 104-byte sun_path limit. A shortSocketPath helper creates them under /tmp instead, and the mount assertion is now platform-aware.

## Testing

- On macOS (Docker Desktop, arm64): docker run with the VM-side mount succeeds and the agent socket is live inside the container; end-to-end 'fleet up' of a devcontainer instance now works (it failed with the mount error before).
- go test ./internal/backend/devcontainer/ passes on macOS (both pre-existing failures gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
