### PR TITLE
feat(ci): macOS CI without Docker - unit job + docker-free integration mode

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,71 @@
+name: macOS
+
+# macOS coverage without macOS Docker: GitHub's hosted macOS runners are
+# Apple Silicon VMs with nested virtualization disabled, so Docker (Desktop,
+# colima, lima) cannot run at all. Instead of a self-hosted Mac, this
+# workflow covers the host-side surface where macOS bugs actually live
+# (BSD userland, sun_path limits, launchd sockets, tmux, process mgmt):
+#
+#   - unit: the full go test suite on macos-latest.
+#   - integration-no-docker: the integration tests marked "# itest:
+#     no-docker" (CLI surface, TUI dialogs, daemon lifecycle, automation
+#     CRUD), run with FLEET_ITEST_NO_DOCKER=1 — see integration/run.sh.
+#
+# True end-to-end `devcontainer up` against Docker Desktop on a Mac remains
+# manual (or a future self-hosted runner).
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  unit-macos:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      # The cli/session unit tests drive a real host tmux (they skip when
+      # it's missing — install it so they actually run here).
+      - name: Install tmux
+        run: |
+          brew install tmux
+          tmux -V
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test
+        run: go test ./...
+
+  integration-macos-no-docker:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install tmux
+        run: |
+          brew install tmux
+          tmux -V
+
+      - name: Build fleet binary
+        run: |
+          go build -o "${RUNNER_TEMP}/fleet" ./cmd/fleet
+          echo "FLEET_BIN=${RUNNER_TEMP}/fleet" >> "${GITHUB_ENV}"
+
+      - name: Run docker-free integration tests
+        env:
+          FLEET_ITEST_NO_DOCKER: "1"
+          # Hosted mac runners are slower than the Linux jobs; give the TUI
+          # polling deadlines the same headroom trick the WSL job uses.
+          FLEET_TUI_WAIT_SCALE: "2"
+        run: ./integration/run.sh

--- a/integration/common.sh
+++ b/integration/common.sh
@@ -601,3 +601,12 @@ tui_assert_not_contains() {
     fail "${msg}: needle=[${needle}]"
   fi
 }
+
+# server_count — number of live `fleet server` daemons for this suite's
+# binary. Shared here because macOS pgrep has no -c flag (the old per-test
+# `pgrep -fc` printed nothing there and every count assertion failed); the
+# pipe form behaves identically on Linux and macOS. `|| true` absorbs
+# pgrep's exit 1 on zero matches under pipefail.
+server_count() {
+  { pgrep -f "${FLEET_BIN} server" 2>/dev/null || true; } | wc -l | tr -d ' '
+}

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -32,31 +32,40 @@ say "Using fleet binary: ${FLEET_BIN}"
 "${FLEET_BIN}" --help >/dev/null || { printf "%b[fatal]%b fleet binary failed to run\n" "${RED}" "${RESET}" >&2; exit 2; }
 
 # 2. Preflight: docker + devcontainer CLI must be available and usable.
-if ! command -v docker >/dev/null 2>&1; then
-  printf "%b[fatal]%b docker CLI not on PATH\n" "${RED}" "${RESET}" >&2
-  exit 2
-fi
-if ! docker info >/dev/null 2>&1; then
-  printf "%b[fatal]%b docker daemon not reachable\n" "${RED}" "${RESET}" >&2
-  exit 2
-fi
-if ! command -v devcontainer >/dev/null 2>&1; then
-  printf "%b[fatal]%b devcontainer CLI not on PATH (npm i -g @devcontainers/cli)\n" "${RED}" "${RESET}" >&2
-  exit 2
-fi
-
-# 3. Pre-pull each fixture image once so individual tests are not waiting
-#    on image pulls. The agent fixture is used by the startup-script tests
-#    (claude / codex install) and is a different image from the default.
-for fixture_dir in "${INTEGRATION_DIR}/fixture" "${INTEGRATION_DIR}/fixture-agent"; do
-  dc_json="${fixture_dir}/.devcontainer/devcontainer.json"
-  [ -f "${dc_json}" ] || continue
-  fixture_image=$(grep -oE '"image":\s*"[^"]+"' "${dc_json}" | sed -E 's/.*"([^"]+)"$/\1/')
-  if [ -n "${fixture_image}" ]; then
-    say "Pre-pulling fixture image: ${fixture_image}"
-    docker pull -q "${fixture_image}" >/dev/null || true
+#    FLEET_ITEST_NO_DOCKER=1 skips the preflight and (below) restricts the
+#    run to tests marked "# itest: no-docker" — the host-side subset (CLI
+#    surface, TUI dialogs, daemon lifecycle, automation CRUD) that never
+#    creates an instance. This is what lets the suite run on GitHub's
+#    hosted macOS runners, whose Apple Silicon VMs cannot run Docker.
+if [ -z "${FLEET_ITEST_NO_DOCKER:-}" ]; then
+  if ! command -v docker >/dev/null 2>&1; then
+    printf "%b[fatal]%b docker CLI not on PATH\n" "${RED}" "${RESET}" >&2
+    exit 2
   fi
