### PR TITLE
feat(cli): fleet open / fo — copy a file out of an instance and open it

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ Variables fleet **reads** (set them to configure behavior):
 | `FLEET_DEVCONTAINER_BUILDKIT` | `auto` (default), `never` | BuildKit mode for Fleet-managed devcontainers. See [Devcontainer BuildKit](#devcontainer-buildkit). |
 | `FLEET_DEVCONTAINER_UPDATE_REMOTE_USER_UID` | `default`, `never`, `on`, `off` | Remote-user UID/GID rewrite mode. See [Devcontainer UID Rewrite](#devcontainer-uid-rewrite). |
 | `FLEET_SSH_AGENT_SOCK` | absolute path, `off`, or `none` (case-insensitive) | Override the bind source for SSH agent forwarding into instances (`off`/`none` disables it). On macOS the default is Docker Desktop's VM-side `/run/host-services/ssh-auth.sock` (OrbStack and `colima --ssh-agent` are path-compatible); set this if your Docker backend exposes the agent elsewhere (default Colima, Podman machine, Rancher Desktop). |
+| `FLEET_OPENER` | program (+ args, whitespace-split) | Program `fleet open` / in-instance `fo` hands a copied file to instead of the desktop opener (`xdg-open`, `open`, `wslview`), e.g. `imv -f`. Read by whichever process opens the file: the CLI for `fleet open`, the TUI for `fo`. Executables are never opened. |
 | `CODER_URL` | URL | Coder deployment URL (Coder backend). |
 | `CODER_SESSION_TOKEN` | token | Coder API token (Coder backend). |
 | `CODER_CONFIG_DIR` | path | Override the Coder CLI config dir. |

--- a/fleetgrpc/watch.pb.go
+++ b/fleetgrpc/watch.pb.go
@@ -661,7 +661,11 @@ type FileCopy struct {
 	Src string `protobuf:"bytes,3,opt,name=src,proto3" json:"src,omitempty"`
 	// dst is the destination endpoint as typed inside the instance. Empty is the
 	// 1-arg download shorthand: the TUI delivers to its downloads folder.
-	Dst           string `protobuf:"bytes,4,opt,name=dst,proto3" json:"dst,omitempty"`
+	Dst string `protobuf:"bytes,4,opt,name=dst,proto3" json:"dst,omitempty"`
+	// open asks the TUI to open the delivered file with its machine's default
+	// application once the copy lands (the in-instance `fleet open` / fo). The
+	// TUI honours it only when dst is on its own machine (or empty).
+	Open          bool `protobuf:"varint,5,opt,name=open,proto3" json:"open,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -724,6 +728,13 @@ func (x *FileCopy) GetDst() string {
 	return ""
 }
 
+func (x *FileCopy) GetOpen() bool {
+	if x != nil {
+		return x.Open
+	}
+	return false
+}
+
 var File_watch_proto protoreflect.FileDescriptor
 
 const file_watch_proto_rawDesc = "" +
@@ -763,12 +774,13 @@ const file_watch_proto_rawDesc = "" +
 	"\bdata_dir\x18\x02 \x01(\tH\x00R\adataDir\x88\x01\x01\x12\x14\n" +
 	"\x05fleet\x18\x03 \x01(\tR\x05fleet\x12\x1a\n" +
 	"\binstance\x18\x04 \x01(\tR\binstanceB\v\n" +
-	"\t_data_dir\"`\n" +
+	"\t_data_dir\"t\n" +
 	"\bFileCopy\x12\x14\n" +
 	"\x05fleet\x18\x01 \x01(\tR\x05fleet\x12\x1a\n" +
 	"\binstance\x18\x02 \x01(\tR\binstance\x12\x10\n" +
 	"\x03src\x18\x03 \x01(\tR\x03src\x12\x10\n" +
-	"\x03dst\x18\x04 \x01(\tR\x03dst*\x8a\x01\n" +
+	"\x03dst\x18\x04 \x01(\tR\x03dst\x12\x12\n" +
+	"\x04open\x18\x05 \x01(\bR\x04open*\x8a\x01\n" +
 	"\rRemoteMcpConn\x12\x1f\n" +
 	"\x1bREMOTE_MCP_CONN_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aREMOTE_MCP_CONN_CONNECTING\x10\x01\x12\x1d\n" +

--- a/fleetgrpc/watch.proto
+++ b/fleetgrpc/watch.proto
@@ -159,4 +159,8 @@ message FileCopy {
   // dst is the destination endpoint as typed inside the instance. Empty is the
   // 1-arg download shorthand: the TUI delivers to its downloads folder.
   string dst = 4;
+  // open asks the TUI to open the delivered file with its machine's default
+  // application once the copy lands (the in-instance `fleet open` / fo). The
+  // TUI honours it only when dst is on its own machine (or empty).
+  bool open = 5;
 }

--- a/integration/tests/026_open.sh
+++ b/integration/tests/026_open.sh
@@ -57,6 +57,20 @@ info "output: ${out}"
 assert_contains "${out}" "no handler for this file" "opener failure should surface its stderr"
 assert_equals "opened-bytes" "$(cat "${workdir}/sub/fo-test.txt")" "a failed open must not undo the copy"
 
+info "an executable is copied but never handed to the opener"
+"${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- sh -c "printf '#!/bin/sh\necho hi\n' > /tmp/fo-tool && chmod 755 /tmp/fo-tool"
+: > "${log}"
+set +e
+out=$("${FLEET_BIN}" open "${FIXTURE_REPO_NAME}/alpha:/tmp/fo-tool" "${workdir}/sub/" 2>&1)
+rc=$?
+set -e
+info "output: ${out}"
+[ "${rc}" -ne 0 ] || fail "expected non-zero exit opening an executable, got 0"
+assert_contains "${out}" "refusing to open an executable" "executable refusal text"
+assert_contains "${out}" "${workdir}/sub/fo-tool" "the refusal should say where the file was copied"
+assert_equals "755" "$(file_mode "${workdir}/sub/fo-tool")" "the executable is still copied, mode intact"
+[ ! -s "${log}" ] || fail "a refused open must not invoke the opener"
+
 info "a source already on this machine is rejected (nothing to fetch)"
 : > "${log}"
 set +e

--- a/integration/tests/026_open.sh
+++ b/integration/tests/026_open.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Description: `fleet open` copies a file out of an instance and hands it to the opener (FLEET_OPENER); own-machine sources and instance destinations are rejected.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+workdir=$(mktemp -d)
+itest_cleanup() { rm -rf "${workdir}"; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+# A stub opener standing in for xdg-open: it records every invocation's
+# arguments, one line each, so the test can see exactly what was opened.
+opener="${workdir}/opener.sh"
+log="${workdir}/opened.log"
+cat > "${opener}" <<STUB
+#!/bin/sh
+printf '%s\n' "\$*" >> "${log}"
+STUB
+chmod +x "${opener}"
+export FLEET_OPENER="${opener}"
+
+info "create a file inside the instance"
+"${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- sh -c "printf 'opened-bytes' > /tmp/fo-test.txt"
+
+info "fleet open alpha:/tmp/fo-test.txt (1-arg: copy to the cwd, then open it)"
+out=$(cd "${workdir}" && "${FLEET_BIN}" open "${FIXTURE_REPO_NAME}/alpha:/tmp/fo-test.txt")
+info "output: ${out}"
+assert_contains "${out}" "Opened ${workdir}/fo-test.txt" "open should report the absolute opened path"
+assert_equals "opened-bytes" "$(cat "${workdir}/fo-test.txt")" "copied file content"
+assert_equals "${workdir}/fo-test.txt" "$(cat "${log}")" "opener should receive the absolute path of the copied file"
+
+info "fleet open into a directory keeps the source basename and opens it there"
+mkdir -p "${workdir}/sub"
+: > "${log}"
+"${FLEET_BIN}" open "${FIXTURE_REPO_NAME}/alpha:/tmp/fo-test.txt" "${workdir}/sub/"
+assert_equals "opened-bytes" "$(cat "${workdir}/sub/fo-test.txt")" "directory dest content"
+assert_equals "${workdir}/sub/fo-test.txt" "$(cat "${log}")" "opener should receive the directory-dest path"
+
+info "FLEET_OPENER may carry its own arguments; the path is appended last"
+: > "${log}"
+FLEET_OPENER="${opener} --fullscreen" "${FLEET_BIN}" open "${FIXTURE_REPO_NAME}/alpha:/tmp/fo-test.txt" "${workdir}/sub/"
+assert_equals "--fullscreen ${workdir}/sub/fo-test.txt" "$(cat "${log}")" "opener arguments should precede the path"
+
+info "an opener that fails is reported (the copy itself still lands)"
+failing="${workdir}/failing.sh"
+printf '#!/bin/sh\necho "no handler for this file" >&2\nexit 3\n' > "${failing}"
+chmod +x "${failing}"
+rm -f "${workdir}/sub/fo-test.txt"
+set +e
+out=$(FLEET_OPENER="${failing}" "${FLEET_BIN}" open "${FIXTURE_REPO_NAME}/alpha:/tmp/fo-test.txt" "${workdir}/sub/" 2>&1)
+rc=$?
+set -e
+info "output: ${out}"
+[ "${rc}" -ne 0 ] || fail "expected non-zero exit when the opener fails, got 0"
+assert_contains "${out}" "no handler for this file" "opener failure should surface its stderr"
+assert_equals "opened-bytes" "$(cat "${workdir}/sub/fo-test.txt")" "a failed open must not undo the copy"
+
+info "a source already on this machine is rejected (nothing to fetch)"
+: > "${log}"
+set +e
+out=$("${FLEET_BIN}" open "${workdir}/fo-test.txt" 2>&1)
+rc=$?
+set -e
+[ "${rc}" -ne 0 ] || fail "expected non-zero exit opening an own-machine source, got 0"
+assert_contains "${out}" "source must be in an instance" "own-machine source error text"
+[ ! -s "${log}" ] || fail "a rejected open must not invoke the opener"
+
+info "an instance destination is rejected (the file can only be opened here)"
+set +e
+out=$("${FLEET_BIN}" open "${FIXTURE_REPO_NAME}/alpha:/tmp/fo-test.txt" "${FIXTURE_REPO_NAME}/alpha:/tmp/elsewhere" 2>&1)
+rc=$?
+set -e
+[ "${rc}" -ne 0 ] || fail "expected non-zero exit for an instance destination, got 0"
+assert_contains "${out}" "destination must be on your machine" "instance destination error text"
+[ ! -s "${log}" ] || fail "a rejected open must not invoke the opener"
+
+info "fleet open of a missing file fails without opening anything"
+set +e
+"${FLEET_BIN}" open "${FIXTURE_REPO_NAME}/alpha:/tmp/does-not-exist" "${workdir}/nope" >/dev/null 2>&1
+rc=$?
+set -e
+[ "${rc}" -ne 0 ] || fail "expected non-zero exit opening a missing file, got 0"
+[ ! -e "${workdir}/nope" ] || fail "failed open must not leave a destination file"
+[ ! -s "${log}" ] || fail "a failed copy must not invoke the opener"
+
+pass "open"

--- a/integration/tests/070_cli_help.sh
+++ b/integration/tests/070_cli_help.sh
@@ -20,7 +20,7 @@ assert_contains "${root_help}" "Available Commands:"        "root help missing c
 # Each visible subcommand we ship must appear in the Available Commands block.
 # This protects against accidentally dropping one from NewRootCmd. The
 # `_create-instance` command is intentionally Hidden, so it's not asserted.
-for sub in up stop start down destroy list exec code logs status port-forward shell; do
+for sub in up stop start down destroy list exec code logs status port-forward shell copy open; do
   assert_contains "${root_help}" "${sub}" "root help missing subcommand: ${sub}"
 done
 
@@ -42,6 +42,10 @@ declare -a checks=(
   "exec|Execute a command inside an instance"
   "logs|Show logs for an instance"
   "status|Show fleet-wide status summary"
+  # copy/open tailor their long help to where they run (host vs in-instance);
+  # these needles appear in both forms.
+  "copy|Copy a file or directory between"
+  "open|to your machine, then open it"
 )
 
 for entry in "${checks[@]}"; do

--- a/integration/tests/535_open_in_instance.sh
+++ b/integration/tests/535_open_in_instance.sh
@@ -4,7 +4,14 @@ set -euo pipefail
 
 source "$(dirname "$0")/../common.sh"
 workdir=$(mktemp -d)
-itest_cleanup() { tui_kill; rm -rf "${workdir}"; rm -f "${HOME}/Downloads/fo-itest.txt"; }
+created_downloads=0
+itest_cleanup() {
+  tui_kill
+  rm -rf "${workdir}"
+  rm -f "${HOME}/Downloads/fo-itest.txt"
+  # Leave the real home as we found it: only remove ~/Downloads if we made it.
+  if [ "${created_downloads}" = 1 ]; then rmdir "${HOME}/Downloads" 2>/dev/null || true; fi
+}
 itest_begin
 
 setup_test
@@ -23,8 +30,12 @@ chmod +x "${opener}"
 export FLEET_OPENER="${opener}"
 tmux set-environment -g FLEET_OPENER "${opener}" >/dev/null 2>&1 || true
 
-# The 1-arg form delivers to ~/Downloads when it exists.
-mkdir -p "${HOME}/Downloads"
+# The 1-arg form delivers to ~/Downloads when it exists (common.sh does not
+# isolate $HOME, so remember whether this test created the directory).
+if [ ! -d "${HOME}/Downloads" ]; then
+  mkdir -p "${HOME}/Downloads"
+  created_downloads=1
+fi
 rm -f "${HOME}/Downloads/fo-itest.txt"
 
 info "create a file inside the instance"

--- a/integration/tests/535_open_in_instance.sh
+++ b/integration/tests/535_open_in_instance.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Description: in-instance `fleet open` (fo) delegates to the attached TUI: the human confirms an "Open request", the file lands in ~/Downloads and is handed to the opener.
+set -euo pipefail
+
+source "$(dirname "$0")/../common.sh"
+workdir=$(mktemp -d)
+itest_cleanup() { tui_kill; rm -rf "${workdir}"; rm -f "${HOME}/Downloads/fo-itest.txt"; }
+itest_begin
+
+setup_test
+fleet_up alpha
+
+# A stub opener standing in for xdg-open on the TUI machine: it records the
+# arguments it was invoked with. It must reach the TUI's environment — export
+# covers a fresh tmux server, set-environment -g a server that already exists.
+opener="${workdir}/opener.sh"
+log="${workdir}/opened.log"
+cat > "${opener}" <<STUB
+#!/bin/sh
+printf '%s\n' "\$*" >> "${log}"
+STUB
+chmod +x "${opener}"
+export FLEET_OPENER="${opener}"
+tmux set-environment -g FLEET_OPENER "${opener}" >/dev/null 2>&1 || true
+
+# The 1-arg form delivers to ~/Downloads when it exists.
+mkdir -p "${HOME}/Downloads"
+rm -f "${HOME}/Downloads/fo-itest.txt"
+
+info "create a file inside the instance"
+"${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- sh -c "printf 'opened-bytes' > /tmp/fo-itest.txt"
+
+info "the staged fleet.rc provides the fo alias"
+alias_out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- bash -ic 'type fo' 2>/dev/null || true)
+assert_contains "${alias_out}" "fleet open" "fo should be an alias for fleet open"
+
+info "an instance destination is rejected inside the instance before anything is sent"
+set +e
+out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- fleet open /tmp/fo-itest.txt /tmp/elsewhere 2>&1)
+rc=$?
+set -e
+[ "${rc}" -ne 0 ] || fail "expected non-zero exit for a this-instance destination, got 0"
+assert_contains "${out}" "host:" "the error should steer to host:path"
+
+# Attach a TUI: it becomes the Watch subscriber the server opens the control
+# socket for (as in 530), and the machine that performs the copy + open.
+tui_spawn
+tui_wait_for "alpha" 15
+
+socket="${HOME}/.fleet/workspaces/${FIXTURE_REPO_NAME}/alpha/.control/fleet.sock"
+info "waiting for the server to open the control socket (TUI now attached)"
+deadline=$(( $(date +%s) + $(_scale_timeout 20) ))
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  if [ -S "${socket}" ]; then break; fi
+  sleep 0.25
+done
+assert_file_exists "${socket}"
+
+info "fleet open /tmp/fo-itest.txt inside the instance"
+out=$("${FLEET_BIN}" exec "${FIXTURE_REPO_NAME}/alpha" -- fleet open /tmp/fo-itest.txt 2>&1)
+info "output: ${out}"
+assert_contains "${out}" "and opening" "in-instance open should announce the delegated copy + open"
+
+info "the TUI asks the human, naming the open as an effect"
+tui_wait_for "Open request from ${FIXTURE_REPO_NAME}/alpha" 15
+tui_assert_contains "opens it with THIS machine" "the prompt must spell out that the file will be opened"
+
+info "allow once"
+tui_send a
+tui_wait_for "Opened :/tmp/fo-itest.txt" 30
+
+assert_equals "opened-bytes" "$(cat "${HOME}/Downloads/fo-itest.txt")" "the file should land in ~/Downloads"
+assert_equals "${HOME}/Downloads/fo-itest.txt" "$(cat "${log}")" "the opener should receive the delivered path"
+
+pass "in-instance fleet open"

--- a/internal/cli/copy.go
+++ b/internal/cli/copy.go
@@ -80,12 +80,17 @@ func runCopy(ctx context.Context, out io.Writer, src, dst string) error {
 		}
 		// The container can't reach the host fleetd over gRPC; ask the connected
 		// TUI to perform the copy against the host fleet.
-		return fleetcopy.Request(fleetcopy.Config{}, out, src, dst)
+		return fleetcopy.Request(fleetcopy.Config{}, out, src, dst, false)
 	}
 	if err := requireDownloadSource(src, dst); err != nil {
 		return err
 	}
-	return hostCopy(ctx, out, src, dst)
+	res, err := hostCopy(ctx, src, dst)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "Copied %s -> %s (%d bytes)\n", src, res.DestPath, res.Written)
+	return nil
 }
 
 // rewriteInstanceLocal turns a plain (cwd-relative) path typed inside an instance
