### PR TITLE
feat(release): build macOS binaries on tag + OS-aware installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,10 @@ jobs:
           version="${GITHUB_REF_NAME}"
           ldflags="-s -w -X github.com/BenjaminBenetti/fleet-man/internal/version.Version=${version}"
 
-          GOOS=linux GOARCH=amd64 go build -ldflags "${ldflags}" -o dist/fleet-linux-amd64 ./cmd/fleet
-          GOOS=linux GOARCH=arm64 go build -ldflags "${ldflags}" -o dist/fleet-linux-arm64 ./cmd/fleet
+          GOOS=linux  GOARCH=amd64 go build -ldflags "${ldflags}" -o dist/fleet-linux-amd64 ./cmd/fleet
+          GOOS=linux  GOARCH=arm64 go build -ldflags "${ldflags}" -o dist/fleet-linux-arm64 ./cmd/fleet
+          GOOS=darwin GOARCH=amd64 go build -ldflags "${ldflags}" -o dist/fleet-darwin-amd64 ./cmd/fleet
+          GOOS=darwin GOARCH=arm64 go build -ldflags "${ldflags}" -o dist/fleet-darwin-arm64 ./cmd/fleet
 
           cd dist
           sha256sum fleet-* > checksums.txt

--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ location), `TMUX` (enables split-pane mode when run inside tmux), `SSH_AUTH_SOCK
 
 ## Requirements
 
-- Linux, including Ubuntu on WSL2
+- Linux (including Ubuntu on WSL2) or macOS
 - Docker
 - [devcontainer CLI](https://github.com/devcontainers/cli) (`npm install -g @devcontainers/cli`)
 

--- a/install.sh
+++ b/install.sh
@@ -31,11 +31,18 @@ case "$ARCH" in
         ;;
 esac
 
+# Detect OS and map it to the release asset's platform token. Releases ship a
+# binary per OS/arch pair (fleet-linux-amd64, fleet-darwin-arm64, ...); pick the
+# one matching this machine.
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-if [ "$OS" != "linux" ]; then
-    echo "Error: unsupported OS: $OS (only linux is supported)"
-    exit 1
-fi
+case "$OS" in
+    linux)         OS="linux" ;;
+    darwin)        OS="darwin" ;;
+    *)
+        echo "Error: unsupported OS: $OS (supported: linux, darwin)"
+        exit 1
+        ;;
+esac
 
 ASSET="fleet-${OS}-${ARCH}"
 

--- a/install.sh
+++ b/install.sh
@@ -77,8 +77,10 @@ chmod +x "$TMP"
 
 # Ensure install directory exists (fresh macOS installs may not have /usr/local/bin)
 if [ ! -d "$INSTALL_DIR" ]; then
-    echo "Creating ${INSTALL_DIR} (requires sudo)..."
-    sudo mkdir -p "$INSTALL_DIR"
+    if ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
+        echo "Creating ${INSTALL_DIR} (requires sudo)..."
+        sudo mkdir -p "$INSTALL_DIR"
+    fi
 fi
 
 # Install — use sudo if needed

--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,12 @@ fi
 
 chmod +x "$TMP"
 
+# Ensure install directory exists (fresh macOS installs may not have /usr/local/bin)
+if [ ! -d "$INSTALL_DIR" ]; then
+    echo "Creating ${INSTALL_DIR} (requires sudo)..."
+    sudo mkdir -p "$INSTALL_DIR"
+fi
+
 # Install — use sudo if needed
 if [ -w "$INSTALL_DIR" ]; then
     mv "$TMP" "${INSTALL_DIR}/${BINARY}"


### PR DESCRIPTION
Closes #230

## What
- **release.yml**: also build `fleet-darwin-amd64` and `fleet-darwin-arm64`
  alongside the Linux binaries. They flow through the existing `sha256sum
  fleet-*` and `gh release create dist/*` steps, so checksums and the release
  upload cover them with no extra wiring.
- **install.sh**: replace the Linux-only guard with a `uname -s` case
  (linux/darwin), so the installer downloads the matching `fleet-${OS}-${ARCH}`
  asset for the user's machine (Apple Silicon → darwin-arm64, Intel Mac →
  darwin-amd64). Unsupported OSes still fail with a clear message.
- **README.md**: Requirements now list macOS.

## Notes
- macOS binaries are unsigned; `install.sh` downloads via curl (no
  `com.apple.quarantine`), so Gatekeeper won't block running `fleet` from a
  terminal.
- Both darwin targets verified to cross-compile locally.