-done
+  if ! docker info >/dev/null 2>&1; then
+    printf "%b[fatal]%b docker daemon not reachable\n" "${RED}" "${RESET}" >&2
+    exit 2
+  fi
+  if ! command -v devcontainer >/dev/null 2>&1; then
+    printf "%b[fatal]%b devcontainer CLI not on PATH (npm i -g @devcontainers/cli)\n" "${RED}" "${RESET}" >&2
+    exit 2
+  fi
+
+  # 3. Pre-pull each fixture image once so individual tests are not waiting
+  #    on image pulls. The agent fixture is used by the startup-script tests
+  #    (claude / codex install) and is a different image from the default.
+  for fixture_dir in "${INTEGRATION_DIR}/fixture" "${INTEGRATION_DIR}/fixture-agent"; do
+    dc_json="${fixture_dir}/.devcontainer/devcontainer.json"
+    [ -f "${dc_json}" ] || continue
+    fixture_image=$(grep -oE '"image":\s*"[^"]+"' "${dc_json}" | sed -E 's/.*"([^"]+)"$/\1/')
+    if [ -n "${fixture_image}" ]; then
+      say "Pre-pulling fixture image: ${fixture_image}"
+      docker pull -q "${fixture_image}" >/dev/null || true
+    fi
+  done
+else
+  say "FLEET_ITEST_NO_DOCKER set: skipping docker preflight, running docker-free tests only"
+fi
 
 # 4. Iterate tests.
 shopt -s nullglob
@@ -86,8 +95,36 @@ if [ -n "${FLEET_ITEST_RANGE:-}" ]; then
     [ -z "${range_end}" ] || [ "${n}" -lt "$((10#${range_end}))" ] || continue
     shard+=("${test_file}")
   done
+  # Same bash-3.2 constraint as the no-docker filter below: check the
+  # length before expanding the possibly-empty array, and make the
+  # documented empty-shard exit explicit.
+  say "Shard ${FLEET_ITEST_RANGE}: running ${#shard[@]} test(s)"
+  if [ "${#shard[@]}" -eq 0 ]; then
+    say "Empty shard — nothing to do"
+    exit 0
+  fi
   tests=("${shard[@]}")
-  say "Shard ${FLEET_ITEST_RANGE}: running ${#tests[@]} test(s)"
+fi
+
+# No-docker mode: keep only tests that opt in with a "# itest: no-docker"
+# marker line. Opt-in (not inference) so a test that quietly grows a docker
+# dependency fails loudly in review rather than silently joining this set.
+if [ -n "${FLEET_ITEST_NO_DOCKER:-}" ]; then
+  nodocker=()
+  for test_file in "${tests[@]}"; do
+    if grep -q "^# itest: no-docker" "${test_file}"; then
+      nodocker+=("${test_file}")
+    fi
+  done
+  # Length check BEFORE expanding: in bash < 4.4 (macOS ships 3.2),
+  # "${nodocker[@]}" on an empty array is an unbound-variable error under
+  # set -u — the graceful exit below would never be reached.
+  say "No-docker subset: running ${#nodocker[@]} test(s)"
+  if [ "${#nodocker[@]}" -eq 0 ]; then
+    say "No no-docker tests in shard — nothing to do"
+    exit 0
+  fi
+  tests=("${nodocker[@]}")
 fi
 
 # Shared results file — tests append one row each via common.sh helpers.