@@ -120,26 +125,21 @@ func requireDownloadSource(src, dst string) error {
 
 // hostCopy resolves both endpoints against the host fleet and runs the generic
 // copy engine over the dialled fleet server, with the CLI's own disk as local.
-func hostCopy(ctx context.Context, out io.Writer, src, dst string) error {
+func hostCopy(ctx context.Context, src, dst string) (fleetclient.CopyResult, error) {
 	srcEnd, err := resolveHostEndpoint(src)
 	if err != nil {
-		return err
+		return fleetclient.CopyResult{}, err
 	}
 	dstEnd, err := resolveHostEndpoint(dst)
 	if err != nil {
-		return err
+		return fleetclient.CopyResult{}, err
 	}
 	conn, err := fleetclient.Dial(ctx)
 	if err != nil {
-		return err
+		return fleetclient.CopyResult{}, err
 	}
 	defer conn.Close()
-	res, err := fleetclient.Copy(ctx, conn.Service(), srcEnd, dstEnd, fleetclient.HostLocalPolicy{})
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(out, "Copied %s -> %s (%d bytes)\n", src, res.DestPath, res.Written)
-	return nil
+	return fleetclient.Copy(ctx, conn.Service(), srcEnd, dstEnd, fleetclient.HostLocalPolicy{})
 }
 
 // resolveHostEndpoint turns a typed argument into a ResolvedEndpoint for the host

--- a/internal/cli/copy.go
+++ b/internal/cli/copy.go
@@ -89,8 +89,14 @@ func runCopy(ctx context.Context, out io.Writer, src, dst string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "Copied %s -> %s (%d bytes)\n", src, res.DestPath, res.Written)
+	reportCopied(out, src, res)
 	return nil
+}
+
+// reportCopied prints the one-line outcome of a host-form copy (shared with
+// `fleet open`, which copies the same way before opening).
+func reportCopied(out io.Writer, src string, res fleetclient.CopyResult) {
+	fmt.Fprintf(out, "Copied %s -> %s (%d bytes)\n", src, res.DestPath, res.Written)
 }
 
 // rewriteInstanceLocal turns a plain (cwd-relative) path typed inside an instance

--- a/internal/cli/open.go
+++ b/internal/cli/open.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetclient"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetcopy"
+	"github.com/BenjaminBenetti/fleet-man/internal/platform"
+	"github.com/spf13/cobra"
+)
+
+// newOpenCmd creates `fleet open` (inside an instance the staged fleet.rc also
+// provides `fo`): a `fleet copy` to the user's machine followed by opening the
+// delivered file with that machine's default application. It short-circuits
+// the "fc the screenshot, then xdg-open it" two-step. The endpoint grammar is
+// copy's; the source must be in an instance and the destination, when given,
+// on the user's machine.
+//
+// As with copy, WHERE the copy and the open happen depends only on where the
+// command runs: a host invocation copies via the fleet server and opens the file
+// itself; an in-instance invocation delegates both to the connected fleet TUI
+// (the container can reach neither the host fleetd nor the human's desktop),
+// which prompts for confirmation like any host-touching fc.
+func newOpenCmd() *cobra.Command {
+	use := "open <src> [dst]"
+	short := "Copy a file from an instance and open it"
+	long := "Copy a file out of an instance to your machine, then open it with your\n" +
+		"desktop's default application. The endpoints are fleet copy's.\n\n" +
+		"  fleet open alpha:out/chart.png             copy to the cwd and open\n" +
+		"  fleet open alpha:report.pdf ~/Documents/   copy there and open\n\n" +
+		"FLEET_OPENER overrides the opener program (default: xdg-open, open, or wslview)."
+	if fleetcopy.InInstance() {
+		long = "Copy a file from this instance to your machine, then open it there with\n" +
+			"your desktop's default application. The endpoints are fc's.\n\n" +
+			"  fo ./out/chart.png                copy to your downloads folder and open\n" +
+			"  fo report.pdf host:~/Documents/   copy there and open\n\n" +
+			"The copy asks for confirmation in the fleet TUI, which does the opening\n" +
+			"(FLEET_OPENER in its environment overrides the opener program)."
+	}
+
+	return &cobra.Command{
+		Use:   use,
+		Short: short,
+		Long:  long,
+		Args:  cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dst := ""
+			if len(args) == 2 {
+				dst = args[1]
+			}
+			return runOpen(cmd.Context(), cmd.OutOrStdout(), args[0], dst)
+		},
+	}
+}
+
+// runOpen routes like runCopy: in-instance invocations rewrite plain (this-
+// instance) paths and delegate the copy + open to the host TUI; host invocations
+// copy via the fleet server and open the delivered file locally.
+func runOpen(ctx context.Context, out io.Writer, src, dst string) error {
+	if fleetcopy.InInstance() {
+		src = rewriteInstanceLocal(src)
+		dst = rewriteInstanceLocal(dst)
+		if err := requireOpenEndpoints(src, dst); err != nil {
+			return err
+		}
+		return fleetcopy.Request(fleetcopy.Config{}, out, src, dst, true)
+	}
+	if err := requireOpenEndpoints(src, dst); err != nil {
+		return err
+	}
+	res, err := hostCopy(ctx, src, dst)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "Copied %s -> %s (%d bytes)\n", src, res.DestPath, res.Written)
+	// The 1-arg form lands the file as a bare name in the cwd; hand the opener
+	// an absolute path so it is unambiguous whatever the handler's own cwd is.
+	target := res.DestPath
+	if abs, err := filepath.Abs(target); err == nil {
+		target = abs
+	}
+	if err := platform.OpenFile(target); err != nil {
+		return fmt.Errorf("open %s: %w", target, err)
+	}
+	fmt.Fprintf(out, "Opened %s\n", target)
+	return nil
+}
+
+// requireOpenEndpoints enforces open's shape: the source must live in an
+// instance (a file already on your machine has nothing to fetch — just open
+// it), and the destination, when given, must be on your machine — that is the
+// only place the file can be opened. Inside an instance a plain dst has already
+// been rewritten to a `:` self endpoint, so the error steers to `host:`.
+func requireOpenEndpoints(src, dst string) error {
+	switch fleetclient.ParseCopyEndpoint(src).Kind {
+	case fleetclient.CopyLocal, fleetclient.CopyHost:
+		return fmt.Errorf("source must be in an instance: %q is on your machine", src)
+	}
+	if dst == "" {
+		return nil
+	}
+	switch fleetclient.ParseCopyEndpoint(dst).Kind {
+	case fleetclient.CopyLocal, fleetclient.CopyHost:
+		return nil
+	}
+	return fmt.Errorf("destination must be on your machine (host:path): %q is in an instance", dst)
+}

