### PR TITLE
fix(devcontainer): harden FLEET_SSH_AGENT_SOCK parsing (post-merge review of #236)

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ Variables fleet **reads** (set them to configure behavior):
 | `FLEET_SERVER` | `host:port` | Drive a remote daemon over plain TCP (no gateway). |
 | `FLEET_DEVCONTAINER_BUILDKIT` | `auto` (default), `never` | BuildKit mode for Fleet-managed devcontainers. See [Devcontainer BuildKit](#devcontainer-buildkit). |
 | `FLEET_DEVCONTAINER_UPDATE_REMOTE_USER_UID` | `default`, `never`, `on`, `off` | Remote-user UID/GID rewrite mode. See [Devcontainer UID Rewrite](#devcontainer-uid-rewrite). |
-| `FLEET_SSH_AGENT_SOCK` | path, `off`, or `none` | Override the bind source for SSH agent forwarding into instances (`off`/`none` disables it). On macOS the default is Docker Desktop's VM-side `/run/host-services/ssh-auth.sock` (OrbStack and `colima --ssh-agent` are path-compatible); set this if your Docker backend exposes the agent elsewhere (default Colima, Podman machine, Rancher Desktop). |
+| `FLEET_SSH_AGENT_SOCK` | absolute path, `off`, or `none` (case-insensitive) | Override the bind source for SSH agent forwarding into instances (`off`/`none` disables it). On macOS the default is Docker Desktop's VM-side `/run/host-services/ssh-auth.sock` (OrbStack and `colima --ssh-agent` are path-compatible); set this if your Docker backend exposes the agent elsewhere (default Colima, Podman machine, Rancher Desktop). |
 | `CODER_URL` | URL | Coder deployment URL (Coder backend). |
 | `CODER_SESSION_TOKEN` | token | Coder API token (Coder backend). |
 | `CODER_CONFIG_DIR` | path | Override the Coder CLI config dir. |

--- a/internal/backend/devcontainer/clone.go
+++ b/internal/backend/devcontainer/clone.go
@@ -108,7 +108,11 @@ func (devcontainerBackend *DevcontainerBackend) Clone(sourceContainerID, destWor
 		return nil, fmt.Errorf("clone: docker commit failed: %w", err)
 	}
 
-	runArgs := buildCloneRunArgs(imageTag, destWorkspaceDir, workspaceTarget, inspected, mounts)
+	runArgs, err := buildCloneRunArgs(imageTag, destWorkspaceDir, workspaceTarget, inspected, mounts)
+	if err != nil {
+		_ = exec.Command("docker", "rmi", imageTag).Run()
+		return nil, fmt.Errorf("clone: %w", err)
+	}
 	runCmd := exec.Command("docker", runArgs...)
 	out, err := runCmd.Output()
 	if err != nil {
@@ -256,7 +260,7 @@ func findWorkspaceMountTarget(inspected *inspectedContainer) string {
 // ptrace, etc.) still work in the clone. Port bindings are
 // deliberately not propagated — keeping them would collide with the
 // source container if both are running.
-func buildCloneRunArgs(imageTag, destWorkspaceDir, workspaceTarget string, inspected *inspectedContainer, mounts []backend.Mount) []string {
+func buildCloneRunArgs(imageTag, destWorkspaceDir, workspaceTarget string, inspected *inspectedContainer, mounts []backend.Mount) ([]string, error) {
 	args := []string{"run", "-d",
 		"--label", devcontainerLocalFolderLabel + "=" + destWorkspaceDir,
 		"--label", cloneImageLabel + "=" + imageTag,
@@ -301,13 +305,17 @@ func buildCloneRunArgs(imageTag, destWorkspaceDir, workspaceTarget string, inspe
 		args = append(args, "--network", mode)
 	}
 
-	if sock := sshAgentMountSource(); sock != "" {
+	sock, err := sshAgentMountSource()
+	if err != nil {
+		return nil, err
+	}
+	if sock != "" {
 		args = append(args, "--mount", "type=bind,source="+sock+",target="+containerSSHSocketPath)
 	}
 
 	args = append(args, customMountArgs(mounts)...)
 	args = append(args, imageTag)
-	return args
+	return args, nil
 }
 
 // newCloneImageTag returns a unique image tag of the form

--- a/internal/backend/devcontainer/devcontainer_backend.go
+++ b/internal/backend/devcontainer/devcontainer_backend.go
@@ -235,7 +235,11 @@ func (devcontainerBackend *DevcontainerBackend) up(workspaceDir string, mounts [
 	if err != nil {
 		return nil, err
 	}
-	args = append(args, sshUpArgs()...)
+	sshArgs, err := sshUpArgs()
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, sshArgs...)
 	args = append(args, customMountArgs(mounts)...)
 	cmd := exec.Command("devcontainer", args...)
 	env, err := devcontainerEnv(os.Environ())

--- a/internal/backend/devcontainer/ssh.go
+++ b/internal/backend/devcontainer/ssh.go
@@ -1,8 +1,11 @@
 package devcontainer
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // containerSSHSocketPath is the target path for the SSH agent socket inside
@@ -45,22 +48,37 @@ func hostSSHAuthSock() string {
 	return sock
 }
 
+// agentSockDisabled reports whether an override value is the forwarding
+// kill-switch. Case-insensitive so OFF/None from a shell rc don't fall
+// through and get bind-mounted verbatim as a (nonexistent) source path.
+func agentSockDisabled(override string) bool {
+	return strings.EqualFold(override, "off") || strings.EqualFold(override, "none")
+}
+
 // sshAgentMountSource returns the bind source to use for the SSH agent
 // socket mount, or "" when agent forwarding should be skipped. Shared by
 // devcontainer up and clone so every container-creation path applies the
-// same gate, darwin remap, and override.
-func sshAgentMountSource() string {
-	return sshAgentMountSourceFor(os.Getenv(sshAgentSockOverrideEnv), hostSSHAuthSock(), runtime.GOOS)
+// same gate, darwin remap, and override. An unusable override value is a
+// hard error (matching the other FLEET_* env parsers): silently splicing
+// it into the mount string would resurface as a confusing docker failure
+// far from the cause — commas would even inject extra mount options.
+func sshAgentMountSource() (string, error) {
+	override := strings.TrimSpace(os.Getenv(sshAgentSockOverrideEnv))
+	if override != "" && !agentSockDisabled(override) {
+		if strings.Contains(override, ",") || !filepath.IsAbs(override) {
+			return "", fmt.Errorf("invalid %s value %q (valid: an absolute socket path, or off/none to disable agent forwarding)", sshAgentSockOverrideEnv, override)
+		}
+	}
+	return sshAgentMountSourceFor(override, hostSSHAuthSock(), runtime.GOOS), nil
 }
 
 // sshAgentMountSourceFor is the pure core of sshAgentMountSource, split out
 // so both the linux and darwin branches are testable on any platform.
 func sshAgentMountSourceFor(override, hostSock, goos string) string {
-	switch override {
-	case "off", "none":
+	switch {
+	case agentSockDisabled(override):
 		return ""
-	case "":
-	default:
+	case override != "":
 		return override
 	}
 	if hostSock == "" {
@@ -77,25 +95,32 @@ func sshAgentMountSourceFor(override, hostSock, goos string) string {
 
 // sshUpArgs returns additional devcontainer up arguments to bind-mount the
 // host SSH agent socket and set SSH_AUTH_SOCK inside the container.
-// Returns nil if SSH agent forwarding is not available.
-func sshUpArgs() []string {
-	sock := sshAgentMountSource()
+// Returns nil args if SSH agent forwarding is not available, and an error
+// for an unusable FLEET_SSH_AGENT_SOCK value.
+func sshUpArgs() ([]string, error) {
+	sock, err := sshAgentMountSource()
+	if err != nil {
+		return nil, err
+	}
 	if sock == "" {
-		return nil
+		return nil, nil
 	}
 	return []string{
 		"--mount", "type=bind,source=" + sock + ",target=" + containerSSHSocketPath,
 		"--remote-env", "SSH_AUTH_SOCK=" + containerSSHSocketPath,
-	}
+	}, nil
 }
 
 // sshExecArgs returns additional devcontainer exec arguments to set
 // SSH_AUTH_SOCK inside the container. It uses the same gate as the mount
 // (sshAgentMountSource) so exec sessions export the variable exactly when
 // the socket is actually mounted — e.g. FLEET_SSH_AGENT_SOCK=off suppresses
-// both, and an override path with no host agent enables both.
+// both, and an override path with no host agent enables both. An invalid
+// override already hard-fails instance creation; exec just degrades to no
+// forwarding rather than blocking shells into an existing container.
 func sshExecArgs() []string {
-	if sshAgentMountSource() == "" {
+	sock, err := sshAgentMountSource()
+	if err != nil || sock == "" {
 		return nil
 	}
 	return []string{

--- a/internal/backend/devcontainer/ssh_test.go
+++ b/internal/backend/devcontainer/ssh_test.go
@@ -94,7 +94,10 @@ func TestSSHUpArgs_WithValidSocket(t *testing.T) {
 
 	t.Setenv("SSH_AUTH_SOCK", sockPath)
 	t.Setenv(sshAgentSockOverrideEnv, "")
-	args := sshUpArgs()
+	args, err := sshUpArgs()
+	if err != nil {
+		t.Fatalf("sshUpArgs: %v", err)
+	}
 	if len(args) != 4 {
 		t.Fatalf("expected 4 args, got %d: %v", len(args), args)
 	}
@@ -125,16 +128,40 @@ func TestSSHUpArgs_OverrideOff(t *testing.T) {
 
 	t.Setenv("SSH_AUTH_SOCK", sockPath)
 	t.Setenv(sshAgentSockOverrideEnv, "off")
-	if args := sshUpArgs(); args != nil {
-		t.Errorf("expected nil with %s=off, got %v", sshAgentSockOverrideEnv, args)
+	if args, err := sshUpArgs(); err != nil || args != nil {
+		t.Errorf("expected nil/nil with %s=off, got %v, %v", sshAgentSockOverrideEnv, args, err)
+	}
+}
+
+func TestSSHUpArgs_OverrideCaseAndWhitespace(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", "")
+	// OFF and padded off both disable forwarding rather than becoming a
+	// literal bind source.
+	for _, v := range []string{"OFF", " None ", "off "} {
+		t.Setenv(sshAgentSockOverrideEnv, v)
+		if args, err := sshUpArgs(); err != nil || args != nil {
+			t.Errorf("%s=%q: expected nil/nil, got %v, %v", sshAgentSockOverrideEnv, v, args, err)
+		}
+	}
+}
+
+func TestSSHUpArgs_OverrideInvalid(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", "")
+	// Relative paths and comma-splicing into the mount string are hard
+	// errors, not confusing downstream docker failures.
+	for _, v := range []string{"relative/path.sock", "/run/foo.sock,readonly", "true"} {
+		t.Setenv(sshAgentSockOverrideEnv, v)
+		if _, err := sshUpArgs(); err == nil {
+			t.Errorf("%s=%q: expected error, got none", sshAgentSockOverrideEnv, v)
+		}
 	}
 }
 
 func TestSSHUpArgs_NoSocket(t *testing.T) {
 	t.Setenv("SSH_AUTH_SOCK", "")
 	t.Setenv(sshAgentSockOverrideEnv, "")
-	if args := sshUpArgs(); args != nil {
-		t.Errorf("expected nil, got %v", args)
+	if args, err := sshUpArgs(); err != nil || args != nil {
+		t.Errorf("expected nil/nil, got %v, %v", args, err)
 	}
 }
 


### PR DESCRIPTION
Addresses the two review threads left on #236 after merge.

1. Kill-switch matching: the off/none check was exact-case and untrimmed, unlike the other FLEET_* env parsers (devcontainerUpArgs, devcontainerEnv both TrimSpace). FLEET_SSH_AGENT_SOCK=OFF, or 'off ' with stray whitespace from a shell rc, fell through to the path branch and was bind-mounted verbatim -- reproducing exactly the confusing 'bind source path does not exist' failure class #236 fixed. Now TrimSpace + EqualFold.

2. Malformed overrides: a relative path or a comma-containing value ('/run/foo.sock,readonly') was spliced verbatim into the --mount string, where a comma injects extra mount options. Unusable values are now a hard error naming the env var, raised at instance create/clone time, matching the repo's other env parser conventions. Exec paths degrade to no forwarding instead of blocking shells into an existing container whose creation already validated the value.

Tests cover OFF / ' None ' / 'off ' (disable), relative / comma / non-path values (error), and the existing linux/darwin/override matrix is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)