@@ -123,19 +160,24 @@ source "${INTEGRATION_DIR}/common.sh"
 # (without the .sh suffix). Skipped tests emit a "skip" row and never
 # run; the suite does not fail on them. Used by the WSL CI job to
 # exempt environment-specific known-bad tests.
-declare -A skip_set=()
+#
+# Held as a comma-delimited string probed with a pattern match (not an
+# associative array): macOS ships bash 3.2, which has no `declare -A`,
+# and the no-docker mode runs this script there.
+skip_csv=""
 if [ -n "${FLEET_ITEST_SKIP:-}" ]; then
   IFS=',' read -ra _skip_list <<< "${FLEET_ITEST_SKIP}"
   for s in "${_skip_list[@]}"; do
     s_trimmed=$(printf '%s' "${s}" | tr -d '[:space:]')
-    [ -n "${s_trimmed}" ] && skip_set["${s_trimmed}"]=1
+    [ -n "${s_trimmed}" ] && skip_csv="${skip_csv},${s_trimmed}"
   done
+  skip_csv="${skip_csv},"
 fi
 
 for test_file in "${tests[@]}"; do
   test_name=$(basename "${test_file}" .sh)
   printf "\n"
-  if [ -n "${skip_set[${test_name}]:-}" ]; then
+  if [ -n "${skip_csv}" ] && [[ "${skip_csv}" == *",${test_name},"* ]]; then
     say "${YELLOW}SKIP${RESET} ${test_name} (FLEET_ITEST_SKIP)"
     desc=$(grep -m1 -E '^# Description:' "${test_file}" 2>/dev/null \
       | sed -E 's/^# Description: *//')
@@ -173,14 +215,15 @@ fi
 
 # Any test file that did not emit a row at all is an unexplained crash
 # (e.g. syntax error before itest_begin ran). Surface it as a failure.
-declare -A seen_names
+# Same bash-3.2 constraint as skip_csv above: no associative arrays.
+seen_csv=","
 for row in "${result_rows[@]}"; do
   IFS='|' read -r n _ _ _ <<< "${row}"
-  seen_names["${n}"]=1
+  seen_csv="${seen_csv}${n},"
 done
 for test_file in "${tests[@]}"; do
   n=$(basename "${test_file}" .sh)
-  if [ -z "${seen_names[${n}]:-}" ]; then
+  if [[ "${seen_csv}" != *",${n},"* ]]; then
     failed=$((failed + 1))
     failed_tests+=("${n}")
     result_rows+=("${n}|fail|0|(test did not emit a result — crashed before itest_begin?)")

--- a/integration/tests/070_cli_help.sh
+++ b/integration/tests/070_cli_help.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# itest: no-docker
 # Description: `fleet --help` and every subcommand --help exit 0 and surface their usage.
 set -euo pipefail
 

--- a/integration/tests/170_tui_new_fleet_cancel.sh
+++ b/integration/tests/170_tui_new_fleet_cancel.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# itest: no-docker
 # Description: TUI new-fleet dialog cancel with esc does not create a fleet
 set -euo pipefail
 

--- a/integration/tests/171_tui_new_fleet_with_devcontainer.sh
+++ b/integration/tests/171_tui_new_fleet_with_devcontainer.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# itest: no-docker
 # Description: TUI new-fleet check passes through when repo has a devcontainer.json
 set -euo pipefail
 

--- a/integration/tests/172_tui_new_fleet_no_devcontainer_abort.sh
+++ b/integration/tests/172_tui_new_fleet_no_devcontainer_abort.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# itest: no-docker
 # Description: TUI new-fleet abort path when repo lacks a devcontainer.json
 set -euo pipefail
 

--- a/integration/tests/173_tui_new_fleet_no_devcontainer_setup.sh
+++ b/integration/tests/173_tui_new_fleet_no_devcontainer_setup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# itest: no-docker
 # Description: TUI new-fleet Setup branch adds the fleet and launches the agent
 set -euo pipefail
 