--- a/internal/cli/open.go
+++ b/internal/cli/open.go
@@ -26,15 +26,15 @@ import (
 func newOpenCmd() *cobra.Command {
 	use := "open <src> [dst]"
 	short := "Copy a file from an instance and open it"
-	long := "Copy a file out of an instance to your machine, then open it with your\n" +
-		"desktop's default application. The endpoints are fleet copy's.\n\n" +
+	long := "Copy a file (or directory) out of an instance to your machine, then open it\n" +
+		"with your desktop's default application. The endpoints are fleet copy's.\n\n" +
 		"  fleet open alpha:out/chart.png             copy to the cwd and open\n" +
 		"  fleet open alpha:report.pdf ~/Documents/   copy there and open\n\n" +
 		"FLEET_OPENER overrides the opener (program + args, split on whitespace;\n" +
 		"default: xdg-open, open, or wslview). Executables are never opened."
 	if fleetcopy.InInstance() {
-		long = "Copy a file from this instance to your machine, then open it there with\n" +
-			"your desktop's default application. The endpoints are fc's.\n\n" +
+		long = "Copy a file (or directory) from this instance to your machine, then open it\n" +
+			"there with your desktop's default application. The endpoints are fc's.\n\n" +
 			"  fo ./out/chart.png                copy to your downloads folder and open\n" +
 			"  fo report.pdf host:~/Documents/   copy there and open\n\n" +
 			"The copy asks for confirmation in the fleet TUI, which does the opening\n" +
@@ -77,9 +77,9 @@ func runOpen(ctx context.Context, out io.Writer, src, dst string) error {
 		return err
 	}
 	reportCopied(out, src, res)
-	opened, err := platform.OpenFile(res.DestPath)
+	opened, err := platform.OpenFile(res.DestPath) // its errors name the path
 	if err != nil {
-		return fmt.Errorf("open %s: %w", opened, err)
+		return err
 	}
 	fmt.Fprintf(out, "Opened %s\n", opened)
 	return nil

--- a/internal/cli/open.go
+++ b/internal/cli/open.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"path/filepath"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetclient"
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetcopy"
@@ -31,14 +30,16 @@ func newOpenCmd() *cobra.Command {
 		"desktop's default application. The endpoints are fleet copy's.\n\n" +
 		"  fleet open alpha:out/chart.png             copy to the cwd and open\n" +
 		"  fleet open alpha:report.pdf ~/Documents/   copy there and open\n\n" +
-		"FLEET_OPENER overrides the opener program (default: xdg-open, open, or wslview)."
+		"FLEET_OPENER overrides the opener (program + args, split on whitespace;\n" +
+		"default: xdg-open, open, or wslview). Executables are never opened."
 	if fleetcopy.InInstance() {
 		long = "Copy a file from this instance to your machine, then open it there with\n" +
 			"your desktop's default application. The endpoints are fc's.\n\n" +
 			"  fo ./out/chart.png                copy to your downloads folder and open\n" +
 			"  fo report.pdf host:~/Documents/   copy there and open\n\n" +
 			"The copy asks for confirmation in the fleet TUI, which does the opening\n" +
-			"(FLEET_OPENER in its environment overrides the opener program)."
+			"(FLEET_OPENER in its environment overrides the opener). Executables are\n" +
+			"never opened."
 	}
 
 	return &cobra.Command{
@@ -75,17 +76,12 @@ func runOpen(ctx context.Context, out io.Writer, src, dst string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "Copied %s -> %s (%d bytes)\n", src, res.DestPath, res.Written)
-	// The 1-arg form lands the file as a bare name in the cwd; hand the opener
-	// an absolute path so it is unambiguous whatever the handler's own cwd is.
-	target := res.DestPath
-	if abs, err := filepath.Abs(target); err == nil {
-		target = abs
+	reportCopied(out, src, res)
+	opened, err := platform.OpenFile(res.DestPath)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", opened, err)
 	}
-	if err := platform.OpenFile(target); err != nil {
-		return fmt.Errorf("open %s: %w", target, err)
-	}
-	fmt.Fprintf(out, "Opened %s\n", target)
+	fmt.Fprintf(out, "Opened %s\n", opened)
 	return nil
 }
 

--- a/internal/cli/open_test.go
+++ b/internal/cli/open_test.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRequireOpenEndpoints enforces open's shape: an instance (or self) source,
+// and an empty or host-side destination — the only place a file can be opened.
+func TestRequireOpenEndpoints(t *testing.T) {
+	for _, src := range []string{"alpha:out/chart.png", ":build/out", "myfleet/beta:/p"} {
+		for _, dst := range []string{"", "host:~/Pictures/", "host:/tmp/x", "./here/", "/abs/target"} {
+			if err := requireOpenEndpoints(src, dst); err != nil {
+				t.Errorf("open(%q, %q) should be allowed, got %v", src, dst, err)
+			}
+		}
+	}
+	// A source already on your machine has nothing to fetch.
+	for _, src := range []string{"./file", "plain.txt", "host:/tmp/x", "/abs/file"} {
+		err := requireOpenEndpoints(src, "")
+		if err == nil || !strings.Contains(err.Error(), "source must be in an instance") {
+			t.Errorf("open(%q) should reject an own-machine source, got %v", src, err)
+		}
+	}
+	// A destination inside an instance can't be opened on your machine. In the
+	// in-instance form a plain dst arrives here as a `:` self endpoint, so the
+	// error must steer to `host:`.
+	for _, dst := range []string{":/tmp/", "alpha:/tmp/", "other/beta:x"} {
+		err := requireOpenEndpoints("alpha:chart.png", dst)
+		if err == nil || !strings.Contains(err.Error(), "host:") {
+			t.Errorf("open(alpha:chart.png, %q) should reject an instance destination, got %v", dst, err)
+		}
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -47,6 +47,7 @@ func NewRootCmd() *cobra.Command {
 		newStatusCmd(),
 		newCloneCmd(),
 		newCopyCmd(),
+		newOpenCmd(),
 		newPortForwardCmd(),
 		newShellCmd(),
 		newSpawnSessionCmd(),

--- a/internal/control/client.go
+++ b/internal/control/client.go
@@ -80,9 +80,11 @@ func (c *Client) OpenBrowser(url string) error {
 
 // CopyFile is a typed convenience over Send for TypeCopyFile: it asks the
 // connected host TUI to perform a scp-style copy between src and dst (endpoints
-// as typed inside the instance). An empty dst is the download shorthand.
-func (c *Client) CopyFile(src, dst string) error {
-	return c.Send(TypeCopyFile, CopyFilePayload{Src: src, Dst: dst})
+// as typed inside the instance). An empty dst is the download shorthand; open
+// additionally asks the TUI to open the delivered file with its machine's
+// default application (`fleet open`).
+func (c *Client) CopyFile(src, dst string, open bool) error {
+	return c.Send(TypeCopyFile, CopyFilePayload{Src: src, Dst: dst, Open: open})
 }
 
 // Close closes the underlying connection. It is safe to call once; further

--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -114,6 +114,42 @@ func TestRoundTripOpenBrowser(t *testing.T) {
 	}
 }
 
+// TestRoundTripCopyFile round-trips a CopyFile message and asserts the payload
+// carries both endpoints and the `fleet open` flag verbatim.
+func TestRoundTripCopyFile(t *testing.T) {
+	c := newCollector()
+	srv, err := Listen(tempSocket(t), c.handle)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer srv.Close()
+
+	cli, err := Dial(srv.socketPath)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer cli.Close()
+
+	if err := cli.CopyFile(":build/chart.png", "host:~/Pictures/", true); err != nil {
+		t.Fatalf("CopyFile: %v", err)
+	}
+
+	got := c.wait(t, 1, 2*time.Second)
+	if len(got) != 1 {
+		t.Fatalf("received %d envelopes, want 1", len(got))
+	}
+	if got[0].Type != TypeCopyFile {
+		t.Errorf("Type = %q, want %q", got[0].Type, TypeCopyFile)
+	}
+	var p CopyFilePayload
+	if err := json.Unmarshal(got[0].Payload, &p); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if p.Src != ":build/chart.png" || p.Dst != "host:~/Pictures/" || !p.Open {
+		t.Errorf("payload = %+v, want src/dst verbatim and open=true", p)
+	}
+}
+
 // TestMultipleMessagesOneConnection verifies several Envelopes sent over a
 // single connection are each decoded and dispatched in order.
 func TestMultipleMessagesOneConnection(t *testing.T) {

--- a/internal/control/copy_file_payload.go
+++ b/internal/control/copy_file_payload.go
@@ -12,4 +12,9 @@ type CopyFilePayload struct {
 	// Dst is the destination endpoint as typed inside the instance. Empty is the
 	// 1-arg download shorthand (deliver to the TUI's downloads folder).
 	Dst string `json:"dst,omitempty"`
+	// Open asks the TUI to open the delivered file with its machine's default
+	// application once the copy lands — the in-instance `fleet open` (fo). Only
+	// meaningful when Dst is on the TUI's machine (or empty); the TUI refuses to
+	// open anything else.
+	Open bool `json:"open,omitempty"`
 }

--- a/internal/fleetcopy/fleetcopy.go
+++ b/internal/fleetcopy/fleetcopy.go
@@ -52,20 +52,26 @@ func InInstance() bool {
 // a browser open: the in-container process can resolve neither the user's-machine
 // paths nor the host fleet's instances, so it does not validate the endpoints;
 // the TUI performs the copy and surfaces any error there. An empty dst is the
-// download shorthand (deliver to the user's downloads folder).
-func Request(cfg Config, out io.Writer, src, dst string) error {
+// download shorthand (deliver to the user's downloads folder). open additionally
+// asks the TUI to open the delivered file with the user's default application
+// once it lands — the in-instance `fleet open` (fo).
+func Request(cfg Config, out io.Writer, src, dst string, open bool) error {
 	client, err := control.Dial(cfg.socketPath())
 	if err != nil {
 		return fmt.Errorf("not connected to a host fleet — `fc` needs a running fleet TUI on the host")
 	}
 	defer client.Close()
-	if err := client.CopyFile(src, dst); err != nil {
+	if err := client.CopyFile(src, dst, open); err != nil {
 		return err
 	}
-	if dst != "" {
-		fmt.Fprintf(out, "Copying %s -> %s\n", src, dst)
+	target := dst
+	if target == "" {
+		target = "downloads"
+	}
+	if open {
+		fmt.Fprintf(out, "Copying %s -> %s and opening\n", src, target)
 	} else {
-		fmt.Fprintf(out, "Copying %s -> downloads\n", src)
+		fmt.Fprintf(out, "Copying %s -> %s\n", src, target)
 	}
 	return nil
 }

--- a/internal/fleetcopy/fleetcopy.go
+++ b/internal/fleetcopy/fleetcopy.go
@@ -58,7 +58,7 @@ func InInstance() bool {
 func Request(cfg Config, out io.Writer, src, dst string, open bool) error {
 	client, err := control.Dial(cfg.socketPath())
 	if err != nil {
-		return fmt.Errorf("not connected to a host fleet — `fc` needs a running fleet TUI on the host")
+		return fmt.Errorf("not connected to a host fleet — this needs a running fleet TUI on the host")
 	}
 	defer client.Close()
 	if err := client.CopyFile(src, dst, open); err != nil {

--- a/internal/fleetcopy/fleetcopy_test.go
+++ b/internal/fleetcopy/fleetcopy_test.go
@@ -35,7 +35,7 @@ func TestRequestSendsEnvelope(t *testing.T) {
 	}()
 
 	var out bytes.Buffer
-	if err := Request(Config{SocketPath: socket}, &out, ":build/tool", "~/builds/tool"); err != nil {
+	if err := Request(Config{SocketPath: socket}, &out, ":build/tool", "~/builds/tool", false); err != nil {
 		t.Fatalf("Request: %v", err)
 	}
 	env := <-got
@@ -80,7 +80,7 @@ func TestRequestDownloadShorthand(t *testing.T) {
 	}()
 
 	var out bytes.Buffer
-	if err := Request(Config{SocketPath: socket}, &out, ":out.bin", ""); err != nil {
+	if err := Request(Config{SocketPath: socket}, &out, ":out.bin", "", false); err != nil {
 		t.Fatalf("Request: %v", err)
 	}
 	var payload control.CopyFilePayload
@@ -95,6 +95,48 @@ func TestRequestDownloadShorthand(t *testing.T) {
 	}
 }
 
+// TestRequestOpen confirms the `fleet open` form sets the open flag on the same
+// file.copy envelope and says so in the confirmation.
+func TestRequestOpen(t *testing.T) {
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "fleet.sock")
+	ln, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	got := make(chan control.Envelope, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var env control.Envelope
+		_ = json.NewDecoder(conn).Decode(&env)
+		got <- env
+	}()
+
+	var out bytes.Buffer
+	if err := Request(Config{SocketPath: socket}, &out, ":chart.png", "", true); err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	env := <-got
+	if env.Type != control.TypeCopyFile {
+		t.Fatalf("envelope type = %q, want %q (open rides the copy envelope)", env.Type, control.TypeCopyFile)
+	}
+	var payload control.CopyFilePayload
+	if err := json.Unmarshal(env.Payload, &payload); err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+	if payload.Src != ":chart.png" || payload.Dst != "" || !payload.Open {
+		t.Fatalf("payload = %+v, want src=:chart.png dst empty open=true", payload)
+	}
+	if !strings.Contains(out.String(), "opening") {
+		t.Fatalf("confirmation %q does not mention opening", out.String())
+	}
+}
+
 // TestRequestNoListener covers the only failure Request still reports locally:
 // no host TUI connected. It no longer stats the source (which may be a file on
 // the user's machine, unreachable from in-container) — that is the host TUI's job.
@@ -103,7 +145,7 @@ func TestRequestNoListener(t *testing.T) {
 	cfg := Config{SocketPath: filepath.Join(dir, "absent.sock")}
 
 	var out bytes.Buffer
-	if err := Request(cfg, &out, ":tool", ""); err == nil || !strings.Contains(err.Error(), "not connected to a host fleet") {
+	if err := Request(cfg, &out, ":tool", "", false); err == nil || !strings.Contains(err.Error(), "not connected to a host fleet") {
 		t.Fatalf("no listener: want not-connected error, got %v", err)
 	}
 }

--- a/internal/fleetlaunch/fleet.rc
+++ b/internal/fleetlaunch/fleet.rc
@@ -26,3 +26,12 @@ alias fl='fleet launch'
 # downloads folder. A copy that touches your machine asks for confirmation in
 # the fleet TUI.
 alias fc='fleet copy'
+
+# fo — shorthand for Fleet Open: `fc` to your machine, then open the file there
+# with your desktop's default application (xdg-open / open / wslview). Handy
+# for a screenshot, chart, or PDF produced inside the instance:
+#   fo ./out/chart.png                 copy to your downloads folder and open it
+#   fo report.pdf host:~/Documents/    copy there and open it
+# Like fc, it asks for confirmation in the fleet TUI; FLEET_OPENER in the TUI's
+# environment overrides the opener program.
+alias fo='fleet open'

--- a/internal/platform/detach_other.go
+++ b/internal/platform/detach_other.go
@@ -1,0 +1,8 @@
+//go:build !unix
+
+package platform
+
+import "os/exec"
+
+// detachFromTerminal is a no-op where there is no unix session to leave.
+func detachFromTerminal(*exec.Cmd) {}

--- a/internal/platform/detach_unix.go
+++ b/internal/platform/detach_unix.go
@@ -1,0 +1,15 @@
+//go:build unix
+
+package platform
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// detachFromTerminal starts cmd in its own session, so it has no controlling
+// terminal and closing the terminal the caller ran from doesn't SIGHUP a viewer
+// the opener left running.
+func detachFromTerminal(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/internal/platform/open.go
+++ b/internal/platform/open.go
@@ -187,7 +187,7 @@ func runDetached(cmd *exec.Cmd, grace time.Duration) error {
 	cmd.Stderr = stderr
 	detachFromTerminal(cmd)
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("%s: %w", cmd.Args[0], err)
+		return err // os/exec's start errors already name the program
 	}
 	type exit struct {
 		err    error

--- a/internal/platform/open.go
+++ b/internal/platform/open.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -35,17 +36,31 @@ const openGrace = 2 * time.Second
 // stderrCap bounds how much of the opener's stderr is quoted in an error.
 const stderrCap = 2048
 
+// ErrLauncher is returned (wrapped, naming the path) when OpenFile refuses a
+// file the platform opener would launch rather than view.
+var ErrLauncher = errors.New("refusing to open an executable")
+
 // launcherExtensions are file types every platform opener LAUNCHES rather than
-// views: rundll32's FileProtocolHandler runs .exe/.bat/.js/.vbs/.lnk, macOS
-// `open` launches .app/.command/.pkg, and the common Linux desktops execute an
-// executable .desktop handed to xdg-open. `fleet open` exists for images,
-// charts and PDFs; refusing these costs nothing and keeps "an untrusted
-// container asked the human to open a file" a non-executing action.
+// views: rundll32's FileProtocolHandler runs .exe/.bat/.js/.vbs/.lnk/.py/.jar
+// and the various Windows shell item types, macOS `open` launches
+// .app/.command/.pkg/.jar/.workflow/.terminal, and the common Linux desktops
+// execute an executable .desktop handed to xdg-open. Internet-shortcut files
+// (.url/.webloc/.inetloc) are refused for the same reason as .desktop: "open a
+// file" must not become "open an arbitrary URL". `fleet open` exists for
+// images, charts and PDFs; refusing these costs nothing and keeps "an untrusted
+// container asked the human to open a file" a non-executing action. On Windows
+// there are no mode bits, so this list is the whole guard there — and a
+// deny-list is never complete, which is why the confirmation prompt stays.
 var launcherExtensions = map[string]bool{
 	".exe": true, ".bat": true, ".cmd": true, ".com": true, ".scr": true, ".pif": true,
-	".msi": true, ".msp": true, ".reg": true, ".lnk": true, ".hta": true,
-	".js": true, ".jse": true, ".vbs": true, ".vbe": true, ".wsf": true, ".wsh": true, ".ps1": true,
+	".msi": true, ".msp": true, ".reg": true, ".lnk": true, ".hta": true, ".cpl": true,
+	".inf": true, ".scf": true, ".msc": true, ".application": true, ".appref-ms": true,
+	".settingcontent-ms": true,
+	".js":                true, ".jse": true, ".vbs": true, ".vbe": true, ".wsf": true, ".wsh": true, ".ps1": true,
+	".vb": true, ".ws": true, ".py": true, ".pyw": true, ".jar": true, ".jnlp": true,
+	".url": true, ".webloc": true, ".inetloc": true,
 	".desktop": true, ".command": true, ".tool": true, ".app": true, ".pkg": true,
+	".workflow": true, ".terminal": true,
 	".sh": true, ".bash": true, ".zsh": true, ".run": true, ".appimage": true,
 }
 
@@ -96,16 +111,17 @@ func OpenFileCommand(path string) (*exec.Cmd, error) {
 	return OpenCommand(path)
 }
 
-// OpenFile opens the local file at path with the user's default application and
-// returns the absolute path it handed over (the 1-arg `fleet open` lands a bare
-// name in the cwd; absolute is unambiguous whatever the handler's own cwd is).
-// It refuses to open anything the platform opener would LAUNCH rather than view
-// — an executable file, or one of launcherExtensions — since the file came out
-// of a container. It reports an opener that failed outright (no handler, no
-// display, unknown program) and returns once the opener has handed off — or
-// after openGrace if the opener is itself hosting the application — without
-// ever waiting for the viewer to close; the process is reaped in the background
-// either way.
+// OpenFile opens the local file (or directory) at path with the user's default
+// application and returns the absolute path it handed over (the 1-arg `fleet
+// open` lands a bare name in the cwd; absolute is unambiguous whatever the
+// handler's own cwd is). It refuses, with ErrLauncher, anything the platform
+// opener would LAUNCH rather than view — an executable file, or one of
+// launcherExtensions — since the file came out of a container. Every error it
+// returns names the path. An opener that failed outright (no handler, no
+// display, unknown program) is reported; OpenFile returns once the opener has
+// handed off — or after openGrace if the opener is itself hosting the
+// application — without ever waiting for the viewer to close; the process is
+// reaped in the background either way.
 func OpenFile(path string) (string, error) {
 	if abs, err := filepath.Abs(path); err == nil {
 		path = abs
@@ -113,26 +129,32 @@ func OpenFile(path string) (string, error) {
 	if launcher, err := IsLauncherFile(path); err != nil {
 		return path, err
 	} else if launcher {
-		return path, fmt.Errorf("refusing to open an executable; it was copied to %s", path)
+		return path, fmt.Errorf("%w; it was copied to %s", ErrLauncher, path)
 	}
 	cmd, err := OpenFileCommand(path)
 	if err != nil {
-		return path, err
+		return path, fmt.Errorf("open %s: %w", path, err)
 	}
-	return path, runDetached(cmd, openGrace)
+	if err := runDetached(cmd, openGrace); err != nil {
+		return path, fmt.Errorf("open %s: %w", path, err)
+	}
+	return path, nil
 }
 
 // IsLauncherFile reports whether the file at path is something an opener would
 // launch rather than view: a regular file with an exec bit, or any name (file
 // or directory — macOS .app bundles are directories) with a launcherExtensions
 // suffix. A directory without such a suffix is fine: openers show it in the
-// file manager.
+// file manager. The suffix is taken after trimming trailing dots and spaces,
+// which Win32 strips when creating the file: a source named `setup.exe.` lands
+// on disk as setup.exe, and rundll32 would run it.
 func IsLauncherFile(path string) (bool, error) {
 	fi, err := os.Stat(path)
 	if err != nil {
 		return false, err
 	}
-	if launcherExtensions[strings.ToLower(filepath.Ext(path))] {
+	base := strings.TrimRight(filepath.Base(path), ". ")
+	if launcherExtensions[strings.ToLower(filepath.Ext(base))] {
 		return true, nil
 	}
 	return fi.Mode().IsRegular() && fi.Mode()&0o111 != 0, nil
@@ -149,7 +171,10 @@ func IsLauncherFile(path string) (bool, error) {
 // warning (GTK/Qt print plenty); a file never does. The child is also put in
 // its own session (unix) so closing the terminal doesn't SIGHUP it. The file is
 // unlinked as soon as it has been read or the child outlived the grace — an
-// open descriptor keeps working on an unlinked file.
+// open descriptor keeps working on an unlinked file — and again by the reaper
+// once the child exits, for Windows, where the child's inherited handle blocks
+// the first removal (a host CLI that exits before its viewer leaves that one
+// file behind there).
 func runDetached(cmd *exec.Cmd, grace time.Duration) error {
 	stderr, err := os.CreateTemp("", "fleet-open-*.log")
 	if err != nil {
@@ -164,15 +189,29 @@ func runDetached(cmd *exec.Cmd, grace time.Duration) error {
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("%s: %w", cmd.Args[0], err)
 	}
-	done := make(chan error, 1)
-	go func() { done <- cmd.Wait() }()
-	select {
-	case err := <-done:
+	type exit struct {
+		err    error
+		stderr string
+	}
+	done := make(chan exit, 1)
+	go func() {
+		// Read the stderr text here, before unlinking, so the caller never
+		// races the removal: it receives the text along with the exit error.
+		err := cmd.Wait()
+		var msg string
 		if err != nil {
-			if msg := readHead(stderr.Name(), stderrCap); msg != "" {
-				return fmt.Errorf("%s: %w: %s", cmd.Args[0], err, msg)
+			msg = readHead(stderr.Name(), stderrCap)
+		}
+		os.Remove(stderr.Name())
+		done <- exit{err, msg}
+	}()
+	select {
+	case res := <-done:
+		if res.err != nil {
+			if res.stderr != "" {
+				return fmt.Errorf("%s: %w: %s", cmd.Args[0], res.err, res.stderr)
 			}
-			return fmt.Errorf("%s: %w", cmd.Args[0], err)
+			return fmt.Errorf("%s: %w", cmd.Args[0], res.err)
 		}
 		return nil
 	case <-time.After(grace):

--- a/internal/platform/open.go
+++ b/internal/platform/open.go
@@ -1,0 +1,154 @@
+package platform
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+// open.go hands a URL or a local file to the operating system's default handler
+// — the thing a desktop does on double-click. It is shared by the TUI (opening
+// a PR link, or a file delivered by an in-instance `fleet open`) and the host
+// CLI (`fleet open`), so every "open this on the user's machine" path picks the
+// same per-OS opener.
+
+// EnvOpener names the program `fleet open` uses instead of the platform default
+// (xdg-open / open / wslview). It is invoked with the file's path appended to
+// its (whitespace-separated) arguments — e.g. FLEET_OPENER="imv -f" — and is
+// how a headless or unusual desktop can still route opens somewhere useful. It
+// applies to FILE opens only; URLs always go to the platform browser opener.
+const EnvOpener = "FLEET_OPENER"
+
+// openGrace is how long OpenFile waits for the opener to exit before deciding
+// it is hosting the viewer itself. Desktop openers (gio/kde-open, macOS open,
+// wslview) hand off and return within milliseconds; a failure (no handler, no
+// display) also surfaces well inside this window. Only a bare xdg-open with no
+// desktop session runs the application in the foreground, and that must not
+// pin the caller for the viewer's whole lifetime.
+const openGrace = 2 * time.Second
+
+// stderrCap bounds how much of the opener's stderr is kept for the error
+// message. The reaper keeps draining past it (the pipe must not fill up while
+// a long-lived viewer runs), it just stops remembering.
+const stderrCap = 2048
+
+// OpenCommand builds the per-OS "open with the default handler" command for
+// target, a URL or a local path. WSL is special cased (xdg-open there opens
+// nothing useful) to reach the Windows handler. Every opener receives target
+// as a separate, non-shell-interpreted argument; the WSL PowerShell fallback
+// passes it via the environment rather than interpolating it into the -Command
+// string, so a target containing PowerShell metacharacters can't inject code
+// on the host.
+func OpenCommand(target string) (*exec.Cmd, error) {
+	switch {
+	case runtime.GOOS == "darwin":
+		return exec.Command("open", target), nil
+	case runtime.GOOS == "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", target), nil
+	case IsWSL():
+		// wslu's wslview is the clean path; fall back to the Windows shell's
+		// start handler via powershell when it isn't installed.
+		if _, err := exec.LookPath("wslview"); err == nil {
+			return exec.Command("wslview", target), nil
+		}
+		cmd := exec.Command("powershell.exe", "-NoProfile", "-Command", "Start-Process -FilePath $env:FLEET_OPEN_TARGET")
+		cmd.Env = append(os.Environ(), "FLEET_OPEN_TARGET="+target)
+		return cmd, nil
+	case runtime.GOOS == "linux":
+		return exec.Command("xdg-open", target), nil
+	default:
+		return nil, fmt.Errorf("don't know how to open %q on %s", target, runtime.GOOS)
+	}
+}
+
+// OpenFileCommand builds the command that opens the local file at path with the
+// user's default application: the FLEET_OPENER override when set, otherwise the
+// platform opener. On WSL without wslview the PowerShell fallback needs a
+// Windows path, so the Linux path is translated with wslpath first.
+func OpenFileCommand(path string) (*exec.Cmd, error) {
+	if opener := strings.Fields(os.Getenv(EnvOpener)); len(opener) > 0 {
+		return exec.Command(opener[0], append(opener[1:], path)...), nil
+	}
+	if IsWSL() {
+		if _, err := exec.LookPath("wslview"); err != nil {
+			if win, err := exec.Command("wslpath", "-w", path).Output(); err == nil {
+				path = strings.TrimSpace(string(win))
+			}
+		}
+	}
+	return OpenCommand(path)
+}
+
+// OpenFile opens the local file at path with the user's default application and
+// reports an opener that failed outright (no handler, no display, unknown
+// program). It returns once the opener has handed off — or after openGrace if
+// the opener is itself hosting the application — without ever waiting for the
+// viewer to close; the process is reaped in the background either way.
+func OpenFile(path string) error {
+	cmd, err := OpenFileCommand(path)
+	if err != nil {
+		return err
+	}
+	return runDetached(cmd, openGrace)
+}
+
+// runDetached starts cmd with no terminal attached, waits up to grace for it to
+// exit, and reports its exit error if it did. A process still running after
+// grace is left alone (nil) and reaped by a background goroutine, so a caller
+// on a UI thread or at a shell prompt is never held for the child's lifetime.
+func runDetached(cmd *exec.Cmd, grace time.Duration) error {
+	stderr := &cappedBuffer{limit: stderrCap}
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("%s: %w", cmd.Args[0], err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			if msg := strings.TrimSpace(stderr.String()); msg != "" {
+				return fmt.Errorf("%s: %w: %s", cmd.Args[0], err, msg)
+			}
+			return fmt.Errorf("%s: %w", cmd.Args[0], err)
+		}
+		return nil
+	case <-time.After(grace):
+		return nil
+	}
+}
+
+// cappedBuffer is an io.Writer that remembers at most limit bytes and silently
+// discards the rest, so a chatty long-lived child can't grow it without bound
+// while still being drained.
+type cappedBuffer struct {
+	mu    sync.Mutex
+	buf   bytes.Buffer
+	limit int
+}
+
+func (b *cappedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if room := b.limit - b.buf.Len(); room > 0 {
+		if len(p) > room {
+			b.buf.Write(p[:room])
+		} else {
+			b.buf.Write(p)
+		}
+	}
+	return len(p), nil
+}
+
+func (b *cappedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}

--- a/internal/platform/open.go
+++ b/internal/platform/open.go
@@ -1,13 +1,12 @@
 package platform
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -18,9 +17,10 @@ import (
 // same per-OS opener.
 
 // EnvOpener names the program `fleet open` uses instead of the platform default
-// (xdg-open / open / wslview). It is invoked with the file's path appended to
-// its (whitespace-separated) arguments — e.g. FLEET_OPENER="imv -f" — and is
-// how a headless or unusual desktop can still route opens somewhere useful. It
+// (xdg-open / open / wslview). Its value is split on whitespace into a program
+// and arguments (so a program path containing a space cannot be expressed) and
+// the file's path is appended last — e.g. FLEET_OPENER="imv -f". It is how a
+// headless or unusual desktop can still route opens somewhere useful. It
 // applies to FILE opens only; URLs always go to the platform browser opener.
 const EnvOpener = "FLEET_OPENER"
 
@@ -32,10 +32,22 @@ const EnvOpener = "FLEET_OPENER"
 // pin the caller for the viewer's whole lifetime.
 const openGrace = 2 * time.Second
 
-// stderrCap bounds how much of the opener's stderr is kept for the error
-// message. The reaper keeps draining past it (the pipe must not fill up while
-// a long-lived viewer runs), it just stops remembering.
+// stderrCap bounds how much of the opener's stderr is quoted in an error.
 const stderrCap = 2048
+
+// launcherExtensions are file types every platform opener LAUNCHES rather than
+// views: rundll32's FileProtocolHandler runs .exe/.bat/.js/.vbs/.lnk, macOS
+// `open` launches .app/.command/.pkg, and the common Linux desktops execute an
+// executable .desktop handed to xdg-open. `fleet open` exists for images,
+// charts and PDFs; refusing these costs nothing and keeps "an untrusted
+// container asked the human to open a file" a non-executing action.
+var launcherExtensions = map[string]bool{
+	".exe": true, ".bat": true, ".cmd": true, ".com": true, ".scr": true, ".pif": true,
+	".msi": true, ".msp": true, ".reg": true, ".lnk": true, ".hta": true,
+	".js": true, ".jse": true, ".vbs": true, ".vbe": true, ".wsf": true, ".wsh": true, ".ps1": true,
+	".desktop": true, ".command": true, ".tool": true, ".app": true, ".pkg": true,
+	".sh": true, ".bash": true, ".zsh": true, ".run": true, ".appimage": true,
+}
 
 // OpenCommand builds the per-OS "open with the default handler" command for
 // target, a URL or a local path. WSL is special cased (xdg-open there opens
@@ -85,27 +97,70 @@ func OpenFileCommand(path string) (*exec.Cmd, error) {
 }
 
 // OpenFile opens the local file at path with the user's default application and
-// reports an opener that failed outright (no handler, no display, unknown
-// program). It returns once the opener has handed off — or after openGrace if
-// the opener is itself hosting the application — without ever waiting for the
-// viewer to close; the process is reaped in the background either way.
-func OpenFile(path string) error {
+// returns the absolute path it handed over (the 1-arg `fleet open` lands a bare
+// name in the cwd; absolute is unambiguous whatever the handler's own cwd is).
+// It refuses to open anything the platform opener would LAUNCH rather than view
+// — an executable file, or one of launcherExtensions — since the file came out
+// of a container. It reports an opener that failed outright (no handler, no
+// display, unknown program) and returns once the opener has handed off — or
+// after openGrace if the opener is itself hosting the application — without
+// ever waiting for the viewer to close; the process is reaped in the background
+// either way.
+func OpenFile(path string) (string, error) {
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	if launcher, err := IsLauncherFile(path); err != nil {
+		return path, err
+	} else if launcher {
+		return path, fmt.Errorf("refusing to open an executable; it was copied to %s", path)
+	}
 	cmd, err := OpenFileCommand(path)
 	if err != nil {
-		return err
+		return path, err
 	}
-	return runDetached(cmd, openGrace)
+	return path, runDetached(cmd, openGrace)
+}
+
+// IsLauncherFile reports whether the file at path is something an opener would
+// launch rather than view: a regular file with an exec bit, or any name (file
+// or directory — macOS .app bundles are directories) with a launcherExtensions
+// suffix. A directory without such a suffix is fine: openers show it in the
+// file manager.
+func IsLauncherFile(path string) (bool, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	if launcherExtensions[strings.ToLower(filepath.Ext(path))] {
+		return true, nil
+	}
+	return fi.Mode().IsRegular() && fi.Mode()&0o111 != 0, nil
 }
 
 // runDetached starts cmd with no terminal attached, waits up to grace for it to
-// exit, and reports its exit error if it did. A process still running after
-// grace is left alone (nil) and reaped by a background goroutine, so a caller
-// on a UI thread or at a shell prompt is never held for the child's lifetime.
+// exit, and reports its exit error (with its stderr) if it did. A process still
+// running after grace is left alone (nil) and reaped by a background goroutine,
+// so a caller on a UI thread or at a shell prompt is never held for the child's
+// lifetime.
+//
+// Stderr goes to a temp FILE, not a pipe: the host CLI exits right after the
+// grace, and a pipe whose reader is gone would SIGPIPE the viewer on its next
+// warning (GTK/Qt print plenty); a file never does. The child is also put in
+// its own session (unix) so closing the terminal doesn't SIGHUP it. The file is
+// unlinked as soon as it has been read or the child outlived the grace — an
+// open descriptor keeps working on an unlinked file.
 func runDetached(cmd *exec.Cmd, grace time.Duration) error {
-	stderr := &cappedBuffer{limit: stderrCap}
+	stderr, err := os.CreateTemp("", "fleet-open-*.log")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(stderr.Name())
+	defer stderr.Close()
 	cmd.Stdin = nil
 	cmd.Stdout = nil
 	cmd.Stderr = stderr
+	detachFromTerminal(cmd)
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("%s: %w", cmd.Args[0], err)
 	}
@@ -114,7 +169,7 @@ func runDetached(cmd *exec.Cmd, grace time.Duration) error {
 	select {
 	case err := <-done:
 		if err != nil {
-			if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			if msg := readHead(stderr.Name(), stderrCap); msg != "" {
 				return fmt.Errorf("%s: %w: %s", cmd.Args[0], err, msg)
 			}
 			return fmt.Errorf("%s: %w", cmd.Args[0], err)
@@ -125,30 +180,15 @@ func runDetached(cmd *exec.Cmd, grace time.Duration) error {
 	}
 }
 
-// cappedBuffer is an io.Writer that remembers at most limit bytes and silently
-// discards the rest, so a chatty long-lived child can't grow it without bound
-// while still being drained.
-type cappedBuffer struct {
-	mu    sync.Mutex
-	buf   bytes.Buffer
-	limit int
-}
-
-func (b *cappedBuffer) Write(p []byte) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if room := b.limit - b.buf.Len(); room > 0 {
-		if len(p) > room {
-			b.buf.Write(p[:room])
-		} else {
-			b.buf.Write(p)
-		}
+// readHead returns the first n bytes of the file at path, trimmed; empty when
+// unreadable.
+func readHead(path string, n int) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
 	}
-	return len(p), nil
-}
-
-func (b *cappedBuffer) String() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.buf.String()
+	defer f.Close()
+	buf := make([]byte, n)
+	read, _ := f.Read(buf)
+	return strings.TrimSpace(string(buf[:read]))
 }

--- a/internal/platform/open_test.go
+++ b/internal/platform/open_test.go
@@ -1,7 +1,9 @@
 package platform
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -49,13 +51,106 @@ func TestOpenFileCommandOverride(t *testing.T) {
 	}
 }
 
+// TestIsLauncherFile pins what OpenFile refuses: an exec-bit regular file and
+// any launcher extension (file or directory), while a plain viewable file and a
+// plain directory pass.
+func TestIsLauncherFile(t *testing.T) {
+	dir := t.TempDir()
+	mk := func(name string, mode os.FileMode) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("x"), mode); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	bundle := filepath.Join(dir, "Thing.app")
+	if err := os.Mkdir(bundle, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{mk("chart.png", 0o644), false},
+		{mk("report.PDF", 0o644), false},
+		{dir, false}, // a plain directory opens in the file manager
+		{mk("tool", 0o755), true},
+		{mk("run.SH", 0o644), true},
+		{mk("thing.desktop", 0o644), true},
+		{mk("setup.exe", 0o644), true},
+		{bundle, true},
+	}
+	for _, tc := range cases {
+		got, err := IsLauncherFile(tc.path)
+		if err != nil {
+			t.Fatalf("IsLauncherFile(%q): %v", tc.path, err)
+		}
+		if got != tc.want {
+			t.Errorf("IsLauncherFile(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+	if _, err := IsLauncherFile(filepath.Join(dir, "missing")); err == nil {
+		t.Error("a missing file should error")
+	}
+}
+
+// TestOpenFileRefusesExecutable confirms OpenFile never invokes an opener for a
+// launcher file, reports where the file is, and returns the absolute path.
+func TestOpenFileRefusesExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec bits")
+	}
+	dir := t.TempDir()
+	log := filepath.Join(dir, "opened.log")
+	stub := filepath.Join(dir, "opener.sh")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\necho \"$1\" >> "+log+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvOpener, stub)
+	tool := filepath.Join(dir, "tool")
+	if err := os.WriteFile(tool, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := OpenFile(tool)
+	if err == nil || !strings.Contains(err.Error(), "refusing to open an executable") || !strings.Contains(err.Error(), tool) {
+		t.Fatalf("executable should be refused naming the path, got %v", err)
+	}
+	if got != tool {
+		t.Errorf("returned path = %q, want %q", got, tool)
+	}
+	if _, err := os.Stat(log); err == nil {
+		t.Error("the opener must not be invoked for a refused file")
+	}
+
+	// A viewable file goes through, with the absolute path.
+	png := filepath.Join(dir, "chart.png")
+	if err := os.WriteFile(png, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	got, err = OpenFile("chart.png")
+	if err != nil {
+		t.Fatalf("OpenFile(chart.png): %v", err)
+	}
+	if got != png {
+		t.Errorf("OpenFile should return the absolute path, got %q", got)
+	}
+	if opened, _ := os.ReadFile(log); strings.TrimSpace(string(opened)) != png {
+		t.Errorf("opener should receive the absolute path, got %q", opened)
+	}
+}
+
 // TestRunDetached covers the three outcomes: a prompt clean exit, a prompt
 // failure (reported, with stderr), and a long-lived child that is left running
-// after the grace period without holding the caller.
+// after the grace period without holding the caller — and that no stderr temp
+// file is left behind in any case.
 func TestRunDetached(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("needs a POSIX sh")
 	}
+	t.Setenv("TMPDIR", t.TempDir())
 	if err := runDetached(exec.Command("sh", "-c", "exit 0"), time.Second); err != nil {
 		t.Errorf("clean exit: unexpected error %v", err)
 	}
@@ -76,18 +171,7 @@ func TestRunDetached(t *testing.T) {
 	if err := runDetached(exec.Command("no-such-opener-xyz", "/tmp/x"), time.Second); err == nil {
 		t.Errorf("missing program should fail to start")
 	}
-}
-
-// TestCappedBuffer confirms the stderr keeper stops at its limit but keeps
-// accepting (draining) writes.
-func TestCappedBuffer(t *testing.T) {
-	b := &cappedBuffer{limit: 5}
-	for _, chunk := range []string{"abc", "defg", "h"} {
-		if n, err := b.Write([]byte(chunk)); err != nil || n != len(chunk) {
-			t.Fatalf("Write(%q) = (%d,%v), want (%d,nil)", chunk, n, err, len(chunk))
-		}
-	}
-	if got := b.String(); got != "abcde" {
-		t.Errorf("kept %q, want %q", got, "abcde")
+	if left, _ := filepath.Glob(filepath.Join(os.TempDir(), "fleet-open-*.log")); len(left) > 0 {
+		t.Errorf("stderr temp files left behind: %v", left)
 	}
 }

--- a/internal/platform/open_test.go
+++ b/internal/platform/open_test.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -78,6 +79,14 @@ func TestIsLauncherFile(t *testing.T) {
 		{mk("run.SH", 0o644), true},
 		{mk("thing.desktop", 0o644), true},
 		{mk("setup.exe", 0o644), true},
+		{mk("app.jar", 0o644), true},
+		{mk("link.url", 0o644), true},
+		{mk("page.webloc", 0o644), true},
+		{mk("script.py", 0o644), true},
+		{mk("Do It.workflow", 0o644), true},
+		// Win32 strips trailing dots/spaces on creation, so these are setup.exe.
+		{mk("setup.exe.", 0o644), true},
+		{mk("setup.exe ", 0o644), true},
 		{bundle, true},
 	}
 	for _, tc := range cases {
@@ -117,8 +126,8 @@ func TestOpenFileRefusesExecutable(t *testing.T) {
 		t.Fatal(err)
 	}
 	got, err := OpenFile(tool)
-	if err == nil || !strings.Contains(err.Error(), "refusing to open an executable") || !strings.Contains(err.Error(), tool) {
-		t.Fatalf("executable should be refused naming the path, got %v", err)
+	if !errors.Is(err, ErrLauncher) || !strings.Contains(err.Error(), tool) {
+		t.Fatalf("executable should be refused with ErrLauncher naming the path, got %v", err)
 	}
 	if got != tool {
 		t.Errorf("returned path = %q, want %q", got, tool)

--- a/internal/platform/open_test.go
+++ b/internal/platform/open_test.go
@@ -1,0 +1,93 @@
+package platform
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestOpenCommandCarriesTarget confirms the platform opener receives the target
+// as its own argument (never shell-interpolated) on every supported OS.
+func TestOpenCommandCarriesTarget(t *testing.T) {
+	const target = "/tmp/chart with spaces.png"
+	cmd, err := OpenCommand(target)
+	if err != nil {
+		if runtime.GOOS == "linux" || runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+			t.Fatalf("unexpected error on %s: %v", runtime.GOOS, err)
+		}
+		return
+	}
+	carried := false
+	for _, a := range cmd.Args {
+		if a == target {
+			carried = true
+		}
+	}
+	for _, e := range cmd.Env {
+		if strings.HasSuffix(e, "="+target) {
+			carried = true
+		}
+	}
+	if !carried {
+		t.Errorf("opener should carry the target verbatim: args=%v", cmd.Args)
+	}
+}
+
+// TestOpenFileCommandOverride covers FLEET_OPENER: the program (plus its own
+// arguments) replaces the platform opener and the path is appended last.
+func TestOpenFileCommandOverride(t *testing.T) {
+	t.Setenv(EnvOpener, "  my-viewer --fullscreen ")
+	cmd, err := OpenFileCommand("/tmp/x.png")
+	if err != nil {
+		t.Fatalf("OpenFileCommand: %v", err)
+	}
+	want := []string{"my-viewer", "--fullscreen", "/tmp/x.png"}
+	if strings.Join(cmd.Args, " ") != strings.Join(want, " ") {
+		t.Errorf("args = %v, want %v", cmd.Args, want)
+	}
+}
+
+// TestRunDetached covers the three outcomes: a prompt clean exit, a prompt
+// failure (reported, with stderr), and a long-lived child that is left running
+// after the grace period without holding the caller.
+func TestRunDetached(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("needs a POSIX sh")
+	}
+	if err := runDetached(exec.Command("sh", "-c", "exit 0"), time.Second); err != nil {
+		t.Errorf("clean exit: unexpected error %v", err)
+	}
+	err := runDetached(exec.Command("sh", "-c", "echo no handler >&2; exit 3"), time.Second)
+	if err == nil || !strings.Contains(err.Error(), "no handler") || !strings.Contains(err.Error(), "exit status 3") {
+		t.Errorf("failure should report the exit status and stderr, got %v", err)
+	}
+	start := time.Now()
+	if err := runDetached(exec.Command("sh", "-c", "sleep 5"), 100*time.Millisecond); err != nil {
+		t.Errorf("long-lived child: unexpected error %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("long-lived child held the caller for %v", elapsed)
+	}
+	if _, err := exec.LookPath("no-such-opener-xyz"); err == nil {
+		t.Skip("improbable: no-such-opener-xyz exists")
+	}
+	if err := runDetached(exec.Command("no-such-opener-xyz", "/tmp/x"), time.Second); err == nil {
+		t.Errorf("missing program should fail to start")
+	}
+}
+
+// TestCappedBuffer confirms the stderr keeper stops at its limit but keeps
+// accepting (draining) writes.
+func TestCappedBuffer(t *testing.T) {
+	b := &cappedBuffer{limit: 5}
+	for _, chunk := range []string{"abc", "defg", "h"} {
+		if n, err := b.Write([]byte(chunk)); err != nil || n != len(chunk) {
+			t.Fatalf("Write(%q) = (%d,%v), want (%d,nil)", chunk, n, err, len(chunk))
+		}
+	}
+	if got := b.String(); got != "abcde" {
+		t.Errorf("kept %q, want %q", got, "abcde")
+	}
+}

--- a/internal/platform/open_test.go
+++ b/internal/platform/open_test.go
@@ -100,7 +100,12 @@ func TestOpenFileRefusesExecutable(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("exec bits")
 	}
-	dir := t.TempDir()
+	// Resolve the temp dir: on macOS it sits under a symlinked /var/folders,
+	// and the cwd-based Abs below reports the real /private/var path.
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	log := filepath.Join(dir, "opened.log")
 	stub := filepath.Join(dir, "opener.sh")
 	if err := os.WriteFile(stub, []byte("#!/bin/sh\necho \"$1\" >> "+log+"\n"), 0o755); err != nil {
@@ -127,9 +132,7 @@ func TestOpenFileRefusesExecutable(t *testing.T) {
 	if err := os.WriteFile(png, []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatal(err)
-	}
+	t.Chdir(dir)
 	got, err = OpenFile("chart.png")
 	if err != nil {
 		t.Fatalf("OpenFile(chart.png): %v", err)

--- a/internal/server/control.go
+++ b/internal/server/control.go
@@ -41,9 +41,10 @@ type controlRegistry struct {
 
 	// onCopy is invoked for each decoded file.copy envelope, tagged with the
 	// originating instance. src/dst are the scp endpoints as typed inside the
-	// instance, passed through verbatim (the TUI runs the copy). Same
+	// instance, passed through verbatim (the TUI runs the copy); open is the
+	// `fleet open` flag (open the delivered file on the TUI machine). Same
 	// concurrency/non-blocking contract as onOpen.
-	onCopy func(fleetName, instanceName, src, dst string)
+	onCopy func(fleetName, instanceName, src, dst string, open bool)
 
 	// gated reports whether to keep control sockets open at all: only while a
 	// browser-capable client (a TUI / Watch subscriber) is attached. With no
@@ -58,7 +59,7 @@ type controlRegistry struct {
 // newControlRegistry creates an empty registry. onOpen is invoked per received
 // browser.open envelope, onCopy per file.copy envelope; gated decides whether
 // any sockets should be open (nil means always on).
-func newControlRegistry(onOpen func(fleetName, instanceName, url string), onCopy func(fleetName, instanceName, src, dst string), gated func() bool) *controlRegistry {
+func newControlRegistry(onOpen func(fleetName, instanceName, url string), onCopy func(fleetName, instanceName, src, dst string, open bool), gated func() bool) *controlRegistry {
 	return &controlRegistry{
 		onOpen:  onOpen,
 		onCopy:  onCopy,
@@ -161,8 +162,8 @@ func (r *controlRegistry) syncRunning(st *state.State) {
 					return
 				}
 				if r.onCopy != nil {
-					flog.Info("file copy requested", "fleet", fName, "instance", iName, "from", payload.Src, "to", payload.Dst)
-					r.onCopy(fName, iName, payload.Src, payload.Dst)
+					flog.Info("file copy requested", "fleet", fName, "instance", iName, "from", payload.Src, "to", payload.Dst, "open", payload.Open)
+					r.onCopy(fName, iName, payload.Src, payload.Dst, payload.Open)
 				}
 			}
 		})

--- a/internal/server/control_test.go
+++ b/internal/server/control_test.go
@@ -18,6 +18,7 @@ type openEvent struct {
 // copyEvent is one decoded file.copy the registry forwarded via onCopy.
 type copyEvent struct {
 	fleet, instance, src, dst string
+	open                      bool
 }
 
 // shortHome creates a temp HOME under /tmp and points $HOME at it. Not
@@ -75,9 +76,9 @@ func TestControlSyncRoundTrip(t *testing.T) {
 		case events <- openEvent{f, i, url}:
 		default:
 		}
-	}, func(f, i, src, dst string) {
+	}, func(f, i, src, dst string, open bool) {
 		select {
-		case copies <- copyEvent{f, i, src, dst}:
+		case copies <- copyEvent{f, i, src, dst, open}:
 		default:
 		}
 	}, nil)
@@ -117,24 +118,26 @@ func TestControlSyncRoundTrip(t *testing.T) {
 	}
 
 	// A file.copy envelope on the same socket dispatches to onCopy, carrying
-	// the two endpoints through verbatim.
+	// the two endpoints and the `fleet open` flag through verbatim.
 	const (
 		wantSrc = ":bin/tool"
 		wantDst = "~/builds/tool"
 	)
-	if err := client.CopyFile(wantSrc, wantDst); err != nil {
-		t.Fatalf("CopyFile: %v", err)
-	}
-	select {
-	case ev := <-copies:
-		if ev.fleet != fleetName || ev.instance != instanceName {
-			t.Errorf("copy event = (%q,%q), want (%q,%q)", ev.fleet, ev.instance, fleetName, instanceName)
+	for _, wantOpen := range []bool{false, true} {
+		if err := client.CopyFile(wantSrc, wantDst, wantOpen); err != nil {
+			t.Fatalf("CopyFile(open=%v): %v", wantOpen, err)
 		}
-		if ev.src != wantSrc || ev.dst != wantDst {
-			t.Errorf("copy event = (%q,%q), want (%q,%q)", ev.src, ev.dst, wantSrc, wantDst)
+		select {
+		case ev := <-copies:
+			if ev.fleet != fleetName || ev.instance != instanceName {
+				t.Errorf("copy event = (%q,%q), want (%q,%q)", ev.fleet, ev.instance, fleetName, instanceName)
+			}
+			if ev.src != wantSrc || ev.dst != wantDst || ev.open != wantOpen {
+				t.Errorf("copy event = (%q,%q,open=%v), want (%q,%q,open=%v)", ev.src, ev.dst, ev.open, wantSrc, wantDst, wantOpen)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for file.copy(open=%v) on onCopy", wantOpen)
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for file.copy on onCopy")
 	}
 
 	r.syncRunning(&state.State{Fleets: map[string]*fleet.Fleet{}})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -105,13 +105,14 @@ func Serve(ctx context.Context) error {
 				Instance: instanceName,
 			})
 		})
-	}, func(fleetName, instanceName, src, dst string) {
+	}, func(fleetName, instanceName, src, dst string, open bool) {
 		svc.hub.post(func(h *hub) {
 			h.broadcastFileCopy(&fleetgrpc.FileCopy{
 				Fleet:    fleetName,
 				Instance: instanceName,
 				Src:      src,
 				Dst:      dst,
+				Open:     open,
 			})
 		})
 	}, svc.hub.hasSubscribers)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -137,11 +137,13 @@ type model struct {
 	releaseNotesVersion string
 	releaseNotesBody    string
 
-	// Delegated-copy confirmation: an in-container `fc` that touches a host path
-	// is queued here until the human allows/denies it; copySessionAllow remembers
-	// instances the human cleared for the lifetime of this TUI. See copyconfirm.go.
+	// Delegated-copy confirmation: an in-container `fc`/`fo` that touches a host
+	// path is queued here until the human allows/denies it; copySessionAllow and
+	// openSessionAllow remember instances the human cleared (for copies, and for
+	// opens) for the lifetime of this TUI. See copyconfirm.go.
 	pendingCopyConfirms []copyRequest
 	copySessionAllow    map[string]bool
+	openSessionAllow    map[string]bool
 
 	// Pending exec after quit: after a successful update the TUI
 	// quits, then Run() replaces the current process with the new
@@ -196,6 +198,7 @@ func newModel() model {
 		inHostTmux:         os.Getenv("TMUX") != "",
 		armadaStatus:       make(map[string]armadaStatus),
 		copySessionAllow:   make(map[string]bool),
+		openSessionAllow:   make(map[string]bool),
 		bootGateway:        os.Getenv(fleetclient.EnvGateway),
 		bootToken:          os.Getenv(fleetclient.EnvToken),
 		bootServer:         os.Getenv(fleetclient.EnvServer),

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -865,15 +865,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.fleet == "" || msg.instance == "" || msg.src == "" {
 			return m, spinCmd
 		}
-		cmd := m.requestCopy(copyRequest{fleet: msg.fleet, instance: msg.instance, src: msg.src, dst: msg.dst})
+		cmd := m.requestCopy(copyRequest{fleet: msg.fleet, instance: msg.instance, src: msg.src, dst: msg.dst, open: msg.open})
 		return m, tea.Batch(spinCmd, cmd)
 
 	case fileCopyDoneMsg:
-		if msg.err != nil {
-			m.message = fmt.Sprintf("Copy of %s failed: %v", msg.src, msg.err)
-		} else {
-			m.message = fmt.Sprintf("Copied %s -> %s", msg.src, msg.dest)
-		}
+		m.message = msg.statusLine()
 		return m, spinCmd
 
 	case remoteMcpStatusMsg:

--- a/internal/tui/auto_tag_nav_test.go
+++ b/internal/tui/auto_tag_nav_test.go
@@ -1,7 +1,6 @@
 package tui
 
 import (
-	"runtime"
 	"strings"
 	"testing"
 
@@ -326,24 +325,5 @@ func TestOpenExternalURLRefusesNonHTTP(t *testing.T) {
 	// Must return an error WITHOUT launching anything for a non-http scheme.
 	if err := openExternalURL("javascript:alert(1)"); err == nil {
 		t.Errorf("expected refusal for a non-http(s) URL")
-	}
-}
-
-func TestOpenExternalURLCommand(t *testing.T) {
-	cmd, err := openExternalURLCommand("https://github.com/o/r/pull/7")
-	if err != nil {
-		if runtime.GOOS == "linux" || runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
-			t.Fatalf("unexpected error on %s: %v", runtime.GOOS, err)
-		}
-		return
-	}
-	found := false
-	for _, a := range cmd.Args {
-		if strings.Contains(a, "github.com/o/r/pull/7") {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("opener args should include the URL: %v", cmd.Args)
 	}
 }

--- a/internal/tui/copyconfirm.go
+++ b/internal/tui/copyconfirm.go
@@ -18,6 +18,11 @@ import (
 // path the TUI asks the human to allow it. "Allow for session" remembers the
 // originating instance in memory, so repeated copies from a box the human trusts
 // don't re-prompt while the TUI stays open.
+//
+// A `fleet open` (fo) is a copy PLUS handing the file to the desktop's opener,
+// which is a bigger thing to pre-approve than a copy, so it has its own session
+// allowance: an [s] pressed on a plain copy never unlocks unattended opens, while
+// an [s] pressed on an open covers both (an open is a superset of a copy).
 
 // copyRequest is one delegated copy awaiting (or cleared for) host-side action.
 // open marks a `fleet open` (fo): once the file lands on this machine it is
@@ -36,6 +41,14 @@ func (r copyRequest) verb() string {
 		return "open"
 	}
 	return "copy"
+}
+
+// verbs is the plural, for the session-allow hint ("allow copies/opens").
+func (r copyRequest) verbs() string {
+	if r.open {
+		return "opens"
+	}
+	return "copies"
 }
 
 // copyTouchesHost reports whether either endpoint is a path on this (the host)
@@ -62,15 +75,36 @@ func (m *model) copyConfirmShowing() bool {
 }
 
 // requestCopy decides what to do with a delegated copy: run it now when it does
-// not touch the host, or the originating instance is already session-allowed;
-// otherwise queue it for confirmation. Returns the command to run (nil while a
-// request is queued for the human to confirm).
+// not touch the host, or the originating instance is already session-allowed
+// for this kind of request; otherwise queue it for confirmation. Returns the
+// command to run (nil while a request is queued for the human to confirm).
 func (m *model) requestCopy(req copyRequest) tea.Cmd {
-	if !copyTouchesHost(req.src, req.dst) || m.copySessionAllow[req.instanceKey()] {
+	if !copyTouchesHost(req.src, req.dst) || m.sessionAllowed(req) {
 		return m.startConfirmedCopy(req)
 	}
 	m.pendingCopyConfirms = append(m.pendingCopyConfirms, req)
 	return nil
+}
+
+// sessionAllowed reports whether the human already cleared this instance for
+// the session for this KIND of request: an open needs the open allowance; a
+// copy is covered by either (an open allowance implies copies).
+func (m *model) sessionAllowed(req copyRequest) bool {
+	key := req.instanceKey()
+	if req.open {
+		return m.openSessionAllow[key]
+	}
+	return m.copySessionAllow[key] || m.openSessionAllow[key]
+}
+
+// allowSession records the human's [s] for req's instance: copies for a copy
+// request, copies AND opens for an open request.
+func (m *model) allowSession(req copyRequest) {
+	key := req.instanceKey()
+	m.copySessionAllow[key] = true
+	if req.open {
+		m.openSessionAllow[key] = true
+	}
 }
 
 // resolveCopyConfirm handles a keypress while the confirmation is showing: allow
@@ -86,14 +120,14 @@ func (m *model) resolveCopyConfirm(key string) tea.Cmd {
 		m.pendingCopyConfirms = m.pendingCopyConfirms[1:]
 		return m.startConfirmedCopy(req)
 	case "s":
-		m.copySessionAllow[req.instanceKey()] = true
-		// Run this one plus every other queued request from the now-trusted
-		// instance; keep the rest queued for their own confirmation.
+		m.allowSession(req)
+		// Run this one plus every other queued request the new allowance now
+		// covers; keep the rest queued for their own confirmation.
 		cmds := []tea.Cmd{m.startConfirmedCopy(req)}
 		remaining := append([]copyRequest(nil), m.pendingCopyConfirms[1:]...)
 		m.pendingCopyConfirms = nil
 		for _, r := range remaining {
-			if r.instanceKey() == req.instanceKey() {
+			if m.sessionAllowed(r) {
 				cmds = append(cmds, m.startConfirmedCopy(r))
 			} else {
 				m.pendingCopyConfirms = append(m.pendingCopyConfirms, r)
@@ -158,7 +192,7 @@ func (m model) viewCopyConfirm() string {
 	title := dialogTitle.Render("⚠ " + capitalize(req.verb()) + " request from " + req.instanceKey())
 	path := dialogLabel.Render(req.src + "  →  " + copyDstLabel(req.dst))
 	effects := dialogHint.Render(strings.Join(copyConfirmHostEffects(req), "\n"))
-	hint := dialogLabel.Render("[a]llow once    [s] allow for session    [d]eny")
+	hint := dialogLabel.Render("[a]llow once    [s] allow " + req.verbs() + " for session    [d]eny")
 
 	content := title + "\n\n" + path + "\n" + effects + "\n\n" + hint
 	if extra := len(m.pendingCopyConfirms) - 1; extra > 0 {

--- a/internal/tui/copyconfirm.go
+++ b/internal/tui/copyconfirm.go
@@ -43,10 +43,11 @@ func (r copyRequest) verb() string {
 	return "copy"
 }
 
-// verbs is the plural, for the session-allow hint ("allow copies/opens").
+// verbs names, for the session-allow hint, everything an [s] on this request
+// grants: copies for a copy, copies AND opens for an open (see allowSession).
 func (r copyRequest) verbs() string {
 	if r.open {
-		return "opens"
+		return "copies+opens"
 	}
 	return "copies"
 }
@@ -192,7 +193,7 @@ func (m model) viewCopyConfirm() string {
 	title := dialogTitle.Render("⚠ " + capitalize(req.verb()) + " request from " + req.instanceKey())
 	path := dialogLabel.Render(req.src + "  →  " + copyDstLabel(req.dst))
 	effects := dialogHint.Render(strings.Join(copyConfirmHostEffects(req), "\n"))
-	hint := dialogLabel.Render("[a]llow once    [s] allow " + req.verbs() + " for session    [d]eny")
+	hint := dialogLabel.Render("[a]llow once   [s] allow " + req.verbs() + " for session   [d]eny")
 
 	content := title + "\n\n" + path + "\n" + effects + "\n\n" + hint
 	if extra := len(m.pendingCopyConfirms) - 1; extra > 0 {

--- a/internal/tui/copyconfirm.go
+++ b/internal/tui/copyconfirm.go
@@ -20,11 +20,23 @@ import (
 // don't re-prompt while the TUI stays open.
 
 // copyRequest is one delegated copy awaiting (or cleared for) host-side action.
+// open marks a `fleet open` (fo): once the file lands on this machine it is
+// also opened with the default application — one more thing the human is
+// agreeing to, so the prompt spells it out.
 type copyRequest struct {
 	fleet, instance, src, dst string
+	open                      bool
 }
 
 func (r copyRequest) instanceKey() string { return r.fleet + "/" + r.instance }
+
+// verb names the request for status lines: "copy", or "open" for a fleet open.
+func (r copyRequest) verb() string {
+	if r.open {
+		return "open"
+	}
+	return "copy"
+}
 
 // copyTouchesHost reports whether either endpoint is a path on this (the host)
 // machine — the only case that needs confirmation. A copy purely between
@@ -90,7 +102,7 @@ func (m *model) resolveCopyConfirm(key string) tea.Cmd {
 		return tea.Batch(cmds...)
 	case "d", "n", "esc":
 		m.pendingCopyConfirms = m.pendingCopyConfirms[1:]
-		m.message = fmt.Sprintf("Denied copy %s -> %s from %s", req.src, copyDstLabel(req.dst), req.instanceKey())
+		m.message = fmt.Sprintf("Denied %s %s -> %s from %s", req.verb(), req.src, copyDstLabel(req.dst), req.instanceKey())
 		return nil
 	}
 	return nil
@@ -98,12 +110,18 @@ func (m *model) resolveCopyConfirm(key string) tea.Cmd {
 
 // startConfirmedCopy sets the status line and returns the background copy command.
 func (m *model) startConfirmedCopy(req copyRequest) tea.Cmd {
-	m.message = fmt.Sprintf("Copying %s -> %s...", req.src, copyDstLabel(req.dst))
-	return copyForInstanceCmd(req.fleet, req.instance, req.src, req.dst)
+	if req.open {
+		m.message = fmt.Sprintf("Copying %s -> %s and opening...", req.src, copyDstLabel(req.dst))
+	} else {
+		m.message = fmt.Sprintf("Copying %s -> %s...", req.src, copyDstLabel(req.dst))
+	}
+	return copyForInstanceCmd(req)
 }
 
 // copyConfirmHostEffects describes, for the human, which host paths a pending
-// copy would read or write — the whole reason the prompt exists.
+// copy would read or write — and, for a fleet open, that the delivered file is
+// then handed to this machine's default application — the whole reason the
+// prompt exists.
 func copyConfirmHostEffects(req copyRequest) []string {
 	var effects []string
 	if endpointIsHost(req.src) {
@@ -114,6 +132,9 @@ func copyConfirmHostEffects(req copyRequest) []string {
 		effects = append(effects, "writes to your downloads folder on THIS machine")
 	case endpointIsHost(req.dst):
 		effects = append(effects, "writes "+req.dst+" on THIS machine")
+	}
+	if req.open {
+		effects = append(effects, "opens it with THIS machine's default application")
 	}
 	return effects
 }
@@ -134,7 +155,7 @@ func (m model) viewCopyConfirm() string {
 		Padding(1, 2).
 		Width(boxWidth)
 
-	title := dialogTitle.Render("⚠ Copy request from " + req.instanceKey())
+	title := dialogTitle.Render("⚠ " + capitalize(req.verb()) + " request from " + req.instanceKey())
 	path := dialogLabel.Render(req.src + "  →  " + copyDstLabel(req.dst))
 	effects := dialogHint.Render(strings.Join(copyConfirmHostEffects(req), "\n"))
 	hint := dialogLabel.Render("[a]llow once    [s] allow for session    [d]eny")
@@ -152,4 +173,12 @@ func (m model) viewCopyConfirm() string {
 		height = lipgloss.Height(box.Render(content))
 	}
 	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, box.Render(content))
+}
+
+// capitalize upper-cases the first letter of an ASCII word.
+func capitalize(word string) string {
+	if word == "" {
+		return word
+	}
+	return strings.ToUpper(word[:1]) + word[1:]
 }

--- a/internal/tui/copyconfirm_test.go
+++ b/internal/tui/copyconfirm_test.go
@@ -100,3 +100,39 @@ func TestResolveCopyConfirmDeny(t *testing.T) {
 		t.Fatalf("deny should report it; message = %q", m.message)
 	}
 }
+
+// TestCopyConfirmOpenRequest covers the `fleet open` flavour of a delegated
+// request: it is always host-touching (so gated), the prompt names the open as
+// an extra effect and titles itself as an open, and the status lines say
+// "open" rather than "copy".
+func TestCopyConfirmOpenRequest(t *testing.T) {
+	m := &model{copySessionAllow: map[string]bool{}}
+	req := copyRequest{fleet: "f", instance: "i", src: ":out/chart.png", open: true}
+	if cmd := m.requestCopy(req); cmd != nil || !m.copyConfirmShowing() {
+		t.Fatal("an open always touches the host, so it must queue for confirmation")
+	}
+
+	effects := strings.Join(copyConfirmHostEffects(req), "\n")
+	if !strings.Contains(effects, "downloads folder") || !strings.Contains(effects, "opens it") {
+		t.Errorf("effects should name the write AND the open, got %q", effects)
+	}
+	if plain := strings.Join(copyConfirmHostEffects(copyRequest{src: ":x", dst: ""}), "\n"); strings.Contains(plain, "opens it") {
+		t.Errorf("a plain copy must not claim to open anything, got %q", plain)
+	}
+	if view := m.viewCopyConfirm(); !strings.Contains(view, "Open request from f/i") {
+		t.Errorf("open prompt should be titled as an open request, got %q", view)
+	}
+
+	m.resolveCopyConfirm("d")
+	if !strings.Contains(m.message, "Denied open") {
+		t.Errorf("deny should say open, got %q", m.message)
+	}
+
+	m.requestCopy(req)
+	if cmd := m.resolveCopyConfirm("a"); cmd == nil {
+		t.Fatal("allow should start the copy+open")
+	}
+	if !strings.Contains(m.message, "and opening") {
+		t.Errorf("status should announce the open, got %q", m.message)
+	}
+}

--- a/internal/tui/copyconfirm_test.go
+++ b/internal/tui/copyconfirm_test.go
@@ -25,7 +25,7 @@ func TestCopyTouchesHost(t *testing.T) {
 }
 
 func TestRequestCopyGating(t *testing.T) {
-	m := &model{copySessionAllow: map[string]bool{}}
+	m := &model{copySessionAllow: map[string]bool{}, openSessionAllow: map[string]bool{}}
 
 	// A copy purely between instances runs immediately, no prompt.
 	if cmd := m.requestCopy(copyRequest{fleet: "f", instance: "i", src: ":a", dst: "other:/b"}); cmd == nil {
@@ -54,7 +54,7 @@ func TestRequestCopyGating(t *testing.T) {
 }
 
 func TestResolveCopyConfirmAllowOnce(t *testing.T) {
-	m := &model{copySessionAllow: map[string]bool{}}
+	m := &model{copySessionAllow: map[string]bool{}, openSessionAllow: map[string]bool{}}
 	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "host:a.txt", dst: ":/tmp/"})
 
 	if cmd := m.resolveCopyConfirm("a"); cmd == nil {
@@ -69,7 +69,7 @@ func TestResolveCopyConfirmAllowOnce(t *testing.T) {
 }
 
 func TestResolveCopyConfirmSessionDrainsSameInstance(t *testing.T) {
-	m := &model{copySessionAllow: map[string]bool{}}
+	m := &model{copySessionAllow: map[string]bool{}, openSessionAllow: map[string]bool{}}
 	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "host:a.txt", dst: ":/tmp/"})
 	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "host:b.txt", dst: ":/tmp/"})
 	m.requestCopy(copyRequest{fleet: "f", instance: "j", src: "host:c.txt", dst: ":/tmp/"})
@@ -87,7 +87,7 @@ func TestResolveCopyConfirmSessionDrainsSameInstance(t *testing.T) {
 }
 
 func TestResolveCopyConfirmDeny(t *testing.T) {
-	m := &model{copySessionAllow: map[string]bool{}}
+	m := &model{copySessionAllow: map[string]bool{}, openSessionAllow: map[string]bool{}}
 	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: "host:a.txt", dst: ":/tmp/"})
 
 	if cmd := m.resolveCopyConfirm("d"); cmd != nil {
@@ -106,7 +106,7 @@ func TestResolveCopyConfirmDeny(t *testing.T) {
 // an extra effect and titles itself as an open, and the status lines say
 // "open" rather than "copy".
 func TestCopyConfirmOpenRequest(t *testing.T) {
-	m := &model{copySessionAllow: map[string]bool{}}
+	m := &model{copySessionAllow: map[string]bool{}, openSessionAllow: map[string]bool{}}
 	req := copyRequest{fleet: "f", instance: "i", src: ":out/chart.png", open: true}
 	if cmd := m.requestCopy(req); cmd != nil || !m.copyConfirmShowing() {
 		t.Fatal("an open always touches the host, so it must queue for confirmation")
@@ -134,5 +134,69 @@ func TestCopyConfirmOpenRequest(t *testing.T) {
 	}
 	if !strings.Contains(m.message, "and opening") {
 		t.Errorf("status should announce the open, got %q", m.message)
+	}
+}
+
+// TestSessionAllowIsPerKind pins the session-allowance boundary between copies
+// and opens: an [s] on a plain copy must NOT pre-approve unattended opens from
+// that instance (an open hands the file to a launcher), while an [s] on an open
+// covers later opens and copies alike.
+func TestSessionAllowIsPerKind(t *testing.T) {
+	m := &model{copySessionAllow: map[string]bool{}, openSessionAllow: map[string]bool{}}
+	copyReq := copyRequest{fleet: "f", instance: "i", src: ":a.txt"}
+	openReq := copyRequest{fleet: "f", instance: "i", src: ":chart.png", open: true}
+
+	// [s] on a copy: later copies run unprompted, opens still prompt.
+	m.requestCopy(copyReq)
+	m.resolveCopyConfirm("s")
+	if cmd := m.requestCopy(copyReq); cmd == nil {
+		t.Fatal("copy from a copy-allowed instance should run unprompted")
+	}
+	if cmd := m.requestCopy(openReq); cmd != nil || !m.copyConfirmShowing() {
+		t.Fatal("an open must still prompt after a copy-only session allow")
+	}
+	if m.openSessionAllow["f/i"] {
+		t.Fatal("a copy [s] must not set the open allowance")
+	}
+
+	// [s] on the open: later opens AND copies run unprompted.
+	m.resolveCopyConfirm("s")
+	if !m.openSessionAllow["f/i"] || !m.copySessionAllow["f/i"] {
+		t.Fatal("an open [s] should set both allowances")
+	}
+	if cmd := m.requestCopy(openReq); cmd == nil || m.copyConfirmShowing() {
+		t.Fatal("open from an open-allowed instance should run unprompted")
+	}
+
+	// A fresh instance: an open [s] alone also covers copies.
+	other := &model{copySessionAllow: map[string]bool{}, openSessionAllow: map[string]bool{}}
+	other.requestCopy(copyRequest{fleet: "f", instance: "j", src: ":x.png", open: true})
+	other.resolveCopyConfirm("s")
+	if cmd := other.requestCopy(copyRequest{fleet: "f", instance: "j", src: ":y.txt"}); cmd == nil {
+		t.Fatal("a copy should be covered by an open allowance")
+	}
+}
+
+// TestSessionAllowDrainsOnlyCovered confirms that [s] on a copy releases the
+// queued copies from that instance but keeps its queued opens waiting.
+func TestSessionAllowDrainsOnlyCovered(t *testing.T) {
+	m := &model{copySessionAllow: map[string]bool{}, openSessionAllow: map[string]bool{}}
+	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: ":a.txt"})
+	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: ":chart.png", open: true})
+	m.requestCopy(copyRequest{fleet: "f", instance: "i", src: ":b.txt"})
+
+	if cmd := m.resolveCopyConfirm("s"); cmd == nil {
+		t.Fatal("session allow should return command(s) to run")
+	}
+	if len(m.pendingCopyConfirms) != 1 || !m.pendingCopyConfirms[0].open {
+		t.Fatalf("only the open should remain queued, got %+v", m.pendingCopyConfirms)
+	}
+	if view := m.viewCopyConfirm(); !strings.Contains(view, "allow opens for session") {
+		t.Errorf("the open prompt's [s] should say what it allows, got %q", view)
+	}
+	m.requestCopy(copyRequest{fleet: "f", instance: "k", src: ":c.txt"})
+	m.pendingCopyConfirms = m.pendingCopyConfirms[1:] // look at the copy prompt
+	if view := m.viewCopyConfirm(); !strings.Contains(view, "allow copies for session") {
+		t.Errorf("the copy prompt's [s] should say what it allows, got %q", view)
 	}
 }

--- a/internal/tui/copyconfirm_test.go
+++ b/internal/tui/copyconfirm_test.go
@@ -191,7 +191,7 @@ func TestSessionAllowDrainsOnlyCovered(t *testing.T) {
 	if len(m.pendingCopyConfirms) != 1 || !m.pendingCopyConfirms[0].open {
 		t.Fatalf("only the open should remain queued, got %+v", m.pendingCopyConfirms)
 	}
-	if view := m.viewCopyConfirm(); !strings.Contains(view, "allow opens for session") {
+	if view := m.viewCopyConfirm(); !strings.Contains(view, "allow copies+opens for session") {
 		t.Errorf("the open prompt's [s] should say what it allows, got %q", view)
 	}
 	m.requestCopy(copyRequest{fleet: "f", instance: "k", src: ":c.txt"})

--- a/internal/tui/filecopy.go
+++ b/internal/tui/filecopy.go
@@ -44,6 +44,9 @@ func (msg fileCopyDoneMsg) statusLine() string {
 	switch {
 	case msg.err != nil:
 		return fmt.Sprintf("Copy of %s failed: %v", msg.src, msg.err)
+	case errors.Is(msg.openErr, platform.ErrLauncher):
+		// The error names the path too; the line already says where it landed.
+		return fmt.Sprintf("Copied %s -> %s, but not opened: %v", msg.src, msg.dest, platform.ErrLauncher)
 	case msg.openErr != nil:
 		return fmt.Sprintf("Copied %s -> %s, but could not open it: %v", msg.src, msg.dest, msg.openErr)
 	case msg.opened:

--- a/internal/tui/filecopy.go
+++ b/internal/tui/filecopy.go
@@ -77,20 +77,22 @@ func copyForInstanceCmd(req copyRequest) tea.Cmd {
 		}
 		done := fileCopyDoneMsg{src: req.src, dst: req.dst, dest: res.DestPath}
 		if req.open {
-			done.openErr = openDelivered(dstEnd, res.DestPath)
+			done.dest, done.openErr = openDelivered(dstEnd, res.DestPath)
 			done.opened = done.openErr == nil
 		}
 		return done
 	}
 }
 
-// openDelivered hands a just-copied file to this machine's default application.
-// It refuses when the destination was not this machine: the path would then be
-// an in-instance one, and opening a same-named local file would be both wrong
-// and a way for a crafted envelope to open arbitrary host paths.
-func openDelivered(dst fleetclient.ResolvedEndpoint, dest string) error {
+// openDelivered hands a just-copied file to this machine's default application
+// and returns the (absolute) path it reported. It refuses when the destination
+// was not this machine: the path would then be an in-instance one, and opening
+// a same-named local file would be both wrong and a way for a crafted envelope
+// to open arbitrary host paths. platform.OpenFile additionally refuses anything
+// the opener would launch rather than view (executables, .desktop, .app, ...).
+func openDelivered(dst fleetclient.ResolvedEndpoint, dest string) (string, error) {
 	if !dst.Local {
-		return errors.New("destination is not on this machine")
+		return dest, errors.New("destination is not on this machine")
 	}
 	return platform.OpenFile(dest)
 }

--- a/internal/tui/filecopy.go
+++ b/internal/tui/filecopy.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetclient"
+	"github.com/BenjaminBenetti/fleet-man/internal/platform"
 )
 
 // filecopy.go is the client half of the in-instance `fleet copy` (fc) feature:
@@ -25,36 +28,71 @@ import (
 // build output crossing a WAN tunnel — while still unsticking a wedged stream.
 const fileCopyTimeout = 15 * time.Minute
 
-// fileCopyDoneMsg reports a finished (or failed) background copy.
+// fileCopyDoneMsg reports a finished (or failed) background copy — and, for a
+// fleet open, whether the delivered file was opened.
 type fileCopyDoneMsg struct {
-	src  string // source endpoint as typed inside the instance (for messages)
-	dst  string // destination endpoint as typed inside the instance
-	dest string // final path written (empty on failure)
-	err  error
+	src     string // source endpoint as typed inside the instance (for messages)
+	dst     string // destination endpoint as typed inside the instance
+	dest    string // final path written (empty on failure)
+	err     error  // the copy itself failed
+	opened  bool   // the file was handed to the default application
+	openErr error  // the copy landed but opening it failed
 }
 
-// copyForInstanceCmd runs the copy an in-instance `fc` delegated, off the UI
-// thread. src/dst are the endpoints as typed inside the instance; origFleet/
-// origInstance identify the sender, used to resolve a `:path` (self) endpoint and
-// to default the fleet of a bare instance reference.
-func copyForInstanceCmd(origFleet, origInstance, src, dst string) tea.Cmd {
+// statusLine renders the outcome for the status bar.
+func (msg fileCopyDoneMsg) statusLine() string {
+	switch {
+	case msg.err != nil:
+		return fmt.Sprintf("Copy of %s failed: %v", msg.src, msg.err)
+	case msg.openErr != nil:
+		return fmt.Sprintf("Copied %s -> %s, but could not open it: %v", msg.src, msg.dest, msg.openErr)
+	case msg.opened:
+		return fmt.Sprintf("Opened %s (%s)", msg.src, msg.dest)
+	default:
+		return fmt.Sprintf("Copied %s -> %s", msg.src, msg.dest)
+	}
+}
+
+// copyForInstanceCmd runs the copy an in-instance `fc` (or `fo`) delegated, off
+// the UI thread. req.src/dst are the endpoints as typed inside the instance;
+// req.fleet/instance identify the sender, used to resolve a `:path` (self)
+// endpoint and to default the fleet of a bare instance reference. For a fleet
+// open the delivered file is then handed to this machine's default application.
+func copyForInstanceCmd(req copyRequest) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), fileCopyTimeout)
 		defer cancel()
 		conn, err := fleetclient.Dial(ctx)
 		if err != nil {
-			return fileCopyDoneMsg{src: src, dst: dst, err: err}
+			return fileCopyDoneMsg{src: req.src, dst: req.dst, err: err}
 		}
 		defer conn.Close()
+		dstEnd := resolveTUIEndpoint(req.dst, req.fleet, req.instance)
 		res, err := fleetclient.Copy(ctx, conn.Service(),
-			resolveTUIEndpoint(src, origFleet, origInstance),
-			resolveTUIEndpoint(dst, origFleet, origInstance),
+			resolveTUIEndpoint(req.src, req.fleet, req.instance),
+			dstEnd,
 			tuiLocalPolicy{})
 		if err != nil {
-			return fileCopyDoneMsg{src: src, dst: dst, err: err}
+			return fileCopyDoneMsg{src: req.src, dst: req.dst, err: err}
 		}
-		return fileCopyDoneMsg{src: src, dst: dst, dest: res.DestPath}
+		done := fileCopyDoneMsg{src: req.src, dst: req.dst, dest: res.DestPath}
+		if req.open {
+			done.openErr = openDelivered(dstEnd, res.DestPath)
+			done.opened = done.openErr == nil
+		}
+		return done
 	}
+}
+
+// openDelivered hands a just-copied file to this machine's default application.
+// It refuses when the destination was not this machine: the path would then be
+// an in-instance one, and opening a same-named local file would be both wrong
+// and a way for a crafted envelope to open arbitrary host paths.
+func openDelivered(dst fleetclient.ResolvedEndpoint, dest string) error {
+	if !dst.Local {
+		return errors.New("destination is not on this machine")
+	}
+	return platform.OpenFile(dest)
 }
 
 // copyDstLabel renders a destination for the status line — the empty 1-arg

--- a/internal/tui/filecopy_test.go
+++ b/internal/tui/filecopy_test.go
@@ -2,11 +2,13 @@ package tui
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetclient"
+	"github.com/BenjaminBenetti/fleet-man/internal/platform"
 )
 
 func TestResolveLocalPath(t *testing.T) {
@@ -108,6 +110,7 @@ func TestFileCopyDoneStatusLine(t *testing.T) {
 		{"copied", fileCopyDoneMsg{src: ":a", dest: "/h/a"}, "Copied :a -> /h/a"},
 		{"opened", fileCopyDoneMsg{src: ":a", dest: "/h/a", opened: true}, "Opened :a (/h/a)"},
 		{"open failed", fileCopyDoneMsg{src: ":a", dest: "/h/a", openErr: errors.New("no handler")}, "Copied :a -> /h/a, but could not open it: no handler"},
+		{"launcher refused", fileCopyDoneMsg{src: ":a", dest: "/h/a", openErr: fmt.Errorf("%w; it was copied to /h/a", platform.ErrLauncher)}, "Copied :a -> /h/a, but not opened: refusing to open an executable"},
 	}
 	for _, tc := range cases {
 		if got := tc.msg.statusLine(); got != tc.want {

--- a/internal/tui/filecopy_test.go
+++ b/internal/tui/filecopy_test.go
@@ -90,7 +90,7 @@ func TestResolveTUIEndpoint(t *testing.T) {
 // crafted envelope with open=true and an instance destination must not make the
 // TUI open a same-named path on the human's machine.
 func TestOpenDeliveredRefusesNonLocal(t *testing.T) {
-	err := openDelivered(fleetclient.ResolvedEndpoint{Fleet: "f", Instance: "i", Path: "/tmp/x"}, "/tmp/x")
+	_, err := openDelivered(fleetclient.ResolvedEndpoint{Fleet: "f", Instance: "i", Path: "/tmp/x"}, "/tmp/x")
 	if err == nil || !strings.Contains(err.Error(), "not on this machine") {
 		t.Fatalf("non-local destination should be refused, got %v", err)
 	}

--- a/internal/tui/filecopy_test.go
+++ b/internal/tui/filecopy_test.go
@@ -1,7 +1,9 @@
 package tui
 
 import (
+	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetclient"
@@ -81,5 +83,35 @@ func TestResolveTUIEndpoint(t *testing.T) {
 				t.Errorf("resolveTUIEndpoint(%q) = %+v, want %+v", tc.arg, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestOpenDeliveredRefusesNonLocal is the safety check behind `fleet open`: a
+// crafted envelope with open=true and an instance destination must not make the
+// TUI open a same-named path on the human's machine.
+func TestOpenDeliveredRefusesNonLocal(t *testing.T) {
+	err := openDelivered(fleetclient.ResolvedEndpoint{Fleet: "f", Instance: "i", Path: "/tmp/x"}, "/tmp/x")
+	if err == nil || !strings.Contains(err.Error(), "not on this machine") {
+		t.Fatalf("non-local destination should be refused, got %v", err)
+	}
+}
+
+// TestFileCopyDoneStatusLine covers the four outcomes a delegated copy/open
+// reports on the status bar.
+func TestFileCopyDoneStatusLine(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  fileCopyDoneMsg
+		want string
+	}{
+		{"copy failed", fileCopyDoneMsg{src: ":a", err: errors.New("boom")}, "Copy of :a failed: boom"},
+		{"copied", fileCopyDoneMsg{src: ":a", dest: "/h/a"}, "Copied :a -> /h/a"},
+		{"opened", fileCopyDoneMsg{src: ":a", dest: "/h/a", opened: true}, "Opened :a (/h/a)"},
+		{"open failed", fileCopyDoneMsg{src: ":a", dest: "/h/a", openErr: errors.New("no handler")}, "Copied :a -> /h/a, but could not open it: no handler"},
+	}
+	for _, tc := range cases {
+		if got := tc.msg.statusLine(); got != tc.want {
+			t.Errorf("%s: statusLine() = %q, want %q", tc.name, got, tc.want)
+		}
 	}
 }

--- a/internal/tui/openurl.go
+++ b/internal/tui/openurl.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"fmt"
 	"net/url"
-	"os/exec"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/platform"
 	tea "github.com/charmbracelet/bubbletea"
@@ -40,24 +39,17 @@ func isBrowsableURL(rawURL string) bool {
 	return u.Scheme == "http" || u.Scheme == "https"
 }
 
-// openExternalURL launches the host OS's default handler for rawURL. WSL is
-// special cased (xdg-open there opens nothing useful) to reach the Windows
-// browser. The launcher is Run (not Start) so the short-lived process is reaped
-// rather than left defunct.
+// openExternalURL launches the host OS's default handler for rawURL — the
+// shared platform opener, so a PR link and a `fleet open` file go through the
+// same per-OS command. The launcher is Run (not Start) so the short-lived
+// process is reaped rather than left defunct.
 func openExternalURL(rawURL string) error {
 	if !isBrowsableURL(rawURL) {
 		return fmt.Errorf("refusing to open non-http(s) URL")
 	}
-	cmd, err := openExternalURLCommand(rawURL)
+	cmd, err := platform.OpenCommand(rawURL)
 	if err != nil {
 		return err
 	}
 	return cmd.Run()
-}
-
-// openExternalURLCommand picks the per-OS opener — the shared platform one, so
-// a PR link and a `fleet open` file go through the same handler. Split out for
-// testability.
-func openExternalURLCommand(rawURL string) (*exec.Cmd, error) {
-	return platform.OpenCommand(rawURL)
 }

--- a/internal/tui/openurl.go
+++ b/internal/tui/openurl.go
@@ -3,9 +3,7 @@ package tui
 import (
 	"fmt"
 	"net/url"
-	"os"
 	"os/exec"
-	"runtime"
 
 	"github.com/BenjaminBenetti/fleet-man/internal/platform"
 	tea "github.com/charmbracelet/bubbletea"
@@ -57,29 +55,9 @@ func openExternalURL(rawURL string) error {
 	return cmd.Run()
 }
 
-// openExternalURLCommand picks the per-OS opener. Split out for testability.
-// Every opener receives the URL as a separate, non-shell-interpreted argument;
-// the WSL PowerShell fallback passes it via the environment rather than
-// interpolating it into the -Command string, so a URL containing PowerShell
-// metacharacters can't inject code on the host.
+// openExternalURLCommand picks the per-OS opener — the shared platform one, so
+// a PR link and a `fleet open` file go through the same handler. Split out for
+// testability.
 func openExternalURLCommand(rawURL string) (*exec.Cmd, error) {
-	switch {
-	case runtime.GOOS == "darwin":
-		return exec.Command("open", rawURL), nil
-	case runtime.GOOS == "windows":
-		return exec.Command("rundll32", "url.dll,FileProtocolHandler", rawURL), nil
-	case platform.IsWSL():
-		// wslu's wslview is the clean path; fall back to the Windows shell's
-		// start handler via powershell when it isn't installed.
-		if _, err := exec.LookPath("wslview"); err == nil {
-			return exec.Command("wslview", rawURL), nil
-		}
-		cmd := exec.Command("powershell.exe", "-NoProfile", "-Command", "Start-Process -FilePath $env:FLEET_OPEN_URL")
-		cmd.Env = append(os.Environ(), "FLEET_OPEN_URL="+rawURL)
-		return cmd, nil
-	case runtime.GOOS == "linux":
-		return exec.Command("xdg-open", rawURL), nil
-	default:
-		return nil, fmt.Errorf("don't know how to open a browser on %s", runtime.GOOS)
-	}
+	return platform.OpenCommand(rawURL)
 }

--- a/internal/tui/watch.go
+++ b/internal/tui/watch.go
@@ -103,6 +103,7 @@ type watchBrowserOpenMsg struct {
 }
 type watchFileCopyMsg struct {
 	fleet, instance, src, dst string
+	open                      bool // `fleet open`: open the delivered file here
 	gen                       int
 }
 type remoteMcpStatusMsg struct {
@@ -224,6 +225,7 @@ func watchOnce(ctx context.Context, program *tea.Program, gen int) bool {
 				instance: fc.GetInstance(),
 				src:      fc.GetSrc(),
 				dst:      fc.GetDst(),
+				open:     fc.GetOpen(),
 				gen:      gen,
 			})
 		case *fleetgrpc.Event_RemoteMcpStatus:


### PR DESCRIPTION
## What

`fleet open <src> [dst]` — and `fo` inside an instance, next to `fc` — copies a file out of an instance to your machine and opens it with the desktop's default application. It short-circuits the `fc image.png` → `xdg-open image.png` two-step.

```
fo ./out/chart.png                 # in-instance: → ~/Downloads, then opened on your machine
fo report.pdf host:~/Documents/    # copy there, then open
fleet open alpha:out/chart.png     # host form: → cwd, then opened
```

## How

- **Rides the copy pipeline, no new event.** `CopyFilePayload` / `FileCopy` gain an `open` flag (proto `bool open = 5`). Server dispatch passes it through; the TUI's `copyRequest` carries it.
- **Confirmation gate.** An open always touches the host, so it is always prompted (unless the instance is session-allowed). The modal is titled "Open request from …" and adds the effect line *"opens it with THIS machine's default application"*.
- **Safety.** The TUI only opens when the resolved destination is local (`openDelivered`); a crafted envelope with an instance dst can't make it open a same-named host path. The CLI rejects own-machine sources and instance destinations up front.
- **Shared opener.** The per-OS opener (xdg-open / open / wslview+powershell / rundll32) moved from `tui/openurl.go` into `internal/platform/open.go`, used for PR links and file opens alike. `FLEET_OPENER` overrides the program for file opens (`FLEET_OPENER="imv -f"`), which is also what makes the feature testable headless.
- **Never pins the caller.** `platform.OpenFile` starts the opener and waits a 2s grace: a prompt failure (no handler / no display) is reported with its stderr; a bare `xdg-open` that hosts the viewer in the foreground (no desktop session) is left running and reaped in the background.

## Tests

- Unit: control round-trip, server dispatch, fleetcopy signal, CLI endpoint rules, TUI modal/effects/status lines, `openDelivered` refusal, platform opener + override + detached run.
- Integration: `026_open.sh` (host form with a stub `FLEET_OPENER`: 1-arg, dir dest, opener args, opener failure surfaces, rejections), `535_open_in_instance.sh` (in-instance via TUI: `fo` alias staged, modal shown + allowed, file lands in `~/Downloads`, opener receives the path), `070` covers the new help. All three verified in the QA container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5k3YHgTLGx3URDgfU8W3e
