### PR TITLE
feat(fleet): file:// template fleets — copy a local dir per instance instead of git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ fleet up agent-1 --repo git@github.com:org/my-project.git
 # Reference an existing fleet from anywhere
 fleet up my-project/agent-3
 
+# Fleet a local directory instead of a git remote: file:// marks a TEMPLATE dir
+# that is copied (not cloned) into every new instance. A local path has no repo
+# name, so the fleet must be named explicitly (the TUI prompts for it).
+fleet up scratch/agent-1 --repo file:///home/me/scratch-project
+
 # Configure automation: agents (workers) and triggers (what fires them)
 fleet agent create my-project nightly-builder --system-prompt "Build and report"
 fleet trigger create my-project nightly --agent nightly-builder --cron "0 0 * * *" --prompt "Run the nightly build"

--- a/fleetgrpc/control.pb.go
+++ b/fleetgrpc/control.pb.go
@@ -691,9 +691,11 @@ func (x *GetStateReply) GetActiveJobs() []*JobSummary {
 // CreateFleet adds a fleet (GetOrCreateFleet). Idempotent: returns the existing
 // fleet if present.
 type CreateFleetRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Remote        string                 `protobuf:"bytes,2,opt,name=remote,proto3" json:"remote,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// git URL, or file:///abs/dir for a local template directory that is
+	// copied into each instance instead of cloned.
+	Remote        string `protobuf:"bytes,2,opt,name=remote,proto3" json:"remote,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/fleetgrpc/control.proto
+++ b/fleetgrpc/control.proto
@@ -125,6 +125,8 @@ message GetStateReply {
 // fleet if present.
 message CreateFleetRequest {
   string name = 1;
+  // git URL, or file:///abs/dir for a local template directory that is
+  // copied into each instance instead of cloned.
   string remote = 2;
 }
 

--- a/fleetgrpc/inspect.pb.go
+++ b/fleetgrpc/inspect.pb.go
@@ -23,7 +23,8 @@ const (
 
 type InspectRepoRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// remote_url is the git remote to shallow-clone for inspection.
+	// remote_url is the git remote to shallow-clone for inspection, or a
+	// file:///abs/dir template directory that is inspected in place.
 	RemoteUrl string `protobuf:"bytes,1,opt,name=remote_url,json=remoteUrl,proto3" json:"remote_url,omitempty"`
 	// branch optionally pins the branch to inspect (repo default when empty).
 	Branch string `protobuf:"bytes,2,opt,name=branch,proto3" json:"branch,omitempty"`

--- a/fleetgrpc/inspect.proto
+++ b/fleetgrpc/inspect.proto
@@ -15,7 +15,8 @@ option go_package = "github.com/BenjaminBenetti/fleet-man/fleetgrpc;fleetgrpc";
 // can false-positive when the client has repo access but the daemon doesn't.
 
 message InspectRepoRequest {
-  // remote_url is the git remote to shallow-clone for inspection.
+  // remote_url is the git remote to shallow-clone for inspection, or a
+  // file:///abs/dir template directory that is inspected in place.
   string remote_url = 1;
   // branch optionally pins the branch to inspect (repo default when empty).
   string branch = 2;

--- a/fleetgrpc/jobs.pb.go
+++ b/fleetgrpc/jobs.pb.go
@@ -772,8 +772,10 @@ type CreateInstanceRequest struct {
 	state    protoimpl.MessageState `protogen:"open.v1"`
 	Fleet    string                 `protobuf:"bytes,1,opt,name=fleet,proto3" json:"fleet,omitempty"`
 	Instance string                 `protobuf:"bytes,2,opt,name=instance,proto3" json:"instance,omitempty"`
-	// git URL; optional — for an existing fleet the server resolves it from the
-	// fleet record.
+	// git URL, or file:///abs/dir naming a local template directory (on the
+	// daemon host) that is copied into each instance instead of cloned;
+	// optional — for an existing fleet the server resolves it from the fleet
+	// record.
 	Remote        *string     `protobuf:"bytes,3,opt,name=remote,proto3,oneof" json:"remote,omitempty"`
 	Backend       BackendType `protobuf:"varint,4,opt,name=backend,proto3,enum=fleetgrpc.BackendType" json:"backend,omitempty"`
 	Branch        *string     `protobuf:"bytes,5,opt,name=branch,proto3,oneof" json:"branch,omitempty"`

--- a/fleetgrpc/jobs.proto
+++ b/fleetgrpc/jobs.proto
@@ -154,8 +154,10 @@ message JobDone {
 message CreateInstanceRequest {
   string fleet = 1;
   string instance = 2;
-  // git URL; optional — for an existing fleet the server resolves it from the
-  // fleet record.
+  // git URL, or file:///abs/dir naming a local template directory (on the
+  // daemon host) that is copied into each instance instead of cloned;
+  // optional — for an existing fleet the server resolves it from the fleet
+  // record.
   optional string remote = 3;
   BackendType backend = 4;
   optional string branch = 5;

--- a/integration/README.md
+++ b/integration/README.md
@@ -10,7 +10,8 @@ real docker daemon.
 integration/
 ├── run.sh                      # driver: builds binary, runs every test, teardown between
 ├── common.sh                   # shared helpers: assertions, setup/teardown, fleet_up
-├── fixture/                    # minimal devcontainer fixture cloned via file:// per test
+├── fixture/                    # minimal devcontainer fixture git-cloned (local path) per test;
+│                               # also fed as a file:// template by the template-fleet tests
 │   └── .devcontainer/
 │       └── devcontainer.json
 ├── fixture-no-devcontainer/    # repo template deliberately missing a devcontainer

--- a/integration/common.sh
+++ b/integration/common.sh
@@ -57,9 +57,16 @@ FLEET_BIN="${FLEET_BIN:-fleet}"
 
 # Fleet name is derived from the repo URL basename. We clone the fixture
 # into a dir named "itest-fleet" so resolve.go sees fleet "itest-fleet".
+#
+# FIXTURE_REPO_URL is a PLAIN PATH, which git clones like any other remote
+# (local clone). It must not be a file:// URL: fleet reserves file:// for
+# TEMPLATE fleets (the dir is copied per instance, never cloned, and the
+# fleet name is not derivable). FIXTURE_TEMPLATE_URL is that form of the
+# same fixture, for the template tests.
 FIXTURE_REPO_NAME="itest-fleet"
 FIXTURE_REPO_DIR="${TEST_SCRATCH_DIR}/${FIXTURE_REPO_NAME}"
-FIXTURE_REPO_URL="file://${FIXTURE_REPO_DIR}"
+FIXTURE_REPO_URL="${FIXTURE_REPO_DIR}"
+FIXTURE_TEMPLATE_URL="file://${FIXTURE_REPO_DIR}"
 
 # Default tmux session name used by TUI tests. Overridable per-test.
 TUI_SESSION="${TUI_SESSION:-fleetman-itest}"

--- a/integration/fixture-no-devcontainer/README.md
+++ b/integration/fixture-no-devcontainer/README.md
@@ -3,8 +3,8 @@
 A bare repository deliberately missing `.devcontainer/devcontainer.json`,
 used by the new-fleet devcontainer-check tests to exercise the "no
 devcontainer" dialog (Abort / Setup branches). The check-flow tests
-copy this directory into a throwaway git repo and feed its `file://`
-URL into the TUI's new-fleet dialog.
+copy this directory into a throwaway git repo and feed its local path
+into the TUI's new-fleet dialog.
 
 Keeping it disjoint from the default fixture means the present-fixture
 happy path and the missing-fixture dialog path can each ship a focused

--- a/integration/fixture/README.md
+++ b/integration/fixture/README.md
@@ -3,6 +3,8 @@
 Minimal devcontainer fixture used by the integration test suite.
 
 The suite copies this directory into a throwaway git repo and points
-`fleet up --repo file://<path>` at it. A lightweight debian-base image
+`fleet up --repo <path>` at it (a plain local path git-clones; the
+template-fleet tests use the same dir as `--repo file://<path>`, which
+fleet COPIES instead). A lightweight debian-base image
 keeps test runs fast compared to booting the full fleet-man devcontainer
 (which pulls Go + node + docker-in-docker features).

--- a/integration/tests/103_cli_up_template.sh
+++ b/integration/tests/103_cli_up_template.sh
@@ -46,8 +46,21 @@ printf '%s\n' "${out}"
 [ "${rc}" -ne 0 ] || fail "missing template dir should be rejected"
 assert_contains "${out}" "template dir" "error should name the template dir problem"
 
-ls_out=$("${FLEET_BIN}" ls || true)
-assert_not_contains "${ls_out}" "alpha" "rejected creates must not leave an instance behind"
+# Nothing may be left behind by a rejected create: no instance record (the
+# state file may not even exist yet) and no workspace dir.
+if [ -f "${HOME}/.fleet/state.json" ]; then
+  assert_not_contains "$(cat "${HOME}/.fleet/state.json")" '"alpha"' "rejected creates must not leave an instance record"
+fi
+assert_file_absent "${HOME}/.fleet/workspaces/scratch"
+
+info "fleet up scratch/alpha --repo file://\$HOME (template contains the workspace dir) must fail"
+set +e
+out=$("${FLEET_BIN}" up scratch/alpha --repo "file://${HOME}" 2>&1); rc=$?
+set -e
+printf '%s\n' "${out}"
+[ "${rc}" -ne 0 ] || fail "a template that contains ~/.fleet/workspaces should be rejected"
+assert_contains "${out}" "copied into itself" "error should explain the self-containment"
+assert_file_absent "${HOME}/.fleet/workspaces/scratch"
 
 # ===========================================
 # Happy path: explicit fleet name + template URL.

--- a/integration/tests/103_cli_up_template.sh
+++ b/integration/tests/103_cli_up_template.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Description: `fleet up <fleet>/<name> --repo file:///dir` copies a local template dir into each instance instead of cloning.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_begin
+
+setup_test
+
+# ===========================================
+# A template is any local directory with a devcontainer.json. Build one
+# from the fixture WITHOUT a .git so the test proves the workspace comes
+# from a copy, not a clone. A sentinel file lets us check content + isolation.
+# ===========================================
+template_dir="${TEST_SCRATCH_DIR}/scratch-template"
+rm -rf "${template_dir}"
+mkdir -p "${template_dir}"
+cp -r "${FIXTURE_SRC}/." "${template_dir}/"
+printf 'from-template\n' > "${template_dir}/sentinel.txt"
+template_url="file://${template_dir}"
+
+# ===========================================
+# Error paths first — each must fail BEFORE any instance record exists.
+# ===========================================
+info "fleet up alpha --repo file://... without an explicit fleet name must fail"
+set +e
+out=$("${FLEET_BIN}" up alpha --repo "${template_url}" 2>&1); rc=$?
+set -e
+printf '%s\n' "${out}"
+[ "${rc}" -ne 0 ] || fail "template --repo without <fleet>/<name> should be rejected"
+assert_contains "${out}" "<fleet>/alpha" "error should show the fleet/instance form"
+
+info "fleet up scratch/alpha --branch main on a template must fail"
+set +e
+out=$("${FLEET_BIN}" up scratch/alpha --repo "${template_url}" --branch main 2>&1); rc=$?
+set -e
+printf '%s\n' "${out}"
+[ "${rc}" -ne 0 ] || fail "--branch on a template fleet should be rejected"
+assert_contains "${out}" "branch" "error should mention branch"
+
+info "fleet up scratch/alpha --repo file:///missing must fail"
+set +e
+out=$("${FLEET_BIN}" up scratch/alpha --repo "file://${TEST_SCRATCH_DIR}/does-not-exist" 2>&1); rc=$?
+set -e
+printf '%s\n' "${out}"
+[ "${rc}" -ne 0 ] || fail "missing template dir should be rejected"
+assert_contains "${out}" "template dir" "error should name the template dir problem"
+
+ls_out=$("${FLEET_BIN}" ls || true)
+assert_not_contains "${ls_out}" "alpha" "rejected creates must not leave an instance behind"
+
+# ===========================================
+# Happy path: explicit fleet name + template URL.
+# ===========================================
+info "fleet up scratch/alpha --repo ${template_url}"
+"${FLEET_BIN}" up scratch/alpha --repo "${template_url}"
+
+ws_dir="${HOME}/.fleet/workspaces/scratch/alpha/scratch"
+assert_file_exists "${ws_dir}/sentinel.txt"
+assert_file_exists "${ws_dir}/.devcontainer/devcontainer.json"
+assert_file_absent "${ws_dir}/.git" "workspace must be a copy of the template, not a git clone"
+assert_equals "from-template" "$(cat "${ws_dir}/sentinel.txt")" "template content should be copied"
+
+ls_out=$("${FLEET_BIN}" ls scratch)
+printf '%s\n' "${ls_out}"
+assert_contains "${ls_out}" "scratch"  "fleet name missing from ls"
+assert_contains "${ls_out}" "alpha"    "instance missing from ls"
+assert_contains "${ls_out}" "running"  "instance should be running"
+
+state=$(cat "${HOME}/.fleet/state.json")
+assert_contains "${state}" "\"remote\": \"${template_url}\"" "fleet record should keep the file:// remote"
+
+# ===========================================
+# Isolation: editing the instance never touches the template, and a second
+# instance (no --repo: the fleet's recorded remote is reused) starts from
+# the pristine template again.
+# ===========================================
+info "editing the workspace copy must not modify the template"
+printf 'edited-in-instance\n' > "${ws_dir}/sentinel.txt"
+assert_equals "from-template" "$(cat "${template_dir}/sentinel.txt")" "template must stay pristine"
+
+info "fleet up scratch/beta (reuses the fleet's template remote)"
+"${FLEET_BIN}" up scratch/beta
+beta_ws="${HOME}/.fleet/workspaces/scratch/beta/scratch"
+assert_equals "from-template" "$(cat "${beta_ws}/sentinel.txt")" "second instance should start from the pristine template"
+
+pass "fleet up from a file:// template copies the dir per instance"

--- a/integration/tests/171_tui_new_fleet_with_devcontainer.sh
+++ b/integration/tests/171_tui_new_fleet_with_devcontainer.sh
@@ -21,7 +21,7 @@ tui_send_text "${FIXTURE_REPO_URL}"
 tui_send Enter
 
 info "verifying the no-devcontainer dialog is NEVER shown"
-# Inspecting + add are both fast on a file:// clone, so the next visible
+# Inspecting + add are both fast on a local clone, so the next visible
 # state should be the "Added fleet" status message — not the warn
 # dialog. The repo URL contains the fleet name, so we anchor on the
 # explicit success message rather than the bare fleet name (which would

--- a/integration/tests/174_tui_new_fleet_template.sh
+++ b/integration/tests/174_tui_new_fleet_template.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# itest: no-docker
+# Description: TUI new-fleet with a file:// template URL prompts for the fleet name, then adds the fleet
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+itest_cleanup() { tui_kill; }
+itest_begin
+
+setup_test
+
+info "spawning TUI on empty fleet list"
+tui_spawn
+tui_wait_for "No instances" 15
+
+info "opening new-fleet dialog: it must advertise the file:// option"
+tui_send n
+tui_wait_for "New fleet" 5
+tui_assert_contains "file:///abs/dir" "new-fleet dialog should mention file:// templates"
+
+info "submitting a file:// template URL"
+tui_send_text "${FIXTURE_TEMPLATE_URL}"
+tui_send Enter
+
+info "the fleet-name prompt appears, pre-filled with the dir's base name"
+tui_wait_for "Name:" 5
+tui_assert_contains "Template:" "name prompt should label the source as a template"
+tui_assert_contains "${FIXTURE_REPO_NAME}" "name prompt should suggest the template dir's base name"
+
+info "replacing the suggested name with an explicit one"
+# ctrl+u clears the (cursor-at-end) input; then type the real name.
+tui_send "C-u"
+tui_send_text "scratch-fleet"
+tui_send Enter
+
+info "inspection runs against the template dir and the fleet is added"
+tui_wait_for "Added fleet scratch-fleet" 15
+tui_assert_not_contains "No devcontainer.json found" \
+  "warn dialog appeared even though the template has a devcontainer.json"
+
+info "verifying state persistence"
+assert_file_exists "${HOME}/.fleet/state.json"
+state=$(cat "${HOME}/.fleet/state.json")
+assert_contains "${state}" "\"scratch-fleet\"" "fleet should be persisted under the typed name"
+assert_contains "${state}" "\"remote\": \"${FIXTURE_TEMPLATE_URL}\"" "fleet should record the file:// remote"
+assert_not_contains "${state}" "\"${FIXTURE_REPO_NAME}\": {" "fleet must not be auto-named after the template dir"
+
+pass "TUI new-fleet file:// template prompts for a name and adds the fleet"

--- a/integration/tests/174_tui_new_fleet_template.sh
+++ b/integration/tests/174_tui_new_fleet_template.sh
@@ -25,7 +25,11 @@ tui_send Enter
 info "the fleet-name prompt appears, pre-filled with the dir's base name"
 tui_wait_for "Name:" 5
 tui_assert_contains "Template:" "name prompt should label the source as a template"
-tui_assert_contains "${FIXTURE_REPO_NAME}" "name prompt should suggest the template dir's base name"
+# Anchor on the Name row itself (label, its padding, the input's "> " prompt,
+# then the value), not the bare name — the Template: line above already
+# contains it as the URL's last segment, so a bare match would pass even
+# with an empty prefill.
+tui_assert_contains "Name:     > ${FIXTURE_REPO_NAME}" "name prompt should pre-fill the template dir's base name"
 
 info "replacing the suggested name with an explicit one"
 # ctrl+u clears the (cursor-at-end) input; then type the real name.

--- a/internal/admiralskill/SKILL.md
+++ b/internal/admiralskill/SKILL.md
@@ -83,8 +83,12 @@ tool-call timeout allows it. A blocking call returns
 surfaces as a tool error.
 
 - `fleet_up {fleet, instance, remote?, branch?, backend?, wait?}` creates and
-  starts an instance. `remote` (a git URL) is required only when creating the
-  first instance of a new fleet; after that the fleet's recorded remote is used.
+  starts an instance. `remote` is required only when creating the first
+  instance of a new fleet; after that the fleet's recorded remote is used. It
+  is normally a git URL, but `file:///abs/dir` names a local TEMPLATE directory
+  on the daemon host instead: fleet copies it into each new instance rather
+  than cloning (a template fleet takes no `branch` and only the `devcontainer`
+  backend).
   `backend` selects where it runs: `devcontainer`, `coder`, or `codespaces`.
   Omitted, it falls back to the host's configured default backend
   (`devcontainer` out of the box) — the others need prior configuration, so

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -87,7 +87,7 @@ func newUpCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&repoFlag, "repo", "", "Git remote URL to clone from")
+	cmd.Flags().StringVar(&repoFlag, "repo", "", "Git remote URL to clone, or file:///abs/dir to copy a local template (needs <fleet>/<name>)")
 	cmd.Flags().StringVar(&backendFlag, "backend", "devcontainer", "Backend type: devcontainer, coder, or codespaces")
 	cmd.Flags().StringVar(&branchFlag, "branch", "", "Git branch to check out (defaults to the repository's default branch)")
 	return cmd

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -73,6 +73,9 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backen
 			setFailed(fleetName, instanceName, err)
 			return err
 		}
+		if warn := templateGitFileWarning(wsDir); warn != "" {
+			state.WriteWarn(fleetName, instanceName, warn)
+		}
 	default:
 		// Devcontainer: clone repo first, then provision
 		if err := os.MkdirAll(filepath.Dir(wsDir), 0755); err != nil {

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -119,8 +119,10 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backen
 	// Template worktree/submodule check LAST, and prepended: every provisioning
 	// step above WriteWarns (replacing the banner) on failure, and the TUI shows
 	// the banner's first line — this warning must win that slot.
-	if warn := templateGitFileWarning(wsDir); warn != "" {
-		state.PrependWarn(fleetName, instanceName, warn)
+	if fleet.IsTemplateRemote(remoteURL) {
+		if warn := templateGitFileWarning(wsDir); warn != "" {
+			state.PrependWarn(fleetName, instanceName, warn)
+		}
 	}
 
 	// Success: update state (instance is running even if dotfiles failed)

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -25,6 +25,11 @@ import (
 // When branch is non-empty, the devcontainer clone uses `git clone
 // --branch <branch>` so the instance is provisioned against that ref
 // rather than the repository's default branch.
+//
+// A file:// remote is a local TEMPLATE directory (fleet.IsTemplateRemote):
+// instead of cloning, its contents are copied into the workspace verbatim.
+// Only the devcontainer backend can do that (coder and codespaces provision
+// from a git URL on their own side), and a branch has no meaning for a copy.
 func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backendType fleet.BackendType) (err error) {
 	start := time.Now()
 	flog.Info("instance create started", "fleet", fleetName, "instance", instanceName, "backend", backendType, "branch", branch, "remote", remoteURL)
@@ -41,6 +46,10 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backen
 		setFailed(fleetName, instanceName, err)
 		return err
 	}
+	if err := fleet.ValidateTemplateCreate(remoteURL, branch, backendType); err != nil {
+		setFailed(fleetName, instanceName, err)
+		return err
+	}
 
 	wsDir := filepath.Join(state.WorkspacesDir(), fleetName, instanceName, fleetName)
 
@@ -54,7 +63,17 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backen
 		instanceBackend = backendutil.New(backendType, verbose)
 	}
 
-	if backendType != fleet.BackendCoder && backendType != fleet.BackendCodespaces {
+	switch {
+	case backendType == fleet.BackendCoder || backendType == fleet.BackendCodespaces:
+		// Remote-provisioned backends clone on their own side.
+	case fleet.IsTemplateRemote(remoteURL):
+		// Template fleet: copy the local template dir into the workspace
+		// (the cp stands in for git clone), then provision.
+		if err := copyTemplateTree(remoteURL, wsDir); err != nil {
+			setFailed(fleetName, instanceName, err)
+			return err
+		}
+	default:
 		// Devcontainer: clone repo first, then provision
 		if err := os.MkdirAll(filepath.Dir(wsDir), 0755); err != nil {
 			setFailed(fleetName, instanceName, err)

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -73,9 +73,6 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backen
 			setFailed(fleetName, instanceName, err)
 			return err
 		}
-		if warn := templateGitFileWarning(wsDir); warn != "" {
-			state.WriteWarn(fleetName, instanceName, warn)
-		}
 	default:
 		// Devcontainer: clone repo first, then provision
 		if err := os.MkdirAll(filepath.Dir(wsDir), 0755); err != nil {
@@ -118,6 +115,13 @@ func Run(fleetName, instanceName, remoteURL, branch string, verbose bool, backen
 	// rebuilt container ends up equivalently provisioned. Every step is
 	// best-effort — the instance is marked running even if one fails.
 	finishProvision(instanceBackend, fleetName, instanceName, wsDir, result.ContainerID, resolvedMounts.Symlinks)
+
+	// Template worktree/submodule check LAST, and prepended: every provisioning
+	// step above WriteWarns (replacing the banner) on failure, and the TUI shows
+	// the banner's first line — this warning must win that slot.
+	if warn := templateGitFileWarning(wsDir); warn != "" {
+		state.PrependWarn(fleetName, instanceName, warn)
+	}
 
 	// Success: update state (instance is running even if dotfiles failed)
 	if err := markInstanceRunning(fleetName, instanceName, result.ContainerID); err != nil {

--- a/internal/create/template_copy.go
+++ b/internal/create/template_copy.go
@@ -22,6 +22,9 @@ func copyTemplateTree(remoteURL, wsDir string) error {
 	if err != nil {
 		return err
 	}
+	if err := fleet.ValidateTemplateWorkspace(dir, wsDir); err != nil {
+		return err
+	}
 	if entries, err := os.ReadDir(wsDir); err == nil && len(entries) > 0 {
 		return fmt.Errorf("workspace dir %s already exists and is not empty", wsDir)
 	}

--- a/internal/create/template_copy.go
+++ b/internal/create/template_copy.go
@@ -3,6 +3,7 @@ package create
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 )
@@ -12,20 +13,33 @@ import (
 // and any .git directory survive) into wsDir. It is the template counterpart of
 // `git clone <remote> <wsDir>` — every new instance starts from a pristine copy
 // of the template, and edits inside an instance never touch the template.
+//
+// Like git clone, it refuses a non-empty destination: a stale workspace dir (a
+// destroy whose RemoveAll only warned, a hand-edited state.json) must surface
+// as an error, not be silently merged under the template.
 func copyTemplateTree(remoteURL, wsDir string) error {
-	dir, err := fleet.TemplateDir(remoteURL)
+	dir, err := fleet.ResolveTemplateDir(remoteURL)
 	if err != nil {
 		return err
 	}
-	info, err := os.Stat(dir)
-	if err != nil {
-		return fmt.Errorf("template dir: %w", err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("template path %s is not a directory", dir)
+	if entries, err := os.ReadDir(wsDir); err == nil && len(entries) > 0 {
+		return fmt.Errorf("workspace dir %s already exists and is not empty", wsDir)
 	}
 	if err := copyWorkspaceTree(dir, wsDir); err != nil {
 		return fmt.Errorf("copy template %s: %w", dir, err)
 	}
 	return nil
+}
+
+// templateGitFileWarning reports a copied `.git` that is a FILE rather than a
+// directory — a git worktree checkout or a submodule — whose gitdir pointer
+// still targets the template's repository. Commits made inside the instance
+// would then mutate the template's git state, so the user gets a warning.
+// Returns "" when there is nothing to warn about.
+func templateGitFileWarning(wsDir string) string {
+	info, err := os.Lstat(filepath.Join(wsDir, ".git"))
+	if err != nil || info.IsDir() {
+		return ""
+	}
+	return "template .git is a file (git worktree or submodule): the instance shares the template's git dir, so commits inside it change the template's repo"
 }

--- a/internal/create/template_copy.go
+++ b/internal/create/template_copy.go
@@ -1,0 +1,31 @@
+package create
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+)
+
+// copyTemplateTree materialises a template fleet's workspace: the directory a
+// file:// remote points at is copied (cp -a, so permissions, mtimes, symlinks
+// and any .git directory survive) into wsDir. It is the template counterpart of
+// `git clone <remote> <wsDir>` — every new instance starts from a pristine copy
+// of the template, and edits inside an instance never touch the template.
+func copyTemplateTree(remoteURL, wsDir string) error {
+	dir, err := fleet.TemplateDir(remoteURL)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("template dir: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("template path %s is not a directory", dir)
+	}
+	if err := copyWorkspaceTree(dir, wsDir); err != nil {
+		return fmt.Errorf("copy template %s: %w", dir, err)
+	}
+	return nil
+}

--- a/internal/create/template_copy_test.go
+++ b/internal/create/template_copy_test.go
@@ -1,0 +1,72 @@
+package create
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCopyTemplateTreeCopiesContentsVerbatim covers the cp-for-clone swap:
+// the template's files, nested dirs, and any .git land inside wsDir, and the
+// template itself is untouched afterwards.
+func TestCopyTemplateTreeCopiesContentsVerbatim(t *testing.T) {
+	tmpl := t.TempDir()
+	for rel, body := range map[string]string{
+		"README.md":                       "hello",
+		".devcontainer/devcontainer.json": "{}",
+		".git/HEAD":                       "ref: refs/heads/main",
+		"src/nested/deep.txt":             "deep",
+	} {
+		full := filepath.Join(tmpl, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	wsDir := filepath.Join(t.TempDir(), "fleet", "inst", "fleet")
+	if err := copyTemplateTree("file://"+tmpl, wsDir); err != nil {
+		t.Fatalf("copyTemplateTree: %v", err)
+	}
+	for rel, want := range map[string]string{
+		"README.md":                       "hello",
+		".devcontainer/devcontainer.json": "{}",
+		".git/HEAD":                       "ref: refs/heads/main",
+		"src/nested/deep.txt":             "deep",
+	} {
+		got, err := os.ReadFile(filepath.Join(wsDir, rel))
+		if err != nil {
+			t.Fatalf("%s not copied: %v", rel, err)
+		}
+		if string(got) != want {
+			t.Fatalf("%s = %q, want %q", rel, got, want)
+		}
+	}
+
+	// Editing the copy must not reach back into the template.
+	if err := os.WriteFile(filepath.Join(wsDir, "README.md"), []byte("edited"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(filepath.Join(tmpl, "README.md")); string(got) != "hello" {
+		t.Fatalf("template README changed to %q", got)
+	}
+}
+
+func TestCopyTemplateTreeRejectsBadSources(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "ws")
+	if err := copyTemplateTree("file://"+filepath.Join(t.TempDir(), "missing"), dest); err == nil {
+		t.Fatal("missing template dir should error")
+	}
+	file := filepath.Join(t.TempDir(), "f")
+	if err := os.WriteFile(file, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyTemplateTree("file://"+file, dest); err == nil {
+		t.Fatal("template path that is a file should error")
+	}
+	if err := copyTemplateTree("git@github.com:o/r.git", dest); err == nil {
+		t.Fatal("non-template remote should error")
+	}
+}

--- a/internal/create/template_copy_test.go
+++ b/internal/create/template_copy_test.go
@@ -87,6 +87,23 @@ func TestCopyTemplateTreeRefusesNonEmptyDestination(t *testing.T) {
 	}
 }
 
+// A template that contains the workspace dir must be refused BEFORE cp -a
+// creates wsDir inside it — the template stays untouched.
+func TestCopyTemplateTreeRefusesAncestorTemplate(t *testing.T) {
+	tmpl := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpl, "a.txt"), []byte("a"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	wsDir := filepath.Join(tmpl, ".fleet", "workspaces", "f", "i", "f")
+	err := copyTemplateTree("file://"+tmpl, wsDir)
+	if err == nil || !strings.Contains(err.Error(), "copied into itself") {
+		t.Fatalf("want self-containment error, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmpl, ".fleet")); err == nil {
+		t.Fatal("workspace dir must not have been created inside the template")
+	}
+}
+
 func TestTemplateGitFileWarning(t *testing.T) {
 	ws := t.TempDir()
 	if got := templateGitFileWarning(ws); got != "" {

--- a/internal/create/template_copy_test.go
+++ b/internal/create/template_copy_test.go
@@ -3,6 +3,7 @@ package create
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -51,6 +52,58 @@ func TestCopyTemplateTreeCopiesContentsVerbatim(t *testing.T) {
 	}
 	if got, _ := os.ReadFile(filepath.Join(tmpl, "README.md")); string(got) != "hello" {
 		t.Fatalf("template README changed to %q", got)
+	}
+}
+
+// Like git clone, a non-empty destination is refused rather than merged under
+// the template — a stale workspace dir must surface, not silently mix in.
+func TestCopyTemplateTreeRefusesNonEmptyDestination(t *testing.T) {
+	tmpl := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpl, "a.txt"), []byte("a"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	wsDir := filepath.Join(t.TempDir(), "ws")
+	if err := os.MkdirAll(wsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wsDir, "stale.txt"), []byte("old"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := copyTemplateTree("file://"+tmpl, wsDir)
+	if err == nil || !strings.Contains(err.Error(), "not empty") {
+		t.Fatalf("want non-empty destination error, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(wsDir, "a.txt")); err == nil {
+		t.Fatal("template must not have been copied over a non-empty dir")
+	}
+
+	// An existing but EMPTY dir is fine (MkdirAll of the parent is common).
+	empty := filepath.Join(t.TempDir(), "ws")
+	if err := os.MkdirAll(empty, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyTemplateTree("file://"+tmpl, empty); err != nil {
+		t.Fatalf("empty destination should be accepted: %v", err)
+	}
+}
+
+func TestTemplateGitFileWarning(t *testing.T) {
+	ws := t.TempDir()
+	if got := templateGitFileWarning(ws); got != "" {
+		t.Fatalf("no .git: want no warning, got %q", got)
+	}
+	if err := os.MkdirAll(filepath.Join(ws, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if got := templateGitFileWarning(ws); got != "" {
+		t.Fatalf(".git dir: want no warning, got %q", got)
+	}
+	ws2 := t.TempDir()
+	if err := os.WriteFile(filepath.Join(ws2, ".git"), []byte("gitdir: /elsewhere/.git/worktrees/x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got := templateGitFileWarning(ws2); !strings.Contains(got, "worktree") {
+		t.Fatalf(".git file: want worktree warning, got %q", got)
 	}
 }
 

--- a/internal/devcontainersetup/devcontainersetup.go
+++ b/internal/devcontainersetup/devcontainersetup.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/agent"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 )
 
 // ===========================================
@@ -32,12 +33,23 @@ const skillURL = "https://raw.githubusercontent.com/BenjaminBenetti/fleet-man/ma
 // remoteURL is the git remote of the fleet's repository — the agent
 // will clone it locally so the user can collaboratively author the
 // new .devcontainer/devcontainer.json before pushing.
+//
+// For a file:// template remote there is nothing to clone or push: the
+// agent is pointed at the template directory itself, since that is exactly
+// what fleet copies into each instance.
 func Prompt(remoteURL string) string {
+	target := fmt.Sprintf("The repository to set up is %s.", remoteURL)
+	if dir, err := fleet.TemplateDir(remoteURL); err == nil {
+		target = fmt.Sprintf(
+			"The project to set up is the LOCAL directory %s (a fleet template dir, not a git remote): "+
+				"skip the clone step, work directly in that directory, and skip the commit/push step "+
+				"unless the user asks for it.", dir)
+	}
 	return fmt.Sprintf(
-		"Read %s and follow the instructions. The repository to set up is %s. "+
+		"Read %s and follow the instructions. %s "+
 			"Make sure to consult the latest devcontainer documentation on the web "+
 			"so the configuration you produce reflects the current schema and features.",
-		skillURL, remoteURL,
+		skillURL, target,
 	)
 }
 

--- a/internal/devcontainersetup/devcontainersetup_test.go
+++ b/internal/devcontainersetup/devcontainersetup_test.go
@@ -1,0 +1,30 @@
+package devcontainersetup
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPromptNamesGitRemote(t *testing.T) {
+	p := Prompt("git@github.com:org/repo.git")
+	if !strings.Contains(p, "The repository to set up is git@github.com:org/repo.git.") {
+		t.Fatalf("git prompt missing repository sentence: %q", p)
+	}
+	if strings.Contains(p, "LOCAL directory") {
+		t.Fatalf("git prompt must not use the template wording: %q", p)
+	}
+}
+
+// A template fleet's agent must work in the template dir itself — that is the
+// directory fleet copies — rather than cloning something.
+func TestPromptPointsTemplateAgentAtLocalDir(t *testing.T) {
+	p := Prompt("file:///home/me/scratch")
+	for _, want := range []string{"/home/me/scratch", "LOCAL directory", "skip the clone step"} {
+		if !strings.Contains(p, want) {
+			t.Fatalf("template prompt missing %q: %q", want, p)
+		}
+	}
+	if strings.Contains(p, "file:///home/me/scratch") {
+		t.Fatalf("template prompt should hand the agent a plain path, not the URL: %q", p)
+	}
+}

--- a/internal/fleet/fleet_name_from_remote.go
+++ b/internal/fleet/fleet_name_from_remote.go
@@ -12,8 +12,15 @@ import (
 //	git@github.com:org/fleet-man.git → fleet-man
 //	https://github.com/org/fleet-man.git → fleet-man
 //	https://github.com/org/fleet-man → fleet-man
+//
+// A file:// template remote yields "" on purpose: a local directory name is
+// not an authoritative project name, so the user must supply the fleet name
+// explicitly (see TemplateNameHint for the default the TUI offers).
 func FleetNameFromRemote(remote string) string {
 	remote = strings.TrimSpace(remote)
+	if IsTemplateRemote(remote) {
+		return ""
+	}
 
 	// Handle SSH-style: git@github.com:org/repo.git
 	if strings.Contains(remote, ":") && !strings.Contains(remote, "://") {

--- a/internal/fleet/resolve.go
+++ b/internal/fleet/resolve.go
@@ -13,24 +13,30 @@ type Target struct {
 
 // Resolve parses a user-provided name into a fleet/instance target.
 // It handles three forms:
-//   - "instance"           → fleet inferred from cwd git remote
-//   - "fleet/instance"     → explicit fleet name
+//   - "fleet/instance"     → explicit fleet name (wins over --repo derivation)
 //   - "instance" + repoURL → fleet derived from the repo URL
+//   - "instance"           → fleet inferred from cwd git remote
+//
+// A file:// template --repo has no derivable fleet name, so it REQUIRES the
+// explicit fleet/instance form.
 func Resolve(name string, repoFlag string) (*Target, error) {
-	if repoFlag != "" {
-		fleetName := FleetNameFromRemote(repoFlag)
-		if fleetName == "" {
-			return nil, fmt.Errorf("could not derive fleet name from repo URL %q", repoFlag)
-		}
-		return &Target{Fleet: fleetName, Instance: name}, nil
-	}
-
 	if strings.Contains(name, "/") {
 		parts := strings.SplitN(name, "/", 2)
 		if parts[0] == "" || parts[1] == "" {
 			return nil, fmt.Errorf("invalid target %q: both fleet and instance names are required", name)
 		}
 		return &Target{Fleet: parts[0], Instance: parts[1]}, nil
+	}
+
+	if repoFlag != "" {
+		if IsTemplateRemote(repoFlag) {
+			return nil, fmt.Errorf("a %s template has no derivable fleet name: name the fleet explicitly, e.g. `fleet up <fleet>/%s --repo %s`", TemplateScheme, name, repoFlag)
+		}
+		fleetName := FleetNameFromRemote(repoFlag)
+		if fleetName == "" {
+			return nil, fmt.Errorf("could not derive fleet name from repo URL %q", repoFlag)
+		}
+		return &Target{Fleet: fleetName, Instance: name}, nil
 	}
 
 	// Infer fleet from cwd git remote

--- a/internal/fleet/template_remote.go
+++ b/internal/fleet/template_remote.go
@@ -79,6 +79,23 @@ func ResolveTemplateDir(remote string) (string, error) {
 	return dir, nil
 }
 
+// ValidateTemplateWorkspace rejects a template directory that CONTAINS the
+// workspace dir it would be copied into (file:///home/me, ~/.fleet, the
+// workspaces tree, the fleet's own dir). cp -a would create wsDir inside the
+// template, copy everything up to it — for ~ that is .ssh and every other
+// workspace — and then abort on "cannot copy a directory into itself",
+// leaving a partial workspace and a stray dir inside the user's template.
+func ValidateTemplateWorkspace(dir, wsDir string) error {
+	rel, err := filepath.Rel(dir, wsDir)
+	if err != nil {
+		return nil
+	}
+	if rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))) {
+		return fmt.Errorf("template dir %s contains the workspace dir %s: it would be copied into itself", dir, wsDir)
+	}
+	return nil
+}
+
 // TemplateNameHint suggests a fleet name for a template remote: the base name
 // of the template directory, with whitespace folded to "-" so the suggestion
 // is one ValidateFleetName accepts (the dir may have come in percent-encoded,

--- a/internal/fleet/template_remote.go
+++ b/internal/fleet/template_remote.go
@@ -3,9 +3,9 @@ package fleet
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
-	"unicode"
 )
 
 // TemplateScheme is the URL scheme that marks a fleet remote as a local
@@ -54,6 +54,31 @@ func TemplateDir(remote string) (string, error) {
 	return dir, nil
 }
 
+// templateHostHint reminds a remote-TUI user that the path is checked on the
+// daemon's machine, not theirs. Every ResolveTemplateDir caller (job-start
+// validation, InspectRepo, the workspace copy) runs on the daemon host, so the
+// hint is accurate wherever the error surfaces.
+const templateHostHint = " (the path is resolved on the fleet daemon's host)"
+
+// ResolveTemplateDir is TemplateDir plus the existence check: the directory
+// must exist (on THIS host — the daemon's) and be a directory. Every consumer
+// of a template path goes through here so the rule and its wording cannot
+// drift between them.
+func ResolveTemplateDir(remote string) (string, error) {
+	dir, err := TemplateDir(remote)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return "", fmt.Errorf("template dir: %w%s", err, templateHostHint)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("template path %s is not a directory%s", dir, templateHostHint)
+	}
+	return dir, nil
+}
+
 // TemplateNameHint suggests a fleet name for a template remote: the base name
 // of the template directory. It is only a DEFAULT for the user to confirm or
 // edit — unlike a git URL, a local path carries no authoritative project name,
@@ -64,27 +89,6 @@ func TemplateNameHint(remote string) string {
 		return ""
 	}
 	return filepath.Base(dir)
-}
-
-// ValidateFleetName rejects names that cannot be embedded verbatim where a
-// fleet name ends up: the ~/.fleet/workspaces/<fleet> directory, container
-// names, and the fleet/instance target syntax. Template fleets are the first
-// place a user TYPES a fleet name (git fleets derive theirs from the URL), so
-// the rule lives here rather than in the dialog.
-func ValidateFleetName(name string) error {
-	if name == "" {
-		return fmt.Errorf("fleet name must not be empty")
-	}
-	if strings.ContainsFunc(name, unicode.IsSpace) {
-		return fmt.Errorf("fleet name %q must not contain spaces", name)
-	}
-	if strings.ContainsAny(name, "/\\") {
-		return fmt.Errorf("fleet name %q must not contain path separators", name)
-	}
-	if name == "." || name == ".." {
-		return fmt.Errorf("fleet name %q is not allowed", name)
-	}
-	return nil
 }
 
 // ValidateTemplateCreate checks the create-instance inputs that only make
@@ -99,7 +103,7 @@ func ValidateTemplateCreate(remote, branch string, backendType BackendType) erro
 		return err
 	}
 	if branch != "" {
-		return fmt.Errorf("--branch is not supported for a %s template fleet (the template dir is copied as-is)", TemplateScheme)
+		return fmt.Errorf("a branch cannot be checked out for a %s template fleet (the template dir is copied as-is)", TemplateScheme)
 	}
 	if backendType != BackendDevcontainer {
 		return fmt.Errorf("a %s template fleet requires the devcontainer backend (got %s)", TemplateScheme, backendType)

--- a/internal/fleet/template_remote.go
+++ b/internal/fleet/template_remote.go
@@ -80,15 +80,17 @@ func ResolveTemplateDir(remote string) (string, error) {
 }
 
 // TemplateNameHint suggests a fleet name for a template remote: the base name
-// of the template directory. It is only a DEFAULT for the user to confirm or
-// edit — unlike a git URL, a local path carries no authoritative project name,
-// which is why FleetNameFromRemote refuses to derive one automatically.
+// of the template directory, with whitespace folded to "-" so the suggestion
+// is one ValidateFleetName accepts (the dir may have come in percent-encoded,
+// e.g. file:///tmp/tpl%20space). It is only a DEFAULT for the user to confirm
+// or edit — unlike a git URL, a local path carries no authoritative project
+// name, which is why FleetNameFromRemote refuses to derive one automatically.
 func TemplateNameHint(remote string) string {
 	dir, err := TemplateDir(remote)
 	if err != nil {
 		return ""
 	}
-	return filepath.Base(dir)
+	return strings.Join(strings.Fields(filepath.Base(dir)), "-")
 }
 
 // ValidateTemplateCreate checks the create-instance inputs that only make

--- a/internal/fleet/template_remote.go
+++ b/internal/fleet/template_remote.go
@@ -1,0 +1,108 @@
+package fleet
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+// TemplateScheme is the URL scheme that marks a fleet remote as a local
+// TEMPLATE DIRECTORY rather than a git remote. A template fleet does not
+// clone anything: the directory is copied verbatim (cp -a) into each new
+// instance's workspace, so one-off repos and scratch projects can be fleeted
+// without pushing them anywhere first.
+//
+// The path is resolved on the daemon host (the machine that provisions), so a
+// remote TUI must name a directory that exists THERE, not on the client.
+const TemplateScheme = "file://"
+
+// IsTemplateRemote reports whether remote names a local template directory
+// (file:///abs/path) instead of a git remote to clone.
+func IsTemplateRemote(remote string) bool {
+	return strings.HasPrefix(strings.TrimSpace(remote), TemplateScheme)
+}
+
+// TemplateDir returns the cleaned absolute directory a file:// remote points
+// at. Only the file:///abs/path and file://localhost/abs/path forms are
+// accepted: a relative path has no stable meaning once the daemon (not the
+// user's shell) resolves it, and any other host would silently name a
+// directory on the wrong machine. Percent-escapes are decoded so a URL pasted
+// from a file manager (%20 for a space) resolves to the real path.
+func TemplateDir(remote string) (string, error) {
+	remote = strings.TrimSpace(remote)
+	if !IsTemplateRemote(remote) {
+		return "", fmt.Errorf("%q is not a %s URL", remote, TemplateScheme)
+	}
+	rest := strings.TrimPrefix(remote, TemplateScheme)
+	if strings.HasPrefix(rest, "localhost/") {
+		rest = strings.TrimPrefix(rest, "localhost")
+	}
+	if !strings.HasPrefix(rest, "/") {
+		// file://host/path or file://relative/path: either way the caller
+		// left out the third slash that makes the path absolute.
+		return "", fmt.Errorf("template path must be absolute: use %s/abs/path (got %q)", TemplateScheme, remote)
+	}
+	if decoded, err := url.PathUnescape(rest); err == nil {
+		rest = decoded
+	}
+	dir := filepath.Clean(rest)
+	if dir == "/" {
+		return "", fmt.Errorf("template path must name a directory, not the filesystem root")
+	}
+	return dir, nil
+}
+
+// TemplateNameHint suggests a fleet name for a template remote: the base name
+// of the template directory. It is only a DEFAULT for the user to confirm or
+// edit — unlike a git URL, a local path carries no authoritative project name,
+// which is why FleetNameFromRemote refuses to derive one automatically.
+func TemplateNameHint(remote string) string {
+	dir, err := TemplateDir(remote)
+	if err != nil {
+		return ""
+	}
+	return filepath.Base(dir)
+}
+
+// ValidateFleetName rejects names that cannot be embedded verbatim where a
+// fleet name ends up: the ~/.fleet/workspaces/<fleet> directory, container
+// names, and the fleet/instance target syntax. Template fleets are the first
+// place a user TYPES a fleet name (git fleets derive theirs from the URL), so
+// the rule lives here rather than in the dialog.
+func ValidateFleetName(name string) error {
+	if name == "" {
+		return fmt.Errorf("fleet name must not be empty")
+	}
+	if strings.ContainsFunc(name, unicode.IsSpace) {
+		return fmt.Errorf("fleet name %q must not contain spaces", name)
+	}
+	if strings.ContainsAny(name, "/\\") {
+		return fmt.Errorf("fleet name %q must not contain path separators", name)
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("fleet name %q is not allowed", name)
+	}
+	return nil
+}
+
+// ValidateTemplateCreate checks the create-instance inputs that only make
+// sense for a git remote against a template remote. It is a no-op for git
+// remotes. Both the server (at job start, so `fleet up` fails fast) and
+// create.Run (the enforcement point) call it, so the rule has one home.
+func ValidateTemplateCreate(remote, branch string, backendType BackendType) error {
+	if !IsTemplateRemote(remote) {
+		return nil
+	}
+	if _, err := TemplateDir(remote); err != nil {
+		return err
+	}
+	if branch != "" {
+		return fmt.Errorf("--branch is not supported for a %s template fleet (the template dir is copied as-is)", TemplateScheme)
+	}
+	if backendType != BackendDevcontainer {
+		return fmt.Errorf("a %s template fleet requires the devcontainer backend (got %s)", TemplateScheme, backendType)
+	}
+	return nil
+}

--- a/internal/fleet/template_remote_test.go
+++ b/internal/fleet/template_remote_test.go
@@ -92,6 +92,14 @@ func TestTemplateNameHintIsDirBase(t *testing.T) {
 	if got := TemplateNameHint("file://relative"); got != "" {
 		t.Errorf("TemplateNameHint(invalid) = %q, want empty", got)
 	}
+	// A percent-encoded space decodes to a space, which ValidateFleetName
+	// rejects — the suggestion must already be acceptable.
+	if got := TemplateNameHint("file:///tmp/tpl%20space"); got != "tpl-space" {
+		t.Errorf("TemplateNameHint(%%20) = %q, want tpl-space", got)
+	}
+	if err := ValidateFleetName(TemplateNameHint("file:///tmp/my%20scratch%20dir")); err != nil {
+		t.Errorf("hint must pass ValidateFleetName: %v", err)
+	}
 }
 
 // A template remote must NOT yield a derived fleet name: the user has to

--- a/internal/fleet/template_remote_test.go
+++ b/internal/fleet/template_remote_test.go
@@ -85,6 +85,20 @@ func TestResolveTemplateDirChecksExistence(t *testing.T) {
 	}
 }
 
+func TestValidateTemplateWorkspaceRejectsAncestors(t *testing.T) {
+	ws := "/home/me/.fleet/workspaces/scratch/one/scratch"
+	for _, dir := range []string{"/home/me", "/home/me/.fleet", "/home/me/.fleet/workspaces", "/home/me/.fleet/workspaces/scratch", ws} {
+		if err := ValidateTemplateWorkspace(dir, ws); err == nil {
+			t.Errorf("template %q contains %q: want error", dir, ws)
+		}
+	}
+	for _, dir := range []string{"/home/me/projects/tpl", "/home/me/.fleet/workspaces/other", "/home/me/.fleet/workspaces/scratch-2", "/tmp/x"} {
+		if err := ValidateTemplateWorkspace(dir, ws); err != nil {
+			t.Errorf("template %q is disjoint from %q: got %v", dir, ws, err)
+		}
+	}
+}
+
 func TestTemplateNameHintIsDirBase(t *testing.T) {
 	if got := TemplateNameHint("file:///home/me/scratch-proj/"); got != "scratch-proj" {
 		t.Errorf("TemplateNameHint = %q, want scratch-proj", got)

--- a/internal/fleet/template_remote_test.go
+++ b/internal/fleet/template_remote_test.go
@@ -1,6 +1,8 @@
 package fleet
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -62,6 +64,27 @@ func TestTemplateDirRejectsNonAbsoluteAndNonTemplate(t *testing.T) {
 	}
 }
 
+func TestResolveTemplateDirChecksExistence(t *testing.T) {
+	dir := t.TempDir()
+	got, err := ResolveTemplateDir("file://" + dir)
+	if err != nil || got != dir {
+		t.Fatalf("ResolveTemplateDir(existing) = %q, %v", got, err)
+	}
+	if _, err := ResolveTemplateDir("file://" + filepath.Join(dir, "nope")); err == nil || !strings.Contains(err.Error(), "daemon's host") {
+		t.Fatalf("missing dir: want stat error with the daemon-host hint, got %v", err)
+	}
+	file := filepath.Join(dir, "f")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ResolveTemplateDir("file://" + file); err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("file path: want not-a-directory error, got %v", err)
+	}
+	if _, err := ResolveTemplateDir("file://relative"); err == nil {
+		t.Fatal("relative path must fail before any stat")
+	}
+}
+
 func TestTemplateNameHintIsDirBase(t *testing.T) {
 	if got := TemplateNameHint("file:///home/me/scratch-proj/"); got != "scratch-proj" {
 		t.Errorf("TemplateNameHint = %q, want scratch-proj", got)
@@ -109,19 +132,6 @@ func TestResolveExplicitFleetWinsOverRepoFlag(t *testing.T) {
 	}
 	if target.Fleet != "mine" || target.Instance != "agent-1" {
 		t.Fatalf("target = %+v, want mine/agent-1", target)
-	}
-}
-
-func TestValidateFleetName(t *testing.T) {
-	for _, bad := range []string{"", "a b", "a/b", `a\b`, ".", "..", "\tx"} {
-		if err := ValidateFleetName(bad); err == nil {
-			t.Errorf("ValidateFleetName(%q) = nil, want error", bad)
-		}
-	}
-	for _, good := range []string{"scratch", "my-proj", "proj_2", "a.b"} {
-		if err := ValidateFleetName(good); err != nil {
-			t.Errorf("ValidateFleetName(%q) = %v, want nil", good, err)
-		}
 	}
 }
 

--- a/internal/fleet/template_remote_test.go
+++ b/internal/fleet/template_remote_test.go
@@ -1,0 +1,147 @@
+package fleet
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsTemplateRemote(t *testing.T) {
+	cases := map[string]bool{
+		"file:///home/me/proj":          true,
+		"  file:///home/me/proj ":       true,
+		"file://localhost/home/me/proj": true,
+		"git@github.com:org/repo.git":   false,
+		"https://github.com/org/repo":   false,
+		"/home/me/proj":                 false,
+		"":                              false,
+	}
+	for remote, want := range cases {
+		if got := IsTemplateRemote(remote); got != want {
+			t.Errorf("IsTemplateRemote(%q) = %v, want %v", remote, got, want)
+		}
+	}
+}
+
+func TestTemplateDirAcceptsAbsoluteForms(t *testing.T) {
+	cases := map[string]string{
+		"file:///home/me/proj":          "/home/me/proj",
+		"file:///home/me/proj/":         "/home/me/proj",
+		"  file:///home/me/proj  ":      "/home/me/proj",
+		"file://localhost/home/me/proj": "/home/me/proj",
+		"file:///home/me/my%20dir":      "/home/me/my dir",
+		"file:///home/me/a/../b":        "/home/me/b",
+	}
+	for remote, want := range cases {
+		got, err := TemplateDir(remote)
+		if err != nil {
+			t.Errorf("TemplateDir(%q) error = %v", remote, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("TemplateDir(%q) = %q, want %q", remote, got, want)
+		}
+	}
+}
+
+func TestTemplateDirRejectsNonAbsoluteAndNonTemplate(t *testing.T) {
+	for _, remote := range []string{
+		"file://proj",             // relative — missing third slash
+		"file://host/proj",        // another host
+		"file://",                 // nothing at all
+		"file:///",                // filesystem root
+		"git@github.com:o/r.git",  // not a template at all
+		"https://example.com/x/y", // ditto
+	} {
+		if dir, err := TemplateDir(remote); err == nil {
+			t.Errorf("TemplateDir(%q) = %q, want error", remote, dir)
+		}
+	}
+	_, err := TemplateDir("file://proj")
+	if err == nil || !strings.Contains(err.Error(), "absolute") {
+		t.Errorf("relative path error should explain absolute requirement, got %v", err)
+	}
+}
+
+func TestTemplateNameHintIsDirBase(t *testing.T) {
+	if got := TemplateNameHint("file:///home/me/scratch-proj/"); got != "scratch-proj" {
+		t.Errorf("TemplateNameHint = %q, want scratch-proj", got)
+	}
+	if got := TemplateNameHint("file://relative"); got != "" {
+		t.Errorf("TemplateNameHint(invalid) = %q, want empty", got)
+	}
+}
+
+// A template remote must NOT yield a derived fleet name: the user has to
+// choose one (the TUI prompts, the CLI requires fleet/instance).
+func TestFleetNameFromRemoteRefusesTemplate(t *testing.T) {
+	if got := FleetNameFromRemote("file:///home/me/proj"); got != "" {
+		t.Fatalf("FleetNameFromRemote(file://) = %q, want empty", got)
+	}
+	if got := FleetNameFromRemote("git@github.com:org/proj.git"); got != "proj" {
+		t.Fatalf("git remote derivation regressed: %q", got)
+	}
+}
+
+func TestResolveTemplateRepoRequiresExplicitFleet(t *testing.T) {
+	_, err := Resolve("agent-1", "file:///home/me/proj")
+	if err == nil {
+		t.Fatal("expected error for a template --repo without fleet/instance")
+	}
+	if !strings.Contains(err.Error(), "<fleet>/agent-1") {
+		t.Fatalf("error should show the fleet/instance form, got: %v", err)
+	}
+
+	target, err := Resolve("scratch/agent-1", "file:///home/me/proj")
+	if err != nil {
+		t.Fatalf("Resolve(fleet/instance, template): %v", err)
+	}
+	if target.Fleet != "scratch" || target.Instance != "agent-1" {
+		t.Fatalf("target = %+v", target)
+	}
+}
+
+// An explicit fleet/instance must win over --repo derivation (previously the
+// --repo path ran first and left the slash inside the instance name).
+func TestResolveExplicitFleetWinsOverRepoFlag(t *testing.T) {
+	target, err := Resolve("mine/agent-1", "git@github.com:org/other.git")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if target.Fleet != "mine" || target.Instance != "agent-1" {
+		t.Fatalf("target = %+v, want mine/agent-1", target)
+	}
+}
+
+func TestValidateFleetName(t *testing.T) {
+	for _, bad := range []string{"", "a b", "a/b", `a\b`, ".", "..", "\tx"} {
+		if err := ValidateFleetName(bad); err == nil {
+			t.Errorf("ValidateFleetName(%q) = nil, want error", bad)
+		}
+	}
+	for _, good := range []string{"scratch", "my-proj", "proj_2", "a.b"} {
+		if err := ValidateFleetName(good); err != nil {
+			t.Errorf("ValidateFleetName(%q) = %v, want nil", good, err)
+		}
+	}
+}
+
+func TestValidateTemplateCreate(t *testing.T) {
+	// Git remotes are never constrained here.
+	if err := ValidateTemplateCreate("git@github.com:o/r.git", "feature/x", BackendCoder); err != nil {
+		t.Fatalf("git remote: %v", err)
+	}
+	if err := ValidateTemplateCreate("file:///home/me/proj", "", BackendDevcontainer); err != nil {
+		t.Fatalf("valid template: %v", err)
+	}
+	if err := ValidateTemplateCreate("file:///home/me/proj", "main", BackendDevcontainer); err == nil || !strings.Contains(err.Error(), "branch") {
+		t.Fatalf("template + branch: want branch error, got %v", err)
+	}
+	for _, b := range []BackendType{BackendCoder, BackendCodespaces} {
+		if err := ValidateTemplateCreate("file:///home/me/proj", "", b); err == nil || !strings.Contains(err.Error(), "devcontainer") {
+			t.Fatalf("template + %s: want backend error, got %v", b, err)
+		}
+	}
+	if err := ValidateTemplateCreate("file://relative", "", BackendDevcontainer); err == nil {
+		t.Fatal("relative template path should be rejected")
+	}
+}

--- a/internal/fleet/validate_fleet_name.go
+++ b/internal/fleet/validate_fleet_name.go
@@ -1,0 +1,28 @@
+package fleet
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// ValidateFleetName rejects names that cannot be embedded verbatim where a
+// fleet name ends up: the ~/.fleet/workspaces/<fleet> directory, container
+// names, and the fleet/instance target syntax. Template fleets are the first
+// place a user TYPES a fleet name (git fleets derive theirs from the URL), so
+// the rule lives here rather than in the dialog.
+func ValidateFleetName(name string) error {
+	if name == "" {
+		return fmt.Errorf("fleet name must not be empty")
+	}
+	if strings.ContainsFunc(name, unicode.IsSpace) {
+		return fmt.Errorf("fleet name %q must not contain spaces", name)
+	}
+	if strings.ContainsAny(name, "/\\") {
+		return fmt.Errorf("fleet name %q must not contain path separators", name)
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("fleet name %q is not allowed", name)
+	}
+	return nil
+}

--- a/internal/fleet/validate_fleet_name_test.go
+++ b/internal/fleet/validate_fleet_name_test.go
@@ -1,0 +1,16 @@
+package fleet
+
+import "testing"
+
+func TestValidateFleetName(t *testing.T) {
+	for _, bad := range []string{"", "a b", "a/b", `a\b`, ".", "..", "\tx"} {
+		if err := ValidateFleetName(bad); err == nil {
+			t.Errorf("ValidateFleetName(%q) = nil, want error", bad)
+		}
+	}
+	for _, good := range []string{"scratch", "my-proj", "proj_2", "a.b"} {
+		if err := ValidateFleetName(good); err != nil {
+			t.Errorf("ValidateFleetName(%q) = %v, want nil", good, err)
+		}
+	}
+}

--- a/internal/inspector/inspector.go
+++ b/internal/inspector/inspector.go
@@ -27,6 +27,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 )
 
 // ===========================================
@@ -44,14 +46,21 @@ var ErrNoDevcontainerConfig = errors.New("no devcontainer.json found")
 // ===========================================
 
 // Repo is a handle to a shallow-cloned local copy of a fleet's remote
-// repository. Checks read from Root either directly (path is a normal
-// filesystem location) or via the convenience helpers on this type.
+// repository — or, for a file:// template remote, to the template
+// directory itself. Checks read from Root either directly (path is a
+// normal filesystem location) or via the convenience helpers on this type.
 //
-// A Repo MUST be closed via Close to remove its on-disk clone.
+// A Repo MUST be closed via Close to remove its on-disk clone. Close is a
+// no-op for a template Repo (Keep): Root is the user's own directory.
 type Repo struct {
 	// Root is the absolute path to the working tree of the clone.
 	// Checks may read any file under this path.
 	Root string
+
+	// Keep marks Root as a directory this handle does NOT own — a file://
+	// template dir opened in place — so Close leaves it alone. Zero (a
+	// scratch clone, or a test-built Repo) keeps the remove-on-Close contract.
+	Keep bool
 }
 
 // ===========================================
@@ -71,6 +80,9 @@ func Open(remoteURL, branch string) (*Repo, error) {
 	if remoteURL == "" {
 		return nil, errors.New("remoteURL is empty")
 	}
+	if fleet.IsTemplateRemote(remoteURL) {
+		return openTemplate(remoteURL)
+	}
 	tmpDir, err := os.MkdirTemp("", "fleet-inspect-*")
 	if err != nil {
 		return nil, fmt.Errorf("creating temp dir: %w", err)
@@ -82,10 +94,29 @@ func Open(remoteURL, branch string) (*Repo, error) {
 	return &Repo{Root: tmpDir}, nil
 }
 
+// openTemplate points a Repo at a file:// template directory in place. There
+// is nothing to clone: the checks read the directory that provisioning will
+// copy, and the branch (if any) is ignored because a copy has no refs.
+func openTemplate(remoteURL string) (*Repo, error) {
+	dir, err := fleet.TemplateDir(remoteURL)
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("template dir: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("template path %s is not a directory", dir)
+	}
+	return &Repo{Root: dir, Keep: true}, nil
+}
+
 // Close removes the temporary clone associated with this Repo. Safe to
-// call on a nil receiver or a zero-value Repo.
+// call on a nil receiver or a zero-value Repo. A Keep Repo (a template dir,
+// the user's own directory rather than a scratch clone) is left untouched.
 func (r *Repo) Close() error {
-	if r == nil || r.Root == "" {
+	if r == nil || r.Root == "" || r.Keep {
 		return nil
 	}
 	return os.RemoveAll(r.Root)

--- a/internal/inspector/inspector.go
+++ b/internal/inspector/inspector.go
@@ -98,16 +98,9 @@ func Open(remoteURL, branch string) (*Repo, error) {
 // is nothing to clone: the checks read the directory that provisioning will
 // copy, and the branch (if any) is ignored because a copy has no refs.
 func openTemplate(remoteURL string) (*Repo, error) {
-	dir, err := fleet.TemplateDir(remoteURL)
+	dir, err := fleet.ResolveTemplateDir(remoteURL)
 	if err != nil {
 		return nil, err
-	}
-	info, err := os.Stat(dir)
-	if err != nil {
-		return nil, fmt.Errorf("template dir: %w", err)
-	}
-	if !info.IsDir() {
-		return nil, fmt.Errorf("template path %s is not a directory", dir)
 	}
 	return &Repo{Root: dir, Keep: true}, nil
 }

--- a/internal/inspector/inspector_test.go
+++ b/internal/inspector/inspector_test.go
@@ -93,6 +93,52 @@ func TestCloseRemovesRootDir(t *testing.T) {
 	}
 }
 
+// TestOpenTemplateUsesDirInPlace verifies the file:// path: no clone, Root
+// IS the template directory, and Close leaves the user's directory alone.
+func TestOpenTemplateUsesDirInPlace(t *testing.T) {
+	dir := t.TempDir()
+	dcDir := filepath.Join(dir, ".devcontainer")
+	if err := os.MkdirAll(dcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dcDir, "devcontainer.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repo, err := Open("file://"+dir, "ignored-branch")
+	if err != nil {
+		t.Fatalf("Open(file://): %v", err)
+	}
+	if repo.Root != dir {
+		t.Fatalf("Root = %q, want the template dir %q", repo.Root, dir)
+	}
+	if _, _, err := repo.FindDevcontainerJSON(); err != nil {
+		t.Fatalf("FindDevcontainerJSON on template: %v", err)
+	}
+	if err := repo.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := os.Stat(dcDir); err != nil {
+		t.Fatalf("Close must not delete the template dir: %v", err)
+	}
+}
+
+func TestOpenTemplateRejectsMissingOrFile(t *testing.T) {
+	if _, err := Open("file://"+filepath.Join(t.TempDir(), "nope"), ""); err == nil {
+		t.Fatal("missing template dir should error")
+	}
+	file := filepath.Join(t.TempDir(), "f.txt")
+	if err := os.WriteFile(file, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Open("file://"+file, ""); err == nil {
+		t.Fatal("template path that is a file should error")
+	}
+	if _, err := Open("file://relative/path", ""); err == nil {
+		t.Fatal("relative template path should error")
+	}
+}
+
 // TestCloseOnNilOrZeroValueIsSafe documents that Close is a no-op for
 // uninitialised receivers — the production code defers Close on the
 // success path of Open, but the helper should not panic if invoked on

--- a/internal/server/jobs.go
+++ b/internal/server/jobs.go
@@ -466,6 +466,9 @@ func (s *service) startCreateInstanceJob(req *fleetgrpc.CreateInstanceRequest, a
 		} else {
 			remote = f.Remote
 		}
+		if err := validateTemplateRemote(remote, req.GetBranch(), backendType); err != nil {
+			return err
+		}
 		if _, err := f.GetInstance(instanceName); err == nil {
 			return status.Errorf(codes.AlreadyExists, "instance %s/%s already exists", fleetName, instanceName)
 		}
@@ -492,6 +495,30 @@ func (s *service) startCreateInstanceJob(req *fleetgrpc.CreateInstanceRequest, a
 		return loadInstanceSnapshot(fleetName, instanceName), nil, err
 	})
 	return j, nil
+}
+
+// validateTemplateRemote fails a create FAST — before the StatusCreating record
+// exists — when the fleet's remote is a file:// template and the request asks
+// for something a copied directory cannot honor (a branch, a non-devcontainer
+// backend), or when the template directory is missing on THIS host. create.Run
+// re-checks the same rules; doing it here turns a would-be failed instance
+// record into an immediate RPC error for `fleet up` / the TUI / MCP.
+func validateTemplateRemote(remote, branch string, backendType fleet.BackendType) error {
+	if !fleet.IsTemplateRemote(remote) {
+		return nil
+	}
+	if err := fleet.ValidateTemplateCreate(remote, branch, backendType); err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+	dir, _ := fleet.TemplateDir(remote)
+	info, err := os.Stat(dir)
+	if err != nil {
+		return status.Errorf(codes.FailedPrecondition, "template dir %s: %v (the path is resolved on the fleet daemon's host)", dir, err)
+	}
+	if !info.IsDir() {
+		return status.Errorf(codes.FailedPrecondition, "template path %s is not a directory", dir)
+	}
+	return nil
 }
 
 // CreateInstance starts the provisioning job and relays its events.

--- a/internal/server/jobs.go
+++ b/internal/server/jobs.go
@@ -459,6 +459,12 @@ func (s *service) startCreateInstanceJob(req *fleetgrpc.CreateInstanceRequest, a
 			if req.Remote == nil || req.GetRemote() == "" {
 				return status.Errorf(codes.NotFound, "fleet %q not found and no remote provided", fleetName)
 			}
+			// New fleets only (an existing record keeps whatever name it has):
+			// the name becomes a workspace path component, so `..` or a slash
+			// would escape ~/.fleet/workspaces before anything is cloned/copied.
+			if err := fleet.ValidateFleetName(fleetName); err != nil {
+				return status.Error(codes.InvalidArgument, err.Error())
+			}
 			f = st.GetOrCreateFleet(fleetName, req.GetRemote())
 		}
 		if req.Remote != nil && req.GetRemote() != "" {
@@ -510,13 +516,10 @@ func validateTemplateRemote(remote, branch string, backendType fleet.BackendType
 	if err := fleet.ValidateTemplateCreate(remote, branch, backendType); err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
-	dir, _ := fleet.TemplateDir(remote)
-	info, err := os.Stat(dir)
-	if err != nil {
-		return status.Errorf(codes.FailedPrecondition, "template dir %s: %v (the path is resolved on the fleet daemon's host)", dir, err)
-	}
-	if !info.IsDir() {
-		return status.Errorf(codes.FailedPrecondition, "template path %s is not a directory", dir)
+	// ValidateTemplateCreate already parsed the URL, so a failure here is the
+	// directory itself (missing / not a dir) — a precondition on THIS host.
+	if _, err := fleet.ResolveTemplateDir(remote); err != nil {
+		return status.Error(codes.FailedPrecondition, err.Error())
 	}
 	return nil
 }

--- a/internal/server/jobs.go
+++ b/internal/server/jobs.go
@@ -469,6 +469,15 @@ func (s *service) startCreateInstanceJob(req *fleetgrpc.CreateInstanceRequest, a
 		}
 		if req.Remote != nil && req.GetRemote() != "" {
 			remote = req.GetRemote()
+			// A per-instance --repo may point at another git URL, but not
+			// change KIND: a template copy inside a git fleet (or a clone
+			// inside a template fleet) would leave the record describing
+			// something its instances are not.
+			if ok && fleet.IsTemplateRemote(remote) != fleet.IsTemplateRemote(f.Remote) {
+				return status.Errorf(codes.InvalidArgument,
+					"remote %q does not match fleet %q (%s): a fleet is either a git remote or a %s template, not both",
+					remote, fleetName, remoteKind(f.Remote), fleet.TemplateScheme)
+			}
 		} else {
 			remote = f.Remote
 		}
@@ -508,6 +517,14 @@ func (s *service) startCreateInstanceJob(req *fleetgrpc.CreateInstanceRequest, a
 		return loadInstanceSnapshot(fleetName, instanceName), nil, err
 	})
 	return j, nil
+}
+
+// remoteKind names a fleet remote's kind for error messages.
+func remoteKind(remote string) string {
+	if fleet.IsTemplateRemote(remote) {
+		return "template " + remote
+	}
+	return "git " + remote
 }
 
 // validateTemplateRemote fails a create FAST — before the StatusCreating record

--- a/internal/server/jobs.go
+++ b/internal/server/jobs.go
@@ -479,7 +479,7 @@ func (s *service) startCreateInstanceJob(req *fleetgrpc.CreateInstanceRequest, a
 		if req.GetBackend() == fleetgrpc.BackendType_BACKEND_TYPE_UNSPECIFIED && fleet.IsTemplateRemote(remote) {
 			backendType = fleet.BackendDevcontainer
 		}
-		if err := validateTemplateRemote(remote, req.GetBranch(), backendType); err != nil {
+		if err := validateTemplateRemote(remote, req.GetBranch(), backendType, wsDir); err != nil {
 			return err
 		}
 		if _, err := f.GetInstance(instanceName); err == nil {
@@ -516,7 +516,7 @@ func (s *service) startCreateInstanceJob(req *fleetgrpc.CreateInstanceRequest, a
 // backend), or when the template directory is missing on THIS host. create.Run
 // re-checks the same rules; doing it here turns a would-be failed instance
 // record into an immediate RPC error for `fleet up` / the TUI / MCP.
-func validateTemplateRemote(remote, branch string, backendType fleet.BackendType) error {
+func validateTemplateRemote(remote, branch string, backendType fleet.BackendType, wsDir string) error {
 	if !fleet.IsTemplateRemote(remote) {
 		return nil
 	}
@@ -525,8 +525,13 @@ func validateTemplateRemote(remote, branch string, backendType fleet.BackendType
 	}
 	// ValidateTemplateCreate already parsed the URL, so a failure here is the
 	// directory itself (missing / not a dir) — a precondition on THIS host.
-	if _, err := fleet.ResolveTemplateDir(remote); err != nil {
+	dir, err := fleet.ResolveTemplateDir(remote)
+	if err != nil {
 		return status.Error(codes.FailedPrecondition, err.Error())
+	}
+	// A template that contains its own workspace dir can never be copied.
+	if err := fleet.ValidateTemplateWorkspace(dir, wsDir); err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 	return nil
 }

--- a/internal/server/jobs.go
+++ b/internal/server/jobs.go
@@ -472,6 +472,13 @@ func (s *service) startCreateInstanceJob(req *fleetgrpc.CreateInstanceRequest, a
 		} else {
 			remote = f.Remote
 		}
+		// An UNSPECIFIED backend resolved to the host default (which may be
+		// coder) — for a template fleet, devcontainer is the only backend that
+		// can consume a copied directory, so narrow it the way the TUI's add-
+		// instance dialog does. An explicit coder/codespaces still fails fast.
+		if req.GetBackend() == fleetgrpc.BackendType_BACKEND_TYPE_UNSPECIFIED && fleet.IsTemplateRemote(remote) {
+			backendType = fleet.BackendDevcontainer
+		}
 		if err := validateTemplateRemote(remote, req.GetBranch(), backendType); err != nil {
 			return err
 		}

--- a/internal/server/jobs_template_test.go
+++ b/internal/server/jobs_template_test.go
@@ -96,11 +96,17 @@ func TestCreateInstanceTemplateRejections(t *testing.T) {
 	_, client, cleanup := newTestServer(t)
 	defer cleanup()
 
+	// The workspaces tree itself as the template: contains wsDir.
+	self := "file://" + state.WorkspacesDir()
+	if err := os.MkdirAll(state.WorkspacesDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	cases := []struct {
 		name string
 		req  *fleetgrpc.CreateInstanceRequest
 		code codes.Code
 	}{
+		{"ancestor of wsDir", &fleetgrpc.CreateInstanceRequest{Fleet: "t", Instance: "i", Remote: &self, Backend: fleetgrpc.BackendType_BACKEND_TYPE_DEVCONTAINER}, codes.InvalidArgument},
 		{"branch", &fleetgrpc.CreateInstanceRequest{Fleet: "t", Instance: "i", Remote: &remote, Branch: &branch, Backend: fleetgrpc.BackendType_BACKEND_TYPE_DEVCONTAINER}, codes.InvalidArgument},
 		{"coder", &fleetgrpc.CreateInstanceRequest{Fleet: "t", Instance: "i", Remote: &remote, Backend: fleetgrpc.BackendType_BACKEND_TYPE_CODER}, codes.InvalidArgument},
 		{"codespaces", &fleetgrpc.CreateInstanceRequest{Fleet: "t", Instance: "i", Remote: &remote, Backend: fleetgrpc.BackendType_BACKEND_TYPE_CODESPACES}, codes.InvalidArgument},

--- a/internal/server/jobs_template_test.go
+++ b/internal/server/jobs_template_test.go
@@ -1,0 +1,172 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// stubCreateJob replaces the provisioning seam with one that records the
+// remote it was handed and flips the instance to running.
+func stubCreateJob(t *testing.T) *string {
+	t.Helper()
+	var seen string
+	orig := jobRunCreate
+	jobRunCreate = func(fleetName, instanceName, remote, branch string, verbose bool, b fleet.BackendType) error {
+		seen = remote
+		return state.Update(func(st *state.State) error {
+			if f, ok := st.Fleets[fleetName]; ok {
+				if inst, err := f.GetInstance(instanceName); err == nil {
+					inst.Status = fleet.StatusRunning
+					inst.ContainerID = "fake-cid"
+				}
+			}
+			return nil
+		})
+	}
+	t.Cleanup(func() { jobRunCreate = orig })
+	return &seen
+}
+
+// createErr starts a CreateInstance stream and returns the error its first
+// Recv yields (job-start rejections surface there, before any JobStarted).
+func createErr(t *testing.T, client fleetgrpc.FleetServiceClient, req *fleetgrpc.CreateInstanceRequest) error {
+	t.Helper()
+	stream, err := client.CreateInstance(context.Background(), req)
+	if err != nil {
+		return err
+	}
+	_, err = stream.Recv()
+	return err
+}
+
+func TestCreateInstanceTemplateHappyPathCopiesNotClones(t *testing.T) {
+	isolateFleetDir(t)
+	seen := stubCreateJob(t)
+	tmpl := t.TempDir()
+	remote := "file://" + tmpl
+
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+
+	stream, err := client.CreateInstance(context.Background(), &fleetgrpc.CreateInstanceRequest{
+		Fleet: "scratch", Instance: "i1", Remote: &remote,
+		Backend: fleetgrpc.BackendType_BACKEND_TYPE_DEVCONTAINER,
+	})
+	if err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+	evs := drainJob(t, stream)
+	last := evs[len(evs)-1].GetDone()
+	if last == nil || !last.GetSuccess() {
+		t.Fatalf("want successful JobDone, got %v", evs[len(evs)-1])
+	}
+	if *seen != remote {
+		t.Fatalf("provisioner got remote %q, want the template URL %q", *seen, remote)
+	}
+	st, _ := state.Load()
+	if f := st.Fleets["scratch"]; f == nil || f.Remote != remote {
+		t.Fatalf("fleet record not created with the template remote: %+v", f)
+	}
+}
+
+// Rejections must land BEFORE the StatusCreating record exists so `fleet up`
+// gets an RPC error instead of a failed instance left behind in state.
+func TestCreateInstanceTemplateRejections(t *testing.T) {
+	isolateFleetDir(t)
+	stubCreateJob(t)
+	tmpl := t.TempDir()
+	remote := "file://" + tmpl
+	missing := "file://" + filepath.Join(t.TempDir(), "nope")
+	relative := "file://relative/dir"
+	branch := "main"
+	notADir := filepath.Join(t.TempDir(), "f.txt")
+	if err := os.WriteFile(notADir, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	notADirRemote := "file://" + notADir
+
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+
+	cases := []struct {
+		name string
+		req  *fleetgrpc.CreateInstanceRequest
+		code codes.Code
+	}{
+		{"branch", &fleetgrpc.CreateInstanceRequest{Fleet: "t", Instance: "i", Remote: &remote, Branch: &branch, Backend: fleetgrpc.BackendType_BACKEND_TYPE_DEVCONTAINER}, codes.InvalidArgument},
+		{"coder", &fleetgrpc.CreateInstanceRequest{Fleet: "t", Instance: "i", Remote: &remote, Backend: fleetgrpc.BackendType_BACKEND_TYPE_CODER}, codes.InvalidArgument},
+		{"codespaces", &fleetgrpc.CreateInstanceRequest{Fleet: "t", Instance: "i", Remote: &remote, Backend: fleetgrpc.BackendType_BACKEND_TYPE_CODESPACES}, codes.InvalidArgument},
+		{"relative", &fleetgrpc.CreateInstanceRequest{Fleet: "t", Instance: "i", Remote: &relative, Backend: fleetgrpc.BackendType_BACKEND_TYPE_DEVCONTAINER}, codes.InvalidArgument},
+		{"missing dir", &fleetgrpc.CreateInstanceRequest{Fleet: "t", Instance: "i", Remote: &missing, Backend: fleetgrpc.BackendType_BACKEND_TYPE_DEVCONTAINER}, codes.FailedPrecondition},
+		{"not a dir", &fleetgrpc.CreateInstanceRequest{Fleet: "t", Instance: "i", Remote: &notADirRemote, Backend: fleetgrpc.BackendType_BACKEND_TYPE_DEVCONTAINER}, codes.FailedPrecondition},
+	}
+	for _, tc := range cases {
+		err := createErr(t, client, tc.req)
+		if status.Code(err) != tc.code {
+			t.Errorf("%s: want %v, got %v", tc.name, tc.code, err)
+		}
+	}
+
+	st, _ := state.Load()
+	if f := st.Fleets["t"]; f != nil && len(f.Instances) > 0 {
+		t.Fatalf("rejected creates must not leave instance records: %+v", f.Instances)
+	}
+}
+
+// An existing template fleet enforces the same rules when the remote comes
+// from the fleet record rather than the request (the `fleet up` no --repo path).
+func TestCreateInstanceTemplateFleetRecordRejectsBranch(t *testing.T) {
+	isolateFleetDir(t)
+	stubCreateJob(t)
+	tmpl := t.TempDir()
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"scratch": {Name: "scratch", Remote: "file://" + tmpl},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+
+	branch := "feature/x"
+	err := createErr(t, client, &fleetgrpc.CreateInstanceRequest{
+		Fleet: "scratch", Instance: "i1", Branch: &branch,
+		Backend: fleetgrpc.BackendType_BACKEND_TYPE_DEVCONTAINER,
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("want InvalidArgument for branch on template fleet, got %v", err)
+	}
+	if err := createErr(t, client, &fleetgrpc.CreateInstanceRequest{
+		Fleet: "scratch", Instance: "i1", Backend: fleetgrpc.BackendType_BACKEND_TYPE_DEVCONTAINER,
+	}); err != nil {
+		t.Fatalf("plain create on template fleet should start: %v", err)
+	}
+}
+
+func TestInspectRepoTemplateDirInPlace(t *testing.T) {
+	isolateFleetDir(t)
+	root := fakeRepoDir(t, `{"remoteUser":"vscode"}`)
+	svc := newService()
+	reply, err := svc.InspectRepo(context.Background(), &fleetgrpc.InspectRepoRequest{RemoteUrl: "file://" + root})
+	if err != nil {
+		t.Fatalf("InspectRepo(template): %v", err)
+	}
+	if !reply.GetHasDevcontainer() {
+		t.Fatal("template with devcontainer.json reported as missing")
+	}
+	// The handler's deferred Close must not have removed the user's dir.
+	if _, err := os.Stat(filepath.Join(root, ".devcontainer", "devcontainer.json")); err != nil {
+		t.Fatalf("template dir was removed by inspection: %v", err)
+	}
+	_, err = svc.InspectRepo(context.Background(), &fleetgrpc.InspectRepoRequest{RemoteUrl: "file://" + filepath.Join(t.TempDir(), "nope")})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("missing template dir: want FailedPrecondition, got %v", err)
+	}
+}

--- a/internal/server/jobs_template_test.go
+++ b/internal/server/jobs_template_test.go
@@ -115,9 +115,65 @@ func TestCreateInstanceTemplateRejections(t *testing.T) {
 		}
 	}
 
+	// state.Update discards the whole mutation on error, so not even the
+	// fleet record may leak — assert that directly.
 	st, _ := state.Load()
-	if f := st.Fleets["t"]; f != nil && len(f.Instances) > 0 {
-		t.Fatalf("rejected creates must not leave instance records: %+v", f.Instances)
+	if f := st.Fleets["t"]; f != nil {
+		t.Fatalf("rejected creates must not leave a fleet record: %+v", f)
+	}
+}
+
+// A NEW fleet's name becomes a workspace path component, so the server (not
+// just the TUI dialog) must refuse names that escape ~/.fleet/workspaces.
+func TestCreateInstanceRejectsBadNewFleetName(t *testing.T) {
+	isolateFleetDir(t)
+	stubCreateJob(t)
+	remote := "file://" + t.TempDir()
+	git := "git@x:a.git"
+
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+
+	for _, name := range []string{"..", "a b", "a/b"} {
+		for _, r := range []*string{&remote, &git} {
+			err := createErr(t, client, &fleetgrpc.CreateInstanceRequest{
+				Fleet: name, Instance: "i", Remote: r, Backend: fleetgrpc.BackendType_BACKEND_TYPE_DEVCONTAINER,
+			})
+			if status.Code(err) != codes.InvalidArgument {
+				t.Errorf("fleet %q (remote %q): want InvalidArgument, got %v", name, *r, err)
+			}
+		}
+	}
+	st, _ := state.Load()
+	if len(st.Fleets) != 0 {
+		t.Fatalf("no fleet record may be created for a rejected name: %v", st.Fleets)
+	}
+
+	// An EXISTING record with an odd legacy name is still usable.
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"legacy name": {Name: "legacy name", Remote: git},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := createErr(t, client, &fleetgrpc.CreateInstanceRequest{
+		Fleet: "legacy name", Instance: "i", Backend: fleetgrpc.BackendType_BACKEND_TYPE_DEVCONTAINER,
+	}); err != nil {
+		t.Fatalf("existing fleet with a legacy name must not be blocked: %v", err)
+	}
+}
+
+func TestCreateFleetRejectsBadName(t *testing.T) {
+	isolateFleetDir(t)
+	svc := newService()
+	for _, name := range []string{"..", "a b", "a/b"} {
+		_, err := svc.CreateFleet(context.Background(), &fleetgrpc.CreateFleetRequest{Name: name, Remote: "git@x:a.git"})
+		if status.Code(err) != codes.InvalidArgument {
+			t.Errorf("CreateFleet(%q): want InvalidArgument, got %v", name, err)
+		}
+	}
+	st, _ := state.Load()
+	if len(st.Fleets) != 0 {
+		t.Fatalf("no fleet record may be created for a rejected name: %v", st.Fleets)
 	}
 }
 

--- a/internal/server/jobs_template_test.go
+++ b/internal/server/jobs_template_test.go
@@ -212,6 +212,39 @@ func TestCreateInstanceTemplateFleetRecordRejectsBranch(t *testing.T) {
 	}
 }
 
+// A per-instance --repo must not change the fleet's KIND: no template copy
+// inside a git fleet and no git clone inside a template fleet. Another git
+// URL on a git fleet (the pre-existing override) still works.
+func TestCreateInstanceRejectsMixedRemoteKinds(t *testing.T) {
+	isolateFleetDir(t)
+	stubCreateJob(t)
+	tmpl := "file://" + t.TempDir()
+	if err := state.Save(&state.State{Fleets: map[string]*fleet.Fleet{
+		"gitfleet": {Name: "gitfleet", Remote: "git@x:a.git"},
+		"tplfleet": {Name: "tplfleet", Remote: tmpl},
+	}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+
+	git := "git@x:other.git"
+	dev := fleetgrpc.BackendType_BACKEND_TYPE_DEVCONTAINER
+	if err := createErr(t, client, &fleetgrpc.CreateInstanceRequest{Fleet: "gitfleet", Instance: "i", Remote: &tmpl, Backend: dev}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("template --repo on a git fleet: want InvalidArgument, got %v", err)
+	}
+	if err := createErr(t, client, &fleetgrpc.CreateInstanceRequest{Fleet: "tplfleet", Instance: "i", Remote: &git, Backend: dev}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("git --repo on a template fleet: want InvalidArgument, got %v", err)
+	}
+	if err := createErr(t, client, &fleetgrpc.CreateInstanceRequest{Fleet: "gitfleet", Instance: "i", Remote: &git, Backend: dev}); err != nil {
+		t.Fatalf("another git URL on a git fleet must still be accepted: %v", err)
+	}
+	st, _ := state.Load()
+	if n := len(st.Fleets["tplfleet"].Instances); n != 0 {
+		t.Fatalf("rejected create left %d instance(s) on tplfleet", n)
+	}
+}
+
 func TestInspectRepoTemplateDirInPlace(t *testing.T) {
 	isolateFleetDir(t)
 	root := fakeRepoDir(t, `{"remoteUser":"vscode"}`)

--- a/internal/server/jobs_template_test.go
+++ b/internal/server/jobs_template_test.go
@@ -226,3 +226,45 @@ func TestInspectRepoTemplateDirInPlace(t *testing.T) {
 		t.Fatalf("missing template dir: want FailedPrecondition, got %v", err)
 	}
 }
+
+// An UNSPECIFIED backend normally resolves to the host default; for a template
+// remote it must narrow to devcontainer (as the TUI does) instead of failing
+// with "requires the devcontainer backend (got coder)". An explicit coder is
+// still rejected.
+func TestCreateInstanceTemplateNarrowsUnspecifiedBackend(t *testing.T) {
+	isolateFleetDir(t)
+	seen := stubCreateJob(t)
+	if err := state.SaveConfig(&state.Config{DefaultBackend: string(fleet.BackendCoder)}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	remote := "file://" + t.TempDir()
+
+	_, client, cleanup := newTestServer(t)
+	defer cleanup()
+
+	stream, err := client.CreateInstance(context.Background(), &fleetgrpc.CreateInstanceRequest{
+		Fleet: "scratch", Instance: "i1", Remote: &remote,
+	})
+	if err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
+	evs := drainJob(t, stream)
+	last := evs[len(evs)-1].GetDone()
+	if last == nil || !last.GetSuccess() {
+		t.Fatalf("want successful JobDone, got %v", evs[len(evs)-1])
+	}
+	if last.GetInstance().GetBackend() != fleetgrpc.BackendType_BACKEND_TYPE_DEVCONTAINER {
+		t.Fatalf("instance backend = %v, want devcontainer for a template with an unspecified backend", last.GetInstance().GetBackend())
+	}
+	if *seen != remote {
+		t.Fatalf("provisioner got remote %q", *seen)
+	}
+
+	// Explicit coder is still a fast-fail.
+	err = createErr(t, client, &fleetgrpc.CreateInstanceRequest{
+		Fleet: "scratch", Instance: "i2", Backend: fleetgrpc.BackendType_BACKEND_TYPE_CODER,
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("explicit coder on a template fleet: want InvalidArgument, got %v", err)
+	}
+}

--- a/internal/server/mcp_tools.go
+++ b/internal/server/mcp_tools.go
@@ -68,7 +68,7 @@ func registerMCPTools(srv *mcp.Server, s *service) {
 	// --- lifecycle ---
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "fleet_up",
-		Description: "Create (provision) a new instance in a fleet. Returns immediately with a job_id to poll via fleet_job_status (provisioning takes minutes); pass wait:true to block until done instead. Provide remote (git URL) when creating the first instance of a new fleet.",
+		Description: "Create (provision) a new instance in a fleet. Returns immediately with a job_id to poll via fleet_job_status (provisioning takes minutes); pass wait:true to block until done instead. Provide remote (a git URL, or file:///abs/dir for a local template directory that is copied per instance) when creating the first instance of a new fleet.",
 	}, s.mcpUp)
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "fleet_start",
@@ -365,8 +365,8 @@ func (s *service) mcpLogs(ctx context.Context, _ *mcp.CallToolRequest, in FleetL
 type FleetUpInput struct {
 	Fleet    string `json:"fleet" jsonschema:"fleet name"`
 	Instance string `json:"instance" jsonschema:"instance name"`
-	Remote   string `json:"remote,omitempty" jsonschema:"git remote URL; required only when creating the first instance of a new fleet"`
-	Branch   string `json:"branch,omitempty" jsonschema:"git branch to check out; defaults to the repository's default branch"`
+	Remote   string `json:"remote,omitempty" jsonschema:"git remote URL, or file:///abs/dir naming a local template directory on the daemon host that is copied into each instance instead of cloned; required only when creating the first instance of a new fleet"`
+	Branch   string `json:"branch,omitempty" jsonschema:"git branch to check out; defaults to the repository's default branch. Not allowed for a file:// template fleet"`
 	Backend  string `json:"backend,omitempty" jsonschema:"backend type: devcontainer (default), coder, or codespaces"`
 	Wait     bool   `json:"wait,omitempty" jsonschema:"block until provisioning completes instead of returning a job handle immediately; provisioning takes minutes, so only set this with a generous tool-call timeout"`
 }

--- a/internal/server/mutations.go
+++ b/internal/server/mutations.go
@@ -55,6 +55,13 @@ func (s *service) CreateFleet(_ context.Context, req *fleetgrpc.CreateFleetReque
 		return nil, status.Error(codes.InvalidArgument, "fleet name required")
 	}
 	snapshot, err := s.mutate(func(st *state.State) error {
+		// Get-or-create: only a NEW record takes the name into a workspace
+		// path, so only that branch is gated on ValidateFleetName.
+		if _, exists := st.Fleets[req.GetName()]; !exists {
+			if err := fleet.ValidateFleetName(req.GetName()); err != nil {
+				return status.Error(codes.InvalidArgument, err.Error())
+			}
+		}
 		st.GetOrCreateFleet(req.GetName(), req.GetRemote())
 		return nil
 	})

--- a/internal/state/paths.go
+++ b/internal/state/paths.go
@@ -143,10 +143,13 @@ func WriteWarn(fleetName, instanceName, warning string) {
 // the best-effort provisioning steps that WriteWarn around it — while keeping
 // their text in the file. Recorded to the event log like WriteWarn.
 func PrependWarn(fleetName, instanceName, warning string) {
+	banner := warning
 	if existing, err := os.ReadFile(WarnPath(fleetName, instanceName)); err == nil && len(existing) > 0 {
-		warning = warning + "\n" + string(existing)
+		banner = warning + "\n" + string(existing)
 	}
-	writeWarnFile(fleetName, instanceName, warning)
+	writeWarnFile(fleetName, instanceName, banner)
+	// Only the NEW warning goes to fleet.log; the existing banner text was
+	// logged when it was written.
 	flog.Warn("instance warning", "fleet", fleetName, "instance", instanceName, "warn", warning)
 }
 

--- a/internal/state/paths.go
+++ b/internal/state/paths.go
@@ -137,6 +137,19 @@ func WriteWarn(fleetName, instanceName, warning string) {
 	flog.Warn("instance warning", "fleet", fleetName, "instance", instanceName, "warn", warning)
 }
 
+// PrependWarn puts warning in FRONT of the instance's existing banner (if any)
+// instead of replacing it. The TUI surfaces the banner's first line once the
+// instance is running, so this is for a warning that must not be shadowed by
+// the best-effort provisioning steps that WriteWarn around it — while keeping
+// their text in the file. Recorded to the event log like WriteWarn.
+func PrependWarn(fleetName, instanceName, warning string) {
+	if existing, err := os.ReadFile(WarnPath(fleetName, instanceName)); err == nil && len(existing) > 0 {
+		warning = warning + "\n" + string(existing)
+	}
+	writeWarnFile(fleetName, instanceName, warning)
+	flog.Warn("instance warning", "fleet", fleetName, "instance", instanceName, "warn", warning)
+}
+
 // WriteWarnQuiet writes the banner WITHOUT an event-log record. Poll loops
 // use this so a persistently-failing per-tick warning cannot flood fleet.log.
 func WriteWarnQuiet(fleetName, instanceName, warning string) {

--- a/internal/state/prepend_warn_test.go
+++ b/internal/state/prepend_warn_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+// (fleet.log gets only the new warning; the banner file gets both — see
+// PrependWarn.)
 func TestPrependWarnKeepsExistingBanner(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/state/prepend_warn_test.go
+++ b/internal/state/prepend_warn_test.go
@@ -1,0 +1,30 @@
+package state
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPrependWarnKeepsExistingBanner(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// No existing banner: plain write.
+	PrependWarn("f", "i", "first")
+	got, err := os.ReadFile(WarnPath("f", "i"))
+	if err != nil || string(got) != "first" {
+		t.Fatalf("banner = %q, %v; want %q", got, err, "first")
+	}
+
+	// Existing banner: the new warning leads, the old text survives.
+	WriteWarn("f", "i", "dotfiles failed\ndetails")
+	PrependWarn("f", "i", "template warning")
+	got, _ = os.ReadFile(WarnPath("f", "i"))
+	lines := strings.Split(string(got), "\n")
+	if lines[0] != "template warning" {
+		t.Fatalf("first line = %q, want the prepended warning", lines[0])
+	}
+	if !strings.Contains(string(got), "dotfiles failed\ndetails") {
+		t.Fatalf("existing banner lost: %q", got)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -546,12 +546,13 @@ func (m *model) pruneOrphanedSavedGroups() {
 
 // firstFleetRepo returns the "owner/repo" string for the first fleet's
 // remote URL, or "" if no fleets exist. Used to query GitHub APIs.
+// file:// template fleets are skipped: a local path has no GitHub repo.
 func (m *model) firstFleetRepo() string {
 	if m.st == nil {
 		return ""
 	}
 	for _, f := range m.st.Fleets {
-		if f.Remote != "" {
+		if f.Remote != "" && !fleet.IsTemplateRemote(f.Remote) {
 			return repoFromRemote(f.Remote)
 		}
 	}

--- a/internal/tui/dialog_add_fleet.go
+++ b/internal/tui/dialog_add_fleet.go
@@ -61,6 +61,10 @@ func (fleetPage *fleetPage) updateAddFleet(m *model, msg tea.Msg) tea.Cmd {
 // or in updateAddFleetNoDevcontainer's Setup branch (devcontainer
 // missing but user opted into the agent flow). Aborting either dialog
 // after this point therefore leaves no trace in state.
+//
+// A file:// template URL detours through the name prompt first
+// (viewAddFleetName): a local directory carries no repo name to derive the
+// fleet name from, so the user has to supply one before inspection runs.
 func (fleetPage *fleetPage) saveAddFleet(m *model) tea.Cmd {
 	repoURL := strings.TrimSpace(fleetPage.textInput.Value())
 	if repoURL == "" {
@@ -68,6 +72,9 @@ func (fleetPage *fleetPage) saveAddFleet(m *model) tea.Cmd {
 		fleetPage.mode = viewNormal
 		fleetPage.blurDialogFields()
 		return nil
+	}
+	if fleet.IsTemplateRemote(repoURL) {
+		return fleetPage.promptAddFleetName(m, repoURL)
 	}
 	fleetName := fleet.FleetNameFromRemote(repoURL)
 	if fleetName == "" {
@@ -78,6 +85,90 @@ func (fleetPage *fleetPage) saveAddFleet(m *model) tea.Cmd {
 	}
 
 	fleetPage.addFleet.pendingRepoURL = repoURL
+	fleetPage.addFleet.pendingFleetName = fleetName
+	fleetPage.mode = viewAddFleetInspecting
+	fleetPage.blurDialogFields()
+	m.message = fmt.Sprintf("Inspecting %s...", repoURL)
+	return inspectDevcontainerCmd(fleetName, repoURL)
+}
+
+// ===========================================
+// Template Fleet Name Prompt
+// ===========================================
+
+// promptAddFleetName validates the template URL's shape (an absolute path is
+// the only thing the client can check — the directory itself lives on the
+// daemon host and is verified by the inspection) and switches to the
+// fleet-name prompt, pre-filled with the directory's base name as a
+// suggestion the user can accept or overwrite.
+func (fleetPage *fleetPage) promptAddFleetName(m *model, repoURL string) tea.Cmd {
+	if _, err := fleet.TemplateDir(repoURL); err != nil {
+		// Keep the dialog open so the user can fix the URL in place.
+		m.message = err.Error()
+		return nil
+	}
+	fleetPage.addFleet.pendingRepoURL = repoURL
+	fleetPage.mode = viewAddFleetName
+	fleetPage.textInput.SetValue(fleet.TemplateNameHint(repoURL))
+	fleetPage.textInput.Placeholder = "fleet-name"
+	fleetPage.textInput.CharLimit = 64
+	fleetPage.textInput.CursorEnd()
+	m.message = ""
+	return fleetPage.activateTextInput()
+}
+
+// updateAddFleetName handles the fleet-name prompt shown for a file://
+// template URL. Same key contract as the URL step: enter submits, esc leaves
+// the field, q/esc/ctrl+c cancel the whole new-fleet flow.
+func (fleetPage *fleetPage) updateAddFleetName(m *model, msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if fleetPage.dlg.fieldActive {
+			switch msg.String() {
+			case "enter":
+				return fleetPage.saveAddFleetName(m)
+			case "esc":
+				fleetPage.deactivateTextInput()
+				return nil
+			case "ctrl+c":
+				fleetPage.clearPendingFleet()
+				return fleetPage.cancelTextDialog(m)
+			}
+			var cmd tea.Cmd
+			fleetPage.textInput, cmd = fleetPage.textInput.Update(msg)
+			return cmd
+		}
+
+		switch msg.String() {
+		case "enter", " ":
+			return fleetPage.activateTextInput()
+		case "esc", "q", "Q", "ctrl+c":
+			fleetPage.clearPendingFleet()
+			return fleetPage.cancelTextDialog(m)
+		}
+		if isDialogTextKey(msg) {
+			return fleetPage.activateTextInputWithMsg(msg)
+		}
+	}
+	return nil
+}
+
+// saveAddFleetName validates the typed fleet name and continues into the
+// same inspection the git path runs (against the template dir, on the daemon
+// host). An existing fleet name is refused rather than silently reused:
+// CreateFleet is get-or-create, so "adding" it would keep the OTHER fleet's
+// remote and the user's template would never be copied.
+func (fleetPage *fleetPage) saveAddFleetName(m *model) tea.Cmd {
+	fleetName := strings.TrimSpace(fleetPage.textInput.Value())
+	if err := fleet.ValidateFleetName(fleetName); err != nil {
+		m.message = err.Error()
+		return nil
+	}
+	if _, exists := m.st.Fleets[fleetName]; exists {
+		m.message = fmt.Sprintf("Fleet %s already exists", fleetName)
+		return nil
+	}
+	repoURL := fleetPage.addFleet.pendingRepoURL
 	fleetPage.addFleet.pendingFleetName = fleetName
 	fleetPage.mode = viewAddFleetInspecting
 	fleetPage.blurDialogFields()
@@ -165,7 +256,13 @@ func (fleetPage *fleetPage) handleDevcontainerInspected(m *model, msg devcontain
 	}
 
 	if msg.err != nil {
+		// Back to the URL step. The template name prompt reuses textInput,
+		// so put the URL back where the user expects to correct it.
 		fleetPage.mode = viewAddFleet
+		fleetPage.textInput.SetValue(fleetPage.addFleet.pendingRepoURL)
+		fleetPage.textInput.Placeholder = addFleetURLPlaceholder
+		fleetPage.textInput.CharLimit = 256
+		fleetPage.textInput.CursorEnd()
 		fleetPage.textInput.Focus()
 		m.message = fmt.Sprintf("Could not inspect repo: %v", msg.err)
 		return fleetPage.textInput.Cursor.BlinkCmd()
@@ -288,14 +385,49 @@ type addFleetState struct {
 	pendingFleetName string
 }
 
+// addFleetURLPlaceholder is the New fleet dialog's URL placeholder; the
+// inspection error path re-applies it after the template name prompt has
+// borrowed the input.
+const addFleetURLPlaceholder = "git@github.com:org/repo.git"
+
+// addFleetSourceLabel names the pending source in the inspect / no-devcontainer
+// dialogs: a template dir is copied, not cloned, so calling it "Repo" would
+// misdescribe what fleet is about to do with it.
+func (fleetPage *fleetPage) addFleetSourceLabel() string {
+	if fleet.IsTemplateRemote(fleetPage.addFleet.pendingRepoURL) {
+		return "Template:"
+	}
+	return "Repo:    "
+}
+
 func (fleetPage *fleetPage) renderAddFleetDialog(m *model) string {
 	var b strings.Builder
 	b.WriteString("\n")
 	dialog := fmt.Sprintf(
-		"%s\n\n%s %s\n\n%s",
+		"%s\n\n%s %s\n\n%s\n%s",
 		dialogTitle.Render("New fleet"),
 		dialogLabel.Render("Repo:"),
 		fleetPage.textInput.View(),
+		dimStyle.Render("git URL to clone, or file:///abs/dir to copy a local template dir into each instance"),
+		dialogHint.Render(fleetPage.textDialogHint("Add")),
+	)
+	b.WriteString(dialogBox.Render(dialog))
+	b.WriteString("\n")
+
+	return b.String()
+}
+
+func (fleetPage *fleetPage) renderAddFleetNameDialog(m *model) string {
+	var b strings.Builder
+	b.WriteString("\n")
+	dialog := fmt.Sprintf(
+		"%s\n\n%s %s\n%s %s\n\n%s\n%s",
+		dialogTitle.Render("New fleet"),
+		dialogLabel.Render("Template:"),
+		fleetExpandedStyle.Render(fleetPage.addFleet.pendingRepoURL),
+		dialogLabel.Render("Name:    "),
+		fleetPage.textInput.View(),
+		dimStyle.Render("a local dir has no repo name to derive the fleet name from — pick one"),
 		dialogHint.Render(fleetPage.textDialogHint("Add")),
 	)
 	b.WriteString(dialogBox.Render(dialog))
@@ -310,7 +442,7 @@ func (fleetPage *fleetPage) renderAddFleetInspectingDialog(m *model) string {
 	dialog := fmt.Sprintf(
 		"%s\n\n%s %s\n\n%s %s\n\n%s",
 		dialogTitle.Render("New fleet"),
-		dialogLabel.Render("Repo: "),
+		dialogLabel.Render(fleetPage.addFleetSourceLabel()),
 		fleetExpandedStyle.Render(fleetPage.addFleet.pendingRepoURL),
 		m.spinner.View(),
 		dialogLabel.Render("Inspecting for devcontainer.json..."),
@@ -341,7 +473,7 @@ func (fleetPage *fleetPage) renderAddFleetNoDevcontainerDialog(m *model) string 
 			"This repository has no .devcontainer/devcontainer.json.\n"+
 				"fleet-man needs one before it can provision instances.",
 		),
-		dialogLabel.Render("Repo:"),
+		dialogLabel.Render(fleetPage.addFleetSourceLabel()),
 		fleetExpandedStyle.Render(fleetPage.addFleet.pendingRepoURL),
 		dialogLabel.Render("Setup agent: ")+setupLine,
 		dialogLabel.Render(

--- a/internal/tui/dialog_add_fleet.go
+++ b/internal/tui/dialog_add_fleet.go
@@ -118,8 +118,9 @@ func (fleetPage *fleetPage) promptAddFleetName(m *model, repoURL string) tea.Cmd
 }
 
 // updateAddFleetName handles the fleet-name prompt shown for a file://
-// template URL. Same key contract as the URL step: enter submits, esc leaves
-// the field, q/esc/ctrl+c cancel the whole new-fleet flow.
+// template URL. Inside the field: enter submits, esc leaves the field,
+// ctrl+c cancels. With the field inactive: esc goes BACK to the URL step (so
+// a typo in the path can be fixed without starting over), q/ctrl+c cancel.
 func (fleetPage *fleetPage) updateAddFleetName(m *model, msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
@@ -142,7 +143,9 @@ func (fleetPage *fleetPage) updateAddFleetName(m *model, msg tea.Msg) tea.Cmd {
 		switch msg.String() {
 		case "enter", " ":
 			return fleetPage.activateTextInput()
-		case "esc", "q", "Q", "ctrl+c":
+		case "esc":
+			return fleetPage.returnToAddFleetURL(m)
+		case "q", "Q", "ctrl+c":
 			fleetPage.clearPendingFleet()
 			return fleetPage.cancelTextDialog(m)
 		}
@@ -151,6 +154,19 @@ func (fleetPage *fleetPage) updateAddFleetName(m *model, msg tea.Msg) tea.Cmd {
 		}
 	}
 	return nil
+}
+
+// returnToAddFleetURL reopens the URL step with the pending URL back in the
+// input. The name prompt borrows textInput for the fleet name, so both the
+// esc-back key and the inspection error path need this restore.
+func (fleetPage *fleetPage) returnToAddFleetURL(m *model) tea.Cmd {
+	fleetPage.mode = viewAddFleet
+	fleetPage.textInput.SetValue(fleetPage.addFleet.pendingRepoURL)
+	fleetPage.textInput.Placeholder = addFleetURLPlaceholder
+	fleetPage.textInput.CharLimit = 256
+	fleetPage.textInput.CursorEnd()
+	fleetPage.textInput.Focus()
+	return fleetPage.textInput.Cursor.BlinkCmd()
 }
 
 // saveAddFleetName validates the typed fleet name and continues into the
@@ -256,16 +272,10 @@ func (fleetPage *fleetPage) handleDevcontainerInspected(m *model, msg devcontain
 	}
 
 	if msg.err != nil {
-		// Back to the URL step. The template name prompt reuses textInput,
-		// so put the URL back where the user expects to correct it.
-		fleetPage.mode = viewAddFleet
-		fleetPage.textInput.SetValue(fleetPage.addFleet.pendingRepoURL)
-		fleetPage.textInput.Placeholder = addFleetURLPlaceholder
-		fleetPage.textInput.CharLimit = 256
-		fleetPage.textInput.CursorEnd()
-		fleetPage.textInput.Focus()
+		// Back to the URL step (with the URL restored — the template name
+		// prompt reuses textInput) so the user can correct it in place.
 		m.message = fmt.Sprintf("Could not inspect repo: %v", msg.err)
-		return fleetPage.textInput.Cursor.BlinkCmd()
+		return fleetPage.returnToAddFleetURL(m)
 	}
 
 	if msg.hasDevcontainer {
@@ -417,6 +427,15 @@ func (fleetPage *fleetPage) renderAddFleetDialog(m *model) string {
 	return b.String()
 }
 
+// addFleetNameHint is textDialogHint plus the name prompt's extra key: esc
+// with the field inactive returns to the URL step instead of cancelling.
+func (fleetPage *fleetPage) addFleetNameHint() string {
+	if fleetPage.dlg.fieldActive {
+		return fleetPage.textDialogHint("Add")
+	}
+	return "[enter] Edit  [esc] Back  [q] Cancel"
+}
+
 func (fleetPage *fleetPage) renderAddFleetNameDialog(m *model) string {
 	var b strings.Builder
 	b.WriteString("\n")
@@ -428,7 +447,7 @@ func (fleetPage *fleetPage) renderAddFleetNameDialog(m *model) string {
 		dialogLabel.Render("Name:    "),
 		fleetPage.textInput.View(),
 		dimStyle.Render("a local dir has no repo name to derive the fleet name from — pick one"),
-		dialogHint.Render(fleetPage.textDialogHint("Add")),
+		dialogHint.Render(fleetPage.addFleetNameHint()),
 	)
 	b.WriteString(dialogBox.Render(dialog))
 	b.WriteString("\n")

--- a/internal/tui/dialog_add_fleet.go
+++ b/internal/tui/dialog_add_fleet.go
@@ -163,9 +163,11 @@ func (fleetPage *fleetPage) updateAddFleetName(m *model, msg tea.Msg) tea.Cmd {
 // this restore.
 func (fleetPage *fleetPage) returnToAddFleetURL(m *model) tea.Cmd {
 	fleetPage.mode = viewAddFleet
-	fleetPage.textInput.SetValue(fleetPage.addFleet.pendingRepoURL)
-	fleetPage.textInput.Placeholder = addFleetURLPlaceholder
+	// CharLimit FIRST: SetValue truncates to the current limit, and the name
+	// prompt left it at 64 — a longer path would come back silently cut.
 	fleetPage.textInput.CharLimit = 256
+	fleetPage.textInput.Placeholder = addFleetURLPlaceholder
+	fleetPage.textInput.SetValue(fleetPage.addFleet.pendingRepoURL)
 	fleetPage.textInput.CursorEnd()
 	return fleetPage.activateTextInput()
 }

--- a/internal/tui/dialog_add_fleet.go
+++ b/internal/tui/dialog_add_fleet.go
@@ -157,16 +157,17 @@ func (fleetPage *fleetPage) updateAddFleetName(m *model, msg tea.Msg) tea.Cmd {
 }
 
 // returnToAddFleetURL reopens the URL step with the pending URL back in the
-// input. The name prompt borrows textInput for the fleet name, so both the
-// esc-back key and the inspection error path need this restore.
+// input and the field ACTIVE (cursor and "[esc] Done editing" hint agree, and
+// the user can type straight away). The name prompt borrows textInput for the
+// fleet name, so both the esc-back key and the inspection error path need
+// this restore.
 func (fleetPage *fleetPage) returnToAddFleetURL(m *model) tea.Cmd {
 	fleetPage.mode = viewAddFleet
 	fleetPage.textInput.SetValue(fleetPage.addFleet.pendingRepoURL)
 	fleetPage.textInput.Placeholder = addFleetURLPlaceholder
 	fleetPage.textInput.CharLimit = 256
 	fleetPage.textInput.CursorEnd()
-	fleetPage.textInput.Focus()
-	return fleetPage.textInput.Cursor.BlinkCmd()
+	return fleetPage.activateTextInput()
 }
 
 // saveAddFleetName validates the typed fleet name and continues into the

--- a/internal/tui/dialog_add_fleet.go
+++ b/internal/tui/dialog_add_fleet.go
@@ -478,19 +478,26 @@ func (fleetPage *fleetPage) renderAddFleetNoDevcontainerDialog(m *model) string 
 	var b strings.Builder
 	b.WriteString("\n")
 	agentName, _, agentErr := devcontainersetup.FindAgent()
+	// A template is a local dir: the agent works in it directly, nothing is
+	// cloned. Keep the copy honest about which one this is.
+	isTemplate := fleet.IsTemplateRemote(fleetPage.addFleet.pendingRepoURL)
+	sourceNoun, setupVerb := "repository", "will clone the repo and walk you through configuration"
+	if isTemplate {
+		sourceNoun, setupVerb = "template dir", "will work in the template dir and walk you through configuration"
+	}
 	var setupLine string
 	if agentErr != nil {
 		setupLine = statusCreatingStyle.Render("no agent found") +
 			"  " + dimStyle.Render("install claude, codex, gemini, or copilot to use Setup")
 	} else {
 		setupLine = statusRunningStyle.Render(agentName) +
-			"  " + dimStyle.Render("will clone the repo and walk you through configuration")
+			"  " + dimStyle.Render(setupVerb)
 	}
 	dialog := fmt.Sprintf(
 		"%s\n\n%s\n\n%s %s\n\n%s\n\n%s\n\n%s",
 		warnBanner.Render("  No devcontainer.json found  "),
 		dialogLabel.Render(
-			"This repository has no .devcontainer/devcontainer.json.\n"+
+			"This "+sourceNoun+" has no .devcontainer/devcontainer.json.\n"+
 				"fleet-man needs one before it can provision instances.",
 		),
 		dialogLabel.Render(fleetPage.addFleetSourceLabel()),

--- a/internal/tui/dialog_add_fleet.go
+++ b/internal/tui/dialog_add_fleet.go
@@ -181,9 +181,13 @@ func (fleetPage *fleetPage) saveAddFleetName(m *model) tea.Cmd {
 		m.message = err.Error()
 		return nil
 	}
-	if _, exists := m.st.Fleets[fleetName]; exists {
-		m.message = fmt.Sprintf("Fleet %s already exists", fleetName)
-		return nil
+	// m.st is nil until the first state snapshot lands; the server's
+	// get-or-create still applies then, this check is only the early UX.
+	if m.st != nil {
+		if _, exists := m.st.Fleets[fleetName]; exists {
+			m.message = fmt.Sprintf("Fleet %s already exists", fleetName)
+			return nil
+		}
 	}
 	repoURL := fleetPage.addFleet.pendingRepoURL
 	fleetPage.addFleet.pendingFleetName = fleetName

--- a/internal/tui/dialog_add_fleet_template_test.go
+++ b/internal/tui/dialog_add_fleet_template_test.go
@@ -118,6 +118,21 @@ func TestAddFleetNameRejectsInvalidOrExisting(t *testing.T) {
 	}
 }
 
+// Before the first state snapshot m.st is nil; a fast n → file:// → Enter →
+// Enter must not panic (the server's get-or-create still applies).
+func TestAddFleetNameSubmitWithNilState(t *testing.T) {
+	fp := newFleetPage()
+	m := &model{fleetPage: fp}
+	fp.mode = viewAddFleetName
+	fp.addFleet.pendingRepoURL = "file:///home/me/scratch"
+	fp.textInput.SetValue("scratch")
+	fp.dlg.fieldActive = true
+
+	if cmd := fp.saveAddFleetName(m); cmd == nil || fp.mode != viewAddFleetInspecting {
+		t.Fatalf("nil state: mode=%v cmd=%v, want inspecting with a cmd", fp.mode, cmd != nil)
+	}
+}
+
 func TestAddFleetNameCancelClearsPending(t *testing.T) {
 	for _, key := range []tea.KeyMsg{{Type: tea.KeyRunes, Runes: []rune{'q'}}, {Type: tea.KeyCtrlC}} {
 		fp, m := newAddFleetModel(map[string]*fleet.Fleet{})

--- a/internal/tui/dialog_add_fleet_template_test.go
+++ b/internal/tui/dialog_add_fleet_template_test.go
@@ -155,9 +155,14 @@ func TestAddFleetNameCancelClearsPending(t *testing.T) {
 // template URL restored so a path typo can be fixed without starting over.
 func TestAddFleetNameEscGoesBackToURLStep(t *testing.T) {
 	fp, m := newAddFleetModel(map[string]*fleet.Fleet{})
-	fp.mode = viewAddFleetName
-	fp.addFleet.pendingRepoURL = "file:///home/me/scratch"
-	fp.textInput.SetValue("scratch")
+	// Longer than the name prompt's 64-rune CharLimit: the restore must not
+	// truncate it (a cut path can name a DIFFERENT existing directory).
+	longURL := "file:///home/benjamin/projects/experiments/scratch/very-long-project-name-v2"
+	fp.mode = viewAddFleet
+	fp.textInput.CharLimit = 256 // as the 'n' key sets it before typing
+	fp.textInput.SetValue(longURL)
+	fp.dlg.fieldActive = true
+	fp.saveAddFleet(m) // → name prompt, CharLimit 64
 	fp.dlg.fieldActive = false
 
 	if view := fp.renderAddFleetNameDialog(m); !strings.Contains(view, "[esc] Back") {
@@ -168,8 +173,8 @@ func TestAddFleetNameEscGoesBackToURLStep(t *testing.T) {
 	if fp.mode != viewAddFleet {
 		t.Fatalf("mode = %v, want viewAddFleet", fp.mode)
 	}
-	if got := fp.textInput.Value(); got != "file:///home/me/scratch" {
-		t.Fatalf("textInput = %q, want the template URL restored", got)
+	if got := fp.textInput.Value(); got != longURL {
+		t.Fatalf("textInput = %q, want the full template URL restored (%d runes)", got, len([]rune(longURL)))
 	}
 	if !fp.dlg.fieldActive {
 		t.Fatal("URL field should come back active so the cursor and hint agree")
@@ -321,6 +326,15 @@ func TestEditInstanceTemplateShowsBranchNA(t *testing.T) {
 	}
 	if strings.Contains(view, "default") {
 		t.Fatalf("edit dialog must not show a 'default' branch for a template instance:\n%s", view)
+	}
+
+	// A recorded branch (an instance from before mixed-kind --repo was
+	// rejected) is never hidden behind the n/a text.
+	f.Instances[0].Branch = "main"
+	fp.openEditInstanceDialog(m)
+	view = fp.renderAddInstanceDialog(m)
+	if !strings.Contains(view, "main") || strings.Contains(view, templateBranchDisplay) {
+		t.Fatalf("edit dialog should show the recorded branch, not n/a:\n%s", view)
 	}
 }
 

--- a/internal/tui/dialog_add_fleet_template_test.go
+++ b/internal/tui/dialog_add_fleet_template_test.go
@@ -1,0 +1,263 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
+	"github.com/BenjaminBenetti/fleet-man/internal/state"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func newAddFleetModel(fleets map[string]*fleet.Fleet) (*fleetPage, *model) {
+	fp := newFleetPage()
+	m := &model{st: &state.State{Fleets: fleets}, fleetPage: fp}
+	return fp, m
+}
+
+// A file:// URL must not be inspected straight away: the dialog detours to
+// the name prompt, pre-filled with the directory's base name.
+func TestAddFleetTemplateURLPromptsForName(t *testing.T) {
+	fp, m := newAddFleetModel(map[string]*fleet.Fleet{})
+	fp.mode = viewAddFleet
+	fp.textInput.SetValue("file:///home/me/scratch-proj")
+	fp.dlg.fieldActive = true
+
+	cmd := fp.saveAddFleet(m)
+
+	if fp.mode != viewAddFleetName {
+		t.Fatalf("mode = %v, want viewAddFleetName", fp.mode)
+	}
+	if fp.addFleet.pendingRepoURL != "file:///home/me/scratch-proj" {
+		t.Fatalf("pendingRepoURL = %q", fp.addFleet.pendingRepoURL)
+	}
+	if fp.addFleet.pendingFleetName != "" {
+		t.Fatalf("fleet name must not be derived for a template, got %q", fp.addFleet.pendingFleetName)
+	}
+	if got := fp.textInput.Value(); got != "scratch-proj" {
+		t.Fatalf("name prompt prefill = %q, want dir base name", got)
+	}
+	if !fp.dlg.fieldActive || cmd == nil {
+		t.Fatal("name field should be active (blink cmd returned) so the user can type immediately")
+	}
+	view := fp.renderAddFleetNameDialog(m)
+	for _, want := range []string{"Template:", "file:///home/me/scratch-proj", "Name:"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("name dialog missing %q:\n%s", want, view)
+		}
+	}
+}
+
+// The URL step must advertise the file:// option.
+func TestAddFleetDialogAdvertisesTemplateOption(t *testing.T) {
+	fp, m := newAddFleetModel(map[string]*fleet.Fleet{})
+	fp.mode = viewAddFleet
+	if view := fp.renderAddFleetDialog(m); !strings.Contains(view, "file:///abs/dir") {
+		t.Fatalf("New fleet dialog does not mention file:// templates:\n%s", view)
+	}
+}
+
+func TestAddFleetTemplateRelativePathStaysInDialog(t *testing.T) {
+	fp, m := newAddFleetModel(map[string]*fleet.Fleet{})
+	fp.mode = viewAddFleet
+	fp.textInput.SetValue("file://scratch")
+	fp.dlg.fieldActive = true
+
+	fp.saveAddFleet(m)
+
+	if fp.mode != viewAddFleet {
+		t.Fatalf("mode = %v, want to stay in viewAddFleet for correction", fp.mode)
+	}
+	if !strings.Contains(m.message, "absolute") {
+		t.Fatalf("message = %q, want an absolute-path hint", m.message)
+	}
+}
+
+func TestAddFleetNameSubmitStartsInspection(t *testing.T) {
+	fp, m := newAddFleetModel(map[string]*fleet.Fleet{})
+	fp.mode = viewAddFleetName
+	fp.addFleet.pendingRepoURL = "file:///home/me/scratch"
+	fp.textInput.SetValue("my-scratch")
+	fp.dlg.fieldActive = true
+
+	cmd := fp.updateAddFleetName(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if fp.mode != viewAddFleetInspecting {
+		t.Fatalf("mode = %v, want viewAddFleetInspecting", fp.mode)
+	}
+	if fp.addFleet.pendingFleetName != "my-scratch" {
+		t.Fatalf("pendingFleetName = %q", fp.addFleet.pendingFleetName)
+	}
+	if cmd == nil {
+		t.Fatal("expected the inspect cmd to be returned")
+	}
+	if view := fp.renderAddFleetInspectingDialog(m); !strings.Contains(view, "Template:") {
+		t.Fatalf("inspecting dialog should label a template source as Template:\n%s", view)
+	}
+}
+
+func TestAddFleetNameRejectsInvalidOrExisting(t *testing.T) {
+	fp, m := newAddFleetModel(map[string]*fleet.Fleet{"alpha": {Name: "alpha", Remote: "git@x:a.git"}})
+	fp.mode = viewAddFleetName
+	fp.addFleet.pendingRepoURL = "file:///home/me/scratch"
+	fp.dlg.fieldActive = true
+
+	for _, name := range []string{"", "has space", "a/b", "alpha"} {
+		fp.textInput.SetValue(name)
+		fp.saveAddFleetName(m)
+		if fp.mode != viewAddFleetName {
+			t.Fatalf("name %q: mode = %v, want to stay on the prompt", name, fp.mode)
+		}
+		if m.message == "" {
+			t.Fatalf("name %q: expected an error message", name)
+		}
+	}
+	if !strings.Contains(m.message, "already exists") {
+		t.Fatalf("existing fleet name should be refused, got %q", m.message)
+	}
+}
+
+func TestAddFleetNameCancelClearsPending(t *testing.T) {
+	for _, key := range []tea.KeyMsg{{Type: tea.KeyEsc}, {Type: tea.KeyRunes, Runes: []rune{'q'}}, {Type: tea.KeyCtrlC}} {
+		fp, m := newAddFleetModel(map[string]*fleet.Fleet{})
+		fp.mode = viewAddFleetName
+		fp.addFleet.pendingRepoURL = "file:///home/me/scratch"
+		fp.dlg.fieldActive = key.Type == tea.KeyCtrlC
+
+		fp.updateAddFleetName(m, key)
+
+		if fp.mode != viewNormal {
+			t.Fatalf("key %v: mode = %v, want viewNormal", key, fp.mode)
+		}
+		if fp.addFleet.pendingRepoURL != "" {
+			t.Fatalf("key %v: pending URL not cleared", key)
+		}
+	}
+}
+
+// Inside the field, esc only leaves the field (matching the URL step).
+func TestAddFleetNameEscLeavesFieldFirst(t *testing.T) {
+	fp, m := newAddFleetModel(map[string]*fleet.Fleet{})
+	fp.mode = viewAddFleetName
+	fp.addFleet.pendingRepoURL = "file:///home/me/scratch"
+	fp.dlg.fieldActive = true
+
+	fp.updateAddFleetName(m, tea.KeyMsg{Type: tea.KeyEsc})
+
+	if fp.mode != viewAddFleetName || fp.dlg.fieldActive {
+		t.Fatalf("esc in field: mode=%v active=%v, want prompt kept with field inactive", fp.mode, fp.dlg.fieldActive)
+	}
+}
+
+// After a failed inspection the URL step must show the URL again — the name
+// prompt reused textInput for the fleet name.
+func TestAddFleetInspectErrorRestoresTemplateURL(t *testing.T) {
+	fp, m := newAddFleetModel(map[string]*fleet.Fleet{})
+	fp.mode = viewAddFleetInspecting
+	fp.addFleet.pendingRepoURL = "file:///home/me/scratch"
+	fp.addFleet.pendingFleetName = "scratch"
+	fp.textInput.SetValue("scratch")
+
+	fp.handleDevcontainerInspected(m, devcontainerInspectedMsg{fleetName: "scratch", err: errString("template dir: no such file")})
+
+	if fp.mode != viewAddFleet {
+		t.Fatalf("mode = %v, want viewAddFleet", fp.mode)
+	}
+	if got := fp.textInput.Value(); got != "file:///home/me/scratch" {
+		t.Fatalf("textInput = %q, want the template URL restored", got)
+	}
+	if !strings.Contains(m.message, "no such file") {
+		t.Fatalf("message = %q", m.message)
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+// A template fleet's New instance dialog has no branch to offer and only the
+// devcontainer backend can consume a copied directory.
+func TestAddInstanceTemplateFleetSkipsBranchAndLocksBackend(t *testing.T) {
+	fp := newFleetPage()
+	m := &model{
+		st:         &state.State{Fleets: map[string]*fleet.Fleet{"scratch": {Name: "scratch", Remote: "file:///home/me/scratch"}}},
+		fleetPage:  fp,
+		toolStatus: allToolsFound(),
+		creating:   map[string]bool{},
+	}
+	fp.mode = viewAddInstance
+	fp.dlg.fleet = "scratch"
+	fp.addInst.template = true
+	fp.addInst.backend = fleet.BackendDevcontainer
+	fp.addInst.color = instanceColorWhite
+
+	if got := fp.availableBackendTypes(m); len(got) != 1 || got[0] != fleet.BackendDevcontainer {
+		t.Fatalf("availableBackendTypes = %v, want [devcontainer]", got)
+	}
+	if fp.addInstanceRowEnabled(addInstanceRowBranch) {
+		t.Fatal("branch row must be disabled for a template fleet")
+	}
+	if next := fp.nextAddInstanceRow(addInstanceRowName); next != addInstanceRowColor {
+		t.Fatalf("down from Name landed on row %d, want Color (branch skipped)", next)
+	}
+	if prev := fp.prevAddInstanceRow(addInstanceRowColor); prev != addInstanceRowName {
+		t.Fatalf("up from Color landed on row %d, want Name (branch skipped)", prev)
+	}
+	if view := fp.renderAddInstanceDialog(m); !strings.Contains(view, "n/a") {
+		t.Fatalf("branch row should read n/a for a template fleet:\n%s", view)
+	}
+
+	// A stale branch value must not leak into the create request.
+	var gotBranch, gotRemote string
+	orig := createInstanceRemote
+	createInstanceRemote = func(fleetName, instanceName, remote, branch string, backendType fleet.BackendType) error {
+		gotRemote, gotBranch = remote, branch
+		return nil
+	}
+	t.Cleanup(func() { createInstanceRemote = orig })
+	fp.textInput.SetValue("agent-1")
+	fp.branchInput.SetValue("stale")
+	cmd := fp.submitAddInstance(m)
+	if cmd == nil {
+		t.Fatal("submit should return the create cmd")
+	}
+	cmd()
+	if gotBranch != "" {
+		t.Fatalf("branch %q sent for a template fleet, want empty", gotBranch)
+	}
+	if gotRemote != "file:///home/me/scratch" {
+		t.Fatalf("remote = %q", gotRemote)
+	}
+}
+
+// Pressing 'a' on a template fleet header must arm the template flag before
+// the backend list is computed.
+func TestAddInstanceKeySetsTemplateFlagFromFleetRemote(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	fp := newFleetPage()
+	fp.rows = []row{{kind: rowFleetHeader, fleetName: "scratch"}}
+	m := &model{
+		st:        &state.State{Fleets: map[string]*fleet.Fleet{"scratch": {Name: "scratch", Remote: "file:///home/me/scratch"}}},
+		fleetPage: fp,
+	}
+	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if !fp.addInst.template {
+		t.Fatal("addInst.template not set from the fleet's file:// remote")
+	}
+	if fp.mode == viewAddInstance && fp.addInst.backend != fleet.BackendDevcontainer {
+		t.Fatalf("backend = %v, want devcontainer for a template fleet", fp.addInst.backend)
+	}
+}
+
+func TestFirstFleetRepoSkipsTemplateFleets(t *testing.T) {
+	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{
+		"scratch": {Name: "scratch", Remote: "file:///home/me/scratch"},
+	}}}
+	if got := m.firstFleetRepo(); got != "" {
+		t.Fatalf("firstFleetRepo = %q for a template-only state, want empty", got)
+	}
+	m.st.Fleets["real"] = &fleet.Fleet{Name: "real", Remote: "git@github.com:org/real.git"}
+	if got := m.firstFleetRepo(); got != "org/real" {
+		t.Fatalf("firstFleetRepo = %q, want org/real", got)
+	}
+}

--- a/internal/tui/dialog_add_fleet_template_test.go
+++ b/internal/tui/dialog_add_fleet_template_test.go
@@ -156,6 +156,9 @@ func TestAddFleetNameEscGoesBackToURLStep(t *testing.T) {
 	if got := fp.textInput.Value(); got != "file:///home/me/scratch" {
 		t.Fatalf("textInput = %q, want the template URL restored", got)
 	}
+	if !fp.dlg.fieldActive {
+		t.Fatal("URL field should come back active so the cursor and hint agree")
+	}
 }
 
 // Inside the field, esc only leaves the field (matching the URL step).
@@ -191,6 +194,9 @@ func TestAddFleetInspectErrorRestoresTemplateURL(t *testing.T) {
 	}
 	if !strings.Contains(m.message, "no such file") {
 		t.Fatalf("message = %q", m.message)
+	}
+	if !fp.dlg.fieldActive {
+		t.Fatal("URL field should come back active after an inspect error")
 	}
 }
 

--- a/internal/tui/dialog_add_fleet_template_test.go
+++ b/internal/tui/dialog_add_fleet_template_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/BenjaminBenetti/fleet-man/internal/configutil"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleet"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	tea "github.com/charmbracelet/bubbletea"
@@ -118,7 +119,7 @@ func TestAddFleetNameRejectsInvalidOrExisting(t *testing.T) {
 }
 
 func TestAddFleetNameCancelClearsPending(t *testing.T) {
-	for _, key := range []tea.KeyMsg{{Type: tea.KeyEsc}, {Type: tea.KeyRunes, Runes: []rune{'q'}}, {Type: tea.KeyCtrlC}} {
+	for _, key := range []tea.KeyMsg{{Type: tea.KeyRunes, Runes: []rune{'q'}}, {Type: tea.KeyCtrlC}} {
 		fp, m := newAddFleetModel(map[string]*fleet.Fleet{})
 		fp.mode = viewAddFleetName
 		fp.addFleet.pendingRepoURL = "file:///home/me/scratch"
@@ -132,6 +133,28 @@ func TestAddFleetNameCancelClearsPending(t *testing.T) {
 		if fp.addFleet.pendingRepoURL != "" {
 			t.Fatalf("key %v: pending URL not cleared", key)
 		}
+	}
+}
+
+// esc with the field inactive is "back": the URL step reopens with the
+// template URL restored so a path typo can be fixed without starting over.
+func TestAddFleetNameEscGoesBackToURLStep(t *testing.T) {
+	fp, m := newAddFleetModel(map[string]*fleet.Fleet{})
+	fp.mode = viewAddFleetName
+	fp.addFleet.pendingRepoURL = "file:///home/me/scratch"
+	fp.textInput.SetValue("scratch")
+	fp.dlg.fieldActive = false
+
+	if view := fp.renderAddFleetNameDialog(m); !strings.Contains(view, "[esc] Back") {
+		t.Fatalf("name prompt hint should advertise esc as Back:\n%s", view)
+	}
+	fp.updateAddFleetName(m, tea.KeyMsg{Type: tea.KeyEsc})
+
+	if fp.mode != viewAddFleet {
+		t.Fatalf("mode = %v, want viewAddFleet", fp.mode)
+	}
+	if got := fp.textInput.Value(); got != "file:///home/me/scratch" {
+		t.Fatalf("textInput = %q, want the template URL restored", got)
 	}
 }
 
@@ -231,21 +254,30 @@ func TestAddInstanceTemplateFleetSkipsBranchAndLocksBackend(t *testing.T) {
 }
 
 // Pressing 'a' on a template fleet header must arm the template flag before
-// the backend list is computed.
+// the backend list is computed, and open the dialog locked to devcontainer
+// even when every backend CLI is installed.
 func TestAddInstanceKeySetsTemplateFlagFromFleetRemote(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	origCheck := checkTools
+	checkTools = allToolsFound
+	t.Cleanup(func() { checkTools = origCheck })
+
 	fp := newFleetPage()
 	fp.rows = []row{{kind: rowFleetHeader, fleetName: "scratch"}}
 	m := &model{
 		st:        &state.State{Fleets: map[string]*fleet.Fleet{"scratch": {Name: "scratch", Remote: "file:///home/me/scratch"}}},
 		fleetPage: fp,
+		config:    &configutil.Config{DefaultBackend: string(fleet.BackendCoder)},
 	}
 	fp.updateNormal(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
 	if !fp.addInst.template {
 		t.Fatal("addInst.template not set from the fleet's file:// remote")
 	}
-	if fp.mode == viewAddInstance && fp.addInst.backend != fleet.BackendDevcontainer {
-		t.Fatalf("backend = %v, want devcontainer for a template fleet", fp.addInst.backend)
+	if fp.mode != viewAddInstance {
+		t.Fatalf("mode = %v, want viewAddInstance (message: %q)", fp.mode, m.message)
+	}
+	if fp.addInst.backend != fleet.BackendDevcontainer {
+		t.Fatalf("backend = %v, want devcontainer for a template fleet even with coder as the configured default", fp.addInst.backend)
 	}
 }
 

--- a/internal/tui/dialog_add_fleet_template_test.go
+++ b/internal/tui/dialog_add_fleet_template_test.go
@@ -287,6 +287,43 @@ func TestAddInstanceKeySetsTemplateFlagFromFleetRemote(t *testing.T) {
 	}
 }
 
+// The Edit instance dialog must agree with the New instance dialog: a template
+// instance's locked Branch row reads n/a, not "default".
+func TestEditInstanceTemplateShowsBranchNA(t *testing.T) {
+	fp := newFleetPage()
+	f := &fleet.Fleet{Name: "scratch", Remote: "file:///home/me/scratch", Instances: []*fleet.Instance{{Name: "one"}}}
+	fp.rows = []row{{kind: rowInstance, fleetName: "scratch", instance: f.Instances[0]}}
+	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{"scratch": f}}, fleetPage: fp}
+
+	fp.openEditInstanceDialog(m)
+
+	if !fp.addInst.editing || !fp.addInst.template {
+		t.Fatalf("editing=%v template=%v, want both true", fp.addInst.editing, fp.addInst.template)
+	}
+	view := fp.renderAddInstanceDialog(m)
+	if !strings.Contains(view, templateBranchDisplay) {
+		t.Fatalf("edit dialog should show the template n/a branch text:\n%s", view)
+	}
+	if strings.Contains(view, "default") {
+		t.Fatalf("edit dialog must not show a 'default' branch for a template instance:\n%s", view)
+	}
+}
+
+func TestNoDevcontainerDialogCopyForTemplate(t *testing.T) {
+	fp, m := newAddFleetModel(map[string]*fleet.Fleet{})
+	fp.mode = viewAddFleetNoDevcontainer
+	fp.addFleet.pendingRepoURL = "file:///home/me/scratch"
+	view := fp.renderAddFleetNoDevcontainerDialog(m)
+	if !strings.Contains(view, "This template dir has no") || strings.Contains(view, "clone the repo") {
+		t.Fatalf("template no-devcontainer dialog should not talk about a repository/clone:\n%s", view)
+	}
+	fp.addFleet.pendingRepoURL = "git@github.com:org/repo.git"
+	view = fp.renderAddFleetNoDevcontainerDialog(m)
+	if !strings.Contains(view, "This repository has no") {
+		t.Fatalf("git no-devcontainer dialog copy regressed:\n%s", view)
+	}
+}
+
 func TestFirstFleetRepoSkipsTemplateFleets(t *testing.T) {
 	m := &model{st: &state.State{Fleets: map[string]*fleet.Fleet{
 		"scratch": {Name: "scratch", Remote: "file:///home/me/scratch"},

--- a/internal/tui/dialog_instance.go
+++ b/internal/tui/dialog_instance.go
@@ -74,6 +74,7 @@ func (fleetPage *fleetPage) openEditInstanceDialog(m *model) tea.Cmd {
 
 	fleetPage.mode = viewAddInstance
 	fleetPage.addInst.editing = true
+	fleetPage.addInst.template = fleet.IsTemplateRemote(f.Remote)
 	fleetPage.dlg.fleet = f.Name
 	fleetPage.dlg.inst = instance.Name
 	fleetPage.addInst.backend = instance.Backend
@@ -280,6 +281,11 @@ func (fleetPage *fleetPage) submitAddInstance(m *model) tea.Cmd {
 	}
 
 	branch := strings.TrimSpace(fleetPage.branchInput.Value())
+	if fleetPage.addInst.template {
+		// The branch row is disabled for a template fleet (a copied dir has
+		// no refs); never let a stale value from a previous dialog through.
+		branch = ""
+	}
 
 	// Record the chosen backend as the new default. The instance record itself
 	// is pre-created server-side by the CreateInstance job (no client-side state
@@ -352,8 +358,13 @@ func (fleetPage *fleetPage) activateAddInstanceFieldWithMsg(msg tea.Msg) tea.Cmd
 // addInstanceRowEnabled reports whether a given row is selectable in the
 // current dialog mode. Branch and deploy are locked while editing because
 // they describe how the workspace was originally provisioned and cannot
-// be retroactively changed without recreating the instance.
+// be retroactively changed without recreating the instance. Branch is also
+// locked for a file:// template fleet: the template dir is copied as-is, so
+// there is no ref to check out.
 func (fleetPage *fleetPage) addInstanceRowEnabled(row int) bool {
+	if fleetPage.addInst.template && row == addInstanceRowBranch {
+		return false
+	}
 	if !fleetPage.addInst.editing {
 		return true
 	}
@@ -587,13 +598,22 @@ type addInstanceState struct {
 	backend fleet.BackendType
 	color   string
 	editing bool
+	// template is set when the target fleet's remote is a file:// template
+	// dir: the branch row is disabled and only the devcontainer backend (the
+	// one that provisions from a local workspace copy) is offered.
+	template bool
 }
 
 // availableBackendTypes returns the subset of backend types whose
-// required CLI tool is found on the system.
+// required CLI tool is found on the system. A template fleet is further
+// narrowed to devcontainer — coder and codespaces clone a git URL on their
+// own side and cannot consume a copied local directory.
 func (fleetPage *fleetPage) availableBackendTypes(m *model) []fleet.BackendType {
 	var out []fleet.BackendType
 	for _, backendType := range allBackendTypes {
+		if fleetPage.addInst.template && backendType != fleet.BackendDevcontainer {
+			continue
+		}
 		bin := backendToolRequirements[backendType]
 		if bin == "" {
 			out = append(out, backendType)
@@ -648,6 +668,9 @@ func (fleetPage *fleetPage) renderAddInstanceDialog(m *model) string {
 		}
 		nameField = fleetPage.textInput.View()
 		branchField = fleetPage.branchInput.View()
+		if fleetPage.addInst.template {
+			branchField = dimStyle.Render("n/a (template dir is copied as-is)")
+		}
 		deployField = fmt.Sprintf("[ %s ]", backendTypeLabel(backendType))
 	}
 

--- a/internal/tui/dialog_instance.go
+++ b/internal/tui/dialog_instance.go
@@ -51,6 +51,10 @@ func backendTypeLabel(backendType fleet.BackendType) string {
 	}
 }
 
+// templateBranchDisplay is the locked Branch row text for a file:// template
+// fleet, in both the New and Edit instance dialogs: a copied dir has no ref.
+const templateBranchDisplay = "n/a (template dir is copied as-is)"
+
 // addInstanceRow identifies a focusable row in the add-instance dialog.
 const (
 	addInstanceRowName = iota
@@ -654,6 +658,9 @@ func (fleetPage *fleetPage) renderAddInstanceDialog(m *model) string {
 		if branchDisplay == "" {
 			branchDisplay = "default"
 		}
+		if fleetPage.addInst.template {
+			branchDisplay = templateBranchDisplay
+		}
 		branchField = dimStyle.Render(branchDisplay)
 		deployField = dimStyle.Render(fmt.Sprintf("[ %s ]", backendTypeLabel(backendType)))
 	} else {
@@ -669,7 +676,7 @@ func (fleetPage *fleetPage) renderAddInstanceDialog(m *model) string {
 		nameField = fleetPage.textInput.View()
 		branchField = fleetPage.branchInput.View()
 		if fleetPage.addInst.template {
-			branchField = dimStyle.Render("n/a (template dir is copied as-is)")
+			branchField = dimStyle.Render(templateBranchDisplay)
 		}
 		deployField = fmt.Sprintf("[ %s ]", backendTypeLabel(backendType))
 	}

--- a/internal/tui/dialog_instance.go
+++ b/internal/tui/dialog_instance.go
@@ -656,10 +656,11 @@ func (fleetPage *fleetPage) renderAddInstanceDialog(m *model) string {
 		nameField = fleetPage.textInput.View()
 		branchDisplay := fleetPage.branchInput.Value()
 		if branchDisplay == "" {
+			// A recorded branch (legacy mixed fleets) always shows as-is.
 			branchDisplay = "default"
-		}
-		if fleetPage.addInst.template {
-			branchDisplay = templateBranchDisplay
+			if fleetPage.addInst.template {
+				branchDisplay = templateBranchDisplay
+			}
 		}
 		branchField = dimStyle.Render(branchDisplay)
 		deployField = dimStyle.Render(fmt.Sprintf("[ %s ]", backendTypeLabel(backendType)))

--- a/internal/tui/page_fleet.go
+++ b/internal/tui/page_fleet.go
@@ -212,6 +212,8 @@ func (fleetPage *fleetPage) Update(m *model, msg tea.Msg) tea.Cmd {
 		return fleetPage.updateAddInstance(m, msg)
 	case viewAddFleet:
 		return fleetPage.updateAddFleet(m, msg)
+	case viewAddFleetName:
+		return fleetPage.updateAddFleetName(m, msg)
 	case viewAddFleetInspecting:
 		return fleetPage.updateAddFleetInspecting(m, msg)
 	case viewAddFleetNoDevcontainer:

--- a/internal/tui/page_fleet_keys.go
+++ b/internal/tui/page_fleet_keys.go
@@ -10,6 +10,11 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+// checkTools is the deps.CheckTools seam the add-instance key uses to refresh
+// the deploy-target list; tests stub it so the dialog opens regardless of what
+// CLIs the host has installed.
+var checkTools = deps.CheckTools
+
 // updateNormal handles keyboard input in the default fleet list mode.
 func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
@@ -270,7 +275,7 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 			if f, ok := m.st.Fleets[fleetName]; ok {
 				fleetPage.addInst.template = fleet.IsTemplateRemote(f.Remote)
 			}
-			m.toolStatus = deps.CheckTools()
+			m.toolStatus = checkTools()
 			available := fleetPage.availableBackendTypes(m)
 			if len(available) == 0 {
 				m.message = "No deploy targets available – install devcontainer or coder CLI"

--- a/internal/tui/page_fleet_keys.go
+++ b/internal/tui/page_fleet_keys.go
@@ -264,6 +264,12 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 				m.message = "No fleet selected"
 				break
 			}
+			// Must precede availableBackendTypes: a template fleet narrows
+			// the deploy targets to devcontainer.
+			fleetPage.addInst.template = false
+			if f, ok := m.st.Fleets[fleetName]; ok {
+				fleetPage.addInst.template = fleet.IsTemplateRemote(f.Remote)
+			}
 			m.toolStatus = deps.CheckTools()
 			available := fleetPage.availableBackendTypes(m)
 			if len(available) == 0 {
@@ -296,8 +302,9 @@ func (fleetPage *fleetPage) updateNormal(m *model, msg tea.Msg) tea.Cmd {
 
 		case "n":
 			fleetPage.mode = viewAddFleet
+			fleetPage.clearPendingFleet()
 			fleetPage.textInput.SetValue("")
-			fleetPage.textInput.Placeholder = "git@github.com:org/repo.git"
+			fleetPage.textInput.Placeholder = addFleetURLPlaceholder
 			fleetPage.textInput.CharLimit = 256
 			return fleetPage.activateTextInput()
 

--- a/internal/tui/page_fleet_view.go
+++ b/internal/tui/page_fleet_view.go
@@ -509,6 +509,8 @@ func (fleetPage *fleetPage) viewActiveDialog(m *model) string {
 		return fleetPage.renderAddInstanceDialog(m)
 	case viewAddFleet:
 		return fleetPage.renderAddFleetDialog(m)
+	case viewAddFleetName:
+		return fleetPage.renderAddFleetNameDialog(m)
 	case viewAddFleetInspecting:
 		return fleetPage.renderAddFleetInspectingDialog(m)
 	case viewAddFleetNoDevcontainer:

--- a/internal/tui/view_mode.go
+++ b/internal/tui/view_mode.go
@@ -17,6 +17,7 @@ const (
 	viewAddInstance
 	viewCloneInstance
 	viewAddFleet
+	viewAddFleetName
 	viewAddFleetInspecting
 	viewAddFleetNoDevcontainer
 	viewEditFleet


### PR DESCRIPTION
## Summary

Adds a second kind of fleet source next to git URLs: **`file:///abs/dir`** names a local **template directory**. Every new instance gets a `cp -a` of it into its workspace instead of a `git clone`, so one-off / scratch projects can be fleeted without pushing them anywhere. Because a local path carries no repo name, the fleet name must be supplied explicitly: the TUI prompts for it, the CLI requires `fleet up <fleet>/<name> --repo file:///dir`.

### User-facing
- **TUI → New fleet**: the dialog now says `git URL to clone, or file:///abs/dir to copy a local template dir into each instance`. A `file://` URL goes to a **Name** prompt (pre-filled with the dir's base name, editable), then the usual devcontainer inspection → add. Existing fleet names are refused rather than silently reused.
- **TUI → New instance** on a template fleet: the Branch row is disabled (`n/a (template dir is copied as-is)`) and only the Devcontainer backend is offered.
- **CLI**: `fleet up scratch/agent-1 --repo file:///home/me/scratch`. `--repo file://…` without `<fleet>/<name>` errors with the exact form to use. An explicit `fleet/instance` now also wins over `--repo` name derivation (previously the slash stayed inside the instance name).
- **MCP** `fleet_up.remote` / SKILL.md / README / proto comments document the option.
- **No-devcontainer Setup agent**: for a template it is pointed at the local dir (skip clone/push) instead of a URL.

### Rules for template fleets
- No `--branch` (a copy has no refs) and devcontainer backend only (coder/codespaces clone a git URL on their own side). Both are rejected **at job start** (`InvalidArgument`), as is a missing/non-directory template path (`FailedPrecondition`), so `fleet up` fails fast instead of leaving a failed instance record.
- The path is resolved on the **daemon host** — a remote TUI must name a directory that exists there. The error message says so.
- The template is copied verbatim (including a `.git` if present) and is never modified by instances.

### Implementation
- `internal/fleet/template_remote.go`: `IsTemplateRemote`, `TemplateDir` (absolute-only, `file://localhost/…` accepted, percent-decoding), `TemplateNameHint`, `ValidateFleetName`, `ValidateTemplateCreate` (single home for the rules; called by the server at job start and by `create.Run`). `FleetNameFromRemote` returns `""` for `file://` on purpose.
- `internal/create`: `copyTemplateTree` reuses the clone path's `copyWorkspaceTree` (`cp -a src/. dest/`).
- `internal/inspector`: `Open` opens a template dir **in place**; new exported `Repo.Keep` makes `Close` a no-op so the user's directory is never removed. Devcontainer inspection and home-dir detection work unchanged.
- `internal/tui`: new `viewAddFleetName` mode; `addInst.template` flag drives the instance dialog; `firstFleetRepo` skips template fleets (no GitHub repo to derive).

### Note on semantics
`git clone` itself accepts `file://` for local repos; this PR **reserves** `file://` for templates, as requested. A fleet that previously used a `file://` remote for a local git repo would now be copied instead of cloned (a plain absolute path still git-clones). The integration harness relied on that: `FIXTURE_REPO_URL` is now a plain path (same git-clone semantics) and `FIXTURE_TEMPLATE_URL` is the `file://` form.

## Tests
- Unit: `internal/fleet` (parsing, name derivation refusal, `Resolve`, validation), `internal/inspector` (in-place open, Close keeps dir), `internal/create` (copy + isolation), `internal/server` (fast-fail rejections, fleet-record path, InspectRepo template), `internal/tui` (name prompt flow, cancel/esc, error restores URL, instance dialog rows/backend, stale branch not sent, `a` key arms the flag), `internal/devcontainersetup` (prompt wording).
- Integration: new `103_cli_up_template.sh` (error paths, copy-not-clone, template isolation, second instance reuses the recorded remote) and `174_tui_new_fleet_template.sh` (no-docker: hint, name prompt, add). Ran 010/080/100/103/160/170–174 locally in the ghcr QA image (DinD): all pass.
- `go test ./...`, `go vet ./...`, `golangci-lint run ./...`, `make proto` (comment-only regen) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017q6XhX19AzJ7KuMYhUxcMw