--- a/integration/tests/230_tui_fleet_delete_empty.sh
+++ b/integration/tests/230_tui_fleet_delete_empty.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# itest: no-docker
 # Description: TUI delete on empty fleet uses single-confirm path (no warn dialog)
 set -euo pipefail
 

--- a/integration/tests/391_automation_agent_runs.sh
+++ b/integration/tests/391_automation_agent_runs.sh
@@ -14,7 +14,6 @@ source "$(dirname "$0")/../common.sh"
 itest_cleanup() { pkill -f "${FLEET_BIN} server" >/dev/null 2>&1 || true; }
 itest_begin
 
-server_count() { pgrep -fc "${FLEET_BIN} server" 2>/dev/null || true; }
 
 # Shorten the scheduler's idle timeout + tick so the reap half of the lifecycle
 # verifies in ~a minute instead of the production 2m/30s. The daemon inherits

--- a/integration/tests/392_automation_cli.sh
+++ b/integration/tests/392_automation_cli.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# itest: no-docker
 # Description: fleet agent / fleet trigger CLI CRUD (issue #189) — create, list,
 # edit (rename), and delete automation agents and triggers through a real
 # daemon, asserting the changes round-trip to state.json, that a rename rewrites
@@ -12,7 +13,6 @@ source "$(dirname "$0")/../common.sh"
 itest_cleanup() { pkill -f "${FLEET_BIN} server" >/dev/null 2>&1 || true; }
 itest_begin
 
-server_count() { pgrep -fc "${FLEET_BIN} server" 2>/dev/null || true; }
 
 setup_test
 

--- a/integration/tests/610_server_autospawn.sh
+++ b/integration/tests/610_server_autospawn.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# itest: no-docker
 # Description: a cold `fleet` command auto-spawns the fleetd daemon (socket appears) and the next reuses it.
 set -euo pipefail
 
@@ -6,7 +7,6 @@ source "$(dirname "$0")/../common.sh"
 itest_cleanup() { pkill -f "${FLEET_BIN} server" >/dev/null 2>&1 || true; }
 itest_begin
 
-server_count() { pgrep -fc "${FLEET_BIN} server" 2>/dev/null || true; }
 server_pid() { pgrep -f "${FLEET_BIN} server" 2>/dev/null | head -n1 || true; }
 
 setup_test

--- a/integration/tests/611_server_single_winner.sh
+++ b/integration/tests/611_server_single_winner.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# itest: no-docker
 # Description: concurrent cold commands collapse to exactly one daemon (single-winner flock).
 set -euo pipefail
 
@@ -6,7 +7,6 @@ source "$(dirname "$0")/../common.sh"
 itest_cleanup() { pkill -f "${FLEET_BIN} server" >/dev/null 2>&1 || true; }
 itest_begin
 
-server_count() { pgrep -fc "${FLEET_BIN} server" 2>/dev/null || true; }
 
 setup_test
 seed_fleet_settings "${FIXTURE_REPO_NAME}" false false "" false

--- a/integration/tests/612_server_stale_socket.sh
+++ b/integration/tests/612_server_stale_socket.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# itest: no-docker
 # Description: a hard-killed daemon leaves a stale socket; the next command clears it and respawns cleanly.
 set -euo pipefail
 
@@ -6,7 +7,6 @@ source "$(dirname "$0")/../common.sh"
 itest_cleanup() { pkill -f "${FLEET_BIN} server" >/dev/null 2>&1 || true; }
 itest_begin
 
-server_count() { pgrep -fc "${FLEET_BIN} server" 2>/dev/null || true; }
 
 setup_test
 seed_fleet_settings "${FIXTURE_REPO_NAME}" false false "" false

--- a/integration/tests/613_server_dev_restart.sh
+++ b/integration/tests/613_server_dev_restart.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# itest: no-docker
 # Description: a dev-build client restarts a stale daemon when its binary is newer, and does NOT thrash otherwise.
 set -euo pipefail
 
@@ -11,7 +12,6 @@ source "$(dirname "$0")/../common.sh"
 itest_cleanup() { pkill -f "${FLEET_BIN} server" >/dev/null 2>&1 || true; }
 itest_begin
 
-server_count() { pgrep -fc "${FLEET_BIN} server" 2>/dev/null || true; }
 server_pid() { pgrep -f "${FLEET_BIN} server" 2>/dev/null | head -n1 || true; }
 # wait_one_server [timeout] — wait until exactly one daemon runs, then print its pid.
 wait_one_server() {

--- a/internal/cli/session_commands_test.go
+++ b/internal/cli/session_commands_test.go
@@ -61,17 +61,21 @@ func seedState(t *testing.T, status fleet.InstanceStatus) string {
 // target the developer's running server instead of our private socket. The
 // cleanup's `tmux kill-server` would then murder the developer's session.
 func tmuxIsolatedEnv(tmuxDir string) []string {
-	env := make([]string, 0, len(os.Environ())+1)
+	env := make([]string, 0, len(os.Environ())+2)
 	for _, kv := range os.Environ() {
 		switch {
 		case strings.HasPrefix(kv, "TMUX="),
 			strings.HasPrefix(kv, "TMUX_PANE="),
-			strings.HasPrefix(kv, "TMUX_TMPDIR="):
+			strings.HasPrefix(kv, "TMUX_TMPDIR="),
+			strings.HasPrefix(kv, "HOME="):
 			continue
 		}
 		env = append(env, kv)
 	}
-	return append(env, "TMUX_TMPDIR="+tmuxDir)
+	// HOME points at the tmux dir so shells the tmux server spawns drop
+	// their exit-time files (e.g. zsh history) there, not into the test's
+	// TempDir — whose cleanup races those writes and fails the test.
+	return append(env, "TMUX_TMPDIR="+tmuxDir, "HOME="+tmuxDir)
 }
 
 // useHostTmux skips the test if tmux is missing on PATH, then redirects
@@ -82,7 +86,14 @@ func useHostTmux(t *testing.T) string {
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Skip("tmux not installed on host; skipping integration test")
 	}
-	tmuxDir := t.TempDir()
+	// Not t.TempDir(): tmux appends tmux-$UID/default to TMUX_TMPDIR, and on
+	// macOS the /var/folders/... test temp dirs push the socket path past the
+	// platform's 104-byte sun_path limit ("File name too long").
+	tmuxDir, err := os.MkdirTemp("/tmp", "fmtmux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmuxDir) })
 
 	prevExec := sessionExecCommand
 	sessionExecCommand = func(_, _ string, args []string) (*exec.Cmd, error) {

--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -62,10 +62,18 @@ func (c *collector) wait(t *testing.T, n int, timeout time.Duration) []Envelope 
 	return out
 }
 
-// tempSocket returns a socket path inside a fresh temp dir.
+// tempSocket returns a socket path inside a fresh temp dir. Not t.TempDir():
+// on macOS the /var/folders/... test temp dirs (plus the test name) can push
+// the path past the platform's 104-byte sun_path limit, failing the bind
+// with EINVAL.
 func tempSocket(t *testing.T) string {
 	t.Helper()
-	return filepath.Join(t.TempDir(), SocketName)
+	dir, err := os.MkdirTemp("/tmp", "fmctl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return filepath.Join(dir, SocketName)
 }
 
 // TestRoundTripOpenBrowser dials a listening Server, sends an OpenBrowser

--- a/internal/server/control_test.go
+++ b/internal/server/control_test.go
@@ -20,6 +20,21 @@ type copyEvent struct {
 	fleet, instance, src, dst string
 }
 
+// shortHome creates a temp HOME under /tmp and points $HOME at it. Not
+// t.TempDir(): the control socket lives at
+// $HOME/.fleet/workspaces/<fleet>/<inst>/.control/fleet.sock, and on macOS
+// the /var/folders/... test temp dirs push that past the platform's
+// 104-byte sun_path limit, so the listener never binds.
+func shortHome(t *testing.T) {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "fmctl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	t.Setenv("HOME", dir)
+}
+
 // waitForSocket polls path until it exists or the deadline passes.
 func waitForSocket(t *testing.T, path string, timeout time.Duration) bool {
 	t.Helper()
@@ -45,7 +60,7 @@ func fabricatedRunningState(fleetName, instanceName string) *state.State {
 // client.OpenBrowser round-trips an event into onOpen tagged with the right
 // fleet/instance, and a stopped instance's listener is dropped on the next sync.
 func TestControlSyncRoundTrip(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	shortHome(t)
 
 	const (
 		fleetName    = "alpha"
@@ -134,7 +149,7 @@ func TestControlSyncRoundTrip(t *testing.T) {
 // onOpen must not wedge serveConn, so shutdown() returns promptly. (The test's
 // onOpen drops on a full buffer, mirroring the server's non-blocking hub.post.)
 func TestControlShutdownFullBuffer(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	shortHome(t)
 
 	const (
 		fleetName    = "alpha"
@@ -182,7 +197,7 @@ func TestControlShutdownFullBuffer(t *testing.T) {
 // TestControlSyncIdempotent verifies repeated syncs against an unchanged running
 // set keep the same server pointer (no leak, no recreate).
 func TestControlSyncIdempotent(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	shortHome(t)
 
 	const (
 		fleetName    = "alpha"
@@ -214,7 +229,7 @@ func TestControlSyncIdempotent(t *testing.T) {
 // void (integration test 510). (Short name keeps the temp-HOME socket path under
 // the unix sun_path limit.)
 func TestCtrlGate(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	shortHome(t)
 
 	const (
 		fleetName    = "alpha"


### PR DESCRIPTION
macOS CI as discussed on Slack: unit tests plus a docker-free integration mode on GitHub's hosted macos-latest runners. No self-hosted hardware needed.

Stacked on #236 (branched from it) -- merge that first and this diff shrinks to just the CI work.

## Why no Docker

GitHub's hosted macOS runners are Apple Silicon VMs with nested virtualization disabled, so Docker Desktop / colima / lima cannot run at all. Rather than a self-hosted Mac, this covers the host-side surface where macOS bugs actually live: BSD userland, the 104-byte sun_path limit, tmux, daemon/process management. (True e2e devcontainer-up on a Mac stays manual for now.)

## What's in it

1. `.github/workflows/macos.yml` -- two jobs on macos-latest: `unit-macos` (go vet + full go test, with tmux installed so the cli session tests actually run) and `integration-macos-no-docker`.

2. `FLEET_ITEST_NO_DOCKER=1` mode in `integration/run.sh`: skips the docker/devcontainer preflight and runs only tests marked `# itest: no-docker`. The marker is opt-in, so a test that quietly grows a docker dependency fails loudly in review instead of silently joining the set. run.sh is also bash-3.2 clean now (macOS ships bash 3.2; `declare -A` was a hard error).

3. Markers on the 11 docker-free tests: 070 cli help, 170-173 new-fleet dialogs, 230 fleet-delete-empty, 392 automation CRUD, and the 610-613 daemon lifecycle suite. (391 spawns a real devcontainer instance via the scheduler, so it stays docker-only.)

4. Portable `server_count` in common.sh: macOS pgrep has no `-c` flag, so the six per-test `pgrep -fc` copies printed nothing there and every daemon-count assertion failed. Replaced with a shared `pgrep -f | wc -l` form that behaves identically on Linux.

5. Unit-test fixes for macOS, all the same disease (104-byte sun_path limit on unix sockets under /var/folders/... TempDirs): tmux server sockets in internal/cli, control sockets under $HOME in internal/server, and direct binds in internal/control now use short /tmp dirs. The cli tmux env also points HOME at the tmux dir so zsh exit-time writes can't race TempDir cleanup (was a flake).

## Testing

- Full `go test ./...` green on macOS arm64 (with #236 merged; without it, only the one test #236 fixes is red).
- The no-docker subset passes 11/11 on macOS with docker *blocked* via a failing PATH shim, proving no hidden docker dependency.
- Linux behavior unchanged: preflight, sharding, FLEET_ITEST_SKIP, and the pgrep form all behave identically; existing ubuntu jobs untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
