### PR TITLE
feat(armada): remote fleet over SSH, no gateway needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,13 +229,25 @@ Once connected, the read-only **Public MCP URL** appears (e.g.
 The line shows the live connection state (connecting / connected / error).
 
 A second, independent toggle — **Enable Remote Fleet** — exposes the daemon's
-**gRPC control surface** through the same gateway, so a remote `fleet` binary can
-drive this instance (see [Remote control](#remote-control-grpc)). With it off,
-fleetd never negotiates the gRPC tunnel feature, so the gateway rejects any
-incoming gRPC commands aimed at the daemon. With it on, a read-only **Public GRPC
-URL** appears under the Public MCP URL (computed by the gateway from its
-`--public-grpc-url` flag) — that value is what you feed another `fleet` as
-`FLEET_GATEWAY`. The toggles are independent: expose MCP, remote control, or both.
+**gRPC control surface** so a remote `fleet` binary can drive this instance (see
+[Remote control](#remote-control-grpc)). Turning it on reveals a **Remote Fleet
+via** selector with two transports:
+
+- **Gateway** (the default) — through the same gateway tunnel. With it, a
+  read-only **Public GRPC URL** appears under the Public MCP URL (computed by the
+  gateway from its `--public-grpc-url` flag) — that value is what you feed
+  another `fleet` as `FLEET_GATEWAY`. With the toggle off, fleetd never
+  negotiates the gRPC tunnel feature, so the gateway rejects any incoming gRPC
+  commands aimed at the daemon.
+- **SSH** — no gateway at all. The daemon serves the same token-gated gRPC
+  server on a loopback port (shown on an **SSH Listener** row, and recorded in
+  `~/.fleet/ssh.port`), and a remote machine reaches it over a plain SSH tunnel
+  that *its* fleet daemon maintains — see [Remote control over
+  SSH](#remote-control-over-ssh). Nothing is exposed beyond what `ssh user@host`
+  already grants.
+
+The toggles are independent: expose MCP, remote control, or both. Only remote
+fleet has the SSH transport; MCP and webhooks stay gateway-only.
 
 A third, independent toggle — **Enable Webhook** — exposes this daemon's
 **automation webhook** endpoint through the same gateway. With it on, a read-only
@@ -433,13 +445,49 @@ h2c with no TLS in front of it (a trusted private network).
 > RPC works remotely today; remote interactive shell awaits a server-side `Exec`
 > handler.
 
+### Remote control over SSH
+
+If you can already `ssh` to the machine running a fleet, you don't need a
+gateway. On that machine, set **Settings → Fleet MCP → Enable Remote Fleet** on
+and **Remote Fleet via** to **SSH**. On your machine, register the fleet in
+**Settings → Fleet Armada** as an `ssh://` URL — `ssh://user@host`,
+`ssh://host:2222`, or an alias from your `~/.ssh/config` — and that's it: no
+token to paste, no session id.
+
+Under the hood your **local** fleet daemon owns the connection. When you connect
+(or ping) an `ssh://` remote it runs your `ssh` binary — so keys, agents,
+`ProxyJump` and every other `~/.ssh/config` setting apply unchanged — to read
+the remote's `~/.fleet/ssh.port` and `~/.fleet/mcp.token`, then keeps one
+`ssh -N -L` port-forward to that port alive and hands the TUI (and every
+`fleet` command or `fleet shell` child started from it) a loopback address to
+dial. A remote daemon that has restarted on a new port, or a dropped tunnel, is
+noticed on the next connection and rebuilt automatically. If the remote daemon
+isn't running at all, the probe starts it for you (it looks for `fleet` on the
+remote's `PATH`, then `~/.local/bin`, `~/go/bin`, `/usr/local/bin`).
+
+The daemon has no terminal, so `ssh` runs in **batch mode**: anything that would
+prompt — an unknown host key, a passphrase-locked key with no agent — fails with
+that reason in the remote's status column instead of hanging. Fix it once by
+running `ssh user@host` yourself, then ping again. `ssh` inherits the daemon's
+environment, so an agent socket must be visible to it (restart the daemon from
+a shell that has `SSH_AUTH_SOCK` if it isn't).
+
+You can also drive an `ssh://` fleet from a plain shell:
+
+```bash
+export FLEET_SSH="ssh://user@host"
+fleet ls          # resolved through your local daemon's tunnel
+```
+
 ### Fleet Armada (multiple remote fleets)
 
 Instead of juggling `FLEET_GATEWAY`/`FLEET_TOKEN` by hand, register remote fleets
 once in **Settings → Fleet Armada**: press **+ Remote Fleet**, paste the gateway
-URL and the remote's bearer token, and fleet runs a connection test before
-saving. Each registered remote shows a live connection status (pinged while the
-settings page is open) and a `[ delete ]` button (press twice to confirm).
+URL and the remote's bearer token — or just an `ssh://user@host` URL, which needs
+no token — and fleet runs a connection test before saving. Each registered
+remote shows its transport (`[gtwy]` or `[ssh]`), a live connection status
+(pinged while the settings page is open) and a `[ delete ]` button (press twice
+to confirm).
 
 The main page's list border carries an **Armada selector**
 (`╭─ Armada [ local ] ───╮`). It is part of the normal `j`/`k` (and arrow-key)
@@ -448,12 +496,15 @@ bottom of the list) — or jump straight to it with the **`A`** key or a mouse
 click. Selecting it opens a dropdown of `local` + every registered remote; pick
 one to **switch the TUI live**: the connection, fleet list, sessions, and shells
 all retarget to the chosen daemon. Registering a remote never switches to it;
-every boot starts on `local` unless `FLEET_GATEWAY` (or `FLEET_SERVER`) is set,
-in which case that boot endpoint appears in the dropdown as `(env)`.
+every boot starts on `local` unless `FLEET_GATEWAY`, `FLEET_SSH` or
+`FLEET_SERVER` is set, in which case that boot endpoint appears in the dropdown
+as `(env)`. The selector and the dropdown badge each remote with its transport —
+`╭─ Armada [ desktop ] [ssh] ──╮` — so you always know how you're connected.
 
-Remotes are shown by **hostname** rather than the full gateway URL; if two
-registered fleets live on the same host, they're disambiguated by the first 8
-characters of their session id (`fleet.example.com - 8e7d1f0a`).
+Remotes are shown by **hostname** rather than the full URL; if two registered
+fleets live on the same host, a gateway remote is disambiguated by the first 8
+characters of its session id (`fleet.example.com - 8e7d1f0a`) and an SSH remote
+by its `user@host[:port]`.
 
 The registry is stored on your own machine at `~/.fleet/armada.json` (mode
 `0600` — it holds bearer tokens) and always round-trips through your **local**
@@ -467,6 +518,7 @@ Variables fleet **reads** (set them to configure behavior):
 |----------|-----------------|--------------|
 | `FLEET_GATEWAY` | `https://gw:50051/<id>` (or `http://…` for a cert-less/h2c gateway) | Drive a *remote* daemon through a fleet gateway (full gRPC control). Takes precedence over `FLEET_SERVER` and the local socket. See [Remote MCP](#remote-mcp). |
 | `FLEET_TOKEN` | bearer token | Token for `FLEET_GATEWAY`. Defaults to `~/.fleet/mcp.token` on the daemon's own host. |
+| `FLEET_SSH` | `ssh://[user@]host[:port]` | Drive a remote daemon over an SSH tunnel your local daemon maintains (no gateway, no token). See [Remote control over SSH](#remote-control-over-ssh). |
 | `FLEET_SERVER` | `host:port` | Drive a remote daemon over plain TCP (no gateway). |
 | `FLEET_DEVCONTAINER_BUILDKIT` | `auto` (default), `never` | BuildKit mode for Fleet-managed devcontainers. See [Devcontainer BuildKit](#devcontainer-buildkit). |
 | `FLEET_DEVCONTAINER_UPDATE_REMOTE_USER_UID` | `default`, `never`, `on`, `off` | Remote-user UID/GID rewrite mode. See [Devcontainer UID Rewrite](#devcontainer-uid-rewrite). |

--- a/doc/gateway.md
+++ b/doc/gateway.md
@@ -12,6 +12,15 @@ end‑to‑end for both the MCP and gRPC paths.
 > [Remote MCP](../README.md#remote-mcp) section of the README. This document is
 > the architecture deep‑dive.
 
+> **No gateway needed for remote fleet control between machines you can
+> `ssh` to.** "Remote Fleet via SSH" (`internal/server/sshlisten.go` on the
+> daemon, `internal/server/sshtunnel` on the client's local daemon) serves the
+> same token‑gated gRPC server on a loopback port and reaches it over an
+> `ssh -N -L` forward — no registration, no session ids, no yamux. The gateway
+> described here remains the path for machines with no inbound access at all,
+> and the only path for remote MCP and webhooks. See
+> [Remote control over SSH](../README.md#remote-control-over-ssh).
+
 ---
 
 ## 1. The core idea: a reverse tunnel

--- a/fleetgrpc/armada.pb.go
+++ b/fleetgrpc/armada.pb.go
@@ -21,13 +21,17 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// ArmadaRemote is one registered remote fleet: where its gateway is and the
-// bearer token that authenticates to the daemon behind it.
+// ArmadaRemote is one registered remote fleet: where it is and the bearer
+// token that authenticates to the daemon behind it.
 type ArmadaRemote struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// FLEET_GATEWAY-style URL: <scheme>://<host[:port]>/<session-id>.
+	// Either a FLEET_GATEWAY-style URL (<scheme>://<host[:port]>/<session-id>)
+	// for a fleet reached through a gateway, or an SSH URL
+	// (ssh://[user@]host[:port]) for a fleet reached over an SSH tunnel the LOCAL
+	// daemon maintains (see ResolveArmadaRemote).
 	Url string `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
 	// MCP bearer token; validated by the remote daemon, never by the gateway.
+	// Empty for an ssh:// remote — the token is discovered over SSH on connect.
 	Token         string `protobuf:"bytes,2,opt,name=token,proto3" json:"token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -77,6 +81,111 @@ func (x *ArmadaRemote) GetToken() string {
 	return ""
 }
 
+// ResolveArmadaRemote turns an ssh:// armada URL into something a gRPC client
+// can dial: the LOCAL daemon brings up (or reuses) an SSH port-forward to the
+// remote daemon's token-gated gRPC listener, discovers the remote's bearer token
+// over the same SSH connection, verifies the tunnel end-to-end, and returns the
+// loopback address + token. LOCAL-ONLY: it hands out a bearer token and drives
+// the user's ssh, so the tunnel-facing server refuses it (like Get/SetArmada).
+type ResolveArmadaRemoteRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The ssh://[user@]host[:port] URL (need not be registered in the armada).
+	Url           string `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResolveArmadaRemoteRequest) Reset() {
+	*x = ResolveArmadaRemoteRequest{}
+	mi := &file_armada_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResolveArmadaRemoteRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResolveArmadaRemoteRequest) ProtoMessage() {}
+
+func (x *ResolveArmadaRemoteRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_armada_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResolveArmadaRemoteRequest.ProtoReflect.Descriptor instead.
+func (*ResolveArmadaRemoteRequest) Descriptor() ([]byte, []int) {
+	return file_armada_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *ResolveArmadaRemoteRequest) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
+type ResolveArmadaRemoteReply struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// host:port on the local loopback that forwards to the remote daemon.
+	Addr string `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
+	// The remote daemon's bearer token, sent as `authorization: Bearer <token>`.
+	Token         string `protobuf:"bytes,2,opt,name=token,proto3" json:"token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResolveArmadaRemoteReply) Reset() {
+	*x = ResolveArmadaRemoteReply{}
+	mi := &file_armada_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResolveArmadaRemoteReply) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResolveArmadaRemoteReply) ProtoMessage() {}
+
+func (x *ResolveArmadaRemoteReply) ProtoReflect() protoreflect.Message {
+	mi := &file_armada_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResolveArmadaRemoteReply.ProtoReflect.Descriptor instead.
+func (*ResolveArmadaRemoteReply) Descriptor() ([]byte, []int) {
+	return file_armada_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *ResolveArmadaRemoteReply) GetAddr() string {
+	if x != nil {
+		return x.Addr
+	}
+	return ""
+}
+
+func (x *ResolveArmadaRemoteReply) GetToken() string {
+	if x != nil {
+		return x.Token
+	}
+	return ""
+}
+
 type GetArmadaRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -85,7 +194,7 @@ type GetArmadaRequest struct {
 
 func (x *GetArmadaRequest) Reset() {
 	*x = GetArmadaRequest{}
-	mi := &file_armada_proto_msgTypes[1]
+	mi := &file_armada_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -97,7 +206,7 @@ func (x *GetArmadaRequest) String() string {
 func (*GetArmadaRequest) ProtoMessage() {}
 
 func (x *GetArmadaRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_armada_proto_msgTypes[1]
+	mi := &file_armada_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -110,7 +219,7 @@ func (x *GetArmadaRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetArmadaRequest.ProtoReflect.Descriptor instead.
 func (*GetArmadaRequest) Descriptor() ([]byte, []int) {
-	return file_armada_proto_rawDescGZIP(), []int{1}
+	return file_armada_proto_rawDescGZIP(), []int{3}
 }
 
 type GetArmadaReply struct {
@@ -122,7 +231,7 @@ type GetArmadaReply struct {
 
 func (x *GetArmadaReply) Reset() {
 	*x = GetArmadaReply{}
-	mi := &file_armada_proto_msgTypes[2]
+	mi := &file_armada_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -134,7 +243,7 @@ func (x *GetArmadaReply) String() string {
 func (*GetArmadaReply) ProtoMessage() {}
 
 func (x *GetArmadaReply) ProtoReflect() protoreflect.Message {
-	mi := &file_armada_proto_msgTypes[2]
+	mi := &file_armada_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -147,7 +256,7 @@ func (x *GetArmadaReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetArmadaReply.ProtoReflect.Descriptor instead.
 func (*GetArmadaReply) Descriptor() ([]byte, []int) {
-	return file_armada_proto_rawDescGZIP(), []int{2}
+	return file_armada_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *GetArmadaReply) GetRemotes() []*ArmadaRemote {
@@ -169,7 +278,7 @@ type SetArmadaRequest struct {
 
 func (x *SetArmadaRequest) Reset() {
 	*x = SetArmadaRequest{}
-	mi := &file_armada_proto_msgTypes[3]
+	mi := &file_armada_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -181,7 +290,7 @@ func (x *SetArmadaRequest) String() string {
 func (*SetArmadaRequest) ProtoMessage() {}
 
 func (x *SetArmadaRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_armada_proto_msgTypes[3]
+	mi := &file_armada_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -194,7 +303,7 @@ func (x *SetArmadaRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetArmadaRequest.ProtoReflect.Descriptor instead.
 func (*SetArmadaRequest) Descriptor() ([]byte, []int) {
-	return file_armada_proto_rawDescGZIP(), []int{3}
+	return file_armada_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *SetArmadaRequest) GetRemotes() []*ArmadaRemote {
@@ -213,7 +322,7 @@ type SetArmadaReply struct {
 
 func (x *SetArmadaReply) Reset() {
 	*x = SetArmadaReply{}
-	mi := &file_armada_proto_msgTypes[4]
+	mi := &file_armada_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -225,7 +334,7 @@ func (x *SetArmadaReply) String() string {
 func (*SetArmadaReply) ProtoMessage() {}
 
 func (x *SetArmadaReply) ProtoReflect() protoreflect.Message {
-	mi := &file_armada_proto_msgTypes[4]
+	mi := &file_armada_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -238,7 +347,7 @@ func (x *SetArmadaReply) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetArmadaReply.ProtoReflect.Descriptor instead.
 func (*SetArmadaReply) Descriptor() ([]byte, []int) {
-	return file_armada_proto_rawDescGZIP(), []int{4}
+	return file_armada_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *SetArmadaReply) GetRemotes() []*ArmadaRemote {
@@ -255,6 +364,11 @@ const file_armada_proto_rawDesc = "" +
 	"\farmada.proto\x12\tfleetgrpc\"6\n" +
 	"\fArmadaRemote\x12\x10\n" +
 	"\x03url\x18\x01 \x01(\tR\x03url\x12\x14\n" +
+	"\x05token\x18\x02 \x01(\tR\x05token\".\n" +
+	"\x1aResolveArmadaRemoteRequest\x12\x10\n" +
+	"\x03url\x18\x01 \x01(\tR\x03url\"D\n" +
+	"\x18ResolveArmadaRemoteReply\x12\x12\n" +
+	"\x04addr\x18\x01 \x01(\tR\x04addr\x12\x14\n" +
 	"\x05token\x18\x02 \x01(\tR\x05token\"\x12\n" +
 	"\x10GetArmadaRequest\"C\n" +
 	"\x0eGetArmadaReply\x121\n" +
@@ -276,13 +390,15 @@ func file_armada_proto_rawDescGZIP() []byte {
 	return file_armada_proto_rawDescData
 }
 
-var file_armada_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_armada_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_armada_proto_goTypes = []any{
-	(*ArmadaRemote)(nil),     // 0: fleetgrpc.ArmadaRemote
-	(*GetArmadaRequest)(nil), // 1: fleetgrpc.GetArmadaRequest
-	(*GetArmadaReply)(nil),   // 2: fleetgrpc.GetArmadaReply
-	(*SetArmadaRequest)(nil), // 3: fleetgrpc.SetArmadaRequest
-	(*SetArmadaReply)(nil),   // 4: fleetgrpc.SetArmadaReply
+	(*ArmadaRemote)(nil),               // 0: fleetgrpc.ArmadaRemote
+	(*ResolveArmadaRemoteRequest)(nil), // 1: fleetgrpc.ResolveArmadaRemoteRequest
+	(*ResolveArmadaRemoteReply)(nil),   // 2: fleetgrpc.ResolveArmadaRemoteReply
+	(*GetArmadaRequest)(nil),           // 3: fleetgrpc.GetArmadaRequest
+	(*GetArmadaReply)(nil),             // 4: fleetgrpc.GetArmadaReply
+	(*SetArmadaRequest)(nil),           // 5: fleetgrpc.SetArmadaRequest
+	(*SetArmadaReply)(nil),             // 6: fleetgrpc.SetArmadaReply
 }
 var file_armada_proto_depIdxs = []int32{
 	0, // 0: fleetgrpc.GetArmadaReply.remotes:type_name -> fleetgrpc.ArmadaRemote
@@ -306,7 +422,7 @@ func file_armada_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_armada_proto_rawDesc), len(file_armada_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/fleetgrpc/armada.proto
+++ b/fleetgrpc/armada.proto
@@ -19,12 +19,34 @@ option go_package = "github.com/BenjaminBenetti/fleet-man/fleetgrpc;fleetgrpc";
 // list, and a remote-connected TUI's SetConfig would write the registry to the
 // wrong machine's config.json. Dedicated messages + RPCs avoid both.
 
-// ArmadaRemote is one registered remote fleet: where its gateway is and the
-// bearer token that authenticates to the daemon behind it.
+// ArmadaRemote is one registered remote fleet: where it is and the bearer
+// token that authenticates to the daemon behind it.
 message ArmadaRemote {
-  // FLEET_GATEWAY-style URL: <scheme>://<host[:port]>/<session-id>.
+  // Either a FLEET_GATEWAY-style URL (<scheme>://<host[:port]>/<session-id>)
+  // for a fleet reached through a gateway, or an SSH URL
+  // (ssh://[user@]host[:port]) for a fleet reached over an SSH tunnel the LOCAL
+  // daemon maintains (see ResolveArmadaRemote).
   string url = 1;
   // MCP bearer token; validated by the remote daemon, never by the gateway.
+  // Empty for an ssh:// remote — the token is discovered over SSH on connect.
+  string token = 2;
+}
+
+// ResolveArmadaRemote turns an ssh:// armada URL into something a gRPC client
+// can dial: the LOCAL daemon brings up (or reuses) an SSH port-forward to the
+// remote daemon's token-gated gRPC listener, discovers the remote's bearer token
+// over the same SSH connection, verifies the tunnel end-to-end, and returns the
+// loopback address + token. LOCAL-ONLY: it hands out a bearer token and drives
+// the user's ssh, so the tunnel-facing server refuses it (like Get/SetArmada).
+message ResolveArmadaRemoteRequest {
+  // The ssh://[user@]host[:port] URL (need not be registered in the armada).
+  string url = 1;
+}
+
+message ResolveArmadaRemoteReply {
+  // host:port on the local loopback that forwards to the remote daemon.
+  string addr = 1;
+  // The remote daemon's bearer token, sent as `authorization: Bearer <token>`.
   string token = 2;
 }
 

--- a/fleetgrpc/config.pb.go
+++ b/fleetgrpc/config.pb.go
@@ -321,8 +321,14 @@ type RemoteMcpSettings struct {
 	// does not serve <session-url>/webhook/<name> for this daemon. Independent of
 	// enabled/fleet_enabled — all three ride the SAME outbound tunnel.
 	WebhookEnabled bool `protobuf:"varint,4,opt,name=webhook_enabled,json=webhookEnabled,proto3" json:"webhook_enabled,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// fleet_mode selects how remote fleet control is reached: "gateway" (the
+	// default; empty reads as gateway) rides the gateway tunnel, "ssh" instead
+	// serves the token-gated gRPC server on a loopback port that a remote client
+	// reaches over an SSH tunnel (no gateway involved). Mirrors
+	// state.FleetModeGateway / state.FleetModeSSH; an unknown value is gateway.
+	FleetMode     string `protobuf:"bytes,5,opt,name=fleet_mode,json=fleetMode,proto3" json:"fleet_mode,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RemoteMcpSettings) Reset() {
@@ -381,6 +387,13 @@ func (x *RemoteMcpSettings) GetWebhookEnabled() bool {
 		return x.WebhookEnabled
 	}
 	return false
+}
+
+func (x *RemoteMcpSettings) GetFleetMode() string {
+	if x != nil {
+		return x.FleetMode
+	}
+	return ""
 }
 
 type Config struct {
@@ -678,13 +691,15 @@ const file_config_proto_rawDesc = "" +
 	"\vauto_switch\x18\x02 \x01(\bH\x01R\n" +
 	"autoSwitch\x88\x01\x01B\x1e\n" +
 	"\x1c_multiple_browsers_per_fleetB\x0e\n" +
-	"\f_auto_switch\"\x9c\x01\n" +
+	"\f_auto_switch\"\xbb\x01\n" +
 	"\x11RemoteMcpSettings\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x1f\n" +
 	"\vgateway_url\x18\x02 \x01(\tR\n" +
 	"gatewayUrl\x12#\n" +
 	"\rfleet_enabled\x18\x03 \x01(\bR\ffleetEnabled\x12'\n" +
-	"\x0fwebhook_enabled\x18\x04 \x01(\bR\x0ewebhookEnabled\"\xad\x03\n" +
+	"\x0fwebhook_enabled\x18\x04 \x01(\bR\x0ewebhookEnabled\x12\x1d\n" +
+	"\n" +
+	"fleet_mode\x18\x05 \x01(\tR\tfleetMode\"\xad\x03\n" +
 	"\x06Config\x124\n" +
 	"\ageneral\x18\x01 \x01(\v2\x1a.fleetgrpc.GeneralSettingsR\ageneral\x12.\n" +
 	"\x05agent\x18\x02 \x01(\v2\x18.fleetgrpc.AgentSettingsR\x05agent\x127\n" +

--- a/fleetgrpc/config.proto
+++ b/fleetgrpc/config.proto
@@ -81,6 +81,12 @@ message RemoteMcpSettings {
   // does not serve <session-url>/webhook/<name> for this daemon. Independent of
   // enabled/fleet_enabled — all three ride the SAME outbound tunnel.
   bool webhook_enabled = 4;
+  // fleet_mode selects how remote fleet control is reached: "gateway" (the
+  // default; empty reads as gateway) rides the gateway tunnel, "ssh" instead
+  // serves the token-gated gRPC server on a loopback port that a remote client
+  // reaches over an SSH tunnel (no gateway involved). Mirrors
+  // state.FleetModeGateway / state.FleetModeSSH; an unknown value is gateway.
+  string fleet_mode = 5;
 }
 
 message Config {

--- a/fleetgrpc/service.pb.go
+++ b/fleetgrpc/service.pb.go
@@ -26,7 +26,7 @@ const file_service_proto_rawDesc = "" +
 	"\n" +
 	"\rservice.proto\x12\tfleetgrpc\x1a\farmada.proto\x1a\rcontrol.proto\x1a\vwatch.proto\x1a\n" +
 	"jobs.proto\x1a\fconfig.proto\x1a\n" +
-	"exec.proto\x1a\rinspect.proto2\x95\x16\n" +
+	"exec.proto\x1a\rinspect.proto2\xf8\x16\n" +
 	"\fFleetService\x127\n" +
 	"\x05Hello\x12\x17.fleetgrpc.HelloRequest\x1a\x15.fleetgrpc.HelloReply\x12@\n" +
 	"\bShutdown\x12\x1a.fleetgrpc.ShutdownRequest\x1a\x18.fleetgrpc.ShutdownReply\x12[\n" +
@@ -52,7 +52,8 @@ const file_service_proto_rawDesc = "" +
 	"\tGetConfig\x12\x1b.fleetgrpc.GetConfigRequest\x1a\x19.fleetgrpc.GetConfigReply\x12C\n" +
 	"\tSetConfig\x12\x1b.fleetgrpc.SetConfigRequest\x1a\x19.fleetgrpc.SetConfigReply\x12C\n" +
 	"\tGetArmada\x12\x1b.fleetgrpc.GetArmadaRequest\x1a\x19.fleetgrpc.GetArmadaReply\x12C\n" +
-	"\tSetArmada\x12\x1b.fleetgrpc.SetArmadaRequest\x1a\x19.fleetgrpc.SetArmadaReply\x121\n" +
+	"\tSetArmada\x12\x1b.fleetgrpc.SetArmadaRequest\x1a\x19.fleetgrpc.SetArmadaReply\x12a\n" +
+	"\x13ResolveArmadaRemote\x12%.fleetgrpc.ResolveArmadaRemoteRequest\x1a#.fleetgrpc.ResolveArmadaRemoteReply\x121\n" +
 	"\x04Exec\x12\x11.fleetgrpc.ExecIn\x1a\x12.fleetgrpc.ExecOut(\x010\x01\x12^\n" +
 	"\x12ResolveExecCommand\x12$.fleetgrpc.ResolveExecCommandRequest\x1a\".fleetgrpc.ResolveExecCommandReply\x12^\n" +
 	"\x12ResolveLogsCommand\x12$.fleetgrpc.ResolveLogsCommandRequest\x1a\".fleetgrpc.ResolveLogsCommandReply\x124\n" +
@@ -92,43 +93,45 @@ var file_service_proto_goTypes = []any{
 	(*SetConfigRequest)(nil),              // 22: fleetgrpc.SetConfigRequest
 	(*GetArmadaRequest)(nil),              // 23: fleetgrpc.GetArmadaRequest
 	(*SetArmadaRequest)(nil),              // 24: fleetgrpc.SetArmadaRequest
-	(*ExecIn)(nil),                        // 25: fleetgrpc.ExecIn
-	(*ResolveExecCommandRequest)(nil),     // 26: fleetgrpc.ResolveExecCommandRequest
-	(*ResolveLogsCommandRequest)(nil),     // 27: fleetgrpc.ResolveLogsCommandRequest
-	(*LogsRequest)(nil),                   // 28: fleetgrpc.LogsRequest
-	(*TriggerLogsRequest)(nil),            // 29: fleetgrpc.TriggerLogsRequest
-	(*ForwardChunk)(nil),                  // 30: fleetgrpc.ForwardChunk
-	(*CopyFileRequest)(nil),               // 31: fleetgrpc.CopyFileRequest
-	(*CopyIntoChunk)(nil),                 // 32: fleetgrpc.CopyIntoChunk
-	(*InspectRepoRequest)(nil),            // 33: fleetgrpc.InspectRepoRequest
-	(*GetCoderTemplateParamsRequest)(nil), // 34: fleetgrpc.GetCoderTemplateParamsRequest
-	(*GetBrowserConfigRequest)(nil),       // 35: fleetgrpc.GetBrowserConfigRequest
-	(*PrepareBrowserRequest)(nil),         // 36: fleetgrpc.PrepareBrowserRequest
-	(*HelloReply)(nil),                    // 37: fleetgrpc.HelloReply
-	(*ShutdownReply)(nil),                 // 38: fleetgrpc.ShutdownReply
-	(*FleetTUIConnectedReply)(nil),        // 39: fleetgrpc.FleetTUIConnectedReply
-	(*GetStateReply)(nil),                 // 40: fleetgrpc.GetStateReply
-	(*Event)(nil),                         // 41: fleetgrpc.Event
-	(*JobEvent)(nil),                      // 42: fleetgrpc.JobEvent
-	(*MutationReply)(nil),                 // 43: fleetgrpc.MutationReply
-	(*DeleteBuildkitCacheReply)(nil),      // 44: fleetgrpc.DeleteBuildkitCacheReply
-	(*DeleteDebCacheReply)(nil),           // 45: fleetgrpc.DeleteDebCacheReply
-	(*DeleteImageCacheReply)(nil),         // 46: fleetgrpc.DeleteImageCacheReply
-	(*GetConfigReply)(nil),                // 47: fleetgrpc.GetConfigReply
-	(*SetConfigReply)(nil),                // 48: fleetgrpc.SetConfigReply
-	(*GetArmadaReply)(nil),                // 49: fleetgrpc.GetArmadaReply
-	(*SetArmadaReply)(nil),                // 50: fleetgrpc.SetArmadaReply
-	(*ExecOut)(nil),                       // 51: fleetgrpc.ExecOut
-	(*ResolveExecCommandReply)(nil),       // 52: fleetgrpc.ResolveExecCommandReply
-	(*ResolveLogsCommandReply)(nil),       // 53: fleetgrpc.ResolveLogsCommandReply
-	(*LogLine)(nil),                       // 54: fleetgrpc.LogLine
-	(*TriggerLogsReply)(nil),              // 55: fleetgrpc.TriggerLogsReply
-	(*CopyFileChunk)(nil),                 // 56: fleetgrpc.CopyFileChunk
-	(*CopyIntoReply)(nil),                 // 57: fleetgrpc.CopyIntoReply
-	(*InspectRepoReply)(nil),              // 58: fleetgrpc.InspectRepoReply
-	(*GetCoderTemplateParamsReply)(nil),   // 59: fleetgrpc.GetCoderTemplateParamsReply
-	(*GetBrowserConfigReply)(nil),         // 60: fleetgrpc.GetBrowserConfigReply
-	(*PrepareBrowserReply)(nil),           // 61: fleetgrpc.PrepareBrowserReply
+	(*ResolveArmadaRemoteRequest)(nil),    // 25: fleetgrpc.ResolveArmadaRemoteRequest
+	(*ExecIn)(nil),                        // 26: fleetgrpc.ExecIn
+	(*ResolveExecCommandRequest)(nil),     // 27: fleetgrpc.ResolveExecCommandRequest
+	(*ResolveLogsCommandRequest)(nil),     // 28: fleetgrpc.ResolveLogsCommandRequest
+	(*LogsRequest)(nil),                   // 29: fleetgrpc.LogsRequest
+	(*TriggerLogsRequest)(nil),            // 30: fleetgrpc.TriggerLogsRequest
+	(*ForwardChunk)(nil),                  // 31: fleetgrpc.ForwardChunk
+	(*CopyFileRequest)(nil),               // 32: fleetgrpc.CopyFileRequest
+	(*CopyIntoChunk)(nil),                 // 33: fleetgrpc.CopyIntoChunk
+	(*InspectRepoRequest)(nil),            // 34: fleetgrpc.InspectRepoRequest
+	(*GetCoderTemplateParamsRequest)(nil), // 35: fleetgrpc.GetCoderTemplateParamsRequest
+	(*GetBrowserConfigRequest)(nil),       // 36: fleetgrpc.GetBrowserConfigRequest
+	(*PrepareBrowserRequest)(nil),         // 37: fleetgrpc.PrepareBrowserRequest
+	(*HelloReply)(nil),                    // 38: fleetgrpc.HelloReply
+	(*ShutdownReply)(nil),                 // 39: fleetgrpc.ShutdownReply
+	(*FleetTUIConnectedReply)(nil),        // 40: fleetgrpc.FleetTUIConnectedReply
+	(*GetStateReply)(nil),                 // 41: fleetgrpc.GetStateReply
+	(*Event)(nil),                         // 42: fleetgrpc.Event
+	(*JobEvent)(nil),                      // 43: fleetgrpc.JobEvent
+	(*MutationReply)(nil),                 // 44: fleetgrpc.MutationReply
+	(*DeleteBuildkitCacheReply)(nil),      // 45: fleetgrpc.DeleteBuildkitCacheReply
+	(*DeleteDebCacheReply)(nil),           // 46: fleetgrpc.DeleteDebCacheReply
+	(*DeleteImageCacheReply)(nil),         // 47: fleetgrpc.DeleteImageCacheReply
+	(*GetConfigReply)(nil),                // 48: fleetgrpc.GetConfigReply
+	(*SetConfigReply)(nil),                // 49: fleetgrpc.SetConfigReply
+	(*GetArmadaReply)(nil),                // 50: fleetgrpc.GetArmadaReply
+	(*SetArmadaReply)(nil),                // 51: fleetgrpc.SetArmadaReply
+	(*ResolveArmadaRemoteReply)(nil),      // 52: fleetgrpc.ResolveArmadaRemoteReply
+	(*ExecOut)(nil),                       // 53: fleetgrpc.ExecOut
+	(*ResolveExecCommandReply)(nil),       // 54: fleetgrpc.ResolveExecCommandReply
+	(*ResolveLogsCommandReply)(nil),       // 55: fleetgrpc.ResolveLogsCommandReply
+	(*LogLine)(nil),                       // 56: fleetgrpc.LogLine
+	(*TriggerLogsReply)(nil),              // 57: fleetgrpc.TriggerLogsReply
+	(*CopyFileChunk)(nil),                 // 58: fleetgrpc.CopyFileChunk
+	(*CopyIntoReply)(nil),                 // 59: fleetgrpc.CopyIntoReply
+	(*InspectRepoReply)(nil),              // 60: fleetgrpc.InspectRepoReply
+	(*GetCoderTemplateParamsReply)(nil),   // 61: fleetgrpc.GetCoderTemplateParamsReply
+	(*GetBrowserConfigReply)(nil),         // 62: fleetgrpc.GetBrowserConfigReply
+	(*PrepareBrowserReply)(nil),           // 63: fleetgrpc.PrepareBrowserReply
 }
 var file_service_proto_depIdxs = []int32{
 	0,  // 0: fleetgrpc.FleetService.Hello:input_type -> fleetgrpc.HelloRequest
@@ -156,57 +159,59 @@ var file_service_proto_depIdxs = []int32{
 	22, // 22: fleetgrpc.FleetService.SetConfig:input_type -> fleetgrpc.SetConfigRequest
 	23, // 23: fleetgrpc.FleetService.GetArmada:input_type -> fleetgrpc.GetArmadaRequest
 	24, // 24: fleetgrpc.FleetService.SetArmada:input_type -> fleetgrpc.SetArmadaRequest
-	25, // 25: fleetgrpc.FleetService.Exec:input_type -> fleetgrpc.ExecIn
-	26, // 26: fleetgrpc.FleetService.ResolveExecCommand:input_type -> fleetgrpc.ResolveExecCommandRequest
-	27, // 27: fleetgrpc.FleetService.ResolveLogsCommand:input_type -> fleetgrpc.ResolveLogsCommandRequest
-	28, // 28: fleetgrpc.FleetService.Logs:input_type -> fleetgrpc.LogsRequest
-	29, // 29: fleetgrpc.FleetService.TriggerLogs:input_type -> fleetgrpc.TriggerLogsRequest
-	30, // 30: fleetgrpc.FleetService.Forward:input_type -> fleetgrpc.ForwardChunk
-	31, // 31: fleetgrpc.FleetService.CopyFile:input_type -> fleetgrpc.CopyFileRequest
-	32, // 32: fleetgrpc.FleetService.CopyInto:input_type -> fleetgrpc.CopyIntoChunk
-	33, // 33: fleetgrpc.FleetService.InspectRepo:input_type -> fleetgrpc.InspectRepoRequest
-	34, // 34: fleetgrpc.FleetService.GetCoderTemplateParams:input_type -> fleetgrpc.GetCoderTemplateParamsRequest
-	35, // 35: fleetgrpc.FleetService.GetBrowserConfig:input_type -> fleetgrpc.GetBrowserConfigRequest
-	36, // 36: fleetgrpc.FleetService.PrepareBrowser:input_type -> fleetgrpc.PrepareBrowserRequest
-	37, // 37: fleetgrpc.FleetService.Hello:output_type -> fleetgrpc.HelloReply
-	38, // 38: fleetgrpc.FleetService.Shutdown:output_type -> fleetgrpc.ShutdownReply
-	39, // 39: fleetgrpc.FleetService.FleetTUIConnected:output_type -> fleetgrpc.FleetTUIConnectedReply
-	40, // 40: fleetgrpc.FleetService.GetState:output_type -> fleetgrpc.GetStateReply
-	41, // 41: fleetgrpc.FleetService.Watch:output_type -> fleetgrpc.Event
-	42, // 42: fleetgrpc.FleetService.CreateInstance:output_type -> fleetgrpc.JobEvent
-	42, // 43: fleetgrpc.FleetService.DestroyInstance:output_type -> fleetgrpc.JobEvent
-	42, // 44: fleetgrpc.FleetService.StartInstance:output_type -> fleetgrpc.JobEvent
-	42, // 45: fleetgrpc.FleetService.StopInstance:output_type -> fleetgrpc.JobEvent
-	42, // 46: fleetgrpc.FleetService.CloneInstance:output_type -> fleetgrpc.JobEvent
-	42, // 47: fleetgrpc.FleetService.RebuildInstance:output_type -> fleetgrpc.JobEvent
-	43, // 48: fleetgrpc.FleetService.CreateFleet:output_type -> fleetgrpc.MutationReply
-	43, // 49: fleetgrpc.FleetService.DestroyFleet:output_type -> fleetgrpc.MutationReply
-	43, // 50: fleetgrpc.FleetService.SetFleetSettings:output_type -> fleetgrpc.MutationReply
-	44, // 51: fleetgrpc.FleetService.DeleteBuildkitCache:output_type -> fleetgrpc.DeleteBuildkitCacheReply
-	45, // 52: fleetgrpc.FleetService.DeleteDebCache:output_type -> fleetgrpc.DeleteDebCacheReply
-	46, // 53: fleetgrpc.FleetService.DeleteImageCache:output_type -> fleetgrpc.DeleteImageCacheReply
-	43, // 54: fleetgrpc.FleetService.SetInstanceMetadata:output_type -> fleetgrpc.MutationReply
-	43, // 55: fleetgrpc.FleetService.SetGroupLayout:output_type -> fleetgrpc.MutationReply
-	43, // 56: fleetgrpc.FleetService.DeleteGroupLayout:output_type -> fleetgrpc.MutationReply
-	43, // 57: fleetgrpc.FleetService.SetLastSeenVersion:output_type -> fleetgrpc.MutationReply
-	47, // 58: fleetgrpc.FleetService.GetConfig:output_type -> fleetgrpc.GetConfigReply
-	48, // 59: fleetgrpc.FleetService.SetConfig:output_type -> fleetgrpc.SetConfigReply
-	49, // 60: fleetgrpc.FleetService.GetArmada:output_type -> fleetgrpc.GetArmadaReply
-	50, // 61: fleetgrpc.FleetService.SetArmada:output_type -> fleetgrpc.SetArmadaReply
-	51, // 62: fleetgrpc.FleetService.Exec:output_type -> fleetgrpc.ExecOut
-	52, // 63: fleetgrpc.FleetService.ResolveExecCommand:output_type -> fleetgrpc.ResolveExecCommandReply
-	53, // 64: fleetgrpc.FleetService.ResolveLogsCommand:output_type -> fleetgrpc.ResolveLogsCommandReply
-	54, // 65: fleetgrpc.FleetService.Logs:output_type -> fleetgrpc.LogLine
-	55, // 66: fleetgrpc.FleetService.TriggerLogs:output_type -> fleetgrpc.TriggerLogsReply
-	30, // 67: fleetgrpc.FleetService.Forward:output_type -> fleetgrpc.ForwardChunk
-	56, // 68: fleetgrpc.FleetService.CopyFile:output_type -> fleetgrpc.CopyFileChunk
-	57, // 69: fleetgrpc.FleetService.CopyInto:output_type -> fleetgrpc.CopyIntoReply
-	58, // 70: fleetgrpc.FleetService.InspectRepo:output_type -> fleetgrpc.InspectRepoReply
-	59, // 71: fleetgrpc.FleetService.GetCoderTemplateParams:output_type -> fleetgrpc.GetCoderTemplateParamsReply
-	60, // 72: fleetgrpc.FleetService.GetBrowserConfig:output_type -> fleetgrpc.GetBrowserConfigReply
-	61, // 73: fleetgrpc.FleetService.PrepareBrowser:output_type -> fleetgrpc.PrepareBrowserReply
-	37, // [37:74] is the sub-list for method output_type
-	0,  // [0:37] is the sub-list for method input_type
+	25, // 25: fleetgrpc.FleetService.ResolveArmadaRemote:input_type -> fleetgrpc.ResolveArmadaRemoteRequest
+	26, // 26: fleetgrpc.FleetService.Exec:input_type -> fleetgrpc.ExecIn
+	27, // 27: fleetgrpc.FleetService.ResolveExecCommand:input_type -> fleetgrpc.ResolveExecCommandRequest
+	28, // 28: fleetgrpc.FleetService.ResolveLogsCommand:input_type -> fleetgrpc.ResolveLogsCommandRequest
+	29, // 29: fleetgrpc.FleetService.Logs:input_type -> fleetgrpc.LogsRequest
+	30, // 30: fleetgrpc.FleetService.TriggerLogs:input_type -> fleetgrpc.TriggerLogsRequest
+	31, // 31: fleetgrpc.FleetService.Forward:input_type -> fleetgrpc.ForwardChunk
+	32, // 32: fleetgrpc.FleetService.CopyFile:input_type -> fleetgrpc.CopyFileRequest
+	33, // 33: fleetgrpc.FleetService.CopyInto:input_type -> fleetgrpc.CopyIntoChunk
+	34, // 34: fleetgrpc.FleetService.InspectRepo:input_type -> fleetgrpc.InspectRepoRequest
+	35, // 35: fleetgrpc.FleetService.GetCoderTemplateParams:input_type -> fleetgrpc.GetCoderTemplateParamsRequest
+	36, // 36: fleetgrpc.FleetService.GetBrowserConfig:input_type -> fleetgrpc.GetBrowserConfigRequest
+	37, // 37: fleetgrpc.FleetService.PrepareBrowser:input_type -> fleetgrpc.PrepareBrowserRequest
+	38, // 38: fleetgrpc.FleetService.Hello:output_type -> fleetgrpc.HelloReply
+	39, // 39: fleetgrpc.FleetService.Shutdown:output_type -> fleetgrpc.ShutdownReply
+	40, // 40: fleetgrpc.FleetService.FleetTUIConnected:output_type -> fleetgrpc.FleetTUIConnectedReply
+	41, // 41: fleetgrpc.FleetService.GetState:output_type -> fleetgrpc.GetStateReply
+	42, // 42: fleetgrpc.FleetService.Watch:output_type -> fleetgrpc.Event
+	43, // 43: fleetgrpc.FleetService.CreateInstance:output_type -> fleetgrpc.JobEvent
+	43, // 44: fleetgrpc.FleetService.DestroyInstance:output_type -> fleetgrpc.JobEvent
+	43, // 45: fleetgrpc.FleetService.StartInstance:output_type -> fleetgrpc.JobEvent
+	43, // 46: fleetgrpc.FleetService.StopInstance:output_type -> fleetgrpc.JobEvent
+	43, // 47: fleetgrpc.FleetService.CloneInstance:output_type -> fleetgrpc.JobEvent
+	43, // 48: fleetgrpc.FleetService.RebuildInstance:output_type -> fleetgrpc.JobEvent
+	44, // 49: fleetgrpc.FleetService.CreateFleet:output_type -> fleetgrpc.MutationReply
+	44, // 50: fleetgrpc.FleetService.DestroyFleet:output_type -> fleetgrpc.MutationReply
+	44, // 51: fleetgrpc.FleetService.SetFleetSettings:output_type -> fleetgrpc.MutationReply
+	45, // 52: fleetgrpc.FleetService.DeleteBuildkitCache:output_type -> fleetgrpc.DeleteBuildkitCacheReply
+	46, // 53: fleetgrpc.FleetService.DeleteDebCache:output_type -> fleetgrpc.DeleteDebCacheReply
+	47, // 54: fleetgrpc.FleetService.DeleteImageCache:output_type -> fleetgrpc.DeleteImageCacheReply
+	44, // 55: fleetgrpc.FleetService.SetInstanceMetadata:output_type -> fleetgrpc.MutationReply
+	44, // 56: fleetgrpc.FleetService.SetGroupLayout:output_type -> fleetgrpc.MutationReply
+	44, // 57: fleetgrpc.FleetService.DeleteGroupLayout:output_type -> fleetgrpc.MutationReply
+	44, // 58: fleetgrpc.FleetService.SetLastSeenVersion:output_type -> fleetgrpc.MutationReply
+	48, // 59: fleetgrpc.FleetService.GetConfig:output_type -> fleetgrpc.GetConfigReply
+	49, // 60: fleetgrpc.FleetService.SetConfig:output_type -> fleetgrpc.SetConfigReply
+	50, // 61: fleetgrpc.FleetService.GetArmada:output_type -> fleetgrpc.GetArmadaReply
+	51, // 62: fleetgrpc.FleetService.SetArmada:output_type -> fleetgrpc.SetArmadaReply
+	52, // 63: fleetgrpc.FleetService.ResolveArmadaRemote:output_type -> fleetgrpc.ResolveArmadaRemoteReply
+	53, // 64: fleetgrpc.FleetService.Exec:output_type -> fleetgrpc.ExecOut
+	54, // 65: fleetgrpc.FleetService.ResolveExecCommand:output_type -> fleetgrpc.ResolveExecCommandReply
+	55, // 66: fleetgrpc.FleetService.ResolveLogsCommand:output_type -> fleetgrpc.ResolveLogsCommandReply
+	56, // 67: fleetgrpc.FleetService.Logs:output_type -> fleetgrpc.LogLine
+	57, // 68: fleetgrpc.FleetService.TriggerLogs:output_type -> fleetgrpc.TriggerLogsReply
+	31, // 69: fleetgrpc.FleetService.Forward:output_type -> fleetgrpc.ForwardChunk
+	58, // 70: fleetgrpc.FleetService.CopyFile:output_type -> fleetgrpc.CopyFileChunk
+	59, // 71: fleetgrpc.FleetService.CopyInto:output_type -> fleetgrpc.CopyIntoReply
+	60, // 72: fleetgrpc.FleetService.InspectRepo:output_type -> fleetgrpc.InspectRepoReply
+	61, // 73: fleetgrpc.FleetService.GetCoderTemplateParams:output_type -> fleetgrpc.GetCoderTemplateParamsReply
+	62, // 74: fleetgrpc.FleetService.GetBrowserConfig:output_type -> fleetgrpc.GetBrowserConfigReply
+	63, // 75: fleetgrpc.FleetService.PrepareBrowser:output_type -> fleetgrpc.PrepareBrowserReply
+	38, // [38:76] is the sub-list for method output_type
+	0,  // [0:38] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/fleetgrpc/service.proto
+++ b/fleetgrpc/service.proto
@@ -78,6 +78,9 @@ service FleetService {
   // fleet (see armada.proto).
   rpc GetArmada(GetArmadaRequest) returns (GetArmadaReply);
   rpc SetArmada(SetArmadaRequest) returns (SetArmadaReply);
+  // Resolve an ssh:// armada remote into a dialable loopback address + token
+  // (the local daemon owns the SSH tunnel). Local-only, like Get/SetArmada.
+  rpc ResolveArmadaRemote(ResolveArmadaRemoteRequest) returns (ResolveArmadaRemoteReply);
 
   // ---- Interactive backend operations ----
   rpc Exec(stream ExecIn) returns (stream ExecOut);

--- a/fleetgrpc/service_grpc.pb.go
+++ b/fleetgrpc/service_grpc.pb.go
@@ -44,6 +44,7 @@ const (
 	FleetService_SetConfig_FullMethodName              = "/fleetgrpc.FleetService/SetConfig"
 	FleetService_GetArmada_FullMethodName              = "/fleetgrpc.FleetService/GetArmada"
 	FleetService_SetArmada_FullMethodName              = "/fleetgrpc.FleetService/SetArmada"
+	FleetService_ResolveArmadaRemote_FullMethodName    = "/fleetgrpc.FleetService/ResolveArmadaRemote"
 	FleetService_Exec_FullMethodName                   = "/fleetgrpc.FleetService/Exec"
 	FleetService_ResolveExecCommand_FullMethodName     = "/fleetgrpc.FleetService/ResolveExecCommand"
 	FleetService_ResolveLogsCommand_FullMethodName     = "/fleetgrpc.FleetService/ResolveLogsCommand"
@@ -116,6 +117,9 @@ type FleetServiceClient interface {
 	// fleet (see armada.proto).
 	GetArmada(ctx context.Context, in *GetArmadaRequest, opts ...grpc.CallOption) (*GetArmadaReply, error)
 	SetArmada(ctx context.Context, in *SetArmadaRequest, opts ...grpc.CallOption) (*SetArmadaReply, error)
+	// Resolve an ssh:// armada remote into a dialable loopback address + token
+	// (the local daemon owns the SSH tunnel). Local-only, like Get/SetArmada.
+	ResolveArmadaRemote(ctx context.Context, in *ResolveArmadaRemoteRequest, opts ...grpc.CallOption) (*ResolveArmadaRemoteReply, error)
 	// ---- Interactive backend operations ----
 	Exec(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[ExecIn, ExecOut], error)
 	ResolveExecCommand(ctx context.Context, in *ResolveExecCommandRequest, opts ...grpc.CallOption) (*ResolveExecCommandReply, error)
@@ -472,6 +476,16 @@ func (c *fleetServiceClient) SetArmada(ctx context.Context, in *SetArmadaRequest
 	return out, nil
 }
 
+func (c *fleetServiceClient) ResolveArmadaRemote(ctx context.Context, in *ResolveArmadaRemoteRequest, opts ...grpc.CallOption) (*ResolveArmadaRemoteReply, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ResolveArmadaRemoteReply)
+	err := c.cc.Invoke(ctx, FleetService_ResolveArmadaRemote_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *fleetServiceClient) Exec(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[ExecIn, ExecOut], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &FleetService_ServiceDesc.Streams[7], FleetService_Exec_FullMethodName, cOpts...)
@@ -677,6 +691,9 @@ type FleetServiceServer interface {
 	// fleet (see armada.proto).
 	GetArmada(context.Context, *GetArmadaRequest) (*GetArmadaReply, error)
 	SetArmada(context.Context, *SetArmadaRequest) (*SetArmadaReply, error)
+	// Resolve an ssh:// armada remote into a dialable loopback address + token
+	// (the local daemon owns the SSH tunnel). Local-only, like Get/SetArmada.
+	ResolveArmadaRemote(context.Context, *ResolveArmadaRemoteRequest) (*ResolveArmadaRemoteReply, error)
 	// ---- Interactive backend operations ----
 	Exec(grpc.BidiStreamingServer[ExecIn, ExecOut]) error
 	ResolveExecCommand(context.Context, *ResolveExecCommandRequest) (*ResolveExecCommandReply, error)
@@ -794,6 +811,9 @@ func (UnimplementedFleetServiceServer) GetArmada(context.Context, *GetArmadaRequ
 }
 func (UnimplementedFleetServiceServer) SetArmada(context.Context, *SetArmadaRequest) (*SetArmadaReply, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SetArmada not implemented")
+}
+func (UnimplementedFleetServiceServer) ResolveArmadaRemote(context.Context, *ResolveArmadaRemoteRequest) (*ResolveArmadaRemoteReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ResolveArmadaRemote not implemented")
 }
 func (UnimplementedFleetServiceServer) Exec(grpc.BidiStreamingServer[ExecIn, ExecOut]) error {
 	return status.Errorf(codes.Unimplemented, "method Exec not implemented")
@@ -1253,6 +1273,24 @@ func _FleetService_SetArmada_Handler(srv interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 
+func _FleetService_ResolveArmadaRemote_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ResolveArmadaRemoteRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FleetServiceServer).ResolveArmadaRemote(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: FleetService_ResolveArmadaRemote_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FleetServiceServer).ResolveArmadaRemote(ctx, req.(*ResolveArmadaRemoteRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _FleetService_Exec_Handler(srv interface{}, stream grpc.ServerStream) error {
 	return srv.(FleetServiceServer).Exec(&grpc.GenericServerStream[ExecIn, ExecOut]{ServerStream: stream})
 }
@@ -1500,6 +1538,10 @@ var FleetService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetArmada",
 			Handler:    _FleetService_SetArmada_Handler,
+		},
+		{
+			MethodName: "ResolveArmadaRemote",
+			Handler:    _FleetService_ResolveArmadaRemote_Handler,
 		},
 		{
 			MethodName: "ResolveExecCommand",

--- a/fleetgrpc/watch.pb.go
+++ b/fleetgrpc/watch.pb.go
@@ -394,8 +394,18 @@ type RemoteMcpStatus struct {
 	// CONNECTED and the webhook feature was negotiated (the user enabled "Enable
 	// Webhook"); empty otherwise (incl. from an old gateway).
 	PublicWebhookUrl string `protobuf:"bytes,6,opt,name=public_webhook_url,json=publicWebhookUrl,proto3" json:"public_webhook_url,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// ssh_addr is the loopback address (127.0.0.1:<port>) the daemon's
+	// token-gated gRPC server listens on while remote fleet is enabled in SSH
+	// mode — the port a remote client's SSH tunnel forwards to. Independent of
+	// `state` (which describes the gateway tunnel): empty when the SSH listener is
+	// off or failed. Stamped onto every status by the hub, so it survives the
+	// gateway manager's own status pushes.
+	SshAddr string `protobuf:"bytes,7,opt,name=ssh_addr,json=sshAddr,proto3" json:"ssh_addr,omitempty"`
+	// ssh_error carries the SSH listener's last failure (bind error, missing
+	// token) while it is enabled but not listening; empty otherwise.
+	SshError      string `protobuf:"bytes,8,opt,name=ssh_error,json=sshError,proto3" json:"ssh_error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RemoteMcpStatus) Reset() {
@@ -466,6 +476,20 @@ func (x *RemoteMcpStatus) GetGatewayVersion() string {
 func (x *RemoteMcpStatus) GetPublicWebhookUrl() string {
 	if x != nil {
 		return x.PublicWebhookUrl
+	}
+	return ""
+}
+
+func (x *RemoteMcpStatus) GetSshAddr() string {
+	if x != nil {
+		return x.SshAddr
+	}
+	return ""
+}
+
+func (x *RemoteMcpStatus) GetSshError() string {
+	if x != nil {
+		return x.SshError
 	}
 	return ""
 }
@@ -745,7 +769,7 @@ const file_watch_proto_rawDesc = "" +
 	"\x0fruntime_changed\x18\a \x01(\v2\x19.fleetgrpc.RuntimeChangedH\x00R\x0eruntimeChanged\x12H\n" +
 	"\x11remote_mcp_status\x18\b \x01(\v2\x1a.fleetgrpc.RemoteMcpStatusH\x00R\x0fremoteMcpStatus\x122\n" +
 	"\tfile_copy\x18\t \x01(\v2\x13.fleetgrpc.FileCopyH\x00R\bfileCopyB\x06\n" +
-	"\x04kind\"\xf5\x01\n" +
+	"\x04kind\"\xad\x02\n" +
 	"\x0fRemoteMcpStatus\x12.\n" +
 	"\x05state\x18\x01 \x01(\x0e2\x18.fleetgrpc.RemoteMcpConnR\x05state\x12\x1d\n" +
 	"\n" +
@@ -753,7 +777,9 @@ const file_watch_proto_rawDesc = "" +
 	"\x05error\x18\x03 \x01(\tR\x05error\x12&\n" +
 	"\x0fpublic_grpc_url\x18\x04 \x01(\tR\rpublicGrpcUrl\x12'\n" +
 	"\x0fgateway_version\x18\x05 \x01(\tR\x0egatewayVersion\x12,\n" +
-	"\x12public_webhook_url\x18\x06 \x01(\tR\x10publicWebhookUrl\"6\n" +
+	"\x12public_webhook_url\x18\x06 \x01(\tR\x10publicWebhookUrl\x12\x19\n" +
+	"\bssh_addr\x18\a \x01(\tR\asshAddr\x12\x1b\n" +
+	"\tssh_error\x18\b \x01(\tR\bsshError\"6\n" +
 	"\fStateChanged\x12&\n" +
 	"\x05state\x18\x01 \x01(\v2\x10.fleetgrpc.StateR\x05state\"F\n" +
 	"\x0eRuntimeChanged\x124\n" +

--- a/fleetgrpc/watch.proto
+++ b/fleetgrpc/watch.proto
@@ -107,6 +107,16 @@ message RemoteMcpStatus {
   // CONNECTED and the webhook feature was negotiated (the user enabled "Enable
   // Webhook"); empty otherwise (incl. from an old gateway).
   string public_webhook_url = 6;
+  // ssh_addr is the loopback address (127.0.0.1:<port>) the daemon's
+  // token-gated gRPC server listens on while remote fleet is enabled in SSH
+  // mode — the port a remote client's SSH tunnel forwards to. Independent of
+  // `state` (which describes the gateway tunnel): empty when the SSH listener is
+  // off or failed. Stamped onto every status by the hub, so it survives the
+  // gateway manager's own status pushes.
+  string ssh_addr = 7;
+  // ssh_error carries the SSH listener's last failure (bind error, missing
+  // token) while it is enabled but not listening; empty otherwise.
+  string ssh_error = 8;
 }
 
 // StateChanged is pushed whenever the authoritative PERSISTED model mutates. It

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
 	github.com/ulikunitz/xz v0.5.15
+	golang.org/x/crypto v0.48.0
 	golang.org/x/sys v0.42.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
@@ -66,7 +67,6 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	golang.org/x/arch v0.22.0 // indirect
-	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/text v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,8 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.40.0 h1:36e4zGLqU4yhjlmxEaagx2KuYbJq3EwY8K943ZsHcvg=
+golang.org/x/term v0.40.0/go.mod h1:w2P8uVp06p2iyKKuvXIm7N/y0UCRt3UfJTfZ7oOpglM=
 golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=
 golang.org/x/text v0.34.0/go.mod h1:homfLqTYRFyVYemLBFl5GgL/DWEiH5wcsQ5gSh1yziA=
 golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=

--- a/internal/configutil/configutil.go
+++ b/internal/configutil/configutil.go
@@ -49,3 +49,9 @@ const (
 	AgentToolCopilot = state.AgentToolCopilot
 	AgentToolAuggie  = state.AgentToolAuggie
 )
+
+// RemoteMcpSettings.FleetMode values ("Remote Fleet via" Gateway / SSH).
+const (
+	FleetModeGateway = state.FleetModeGateway
+	FleetModeSSH     = state.FleetModeSSH
+)

--- a/internal/fleetclient/dial.go
+++ b/internal/fleetclient/dial.go
@@ -35,7 +35,7 @@ func (c *Conn) Close() error { return c.conn.Close() }
 // version handshake (relaunching a too-old local server, or erroring on an
 // incompatible remote/newer one). For a remote endpoint it dials only.
 func Dial(ctx context.Context) (*Conn, error) {
-	ep, err := selectEndpoint()
+	ep, err := selectEndpoint(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/fleetclient/endpoint.go
+++ b/internal/fleetclient/endpoint.go
@@ -10,6 +10,7 @@
 package fleetclient
 
 import (
+	"context"
 	"os"
 	"strings"
 
@@ -29,6 +30,10 @@ const (
 	// EnvServer points the client at a plain remote TCP daemon:
 	// FLEET_SERVER=host:port.
 	EnvServer = "FLEET_SERVER"
+	// EnvSSH points the client at a daemon reached over an SSH tunnel the LOCAL
+	// daemon maintains: FLEET_SSH=ssh://[user@]host[:port]. Resolved to a
+	// loopback address + token per dial via the local ResolveArmadaRemote RPC.
+	EnvSSH = "FLEET_SSH"
 	// EnvToken carries the bearer token for a gateway/remote daemon; falls back
 	// to ~/.fleet/mcp.token (see BearerToken).
 	EnvToken = "FLEET_TOKEN"
@@ -76,14 +81,21 @@ func (e remoteEndpoint) DialOptions() []grpc.DialOption { return insecureCreds()
 //   - FLEET_GATEWAY=https://gw:50051/<id> (or http://… behind a TLS-terminating
 //     proxy) → through a fleet gateway (the bearer token from FLEET_TOKEN, or
 //     ~/.fleet/mcp.token for a same-host user).
+//   - FLEET_SSH=ssh://[user@]host[:port] → through an SSH tunnel the local
+//     daemon maintains (resolved per dial; needs the local daemon, which
+//     auto-spawns).
 //   - FLEET_SERVER=host:port → a plain remote TCP target.
 //   - otherwise → the local auto-spawned unix socket.
 //
-// It errors only when FLEET_GATEWAY is set but malformed. Remote endpoints
-// (gateway/server) are not auto-spawned and a version mismatch is a hard error.
-func selectEndpoint() (Endpoint, error) {
+// It errors when FLEET_GATEWAY/FLEET_SSH is set but malformed, or the SSH
+// tunnel cannot be brought up. Remote endpoints are not auto-spawned and a
+// version mismatch is a hard error.
+func selectEndpoint(ctx context.Context) (Endpoint, error) {
 	if gw := os.Getenv(EnvGateway); gw != "" {
 		return newGatewayEndpoint(gw, gatewayToken())
+	}
+	if ssh := os.Getenv(EnvSSH); ssh != "" {
+		return newSSHEndpoint(ctx, ssh)
 	}
 	if addr := os.Getenv(EnvServer); addr != "" {
 		return remoteEndpoint{addr: addr}, nil
@@ -92,11 +104,24 @@ func selectEndpoint() (Endpoint, error) {
 }
 
 // IsRemote reports whether the client is pointed at a remote daemon
-// (FLEET_GATEWAY or FLEET_SERVER set) rather than the local auto-spawned
-// socket. Client-host concerns — dependency checks, the local-exec TTY
-// carve-out — only apply when this is false.
+// (FLEET_GATEWAY, FLEET_SSH or FLEET_SERVER set) rather than the local
+// auto-spawned socket. Client-host concerns — dependency checks, the local-exec
+// TTY carve-out — only apply when this is false.
 func IsRemote() bool {
-	return os.Getenv(EnvGateway) != "" || os.Getenv(EnvServer) != ""
+	return os.Getenv(EnvGateway) != "" || os.Getenv(EnvSSH) != "" || os.Getenv(EnvServer) != ""
+}
+
+// IsSSH reports whether the client reaches the daemon over an SSH tunnel
+// (FLEET_SSH set).
+func IsSSH() bool {
+	return os.Getenv(EnvSSH) != ""
+}
+
+// IsSSHURL reports whether a fleet-armada URL names an SSH remote (ssh://…)
+// rather than a gateway. The scheme decides the transport everywhere a remote
+// URL is handled (registry, switch, ping, labels).
+func IsSSHURL(raw string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(raw)), "ssh://")
 }
 
 // IsGateway reports whether the client reaches the daemon THROUGH a fleet

--- a/internal/fleetclient/grpc_gateway_test.go
+++ b/internal/fleetclient/grpc_gateway_test.go
@@ -1,6 +1,7 @@
 package fleetclient
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,7 +76,7 @@ func TestSelectEndpointGatewayPrecedence(t *testing.T) {
 	t.Setenv("FLEET_SERVER", "1.2.3.4:9000") // gateway must win
 	t.Setenv("FLEET_TOKEN", "tok")
 
-	ep, err := selectEndpoint()
+	ep, err := selectEndpoint(context.Background())
 	if err != nil {
 		t.Fatalf("selectEndpoint: %v", err)
 	}
@@ -98,7 +99,7 @@ func TestSelectEndpointGatewayPrecedence(t *testing.T) {
 // an error rather than a silently-broken endpoint.
 func TestSelectEndpointBadGateway(t *testing.T) {
 	t.Setenv("FLEET_GATEWAY", "ftp://nope")
-	if _, err := selectEndpoint(); err == nil {
+	if _, err := selectEndpoint(context.Background()); err == nil {
 		t.Fatal("malformed FLEET_GATEWAY should error")
 	}
 }

--- a/internal/fleetclient/ping.go
+++ b/internal/fleetclient/ping.go
@@ -15,16 +15,25 @@ import (
 const pingTimeout = 3 * time.Second
 
 // Ping dials a fleet-armada remote (a FLEET_GATEWAY-style URL plus its bearer
-// token) and runs one Hello round trip, validating connectivity, gateway
-// routing, and daemon auth in a single RPC. It deliberately skips the version
-// reconcile that Dial runs, so a version-skewed remote still answers and the
-// caller can render its real reachability (and compare ServerVersion itself).
+// token, or an ssh:// URL whose token is discovered by the local daemon) and
+// runs one Hello round trip, validating connectivity, routing, and daemon auth
+// in a single RPC. It deliberately skips the version reconcile that Dial runs,
+// so a version-skewed remote still answers and the caller can render its real
+// reachability (and compare ServerVersion itself).
 //
 // The gRPC status code distinguishes the failure for status indicators:
-// Unavailable = gateway unreachable, NotFound = unknown session or the remote
-// daemon is offline / has Remote Fleet disabled, Unauthenticated = bad token.
-func Ping(ctx context.Context, gatewayURL, token string) (*fleetgrpc.HelloReply, error) {
-	ep, err := newGatewayEndpoint(gatewayURL, token)
+// Unavailable = gateway/tunnel unreachable, NotFound = unknown session or the
+// remote daemon is offline / has Remote Fleet disabled, Unauthenticated = bad
+// token, FailedPrecondition = the local daemon could not bring the ssh tunnel up
+// (its message says why).
+func Ping(ctx context.Context, remoteURL, token string) (*fleetgrpc.HelloReply, error) {
+	var ep Endpoint
+	var err error
+	if IsSSHURL(remoteURL) {
+		ep, err = newSSHEndpoint(ctx, remoteURL)
+	} else {
+		ep, err = newGatewayEndpoint(remoteURL, token)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/fleetclient/ssh_endpoint.go
+++ b/internal/fleetclient/ssh_endpoint.go
@@ -1,0 +1,82 @@
+package fleetclient
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"google.golang.org/grpc"
+)
+
+// ssh_endpoint.go reaches a daemon over an SSH tunnel, with NO gateway. The
+// LOCAL daemon owns the tunnel (internal/server/sshtunnel): it ssh-forwards a
+// loopback port to the remote daemon's token-gated gRPC listener and discovers
+// the remote's bearer token over the same SSH connection. So an ssh endpoint
+// is resolved, not parsed — every dial asks the local daemon (ResolveArmadaRemote,
+// a local-only RPC) for the current loopback address + token, which also makes
+// the local daemon bring the tunnel up or rebuild a dead one. The resulting
+// endpoint is then an ordinary plaintext-loopback gRPC target carrying the
+// bearer token per RPC, exactly like the gateway endpoint minus the routing
+// header.
+
+// sshResolveTimeout bounds one resolve: the local daemon may have to auto-spawn,
+// then ssh (connect + auth + a possible remote daemon start) and verify.
+const sshResolveTimeout = 90 * time.Second
+
+// sshEndpoint is a resolved ssh:// remote. Not auto-spawnable (the daemon is on
+// another machine); IsLocal is false so the version handshake treats a mismatch
+// as a hard error.
+type sshEndpoint struct {
+	rawURL string // the ssh:// URL, for String()
+	addr   string // loopback host:port of the local daemon's forward
+	token  string // the remote daemon's bearer token
+}
+
+// resolveSSHRemote asks the LOCAL daemon for the tunnel endpoint of rawURL.
+// Package var so the TUI/CLI tests can stub the round trip.
+var resolveSSHRemote = func(ctx context.Context, rawURL string) (addr, token string, err error) {
+	rctx, cancel := context.WithTimeout(ctx, sshResolveTimeout)
+	defer cancel()
+	conn, err := DialLocal(rctx)
+	if err != nil {
+		return "", "", fmt.Errorf("local fleet daemon (owns the ssh tunnel): %w", err)
+	}
+	defer conn.Close()
+	reply, err := conn.Service().ResolveArmadaRemote(rctx, &fleetgrpc.ResolveArmadaRemoteRequest{Url: rawURL})
+	if err != nil {
+		return "", "", err
+	}
+	return reply.GetAddr(), reply.GetToken(), nil
+}
+
+// newSSHEndpoint validates rawURL's shape cheaply, then resolves it through the
+// local daemon (which parses it strictly and brings the tunnel up).
+func newSSHEndpoint(ctx context.Context, rawURL string) (sshEndpoint, error) {
+	if !IsSSHURL(rawURL) {
+		return sshEndpoint{}, fmt.Errorf("FLEET_SSH must be an ssh://[user@]host[:port] URL, got %q", rawURL)
+	}
+	addr, token, err := resolveSSHRemote(ctx, rawURL)
+	if err != nil {
+		return sshEndpoint{}, err
+	}
+	if addr == "" {
+		return sshEndpoint{}, fmt.Errorf("local daemon returned no tunnel address for %s", rawURL)
+	}
+	return sshEndpoint{rawURL: rawURL, addr: addr, token: token}, nil
+}
+
+// Target is the loopback forward (a plain TCP gRPC target).
+func (e sshEndpoint) Target() string { return "dns:///" + e.addr }
+
+// IsLocal is false — no auto-spawn / version-restart for a remote daemon.
+func (e sshEndpoint) IsLocal() bool { return false }
+
+// String is the ssh URL (which carries no secret).
+func (e sshEndpoint) String() string { return e.rawURL }
+
+// DialOptions: plaintext to the loopback forward (ssh is the encrypted hop),
+// plus the bearer token the remote daemon's interceptor requires.
+func (e sshEndpoint) DialOptions() []grpc.DialOption {
+	return append(insecureCreds(), grpc.WithPerRPCCredentials(gatewayPerRPC{token: e.token}))
+}

--- a/internal/fleetclient/ssh_endpoint_test.go
+++ b/internal/fleetclient/ssh_endpoint_test.go
@@ -1,0 +1,87 @@
+package fleetclient
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestIsSSHURL(t *testing.T) {
+	for raw, want := range map[string]bool{
+		"ssh://ben@desktop":             true,
+		"  SSH://desktop:2222 ":         true,
+		"https://gw.example.com/abc":    false,
+		"http://gw.example.com:50051/x": false,
+		"desktop":                       false,
+		"":                              false,
+	} {
+		if got := IsSSHURL(raw); got != want {
+			t.Errorf("IsSSHURL(%q) = %v, want %v", raw, got, want)
+		}
+	}
+}
+
+// TestSelectEndpointSSH: FLEET_SSH resolves through the local daemon into a
+// loopback target carrying the discovered token; FLEET_GATEWAY still wins when
+// both are set (the TUI only ever sets one); the endpoint is remote.
+func TestSelectEndpointSSH(t *testing.T) {
+	t.Setenv(EnvGateway, "")
+	t.Setenv(EnvServer, "")
+	t.Setenv(EnvSSH, "ssh://ben@desktop")
+
+	orig := resolveSSHRemote
+	var resolved string
+	resolveSSHRemote = func(_ context.Context, rawURL string) (string, string, error) {
+		resolved = rawURL
+		return "127.0.0.1:40001", "tok-remote", nil
+	}
+	defer func() { resolveSSHRemote = orig }()
+
+	ep, err := selectEndpoint(context.Background())
+	if err != nil {
+		t.Fatalf("selectEndpoint: %v", err)
+	}
+	if resolved != "ssh://ben@desktop" {
+		t.Fatalf("resolved %q, want the FLEET_SSH url", resolved)
+	}
+	if ep.Target() != "dns:///127.0.0.1:40001" || ep.IsLocal() || ep.String() != "ssh://ben@desktop" {
+		t.Fatalf("endpoint = %s / target %s / local %v", ep, ep.Target(), ep.IsLocal())
+	}
+	sshEp, ok := ep.(sshEndpoint)
+	if !ok || sshEp.token != "tok-remote" {
+		t.Fatalf("endpoint should carry the discovered token: %+v", ep)
+	}
+	md, err := gatewayPerRPC{token: sshEp.token}.GetRequestMetadata(context.Background())
+	if err != nil || md["authorization"] != "Bearer tok-remote" {
+		t.Fatalf("per-RPC metadata = %v, %v", md, err)
+	}
+	if !IsRemote() || !IsSSH() || IsGateway() {
+		t.Fatalf("IsRemote=%v IsSSH=%v IsGateway=%v", IsRemote(), IsSSH(), IsGateway())
+	}
+
+	t.Setenv(EnvGateway, "https://gw.example.com/abc")
+	if ep, err := selectEndpoint(context.Background()); err != nil || ep.String() != "https://gw.example.com/abc" {
+		t.Fatalf("FLEET_GATEWAY should take precedence: %v, %v", ep, err)
+	}
+}
+
+func TestSelectEndpointSSHErrors(t *testing.T) {
+	t.Setenv(EnvGateway, "")
+	t.Setenv(EnvServer, "")
+
+	t.Setenv(EnvSSH, "desktop")
+	if _, err := selectEndpoint(context.Background()); err == nil || !strings.Contains(err.Error(), "ssh://") {
+		t.Fatalf("malformed FLEET_SSH: %v", err)
+	}
+
+	t.Setenv(EnvSSH, "ssh://desktop")
+	orig := resolveSSHRemote
+	resolveSSHRemote = func(context.Context, string) (string, string, error) {
+		return "", "", errors.New("ssh: Permission denied (publickey).")
+	}
+	defer func() { resolveSSHRemote = orig }()
+	if _, err := selectEndpoint(context.Background()); err == nil || !strings.Contains(err.Error(), "Permission denied") {
+		t.Fatalf("resolve failure should surface verbatim: %v", err)
+	}
+}

--- a/internal/fleetpaths/paths.go
+++ b/internal/fleetpaths/paths.go
@@ -68,6 +68,17 @@ func McpPortPath() string {
 	return filepath.Join(Dir(), "mcp.port")
 }
 
+// SSHPortPath records the loopback TCP port the server's token-gated gRPC
+// listener bound to while remote fleet is enabled in SSH mode (Settings → Fleet
+// MCP → Remote Fleet via SSH). Like McpPortPath it is a non-authoritative
+// liveness/discovery hint: written when the listener comes up and removed when
+// it stops or the server shuts down. A remote client's discovery script reads it
+// (with McpTokenPath) over SSH to learn what to port-forward to; its absence
+// means "daemon not running, or SSH mode off".
+func SSHPortPath() string {
+	return filepath.Join(Dir(), "ssh.port")
+}
+
 // McpTokenPath holds the bearer token a client must send to the MCP HTTP server.
 // The TCP port is reachable by any local user, so (unlike the 0600 unix socket)
 // the port alone is not an access boundary; the token file is written 0600 so

--- a/internal/protoconv/config.go
+++ b/internal/protoconv/config.go
@@ -24,6 +24,7 @@ func ConfigToProto(c *configutil.Config) *fleetgrpc.Config {
 			GatewayUrl:     c.RemoteMcpSettings.GatewayURL,
 			FleetEnabled:   c.RemoteMcpSettings.FleetEnabled,
 			WebhookEnabled: c.RemoteMcpSettings.WebhookEnabled,
+			FleetMode:      c.RemoteMcpSettings.FleetMode,
 		},
 		DefaultBackend: BackendToProto(fleet.BackendType(c.DefaultBackend)),
 	}
@@ -130,6 +131,7 @@ func ConfigFromProto(pc *fleetgrpc.Config, base *configutil.Config) *configutil.
 		c.RemoteMcpSettings.GatewayURL = rm.GetGatewayUrl()
 		c.RemoteMcpSettings.FleetEnabled = rm.GetFleetEnabled()
 		c.RemoteMcpSettings.WebhookEnabled = rm.GetWebhookEnabled()
+		c.RemoteMcpSettings.FleetMode = rm.GetFleetMode()
 	}
 
 	c.DefaultBackend = string(BackendFromProto(pc.GetDefaultBackend()))

--- a/internal/protoconv/wire_test.go
+++ b/internal/protoconv/wire_test.go
@@ -161,7 +161,7 @@ func TestConfigWirePlacement(t *testing.T) {
 	pinArity[state.DotfilesSettings](t, 3)
 	pinArity[state.CodespacesSettings](t, 3)
 	pinArity[state.BrowserSettings](t, 2)
-	pinArity[state.RemoteMcpSettings](t, 4)
+	pinArity[state.RemoteMcpSettings](t, 5)
 
 	vim := false
 	multi := true
@@ -171,7 +171,7 @@ func TestConfigWirePlacement(t *testing.T) {
 		DotfilesSettings:   state.DotfilesSettings{AutoInstall: true, RepoURL: "ru", InstallScript: "is"},
 		CodespacesSettings: state.CodespacesSettings{Machine: "ma", IdleTimeout: "it", DevcontainerPath: "dp"},
 		BrowserSettings:    state.BrowserSettings{MultipleBrowsersPerFleet: &multi},
-		RemoteMcpSettings:  state.RemoteMcpSettings{GatewayURL: "gu"},
+		RemoteMcpSettings:  state.RemoteMcpSettings{GatewayURL: "gu", FleetMode: "fm"},
 		DefaultBackend:     string(fleet.BackendCoder),
 	})
 	if pc.GetGeneral().TmuxVimKeys == nil || pc.GetGeneral().GetTmuxVimKeys() ||
@@ -190,8 +190,8 @@ func TestConfigWirePlacement(t *testing.T) {
 	if b := pc.GetBrowser(); !b.GetMultipleBrowsersPerFleet() || b.AutoSwitch != nil {
 		t.Fatalf("browser tri-states wire placement wrong: %+v", b)
 	}
-	if pc.GetRemoteMcp().GetGatewayUrl() != "gu" {
-		t.Fatalf("remote-mcp url wire placement wrong: %+v", pc.GetRemoteMcp())
+	if pc.GetRemoteMcp().GetGatewayUrl() != "gu" || pc.GetRemoteMcp().GetFleetMode() != "fm" {
+		t.Fatalf("remote-mcp url/mode wire placement wrong: %+v", pc.GetRemoteMcp())
 	}
 	if pc.GetDefaultBackend() != fleetgrpc.BackendType_BACKEND_TYPE_CODER {
 		t.Fatalf("default backend wire placement wrong: %v", pc.GetDefaultBackend())

--- a/internal/server/armada.go
+++ b/internal/server/armada.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
 	"github.com/BenjaminBenetti/fleet-man/internal/flog"
+	"github.com/BenjaminBenetti/fleet-man/internal/server/sshtunnel"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -45,7 +46,40 @@ func (s *service) SetArmada(_ context.Context, req *fleetgrpc.SetArmadaRequest) 
 	// Never log URLs-with-tokens or tokens; the count is the useful signal.
 	flog.Info("armada updated", "remotes", len(saved.Remotes))
 
+	// Drop the ssh forwards of remotes that were just removed (a forward to a
+	// remote the user deleted has no owner left). nil in newService() tests.
+	if s.sshTunnels != nil {
+		keep := make([]string, 0, len(saved.Remotes))
+		for _, r := range saved.Remotes {
+			keep = append(keep, r.URL)
+		}
+		s.sshTunnels.Prune(keep)
+	}
+
 	return &fleetgrpc.SetArmadaReply{Remotes: armadaToProto(saved)}, nil
+}
+
+// ResolveArmadaRemote brings up (or reuses) the local ssh forward for an ssh://
+// remote and returns the loopback address + bearer token a client dials (see
+// internal/server/sshtunnel). LOCAL-ONLY (remote_auth.go): it returns a
+// credential and runs the user's ssh. Failures are FailedPrecondition with a
+// user-facing message — the settings page shows it verbatim as the remote's
+// status — except a malformed URL, which is InvalidArgument.
+func (s *service) ResolveArmadaRemote(ctx context.Context, req *fleetgrpc.ResolveArmadaRemoteRequest) (*fleetgrpc.ResolveArmadaRemoteReply, error) {
+	if !sshtunnel.IsSSHURL(req.GetUrl()) {
+		return nil, status.Errorf(codes.InvalidArgument, "not an ssh:// remote: %q", req.GetUrl())
+	}
+	if _, err := sshtunnel.ParseURL(req.GetUrl()); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	if s.sshTunnels == nil {
+		return nil, status.Error(codes.Unavailable, "ssh tunnels are not available on this daemon")
+	}
+	ep, err := s.sshTunnels.Resolve(ctx, req.GetUrl())
+	if err != nil {
+		return nil, status.Error(codes.FailedPrecondition, err.Error())
+	}
+	return &fleetgrpc.ResolveArmadaRemoteReply{Addr: ep.Addr, Token: ep.Token}, nil
 }
 
 func armadaToProto(a *state.Armada) []*fleetgrpc.ArmadaRemote {

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -31,6 +31,20 @@ func (s *service) GetConfig(_ context.Context, _ *fleetgrpc.GetConfigRequest) (*
 // SetConfig replaces the whole config (the settings page sends the full edited
 // Config). It returns the post-save config so the caller picks up SaveConfig's
 // applyDefaults() normalization (e.g. an unknown agent tool snapped to claude).
+// reconcileRemote converges both remote-control transports on the settings:
+// the gateway tunnel negotiates grpc only in gateway mode, and the SSH loopback
+// listener is up only in SSH mode — so flipping the mode moves the surface
+// rather than doubling it. nil-safe for tests that use newService() without a
+// serve loop.
+func (s *service) reconcileRemote(rm state.RemoteMcpSettings) {
+	if s.remote != nil {
+		s.remote.Reconcile(rm.Enabled, rm.FleetViaGateway(), rm.WebhookEnabled, rm.GatewayURL)
+	}
+	if s.sshListen != nil {
+		s.sshListen.Reconcile(rm.FleetViaSSH())
+	}
+}
+
 func (s *service) SetConfig(_ context.Context, req *fleetgrpc.SetConfigRequest) (*fleetgrpc.SetConfigReply, error) {
 	s.muWrite.Lock()
 	defer s.muWrite.Unlock()
@@ -43,13 +57,10 @@ func (s *service) SetConfig(_ context.Context, req *fleetgrpc.SetConfigRequest) 
 		return nil, status.Errorf(codes.Internal, "reload config: %v", err)
 	}
 
-	// Converge the remote-gateway tunnel to the saved settings. Reconcile is
-	// non-blocking (it just records desired state and nudges the supervisor), so
-	// calling it while muWrite is held cannot deadlock. nil during tests that use
-	// newService() without a serve loop.
-	if s.remote != nil {
-		s.remote.Reconcile(saved.RemoteMcpSettings.Enabled, saved.RemoteMcpSettings.FleetEnabled, saved.RemoteMcpSettings.WebhookEnabled, saved.RemoteMcpSettings.GatewayURL)
-	}
+	// Converge the remote transports (gateway tunnel + SSH listener) to the
+	// saved settings. Both reconciles are non-blocking / quick, so calling them
+	// while muWrite is held cannot deadlock.
+	s.reconcileRemote(saved.RemoteMcpSettings)
 
 	// The remote-gateway fields are the ones whose effects outlive this RPC (the
 	// tunnel supervisor reacts to them), so call them out; the manager logs the

--- a/internal/server/hub.go
+++ b/internal/server/hub.go
@@ -35,6 +35,13 @@ type hub struct {
 	// RemoteMcpStatus event and cached here so a newly-attached subscriber gets
 	// the current status in its initial snapshot. Defaults to DISABLED.
 	remoteMcp *fleetgrpc.RemoteMcpStatus
+	// sshAddr / sshErr are the "Remote Fleet via SSH" loopback listener's state
+	// (owned by the loop). They ride the same RemoteMcpStatus event as the
+	// gateway tunnel status, but have a DIFFERENT producer (sshlisten.go vs
+	// remote.Manager), so the hub stamps them onto every status it caches or
+	// fans out — otherwise the gateway manager's next push would wipe them.
+	sshAddr string
+	sshErr  string
 
 	// runtimeWanted is true while at least one subscriber asked for runtime;
 	// the runtime pollers read it lock-free to gate their expensive work.
@@ -208,6 +215,10 @@ func (h *hub) broadcastRemoteMcpStatus(st *fleetgrpc.RemoteMcpStatus) {
 	if st == nil {
 		return
 	}
+	// Stamp the SSH listener fields onto a copy (the producer's message is not
+	// ours to mutate) so the merged status is what gets cached and fanned out.
+	st = proto.Clone(st).(*fleetgrpc.RemoteMcpStatus)
+	st.SshAddr, st.SshError = h.sshAddr, h.sshErr
 	if proto.Equal(h.remoteMcp, st) {
 		return
 	}
@@ -215,6 +226,13 @@ func (h *hub) broadcastRemoteMcpStatus(st *fleetgrpc.RemoteMcpStatus) {
 	for sub := range h.subs {
 		sub.enqueueRemoteMcp(st)
 	}
+}
+
+// setSSHStatus records the SSH listener's state and re-broadcasts the merged
+// RemoteMcpStatus (the gateway part unchanged). Runs on the hub loop.
+func (h *hub) setSSHStatus(addr, errMsg string) {
+	h.sshAddr, h.sshErr = addr, errMsg
+	h.broadcastRemoteMcpStatus(h.remoteMcp)
 }
 
 func runtimeKey(fleetName, instance string) string { return fleetName + "/" + instance }

--- a/internal/server/remote_auth.go
+++ b/internal/server/remote_auth.go
@@ -31,8 +31,9 @@ const authMetadataKey = "authorization"
 // client's LOCAL dial (fleetclient.DialLocal), so denying them remotely never
 // breaks a legitimate caller. Keys are gRPC full method names.
 var localOnlyMethods = map[string]bool{
-	"/fleetgrpc.FleetService/GetArmada": true,
-	"/fleetgrpc.FleetService/SetArmada": true,
+	"/fleetgrpc.FleetService/GetArmada":           true,
+	"/fleetgrpc.FleetService/SetArmada":           true,
+	"/fleetgrpc.FleetService/ResolveArmadaRemote": true, // hands out a remote's bearer token + drives the user's ssh
 }
 
 // bearerAuthInterceptors returns unary + stream interceptors that require

--- a/internal/server/remote_auth_test.go
+++ b/internal/server/remote_auth_test.go
@@ -91,6 +91,9 @@ func TestTunnelDeniesArmadaEvenWithToken(t *testing.T) {
 	if _, err := client.SetArmada(withToken, &fleetgrpc.SetArmadaRequest{}); status.Code(err) != codes.PermissionDenied {
 		t.Fatalf("SetArmada over tunnel WITH token: want PermissionDenied, got %v", err)
 	}
+	if _, err := client.ResolveArmadaRemote(withToken, &fleetgrpc.ResolveArmadaRemoteRequest{Url: "ssh://x"}); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("ResolveArmadaRemote over tunnel WITH token: want PermissionDenied, got %v", err)
+	}
 
 	// The same RPCs are served on the auth-less local server.
 	isolateFleetDir(t)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/internal/fleetpaths"
 	"github.com/BenjaminBenetti/fleet-man/internal/flog"
 	"github.com/BenjaminBenetti/fleet-man/internal/server/remote"
+	"github.com/BenjaminBenetti/fleet-man/internal/server/sshtunnel"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	"github.com/BenjaminBenetti/fleet-man/internal/version"
 	"google.golang.org/grpc"
@@ -168,6 +169,20 @@ func Serve(ctx context.Context) error {
 	// Both ride the same tunnel and are only wired when MCP is up (we need its
 	// loopback port for the tunnel to come up at all). The webhook receiver, unlike
 	// gRPC, does NOT need the MCP token, so it is wired independently of it.
+	// newTokenGatedServer builds a grpc.Server serving the SAME FleetService,
+	// gated by the MCP bearer token — the shape both remote transports serve:
+	// the gateway tunnel (below) and the SSH loopback listener (sshlisten.go).
+	newTokenGatedServer := func() (*grpc.Server, error) {
+		token, err := loadOrCreateMCPToken()
+		if err != nil {
+			return nil, fmt.Errorf("load bearer token: %w", err)
+		}
+		authUnary, authStream := bearerAuthInterceptors(token)
+		gs := grpc.NewServer(grpc.ChainUnaryInterceptor(authUnary), grpc.ChainStreamInterceptor(authStream))
+		fleetgrpc.RegisterFleetServiceServer(gs, svc)
+		return gs, nil
+	}
+
 	var remoteOpts []remote.Option
 	if mcpPort != 0 {
 		webhookLis := remote.NewChanListener()
@@ -176,11 +191,8 @@ func Serve(ctx context.Context) error {
 		defer webhookSrv.Close()
 		remoteOpts = append(remoteOpts, remote.WithWebhookListener(webhookLis))
 
-		if token, err := loadOrCreateMCPToken(); err == nil {
+		if tunnelGRPC, err := newTokenGatedServer(); err == nil {
 			grpcLis := remote.NewChanListener()
-			authUnary, authStream := bearerAuthInterceptors(token)
-			tunnelGRPC := grpc.NewServer(grpc.ChainUnaryInterceptor(authUnary), grpc.ChainStreamInterceptor(authStream))
-			fleetgrpc.RegisterFleetServiceServer(tunnelGRPC, svc)
 			go func() { _ = tunnelGRPC.Serve(grpcLis) }()
 			defer tunnelGRPC.Stop()
 			remoteOpts = append(remoteOpts, remote.WithGRPCListener(grpcLis))
@@ -188,6 +200,22 @@ func Serve(ctx context.Context) error {
 			flog.Warn("remote grpc: load token", "err", err)
 		}
 	}
+
+	// Remote fleet via SSH (no gateway): the token-gated server on a loopback
+	// port, converged from config like the tunnel. Independent of MCP being up
+	// — it needs only the token. Stopped (and ssh.port removed) on shutdown.
+	svc.sshListen = &sshListener{
+		newServer: newTokenGatedServer,
+		publish: func(addr, errMsg string) {
+			svc.hub.post(func(h *hub) { h.setSSHStatus(addr, errMsg) })
+		},
+	}
+	defer svc.sshListen.Stop()
+
+	// Outbound ssh forwards to this user's ssh:// armada remotes (client-side
+	// role of the same feature). Torn down with the daemon.
+	svc.sshTunnels = sshtunnel.New(hubCtx)
+	defer svc.sshTunnels.Close()
 
 	// Remote gateway tunnel: an outbound, OPT-IN connection that exposes the
 	// loopback MCP server ("Enable Remote MCP") and/or the gRPC server above
@@ -202,7 +230,7 @@ func Serve(ctx context.Context) error {
 	}, remoteOpts...)
 	go svc.remote.Run(hubCtx)
 	if cfg, err := state.LoadConfig(); err == nil {
-		svc.remote.Reconcile(cfg.RemoteMcpSettings.Enabled, cfg.RemoteMcpSettings.FleetEnabled, cfg.RemoteMcpSettings.WebhookEnabled, cfg.RemoteMcpSettings.GatewayURL)
+		svc.reconcileRemote(cfg.RemoteMcpSettings)
 	} else {
 		flog.Warn("remote mcp: load config", "err", err)
 	}

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
 	"github.com/BenjaminBenetti/fleet-man/internal/protoconv"
 	"github.com/BenjaminBenetti/fleet-man/internal/server/remote"
+	"github.com/BenjaminBenetti/fleet-man/internal/server/sshtunnel"
 	"github.com/BenjaminBenetti/fleet-man/internal/state"
 	"github.com/BenjaminBenetti/fleet-man/internal/version"
 	"google.golang.org/grpc/codes"
@@ -32,6 +33,13 @@ type service struct {
 	// after the MCP listener binds (so it knows the loopback port); nil for tests
 	// that use newService() without a serve loop, so callers must nil-check.
 	remote *remote.Manager
+
+	// sshListen serves the token-gated gRPC server on a loopback port while
+	// remote fleet is enabled in SSH mode (sshlisten.go); sshTunnels maintains
+	// this machine's OUTBOUND ssh forwards to ssh:// armada remotes
+	// (ResolveArmadaRemote). Both set in server.go; nil in newService() tests.
+	sshListen  *sshListener
+	sshTunnels *sshtunnel.Manager
 
 	// bgCtx is cancelled at server shutdown (set to the serve loop's hubCtx in
 	// server.go). Background work spawned by RPC handlers — e.g. the TUI-connect

--- a/internal/server/sshlisten.go
+++ b/internal/server/sshlisten.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"errors"
+	"net"
+	"os"
+	"strconv"
+	"sync"
+
+	"github.com/BenjaminBenetti/fleet-man/internal/atomicfile"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetpaths"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
+	"google.golang.org/grpc"
+)
+
+// sshlisten.go is the daemon side of "Remote Fleet via SSH": while remote fleet
+// is enabled in SSH mode, the SAME token-gated FleetService the gateway tunnel
+// serves is ALSO served on a loopback TCP port, and the port is recorded in
+// ~/.fleet/ssh.port. A remote client's local daemon ssh-forwards to that port
+// (internal/server/sshtunnel) after reading the port + bearer token over SSH —
+// no gateway, no session ids. Loopback + bearer token is the same posture as
+// the MCP HTTP server: any local user can reach the port, only the token holder
+// gets in. The listener is built fresh on every enable (a grpc.Server can't
+// stop serving ONE of its listeners while keeping others), and Stop drops its
+// live connections, so a disable cuts remote control immediately.
+
+// sshListener converges the loopback listener on a desired on/off state.
+type sshListener struct {
+	// newServer builds a token-gated grpc.Server with the FleetService
+	// registered (server.go wires it with the bearer interceptors). It returns an
+	// error when the bearer token cannot be loaded — then there is nothing safe
+	// to serve, and the error is what the settings page shows.
+	newServer func() (*grpc.Server, error)
+	// publish reports the listener's state to the hub: addr while listening ("" when
+	// off), errMsg while enabled-but-failed.
+	publish func(addr, errMsg string)
+
+	mu  sync.Mutex
+	srv *grpc.Server
+	lis net.Listener
+}
+
+// Reconcile converges to enabled. Idempotent and cheap on no change, so it is
+// safe to call on every SetConfig (like remote.Manager.Reconcile).
+func (l *sshListener) Reconcile(enabled bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	switch {
+	case enabled && l.srv == nil:
+		l.startLocked()
+	case !enabled && l.srv != nil:
+		l.stopLocked()
+		l.publish("", "")
+	}
+}
+
+// Stop tears the listener down (daemon shutdown). Also removes the port file
+// so a discovery script never sees a stale hint.
+func (l *sshListener) Stop() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.srv != nil {
+		l.stopLocked()
+	}
+}
+
+func (l *sshListener) startLocked() {
+	srv, err := l.newServer()
+	if err != nil {
+		flog.Warn("remote fleet via ssh: build server", "err", err)
+		l.publish("", err.Error())
+		return
+	}
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		flog.Warn("remote fleet via ssh: listen", "err", err)
+		l.publish("", "listen: "+err.Error())
+		return
+	}
+	port := lis.Addr().(*net.TCPAddr).Port
+	// The port file is the remote client's discovery hint (read over SSH with
+	// mcp.token). 0o600 like the other ~/.fleet discovery files. ~/.fleet exists
+	// by the time Serve runs the first Reconcile, but ensure it (cheap) so a
+	// test or an early caller can't fail on a missing parent.
+	if _, err := fleetpaths.EnsureDir(); err != nil {
+		flog.Warn("remote fleet via ssh: ensure fleet dir", "err", err)
+		_ = lis.Close()
+		l.publish("", "ensure fleet dir: "+err.Error())
+		return
+	}
+	if err := atomicfile.Write(fleetpaths.SSHPortPath(), []byte(strconv.Itoa(port)), 0o600); err != nil {
+		flog.Warn("remote fleet via ssh: write ssh.port", "err", err)
+		_ = lis.Close()
+		l.publish("", "write ssh.port: "+err.Error())
+		return
+	}
+	l.srv, l.lis = srv, lis
+	go func() { _ = srv.Serve(lis) }()
+	flog.Info("remote fleet via ssh listening", "addr", lis.Addr().String())
+	l.publish(lis.Addr().String(), "")
+}
+
+func (l *sshListener) stopLocked() {
+	l.srv.Stop() // closes the listener and every live connection
+	l.srv, l.lis = nil, nil
+	if err := os.Remove(fleetpaths.SSHPortPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
+		flog.Warn("remote fleet via ssh: remove ssh.port", "err", err)
+	}
+	flog.Info("remote fleet via ssh stopped")
+}

--- a/internal/server/sshlisten_test.go
+++ b/internal/server/sshlisten_test.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/fleetpaths"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+type sshStatus struct{ addr, err string }
+
+func newTestSSHListener(t *testing.T, token string) (*sshListener, *[]sshStatus) {
+	t.Helper()
+	isolateFleetDir(t)
+	var published []sshStatus
+	l := &sshListener{
+		newServer: func() (*grpc.Server, error) {
+			authUnary, authStream := bearerAuthInterceptors(token)
+			gs := grpc.NewServer(grpc.ChainUnaryInterceptor(authUnary), grpc.ChainStreamInterceptor(authStream))
+			fleetgrpc.RegisterFleetServiceServer(gs, newService())
+			return gs, nil
+		},
+		publish: func(addr, errMsg string) { published = append(published, sshStatus{addr, errMsg}) },
+	}
+	t.Cleanup(l.Stop)
+	return l, &published
+}
+
+func helloAt(t *testing.T, addr, token string) error {
+	t.Helper()
+	cc, err := grpc.NewClient("dns:///"+addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cc.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if token != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+	}
+	_, err = fleetgrpc.NewFleetServiceClient(cc).Hello(ctx, &fleetgrpc.HelloRequest{})
+	return err
+}
+
+// TestSSHListenerLifecycle: enabling binds a loopback port, records it in
+// ssh.port, serves the token-gated service; disabling stops serving and
+// removes the hint. Re-enabling is a no-op while up.
+func TestSSHListenerLifecycle(t *testing.T) {
+	l, published := newTestSSHListener(t, "tok")
+
+	l.Reconcile(true)
+	if len(*published) != 1 || (*published)[0].addr == "" || (*published)[0].err != "" {
+		t.Fatalf("enable published %+v", *published)
+	}
+	addr := (*published)[0].addr
+	host, _, _ := net.SplitHostPort(addr)
+	if host != "127.0.0.1" {
+		t.Fatalf("listener must be loopback-only, got %s", addr)
+	}
+	data, err := os.ReadFile(fleetpaths.SSHPortPath())
+	if err != nil {
+		t.Fatalf("ssh.port not written: %v", err)
+	}
+	if _, port, _ := net.SplitHostPort(addr); string(data) != port {
+		t.Fatalf("ssh.port = %q, want %s", data, port)
+	}
+	if _, err := strconv.Atoi(string(data)); err != nil {
+		t.Fatalf("ssh.port not numeric: %q", data)
+	}
+
+	if err := helloAt(t, addr, "tok"); err != nil {
+		t.Fatalf("Hello with token: %v", err)
+	}
+	if err := helloAt(t, addr, ""); status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("Hello without token: want Unauthenticated, got %v", err)
+	}
+
+	l.Reconcile(true) // no change
+	if len(*published) != 1 {
+		t.Fatalf("re-enable must be a no-op, published %+v", *published)
+	}
+
+	l.Reconcile(false)
+	if len(*published) != 2 || (*published)[1] != (sshStatus{}) {
+		t.Fatalf("disable published %+v", *published)
+	}
+	if _, err := os.Stat(fleetpaths.SSHPortPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("ssh.port should be removed on disable, stat err = %v", err)
+	}
+	if err := helloAt(t, addr, "tok"); err == nil {
+		t.Fatal("listener should be closed after disable")
+	}
+}
+
+// TestSSHListenerServerBuildFailure: when the bearer token can't be loaded the
+// listener publishes the error and opens nothing.
+func TestSSHListenerServerBuildFailure(t *testing.T) {
+	l, published := newTestSSHListener(t, "tok")
+	l.newServer = func() (*grpc.Server, error) { return nil, errors.New("no token") }
+	l.Reconcile(true)
+	if len(*published) != 1 || (*published)[0].addr != "" || (*published)[0].err != "no token" {
+		t.Fatalf("published %+v", *published)
+	}
+	if _, err := os.Stat(fleetpaths.SSHPortPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatal("no ssh.port should exist after a failed enable")
+	}
+}

--- a/internal/server/sshtunnel/discover.go
+++ b/internal/server/sshtunnel/discover.go
@@ -1,0 +1,146 @@
+package sshtunnel
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// discover.go learns what to tunnel to: the remote daemon's SSH-mode gRPC port
+// and its bearer token, both plain files under the remote ~/.fleet. It runs a
+// small POSIX sh script over ssh (fed on stdin, so the remote login shell's
+// flavour doesn't matter and nothing has to be quoted) rather than a remote
+// `fleet` command — a non-interactive ssh gets no ~/.bashrc, so `fleet` is
+// often not on PATH. The script does try to START the remote daemon when it is
+// down (the port file is a liveness hint, removed on shutdown) by running a
+// cheap client command through the usual auto-spawn path, probing the common
+// install locations.
+
+// discoverTimeout bounds one discovery round trip: ssh connect + auth, plus a
+// possible daemon auto-spawn (the script waits up to ~10s for it).
+const discoverTimeout = 45 * time.Second
+
+// discoverScript is the remote-side probe. Its single stdout result line is one
+// of:
+//
+//	FLEET_OK <port> <token>   listener up; tunnel to <port>, auth with <token>
+//	FLEET_SSH_OFF             daemon running but Remote Fleet via SSH is off
+//	FLEET_NO_DAEMON           no daemon and none could be started (fleet not
+//	                          installed, or the client command failed)
+//
+// ssh.port is written when the SSH listener comes up and removed when it stops
+// or the daemon exits; server.version is written at the END of daemon startup
+// (after the listener converged) and removed on exit, so once it exists the
+// port file is either there or never will be — the wait loop keys on both.
+const discoverScript = `d="$HOME/.fleet"
+if [ ! -s "$d/ssh.port" ] && [ ! -e "$d/server.version" ]; then
+  started=
+  for c in "$(command -v fleet 2>/dev/null)" "$HOME/.local/bin/fleet" "$HOME/go/bin/fleet" /usr/local/bin/fleet /opt/homebrew/bin/fleet; do
+    if [ -n "$c" ] && [ -x "$c" ]; then
+      if "$c" list >/dev/null 2>&1 </dev/null; then started=1; fi
+      break
+    fi
+  done
+  if [ -n "$started" ]; then
+    i=0
+    while [ ! -s "$d/ssh.port" ] && [ ! -e "$d/server.version" ] && [ "$i" -lt 10 ]; do
+      sleep 1
+      i=$((i+1))
+    done
+  fi
+fi
+if [ -s "$d/ssh.port" ] && [ -s "$d/mcp.token" ]; then
+  printf 'FLEET_OK %s %s\n' "$(cat "$d/ssh.port")" "$(cat "$d/mcp.token")"
+elif [ -e "$d/server.version" ]; then
+  echo FLEET_SSH_OFF
+else
+  echo FLEET_NO_DAEMON
+fi
+`
+
+// Discovery is what the remote reported: the loopback port its SSH-mode gRPC
+// listener is bound to and the bearer token it expects.
+type Discovery struct {
+	Port  int
+	Token string
+}
+
+// discoverOverSSH runs discoverScript on the target and parses its result.
+func discoverOverSSH(ctx context.Context, t Target) (Discovery, error) {
+	ctx, cancel := context.WithTimeout(ctx, discoverTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "ssh", t.sshArgs()...)
+	cmd.Args = append(cmd.Args, "sh")
+	cmd.Stdin = strings.NewReader(discoverScript)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.WaitDelay = 2 * time.Second
+	setSysProcAttr(cmd)
+	runErr := cmd.Run()
+	d, parseErr := parseDiscovery(stdout.String())
+	if parseErr == nil {
+		return d, nil
+	}
+	if ctx.Err() != nil {
+		return Discovery{}, fmt.Errorf("ssh timed out after %s", discoverTimeout)
+	}
+	if runErr != nil {
+		// ssh itself failed (auth, host key, unreachable): its stderr says why.
+		if line := lastLine(stderr.String()); line != "" {
+			return Discovery{}, fmt.Errorf("ssh: %s", line)
+		}
+		return Discovery{}, fmt.Errorf("ssh: %w", runErr)
+	}
+	return Discovery{}, parseErr
+}
+
+// Sentinel errors for the two "ssh worked, but no listener" outcomes, so callers
+// can word them for the user (they name the host).
+var (
+	ErrSSHModeOff = errors.New("Remote Fleet via SSH is not enabled on the remote (Settings → Fleet MCP), or its fleet is too old")
+	ErrNoDaemon   = errors.New("no fleet daemon is running on the remote and none could be started (is fleet installed there?)")
+)
+
+// parseDiscovery finds the FLEET_* result line in the script's stdout (scanning
+// every line, so a chatty remote shell profile can't break it).
+func parseDiscovery(out string) (Discovery, error) {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "FLEET_OK "):
+			fields := strings.Fields(line)
+			if len(fields) != 3 {
+				return Discovery{}, fmt.Errorf("malformed discovery reply: %q", line)
+			}
+			port, err := strconv.Atoi(fields[1])
+			if err != nil || port <= 0 || port > 65535 {
+				return Discovery{}, fmt.Errorf("malformed discovery port: %q", fields[1])
+			}
+			return Discovery{Port: port, Token: fields[2]}, nil
+		case line == "FLEET_SSH_OFF":
+			return Discovery{}, ErrSSHModeOff
+		case line == "FLEET_NO_DAEMON":
+			return Discovery{}, ErrNoDaemon
+		}
+	}
+	return Discovery{}, errors.New("no discovery reply from the remote (is `sh` available there?)")
+}
+
+// lastLine returns the last non-empty line of s, trimmed — ssh's diagnostic is
+// normally its final line ("Permission denied (publickey).", "Host key
+// verification failed.", "connect to host …: Connection refused").
+func lastLine(s string) string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if l := strings.TrimSpace(lines[i]); l != "" {
+			return l
+		}
+	}
+	return ""
+}

--- a/internal/server/sshtunnel/discover_test.go
+++ b/internal/server/sshtunnel/discover_test.go
@@ -1,0 +1,129 @@
+package sshtunnel
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseDiscovery(t *testing.T) {
+	d, err := parseDiscovery("motd noise\nFLEET_OK 41234 tok-abc\n")
+	if err != nil || d != (Discovery{Port: 41234, Token: "tok-abc"}) {
+		t.Fatalf("ok line: %+v, %v", d, err)
+	}
+	if _, err := parseDiscovery("FLEET_SSH_OFF\n"); !errors.Is(err, ErrSSHModeOff) {
+		t.Fatalf("ssh off: %v", err)
+	}
+	if _, err := parseDiscovery("FLEET_NO_DAEMON\n"); !errors.Is(err, ErrNoDaemon) {
+		t.Fatalf("no daemon: %v", err)
+	}
+	for _, bad := range []string{"", "garbage", "FLEET_OK 41234", "FLEET_OK notaport tok", "FLEET_OK 70000 tok"} {
+		if _, err := parseDiscovery(bad); err == nil {
+			t.Errorf("parseDiscovery(%q) should fail", bad)
+		}
+	}
+}
+
+// fakeFleet writes a stand-in `fleet` executable into a fresh directory and
+// returns that directory, to be put FIRST on the probe's PATH. The real fleet
+// (this devcontainer ships one in /usr/bin) must never be reached from a test:
+// `fleet list` would auto-spawn a real daemon under the temp HOME.
+func fakeFleet(t *testing.T, body string) string {
+	t.Helper()
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "fleet"), []byte("#!/bin/sh\n"+body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+// runScript executes discoverScript with sh against an isolated HOME, with
+// fakeBin (a fakeFleet dir) shadowing any real fleet, returning stdout.
+func runScript(t *testing.T, home, fakeBin string) string {
+	t.Helper()
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("no sh on PATH")
+	}
+	cmd := exec.Command(sh)
+	cmd.Stdin = strings.NewReader(discoverScript)
+	cmd.Env = []string{"HOME=" + home, "PATH=" + fakeBin + ":/usr/bin:/bin"}
+	var out, errb bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &out, &errb
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("script failed: %v\nstderr: %s", err, errb.String())
+	}
+	return out.String()
+}
+
+// TestDiscoverScript runs the real remote-side probe under sh across its three
+// outcomes, so the shell and the Go parser are proven against each other.
+func TestDiscoverScript(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".fleet")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Nothing there, and the client command fails (fleet can't start a daemon):
+	// no daemon — and no wait loop, since nothing was started.
+	broken := fakeFleet(t, "exit 1\n")
+	if _, err := parseDiscovery(runScript(t, home, broken)); !errors.Is(err, ErrNoDaemon) {
+		t.Fatalf("empty ~/.fleet: want ErrNoDaemon, got %v", err)
+	}
+
+	// A running daemon (server.version) without the SSH listener: mode off; the
+	// script must not even try to spawn (a fake that would "succeed" is unused).
+	if err := os.WriteFile(filepath.Join(dir, "server.version"), []byte("v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseDiscovery(runScript(t, home, broken)); !errors.Is(err, ErrSSHModeOff) {
+		t.Fatalf("version but no port: want ErrSSHModeOff, got %v", err)
+	}
+
+	// Listener up: port + token come back.
+	if err := os.WriteFile(filepath.Join(dir, "ssh.port"), []byte("41234"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "mcp.token"), []byte("tok-abc\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	d, err := parseDiscovery(runScript(t, home, broken))
+	if err != nil || d != (Discovery{Port: 41234, Token: "tok-abc"}) {
+		t.Fatalf("listener up: %+v, %v", d, err)
+	}
+}
+
+// TestDiscoverScriptStartsDaemon covers the auto-spawn branch: with no daemon
+// files present, the script finds `fleet` on PATH, runs it, and waits for the
+// files it writes. The fake fleet stands in for the daemon's startup by
+// writing ssh.port + mcp.token + server.version itself.
+func TestDiscoverScriptStartsDaemon(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".fleet")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	bin := fakeFleet(t,
+		"[ \"$1\" = list ] || exit 9\n"+ // the script must call a cheap client command
+			"printf 40001 > \"$HOME/.fleet/ssh.port\"\n"+
+			"printf tok-spawned > \"$HOME/.fleet/mcp.token\"\n"+
+			"printf v1 > \"$HOME/.fleet/server.version\"\n")
+	d, err := parseDiscovery(runScript(t, home, bin))
+	if err != nil || d != (Discovery{Port: 40001, Token: "tok-spawned"}) {
+		t.Fatalf("spawn path: %+v, %v", d, err)
+	}
+}
+
+func TestLastLine(t *testing.T) {
+	if got := lastLine("Warning: x\nben@host: Permission denied (publickey).\n\n"); got != "ben@host: Permission denied (publickey)." {
+		t.Fatalf("lastLine = %q", got)
+	}
+	if got := lastLine("\n  \n"); got != "" {
+		t.Fatalf("lastLine(blank) = %q", got)
+	}
+}

--- a/internal/server/sshtunnel/e2e_test.go
+++ b/internal/server/sshtunnel/e2e_test.go
@@ -1,0 +1,346 @@
+package sshtunnel
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+// e2e_test.go drives the PRODUCTION discovery + forward code through the real
+// `ssh` binary against a tiny in-process SSH server (x/crypto/ssh) that speaks
+// just enough of the protocol: public-key auth, an "exec" session (the
+// discovery script under sh), and "direct-tcpip" channels (the -L forward).
+// The "remote" ~/.fleet is a temp dir whose ssh.port points at an in-process
+// token-gated gRPC server, so the whole chain — script over ssh, port-forward,
+// bearer-token Hello — is exercised end to end without a system sshd.
+
+// testSSHServer is the minimal server. remoteHome is the HOME the exec'd
+// command sees (the fake remote's ~/.fleet lives under it).
+type testSSHServer struct {
+	addr       string
+	hostPub    ssh.PublicKey
+	remoteHome string
+	stop       func()
+}
+
+func startTestSSHServer(t *testing.T, clientPub ssh.PublicKey, remoteHome string) *testSSHServer {
+	t.Helper()
+	_, hostPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostSigner, err := ssh.NewSignerFromKey(hostPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &ssh.ServerConfig{
+		PublicKeyCallback: func(_ ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+			if bytes.Equal(key.Marshal(), clientPub.Marshal()) {
+				return nil, nil
+			}
+			return nil, errors.New("unknown key")
+		},
+	}
+	cfg.AddHostKey(hostSigner)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := &testSSHServer{addr: ln.Addr().String(), hostPub: hostSigner.PublicKey(), remoteHome: remoteHome}
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	srv.stop = func() {
+		cancel()
+		_ = ln.Close()
+		wg.Wait()
+	}
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				srv.serveConn(ctx, c, cfg)
+			}()
+		}
+	}()
+	t.Cleanup(srv.stop)
+	return srv
+}
+
+func (s *testSSHServer) serveConn(ctx context.Context, c net.Conn, cfg *ssh.ServerConfig) {
+	defer c.Close()
+	conn, chans, reqs, err := ssh.NewServerConn(c, cfg)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	go ssh.DiscardRequests(reqs)
+	context.AfterFunc(ctx, func() { _ = conn.Close() })
+	for newCh := range chans {
+		switch newCh.ChannelType() {
+		case "session":
+			go s.handleSession(newCh)
+		case "direct-tcpip":
+			go handleDirectTCPIP(newCh)
+		default:
+			_ = newCh.Reject(ssh.UnknownChannelType, "unsupported")
+		}
+	}
+}
+
+// handleSession runs the "exec" command (the discovery probe runs `sh` with
+// the script on stdin) under the fake remote's HOME.
+func (s *testSSHServer) handleSession(newCh ssh.NewChannel) {
+	ch, reqs, err := newCh.Accept()
+	if err != nil {
+		return
+	}
+	defer ch.Close()
+	for req := range reqs {
+		switch req.Type {
+		case "exec":
+			var payload struct{ Command string }
+			if err := ssh.Unmarshal(req.Payload, &payload); err != nil {
+				_ = req.Reply(false, nil)
+				continue
+			}
+			_ = req.Reply(true, nil)
+			cmd := exec.Command("sh", "-c", payload.Command)
+			cmd.Env = []string{"HOME=" + s.remoteHome, "PATH=/usr/bin:/bin"}
+			cmd.Stdin = ch
+			cmd.Stdout = ch
+			cmd.Stderr = ch.Stderr()
+			status := uint32(0)
+			if err := cmd.Run(); err != nil {
+				var exitErr *exec.ExitError
+				if errors.As(err, &exitErr) {
+					status = uint32(exitErr.ExitCode())
+				} else {
+					status = 255
+				}
+			}
+			var buf [4]byte
+			binary.BigEndian.PutUint32(buf[:], status)
+			_, _ = ch.SendRequest("exit-status", false, buf[:])
+			return
+		default:
+			_ = req.Reply(false, nil)
+		}
+	}
+}
+
+// handleDirectTCPIP is the -L forward: dial what the client asked for and pipe.
+func handleDirectTCPIP(newCh ssh.NewChannel) {
+	var payload struct {
+		Host     string
+		Port     uint32
+		OrigHost string
+		OrigPort uint32
+	}
+	if err := ssh.Unmarshal(newCh.ExtraData(), &payload); err != nil {
+		_ = newCh.Reject(ssh.ConnectionFailed, "bad payload")
+		return
+	}
+	target, err := net.DialTimeout("tcp", net.JoinHostPort(payload.Host, strconv.Itoa(int(payload.Port))), 3*time.Second)
+	if err != nil {
+		_ = newCh.Reject(ssh.ConnectionFailed, err.Error())
+		return
+	}
+	ch, reqs, err := newCh.Accept()
+	if err != nil {
+		_ = target.Close()
+		return
+	}
+	go ssh.DiscardRequests(reqs)
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(target, ch); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(ch, target); done <- struct{}{} }()
+	<-done
+	_ = ch.Close()
+	_ = target.Close()
+}
+
+// clientSSHHome builds the ssh CLIENT side (the daemon's): a key pair, a
+// known_hosts entry for the test server, and a config that pins them for
+// 127.0.0.1. finish installs that config via the -F seam (OpenSSH ignores
+// $HOME for ~/.ssh), restoring the production args when the test ends.
+func clientSSHHome(t *testing.T) (home string, pub ssh.PublicKey, finish func(srv *testSSHServer)) {
+	t.Helper()
+	home = t.TempDir()
+	dir := filepath.Join(home, ".ssh")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	pubKey, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemBlock, err := ssh.MarshalPrivateKey(priv, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "id_ed25519"), pem.EncodeToMemory(pemBlock), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pub, err = ssh.NewPublicKey(pubKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finish = func(srv *testSSHServer) {
+		_, port, _ := net.SplitHostPort(srv.addr)
+		line := knownhosts.Line([]string{"[127.0.0.1]:" + port}, srv.hostPub)
+		if err := os.WriteFile(filepath.Join(dir, "known_hosts"), []byte(line+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg := fmt.Sprintf("Host 127.0.0.1\n  IdentityFile %s\n  IdentitiesOnly yes\n  UserKnownHostsFile %s\n  StrictHostKeyChecking yes\n",
+			filepath.Join(dir, "id_ed25519"), filepath.Join(dir, "known_hosts"))
+		cfgPath := filepath.Join(dir, "config")
+		if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		orig := sshBaseArgs
+		sshBaseArgs = append([]string{"-F", cfgPath}, orig...)
+		t.Cleanup(func() { sshBaseArgs = orig })
+	}
+	return home, pub, finish
+}
+
+// TestEndToEndOverRealSSH: discovery script over the real ssh binary, the -L
+// forward, and a bearer-token Hello through it; then a remote-daemon restart
+// (new port + token) is healed by the next Resolve; then Close kills ssh.
+func TestEndToEndOverRealSSH(t *testing.T) {
+	if _, err := exec.LookPath("ssh"); err != nil {
+		t.Skip("no ssh binary on PATH")
+	}
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("no sh on PATH")
+	}
+
+	// The fake remote: a ~/.fleet whose ssh.port names an in-process daemon.
+	remoteHome := t.TempDir()
+	remoteFleet := filepath.Join(remoteHome, ".fleet")
+	if err := os.MkdirAll(remoteFleet, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	rd := startRemoteDaemon(t, "tok-1")
+	writeRemoteFiles := func(port int, token string) {
+		for name, val := range map[string]string{"ssh.port": strconv.Itoa(port), "mcp.token": token + "\n", "server.version": "test"} {
+			if err := os.WriteFile(filepath.Join(remoteFleet, name), []byte(val), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	writeRemoteFiles(rd.port, "tok-1")
+
+	_, clientPub, finish := clientSSHHome(t)
+	srv := startTestSSHServer(t, clientPub, remoteHome)
+	finish(srv)
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	_, port, _ := net.SplitHostPort(srv.addr)
+	rawURL := "ssh://tester@127.0.0.1:" + port
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := New(ctx)
+	defer m.Close()
+
+	ep, err := m.Resolve(ctx, rawURL)
+	if err != nil {
+		t.Fatalf("Resolve over real ssh: %v", err)
+	}
+	if ep.Token != "tok-1" {
+		t.Fatalf("discovered token = %q", ep.Token)
+	}
+	// The endpoint is usable by an ordinary client with the token.
+	if err := helloThrough(ctx, ep.Addr, ep.Token); err != nil {
+		t.Fatalf("Hello through the forward: %v", err)
+	}
+	if err := helloThrough(ctx, ep.Addr, "wrong"); err == nil {
+		t.Fatal("the remote must still enforce its token through the tunnel")
+	}
+
+	// Remote daemon restarts elsewhere with a new token: the next Resolve
+	// notices the stale forward, re-discovers, and rebuilds on the same local
+	// address.
+	rd.srv.Stop()
+	rd2 := startRemoteDaemon(t, "tok-2")
+	writeRemoteFiles(rd2.port, "tok-2")
+	ep2, err := m.Resolve(ctx, rawURL)
+	if err != nil {
+		t.Fatalf("Resolve after remote restart: %v", err)
+	}
+	if ep2.Addr != ep.Addr || ep2.Token != "tok-2" {
+		t.Fatalf("after restart: %+v (was %+v)", ep2, ep)
+	}
+	if err := helloThrough(ctx, ep2.Addr, ep2.Token); err != nil {
+		t.Fatalf("Hello after rebuild: %v", err)
+	}
+
+	// SSH mode switched off on the remote: discovery reports it by name.
+	_ = os.Remove(filepath.Join(remoteFleet, "ssh.port"))
+	rd2.srv.Stop()
+	_, err = m.Resolve(ctx, rawURL)
+	if !errors.Is(err, ErrSSHModeOff) {
+		t.Fatalf("want ErrSSHModeOff, got %v", err)
+	}
+
+	m.Close()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if c, err := net.DialTimeout("tcp", ep.Addr, 100*time.Millisecond); err != nil {
+			return
+		} else {
+			_ = c.Close()
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("Close should have killed the ssh forward")
+}
+
+// TestEndToEndAuthFailureIsReported: a client key the server doesn't know
+// fails discovery with ssh's own diagnostic (batch mode: no prompt, no hang).
+func TestEndToEndAuthFailureIsReported(t *testing.T) {
+	if _, err := exec.LookPath("ssh"); err != nil {
+		t.Skip("no ssh binary on PATH")
+	}
+	_, _, finish := clientSSHHome(t)
+	_, otherPub, _ := clientSSHHome(t) // a different key: the server won't accept ours
+	srv := startTestSSHServer(t, otherPub, t.TempDir())
+	finish(srv)
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	_, port, _ := net.SplitHostPort(srv.addr)
+	m := New(context.Background())
+	defer m.Close()
+	start := time.Now()
+	_, err := m.Resolve(context.Background(), "ssh://tester@127.0.0.1:"+port)
+	if err == nil || !bytes.Contains([]byte(err.Error()), []byte("Permission denied")) {
+		t.Fatalf("want ssh's Permission denied, got %v", err)
+	}
+	if time.Since(start) > 20*time.Second {
+		t.Fatalf("auth failure took %s — batch mode should fail fast", time.Since(start))
+	}
+}

--- a/internal/server/sshtunnel/forward.go
+++ b/internal/server/sshtunnel/forward.go
@@ -1,0 +1,157 @@
+package sshtunnel
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// forward.go runs the long-lived `ssh -N -L` port-forward for one remote and
+// waits for it to become usable.
+
+// forwardReadyTimeout bounds the wait for ssh to bind the local forward (connect
+// + auth; ssh only binds -L listeners once authenticated).
+const forwardReadyTimeout = 30 * time.Second
+
+// forwardProc is a running forward: Done closes when the process exits, Err is
+// its captured stderr (last line) once done, Kill tears it down.
+type forwardProc interface {
+	Done() <-chan struct{}
+	Err() string
+	Kill()
+}
+
+// sshForward is the production forwardProc: an `ssh -N -L` child.
+type sshForward struct {
+	cmd    *exec.Cmd
+	stderr *boundedBuffer
+	done   chan struct{}
+	once   sync.Once
+}
+
+func (f *sshForward) Done() <-chan struct{} { return f.done }
+func (f *sshForward) Err() string           { return lastLine(f.stderr.String()) }
+func (f *sshForward) Kill() {
+	f.once.Do(func() {
+		if f.cmd.Process != nil {
+			_ = f.cmd.Process.Kill()
+		}
+	})
+}
+
+// startForward spawns `ssh -N -L 127.0.0.1:<local>:127.0.0.1:<remote> target`.
+// ctx is the daemon lifetime (the child dies with it); ExitOnForwardFailure
+// makes a local bind failure (port taken) a prompt non-zero exit rather than a
+// silently useless session, which the Manager retries on a fresh port.
+func startForward(ctx context.Context, t Target, localPort, remotePort int) (forwardProc, error) {
+	spec := fmt.Sprintf("%s:%s", loopback(localPort), loopback(remotePort))
+	cmd := exec.CommandContext(ctx, "ssh", t.sshArgs("-o", "ExitOnForwardFailure=yes", "-N", "-L", spec)...)
+	stderr := &boundedBuffer{max: 4096}
+	cmd.Stderr = stderr
+	cmd.WaitDelay = 2 * time.Second
+	setSysProcAttr(cmd)
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start ssh: %w", err)
+	}
+	f := &sshForward{cmd: cmd, stderr: stderr, done: make(chan struct{})}
+	go func() {
+		_ = cmd.Wait()
+		close(f.done)
+	}()
+	return f, nil
+}
+
+// waitForwardReady polls the local forward port until ssh accepts on it (bound
+// after auth), the process exits (its stderr becomes the error), or the timeout.
+// The exit check comes FIRST each round so a prompt ssh failure (auth, host
+// key, bind) is reported as such rather than masked by a probe.
+func waitForwardReady(ctx context.Context, proc forwardProc, localPort int) error {
+	deadline := time.After(forwardReadyTimeout)
+	addr := loopback(localPort)
+	for {
+		select {
+		case <-proc.Done():
+			if msg := proc.Err(); msg != "" {
+				return fmt.Errorf("ssh: %s", msg)
+			}
+			return fmt.Errorf("ssh exited before the tunnel came up")
+		default:
+		}
+		c, err := net.DialTimeout("tcp", addr, 300*time.Millisecond)
+		if err == nil {
+			_ = c.Close()
+			return nil
+		}
+		select {
+		case <-proc.Done():
+			if msg := proc.Err(); msg != "" {
+				return fmt.Errorf("ssh: %s", msg)
+			}
+			return fmt.Errorf("ssh exited before the tunnel came up")
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			return fmt.Errorf("ssh tunnel did not come up within %s", forwardReadyTimeout)
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+// portFree reports whether the loopback port can be bound right now (the
+// pre-spawn check that keeps a squatter from being mistaken for our forward).
+func portFree(port int) bool {
+	l, err := net.Listen("tcp", loopback(port))
+	if err != nil {
+		return false
+	}
+	_ = l.Close()
+	return true
+}
+
+// isBindFailure recognises ssh's "local port already in use" diagnostics, the
+// one forward failure worth retrying on another port.
+func isBindFailure(msg string) bool {
+	return strings.Contains(msg, "Address already in use") || strings.Contains(msg, "Could not request local forwarding")
+}
+
+// freePort asks the kernel for an unused loopback port (bind :0, read, close).
+// The port can in principle be taken before ssh binds it — the Manager retries
+// a bind failure with a new one.
+func freePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+// boundedBuffer keeps the LAST max bytes written (ssh's diagnostics are short,
+// but a verbose session must not grow without bound over a long tunnel life).
+type boundedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+	max int
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf.Write(p)
+	if b.buf.Len() > b.max {
+		trimmed := b.buf.Bytes()[b.buf.Len()-b.max:]
+		b.buf = *bytes.NewBuffer(append([]byte(nil), trimmed...))
+	}
+	return len(p), nil
+}
+
+func (b *boundedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}

--- a/internal/server/sshtunnel/manager.go
+++ b/internal/server/sshtunnel/manager.go
@@ -1,0 +1,234 @@
+package sshtunnel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"github.com/BenjaminBenetti/fleet-man/internal/flog"
+	"github.com/BenjaminBenetti/fleet-man/internal/version"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// helloTimeout bounds the end-to-end check through an (allegedly) live forward.
+// Generous: it rides an established ssh session, so it is one RTT + the remote
+// daemon's Hello.
+const helloTimeout = 5 * time.Second
+
+// Manager owns the SSH forwards, one per canonical ssh:// URL. All methods are
+// safe for concurrent use; bring-up is serialized PER REMOTE, so a burst of
+// client dials (the TUI opens its Watch stream, a mutation conn, and a status
+// ping at once) shares a single ssh spawn rather than racing three.
+type Manager struct {
+	ctx     context.Context // daemon lifetime: cancelling it kills every forward
+	mu      sync.Mutex
+	tunnels map[string]*tunnel
+
+	// Seams (production defaults; tests swap them for in-process fakes).
+	discover func(ctx context.Context, t Target) (Discovery, error)
+	forward  func(ctx context.Context, t Target, localPort, remotePort int) (forwardProc, error)
+	hello    func(ctx context.Context, addr, token string) error
+}
+
+// tunnel is the state of one remote's forward. proc is nil while down; once a
+// forward is up localPort is kept stable across rebuilds (only a bind failure
+// moves it), so a client that cached the address survives a remote restart.
+type tunnel struct {
+	mu        sync.Mutex
+	target    Target
+	localPort int
+	remote    Discovery
+	proc      forwardProc
+}
+
+// New returns a Manager whose forwards live until ctx is cancelled (or Close).
+func New(ctx context.Context) *Manager {
+	return &Manager{
+		ctx:      ctx,
+		tunnels:  make(map[string]*tunnel),
+		discover: discoverOverSSH,
+		forward:  startForward,
+		hello:    helloThrough,
+	}
+}
+
+// Endpoint is what a client needs to reach a remote: the loopback address of
+// the forward and the remote daemon's bearer token.
+type Endpoint struct {
+	Addr  string
+	Token string
+}
+
+// Resolve returns a verified, dialable endpoint for rawURL, bringing the
+// forward up (or rebuilding a dead/stale one) as needed:
+//
+//  1. forward already up and a Hello through it succeeds → return it;
+//  2. otherwise discover the remote port + token over ssh, spawn the forward
+//     (retrying a local bind collision on a fresh port), wait for it to bind,
+//     and verify with a Hello.
+//
+// A Hello failure on a live forward is how a REMOTE daemon restart (new port)
+// is noticed: the stale forward is torn down and rebuilt from a fresh
+// discovery. Errors are worded for the settings page's status column.
+func (m *Manager) Resolve(ctx context.Context, rawURL string) (Endpoint, error) {
+	t, err := ParseURL(rawURL)
+	if err != nil {
+		return Endpoint{}, err
+	}
+	tn := m.tunnelFor(t)
+	tn.mu.Lock()
+	defer tn.mu.Unlock()
+
+	if tn.proc != nil {
+		select {
+		case <-tn.proc.Done():
+			flog.Warn("ssh tunnel exited; rebuilding", "remote", t.String(), "err", tn.proc.Err())
+			tn.proc = nil
+		default:
+			ep := Endpoint{Addr: loopback(tn.localPort), Token: tn.remote.Token}
+			if err := m.hello(ctx, ep.Addr, ep.Token); err == nil {
+				return ep, nil
+			} else {
+				flog.Warn("ssh tunnel stale; rebuilding", "remote", t.String(), "err", err)
+			}
+			tn.proc.Kill()
+			tn.proc = nil
+		}
+	}
+
+	disc, err := m.discover(ctx, t)
+	if err != nil {
+		return Endpoint{}, fmt.Errorf("%s: %w", t.Host, err)
+	}
+	// Bring-up, retried on a fresh local port when ssh could not bind the chosen
+	// one. The port is checked free BEFORE spawning (a squatter would otherwise
+	// accept our readiness probe and ssh's bind failure would go unnoticed until
+	// the Hello), and a failed Hello re-checks ssh's stderr for the same reason —
+	// a squatter that arrived during ssh's connect+auth window.
+	ep := Endpoint{Token: disc.Token}
+	for attempt := 0; ; attempt++ {
+		if tn.localPort == 0 || !portFree(tn.localPort) {
+			port, err := freePort()
+			if err != nil {
+				return Endpoint{}, fmt.Errorf("pick local port: %w", err)
+			}
+			tn.localPort = port
+		}
+		ep.Addr = loopback(tn.localPort)
+		proc, err := m.forward(m.ctx, t, tn.localPort, disc.Port)
+		if err != nil {
+			return Endpoint{}, err
+		}
+		err = waitForwardReady(ctx, proc, tn.localPort)
+		if err == nil {
+			if err = m.hello(ctx, ep.Addr, ep.Token); err != nil {
+				err = fmt.Errorf("tunnel up but the remote daemon did not answer: %w", err)
+			}
+		}
+		if err == nil {
+			tn.proc = proc
+			tn.remote = disc
+			break
+		}
+		proc.Kill()
+		if attempt < 2 && (isBindFailure(err.Error()) || isBindFailure(waitErr(proc))) {
+			flog.Warn("ssh tunnel local port taken; retrying on another", "remote", t.String(), "port", tn.localPort)
+			tn.localPort = 0
+			continue
+		}
+		return Endpoint{}, err
+	}
+	flog.Info("ssh tunnel up", "remote", t.String(), "local", ep.Addr, "remotePort", disc.Port)
+	return ep, nil
+}
+
+// waitErr waits (briefly) for a killed forward to exit and returns its stderr
+// diagnostic, so a bind failure that raced our readiness probe is still seen.
+func waitErr(proc forwardProc) string {
+	select {
+	case <-proc.Done():
+	case <-time.After(2 * time.Second):
+	}
+	return proc.Err()
+}
+
+// tunnelFor returns (creating if needed) the tunnel record for t.
+func (m *Manager) tunnelFor(t Target) *tunnel {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := t.String()
+	tn, ok := m.tunnels[key]
+	if !ok {
+		tn = &tunnel{target: t}
+		m.tunnels[key] = tn
+	}
+	return tn
+}
+
+// Prune tears down every forward whose remote is not in keep (the armada
+// registry after an edit). Entries that don't parse are ignored.
+func (m *Manager) Prune(keep []string) {
+	want := make(map[string]bool, len(keep))
+	for _, raw := range keep {
+		if t, err := ParseURL(raw); err == nil {
+			want[t.String()] = true
+		}
+	}
+	m.mu.Lock()
+	var drop []*tunnel
+	for key, tn := range m.tunnels {
+		if !want[key] {
+			drop = append(drop, tn)
+			delete(m.tunnels, key)
+		}
+	}
+	m.mu.Unlock()
+	for _, tn := range drop {
+		tn.mu.Lock()
+		if tn.proc != nil {
+			tn.proc.Kill()
+			tn.proc = nil
+		}
+		tn.mu.Unlock()
+		flog.Info("ssh tunnel removed", "remote", tn.target.String())
+	}
+}
+
+// Close kills every forward (daemon shutdown).
+func (m *Manager) Close() {
+	m.Prune(nil)
+}
+
+// bearer attaches `authorization: Bearer <token>` to every RPC (the remote's
+// tunnel-facing server is token-gated). Same wire shape as fleetclient's, which
+// the import boundary keeps on the other side.
+type bearer string
+
+func (b bearer) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	return map[string]string{"authorization": "Bearer " + string(b)}, nil
+}
+func (bearer) RequireTransportSecurity() bool { return false }
+
+// helloThrough runs one Hello RPC against addr with token: the end-to-end proof
+// that the forward reaches a live, matching daemon (ssh accepting the local
+// connection alone proves nothing — it connects to the remote port lazily).
+func helloThrough(ctx context.Context, addr, token string) error {
+	if token == "" {
+		return errors.New("no bearer token")
+	}
+	cc, err := grpc.NewClient("dns:///"+addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithPerRPCCredentials(bearer(token)))
+	if err != nil {
+		return err
+	}
+	defer cc.Close()
+	hctx, cancel := context.WithTimeout(ctx, helloTimeout)
+	defer cancel()
+	_, err = fleetgrpc.NewFleetServiceClient(cc).Hello(hctx, &fleetgrpc.HelloRequest{ClientVersion: version.Version})
+	return err
+}

--- a/internal/server/sshtunnel/manager_test.go
+++ b/internal/server/sshtunnel/manager_test.go
@@ -1,0 +1,285 @@
+package sshtunnel
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/BenjaminBenetti/fleet-man/fleetgrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// remoteDaemon is a stand-in for the remote's token-gated gRPC server: it
+// answers Hello only with the right bearer token, on a loopback port.
+type remoteDaemon struct {
+	fleetgrpc.UnimplementedFleetServiceServer
+	token string
+	srv   *grpc.Server
+	port  int
+}
+
+func (r *remoteDaemon) Hello(ctx context.Context, _ *fleetgrpc.HelloRequest) (*fleetgrpc.HelloReply, error) {
+	md, _ := metadata.FromIncomingContext(ctx)
+	if v := md.Get("authorization"); len(v) == 0 || v[0] != "Bearer "+r.token {
+		return nil, status.Error(codes.Unauthenticated, "invalid token")
+	}
+	return &fleetgrpc.HelloReply{ServerVersion: "remote"}, nil
+}
+
+func startRemoteDaemon(t *testing.T, token string) *remoteDaemon {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &remoteDaemon{token: token, srv: grpc.NewServer(), port: lis.Addr().(*net.TCPAddr).Port}
+	fleetgrpc.RegisterFleetServiceServer(r.srv, r)
+	go func() { _ = r.srv.Serve(lis) }()
+	t.Cleanup(r.srv.Stop)
+	return r
+}
+
+// fakeForward is an in-process "ssh -L": a loopback listener on localPort that
+// pipes each connection to remotePort. Kill closes it (Done fires).
+type fakeForward struct {
+	lis  net.Listener
+	done chan struct{}
+	once sync.Once
+	err  string
+}
+
+func (f *fakeForward) Done() <-chan struct{} { return f.done }
+func (f *fakeForward) Err() string           { return f.err }
+func (f *fakeForward) Kill() {
+	f.once.Do(func() {
+		if f.lis != nil {
+			_ = f.lis.Close()
+		}
+		close(f.done)
+	})
+}
+
+func newFakeForward(localPort, remotePort int) (forwardProc, error) {
+	lis, err := net.Listen("tcp", loopback(localPort))
+	if err != nil {
+		f := &fakeForward{done: make(chan struct{}), err: "bind [127.0.0.1]:" + loopback(localPort) + ": Address already in use"}
+		f.Kill() // like ssh with ExitOnForwardFailure: exits at once with the bind diagnostic
+		return f, nil
+	}
+	f := &fakeForward{lis: lis, done: make(chan struct{})}
+	go func() {
+		for {
+			c, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer c.Close()
+				r, err := net.Dial("tcp", loopback(remotePort))
+				if err != nil {
+					return // ssh closes the channel when the remote connect fails
+				}
+				defer r.Close()
+				// Like ssh's channel: when EITHER side hangs up, tear the pair
+				// down — a readiness probe that connects and closes must release
+				// the remote's accepted socket too, or a grpc server sits in its
+				// preface handshake (and its Stop waits on it).
+				done := make(chan struct{}, 2)
+				go func() { _, _ = io.Copy(r, c); done <- struct{}{} }()
+				go func() { _, _ = io.Copy(c, r); done <- struct{}{} }()
+				<-done
+			}()
+		}
+	}()
+	return f, nil
+}
+
+// newTestManager wires a Manager whose discovery is a stub and whose forward is
+// in-process, keeping the REAL hello check (so the Hello round trip through the
+// forward is what proves the tunnel).
+func newTestManager(t *testing.T, disc func() (Discovery, error)) (*Manager, *int) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	m := New(ctx)
+	spawns := 0
+	m.discover = func(context.Context, Target) (Discovery, error) { return disc() }
+	m.forward = func(_ context.Context, _ Target, localPort, remotePort int) (forwardProc, error) {
+		spawns++
+		return newFakeForward(localPort, remotePort)
+	}
+	t.Cleanup(m.Close)
+	return m, &spawns
+}
+
+func TestResolveBringsUpAndReusesTunnel(t *testing.T) {
+	rd := startRemoteDaemon(t, "tok")
+	m, spawns := newTestManager(t, func() (Discovery, error) { return Discovery{Port: rd.port, Token: "tok"}, nil })
+
+	ep, err := m.Resolve(context.Background(), "ssh://ben@desktop")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if ep.Token != "tok" || !strings.HasPrefix(ep.Addr, "127.0.0.1:") {
+		t.Fatalf("endpoint = %+v", ep)
+	}
+	// A second Resolve (another spelling of the same remote) reuses the live
+	// forward: same address, no new spawn.
+	ep2, err := m.Resolve(context.Background(), "SSH://ben@Desktop/")
+	if err != nil {
+		t.Fatalf("Resolve again: %v", err)
+	}
+	if ep2 != ep || *spawns != 1 {
+		t.Fatalf("second resolve: %+v (spawns=%d), want reuse of %+v", ep2, *spawns, ep)
+	}
+}
+
+// TestResolveRebuildsStaleTunnel simulates the remote daemon restarting on a
+// NEW port: the live forward now points at a dead port, the Hello check fails,
+// and Resolve re-discovers and rebuilds — on the same local port.
+func TestResolveRebuildsStaleTunnel(t *testing.T) {
+	rd := startRemoteDaemon(t, "tok")
+	current := rd
+	m, spawns := newTestManager(t, func() (Discovery, error) { return Discovery{Port: current.port, Token: current.token}, nil })
+
+	ep, err := m.Resolve(context.Background(), "ssh://desktop")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	rd.srv.Stop()                          // remote daemon goes away…
+	current = startRemoteDaemon(t, "tok2") // …and comes back elsewhere with a fresh token
+
+	ep2, err := m.Resolve(context.Background(), "ssh://desktop")
+	if err != nil {
+		t.Fatalf("Resolve after restart: %v", err)
+	}
+	if ep2.Addr != ep.Addr {
+		t.Fatalf("local address should stay stable across a rebuild: %s -> %s", ep.Addr, ep2.Addr)
+	}
+	if ep2.Token != "tok2" || *spawns != 2 {
+		t.Fatalf("rebuild: %+v spawns=%d, want new token + one respawn", ep2, *spawns)
+	}
+}
+
+// TestResolveMovesOffTakenPort: the tunnel's remembered local port is now held
+// by another process — Resolve must notice before spawning and move to a fresh
+// port (one spawn, never pointed at the squatter).
+func TestResolveMovesOffTakenPort(t *testing.T) {
+	rd := startRemoteDaemon(t, "tok")
+	m, spawns := newTestManager(t, func() (Discovery, error) { return Discovery{Port: rd.port, Token: "tok"}, nil })
+
+	taken, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer taken.Close()
+	tgt, _ := ParseURL("ssh://desktop")
+	m.tunnelFor(tgt).localPort = taken.Addr().(*net.TCPAddr).Port
+
+	ep, err := m.Resolve(context.Background(), "ssh://desktop")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if ep.Addr == taken.Addr().String() || *spawns != 1 {
+		t.Fatalf("expected a fresh port without a wasted spawn: %+v spawns=%d", ep, *spawns)
+	}
+}
+
+// TestResolveRetriesBindRace: the port is free at the pre-check but ssh still
+// fails to bind it (a squatter in ssh's connect window). The forward exits with
+// the bind diagnostic; Resolve must retry on another port.
+func TestResolveRetriesBindRace(t *testing.T) {
+	rd := startRemoteDaemon(t, "tok")
+	m, spawns := newTestManager(t, func() (Discovery, error) { return Discovery{Port: rd.port, Token: "tok"}, nil })
+	var squatter net.Listener
+	realForward := m.forward
+	m.forward = func(ctx context.Context, t Target, localPort, remotePort int) (forwardProc, error) {
+		if *spawns == 0 {
+			// Grab the port just before "ssh" binds it.
+			l, err := net.Listen("tcp", loopback(localPort))
+			if err != nil {
+				return nil, err
+			}
+			squatter = l
+		}
+		return realForward(ctx, t, localPort, remotePort)
+	}
+	defer func() {
+		if squatter != nil {
+			_ = squatter.Close()
+		}
+	}()
+
+	ep, err := m.Resolve(context.Background(), "ssh://desktop")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if ep.Addr == squatter.Addr().String() || *spawns != 2 {
+		t.Fatalf("expected a retry on a fresh port: %+v spawns=%d", ep, *spawns)
+	}
+}
+
+func TestResolveSurfacesDiscoveryErrors(t *testing.T) {
+	m, spawns := newTestManager(t, func() (Discovery, error) { return Discovery{}, ErrSSHModeOff })
+	if _, err := m.Resolve(context.Background(), "ssh://desktop"); !errors.Is(err, ErrSSHModeOff) {
+		t.Fatalf("want ErrSSHModeOff, got %v", err)
+	}
+	if *spawns != 0 {
+		t.Fatal("no forward should be spawned when discovery fails")
+	}
+	if _, err := m.Resolve(context.Background(), "https://gw/abc"); err == nil {
+		t.Fatal("a non-ssh URL must be rejected")
+	}
+}
+
+// TestResolveWrongTokenFails: the forward comes up but the remote refuses the
+// discovered token — Resolve reports it and tears the forward down.
+func TestResolveWrongTokenFails(t *testing.T) {
+	rd := startRemoteDaemon(t, "real")
+	m, _ := newTestManager(t, func() (Discovery, error) { return Discovery{Port: rd.port, Token: "stale"}, nil })
+	_, err := m.Resolve(context.Background(), "ssh://desktop")
+	if err == nil || status.Code(errors.Unwrap(err)) != codes.Unauthenticated {
+		t.Fatalf("want Unauthenticated, got %v", err)
+	}
+	tgt, _ := ParseURL("ssh://desktop")
+	if m.tunnelFor(tgt).proc != nil {
+		t.Fatal("failed verification must not leave a forward running")
+	}
+}
+
+func TestPruneKillsDroppedRemotes(t *testing.T) {
+	rd := startRemoteDaemon(t, "tok")
+	m, _ := newTestManager(t, func() (Discovery, error) { return Discovery{Port: rd.port, Token: "tok"}, nil })
+	if _, err := m.Resolve(context.Background(), "ssh://a"); err != nil {
+		t.Fatal(err)
+	}
+	epB, err := m.Resolve(context.Background(), "ssh://b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.Prune([]string{"ssh://b", "https://gw/keep-me-ignored"})
+	if len(m.tunnels) != 1 {
+		t.Fatalf("tunnels after prune = %d, want 1", len(m.tunnels))
+	}
+	// b still serves; a's forward is gone.
+	if err := helloThrough(context.Background(), epB.Addr, "tok"); err != nil {
+		t.Fatalf("kept remote should still answer: %v", err)
+	}
+	m.Close()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := net.DialTimeout("tcp", epB.Addr, 100*time.Millisecond); err != nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("Close should tear down every forward")
+}

--- a/internal/server/sshtunnel/procattr_linux.go
+++ b/internal/server/sshtunnel/procattr_linux.go
@@ -1,0 +1,14 @@
+package sshtunnel
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setSysProcAttr asks the kernel to SIGTERM the ssh child if the daemon dies
+// without cleaning up (SIGKILL, OOM), so a forward never outlives its owner and
+// squats the loopback port for the next daemon. Linux-only; other platforms
+// rely on Manager.Close (orderly shutdown) alone.
+func setSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGTERM}
+}

--- a/internal/server/sshtunnel/procattr_other.go
+++ b/internal/server/sshtunnel/procattr_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package sshtunnel
+
+import "os/exec"
+
+// setSysProcAttr is a no-op off Linux (no parent-death signal there); an
+// orphaned forward is bounded by Manager.Close on orderly shutdown and by ssh's
+// own keepalives.
+func setSysProcAttr(*exec.Cmd) {}

--- a/internal/server/sshtunnel/url.go
+++ b/internal/server/sshtunnel/url.go
@@ -1,0 +1,130 @@
+// Package sshtunnel maintains, on the LOCAL fleet daemon, one SSH port-forward
+// per ssh:// fleet-armada remote so a `fleet` client (the TUI, a CLI command, a
+// `fleet shell` child) can reach a remote daemon's token-gated gRPC server
+// without a fleet gateway: the remote daemon listens on a loopback port
+// (Settings → Fleet MCP → Remote Fleet via SSH; see internal/server/sshlisten.go)
+// and this package tunnels to it with the user's own `ssh` binary, so
+// ~/.ssh/config aliases, keys, agents, and ProxyJump all apply unchanged.
+//
+// The daemon — not the TUI — owns the tunnels because the armada registry
+// already lives there, a tunnel then outlives any one TUI (tmux panes spawned
+// by `fleet shell` keep working across a TUI restart), and every client on the
+// machine shares one ssh process per remote instead of spawning its own. The
+// entry point is Manager.Resolve, served by the local-only ResolveArmadaRemote
+// RPC: it discovers the remote listener's port + bearer token over SSH (a small
+// POSIX sh script, no remote `fleet` command needed), brings the forward up,
+// verifies it end-to-end with a Hello RPC, and returns the loopback address the
+// client should dial. There is no reconnect loop: a dead or stale forward is
+// rebuilt on the next Resolve, which every client dial triggers.
+package sshtunnel
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// Target is a parsed ssh:// URL: where to ssh. Port is "" for the ssh default
+// (the user's ~/.ssh/config still applies, so Host may be an alias).
+type Target struct {
+	User string
+	Host string
+	Port string
+}
+
+// IsSSHURL reports whether raw is an ssh:// URL (scheme compared
+// case-insensitively). Mirrors fleetclient.IsSSHURL, which the import boundary
+// keeps separate.
+func IsSSHURL(raw string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(raw)), "ssh://")
+}
+
+// ParseURL parses ssh://[user@]host[:port]. It rejects anything that would let
+// the host or user be read by ssh as an option (a leading "-"), a path/query
+// (nothing to do with them), and an empty host.
+func ParseURL(raw string) (Target, error) {
+	raw = strings.TrimSpace(raw)
+	if !IsSSHURL(raw) {
+		return Target{}, fmt.Errorf("not an ssh:// URL: %q", raw)
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return Target{}, fmt.Errorf("parse ssh url: %w", err)
+	}
+	t := Target{Host: strings.ToLower(u.Hostname()), Port: u.Port()}
+	if u.User != nil {
+		t.User = u.User.Username()
+		if _, hasPw := u.User.Password(); hasPw {
+			return Target{}, fmt.Errorf("ssh url must not carry a password: use keys or an agent")
+		}
+	}
+	if t.Host == "" {
+		return Target{}, fmt.Errorf("ssh url has no host: %q", raw)
+	}
+	if strings.HasPrefix(t.Host, "-") || strings.HasPrefix(t.User, "-") {
+		return Target{}, fmt.Errorf("ssh url host/user must not start with '-': %q", raw)
+	}
+	if (u.Path != "" && u.Path != "/") || u.RawQuery != "" || u.Fragment != "" {
+		return Target{}, fmt.Errorf("ssh url must be ssh://[user@]host[:port] with no path: %q", raw)
+	}
+	return t, nil
+}
+
+// String renders the canonical URL (ssh://[user@]host[:port]) — the key the
+// Manager dedupes tunnels on, so two spellings of one remote share a tunnel.
+func (t Target) String() string {
+	var b strings.Builder
+	b.WriteString("ssh://")
+	if t.User != "" {
+		b.WriteString(t.User)
+		b.WriteByte('@')
+	}
+	if strings.Contains(t.Host, ":") {
+		b.WriteString("[" + t.Host + "]") // IPv6 literal
+	} else {
+		b.WriteString(t.Host)
+	}
+	if t.Port != "" {
+		b.WriteByte(':')
+		b.WriteString(t.Port)
+	}
+	return b.String()
+}
+
+// destination is the ssh command's destination operand ([user@]host).
+func (t Target) destination() string {
+	if t.User != "" {
+		return t.User + "@" + t.Host
+	}
+	return t.Host
+}
+
+// sshBaseArgs are the options every ssh invocation starts with: batch mode so
+// a daemon with no TTY can never hang on a prompt (an unknown host key or a
+// passphrase-locked key fails fast with a clear stderr instead), a bounded
+// connect, and keepalives so a dead peer is noticed. A package var so tests can
+// prepend "-F <config>" — OpenSSH resolves ~/.ssh from the passwd entry, not
+// $HOME, so a test cannot redirect it any other way.
+var sshBaseArgs = []string{
+	"-o", "BatchMode=yes",
+	"-o", "ConnectTimeout=15",
+	"-o", "ServerAliveInterval=15",
+	"-o", "ServerAliveCountMax=3",
+}
+
+// sshArgs builds the argv (after "ssh") for one invocation: the base options,
+// the port, the caller's extra flags, then the destination.
+func (t Target) sshArgs(extra ...string) []string {
+	args := append([]string(nil), sshBaseArgs...)
+	if t.Port != "" {
+		args = append(args, "-p", t.Port)
+	}
+	args = append(args, extra...)
+	return append(args, t.destination())
+}
+
+// loopback renders 127.0.0.1:<port>.
+func loopback(port int) string {
+	return net.JoinHostPort("127.0.0.1", fmt.Sprint(port))
+}

--- a/internal/server/sshtunnel/url_test.go
+++ b/internal/server/sshtunnel/url_test.go
@@ -1,0 +1,80 @@
+package sshtunnel
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseURL(t *testing.T) {
+	cases := []struct {
+		raw     string
+		want    Target
+		wantErr string
+	}{
+		{raw: "ssh://ben@desktop", want: Target{User: "ben", Host: "desktop"}},
+		{raw: "ssh://desktop", want: Target{Host: "desktop"}},
+		{raw: "SSH://Ben@Desktop.Local:2222", want: Target{User: "Ben", Host: "desktop.local", Port: "2222"}},
+		{raw: "  ssh://ben@10.0.0.5/  ", want: Target{User: "ben", Host: "10.0.0.5"}},
+		{raw: "ssh://ben@[::1]:22", want: Target{User: "ben", Host: "::1", Port: "22"}},
+		{raw: "https://gw.example.com/abc", wantErr: "not an ssh:// URL"},
+		{raw: "ssh://", wantErr: "no host"},
+		{raw: "ssh://ben:pw@host", wantErr: "password"},
+		{raw: "ssh://-oProxyCommand=evil@host", wantErr: "'-'"},
+		{raw: "ssh://host/path", wantErr: "no path"},
+		{raw: "ssh://host?x=1", wantErr: "no path"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			got, err := ParseURL(tc.raw)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("ParseURL(%q) err = %v, want containing %q", tc.raw, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseURL(%q): %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Fatalf("ParseURL(%q) = %+v, want %+v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTargetStringCanonical pins the dedupe key: two spellings of one remote
+// (case, trailing slash, whitespace) share a tunnel; user/port differences don't.
+func TestTargetStringCanonical(t *testing.T) {
+	a, _ := ParseURL("ssh://ben@Desktop/")
+	b, _ := ParseURL(" SSH://ben@desktop ")
+	if a.String() != b.String() || a.String() != "ssh://ben@desktop" {
+		t.Fatalf("canonical mismatch: %q vs %q", a.String(), b.String())
+	}
+	c, _ := ParseURL("ssh://ben@desktop:2222")
+	if c.String() != "ssh://ben@desktop:2222" {
+		t.Fatalf("port dropped from canonical form: %q", c.String())
+	}
+	v6, _ := ParseURL("ssh://[::1]:22")
+	if v6.String() != "ssh://[::1]:22" {
+		t.Fatalf("ipv6 canonical form: %q", v6.String())
+	}
+}
+
+// TestSSHArgs pins the batch-mode flags (a daemon can never answer a prompt),
+// the -p placement, and that the destination is LAST (after any extra flags).
+func TestSSHArgs(t *testing.T) {
+	tgt := Target{User: "ben", Host: "desktop", Port: "2222"}
+	args := tgt.sshArgs("-N", "-L", "127.0.0.1:1:127.0.0.1:2")
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"-o BatchMode=yes", "-o ConnectTimeout=15", "-p 2222", "-N -L 127.0.0.1:1:127.0.0.1:2"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("args %q missing %q", joined, want)
+		}
+	}
+	if args[len(args)-1] != "ben@desktop" {
+		t.Errorf("destination must be the last arg, got %q", args[len(args)-1])
+	}
+	if got := (Target{Host: "h"}).sshArgs(); got[len(got)-1] != "h" {
+		t.Errorf("userless destination = %q, want h", got[len(got)-1])
+	}
+}

--- a/internal/state/remote_mcp_settings.go
+++ b/internal/state/remote_mcp_settings.go
@@ -10,6 +10,12 @@ import "strings"
 // unchanged and stays loopback-only; the gateway tunnel dials OUT to GatewayURL
 // and reverse-proxies inbound requests back to it.
 //
+// Remote fleet control has a second transport: FleetMode == FleetModeSSH skips
+// the gateway entirely and instead serves the token-gated gRPC server on a
+// loopback TCP port that a remote client reaches over an SSH tunnel (see
+// internal/server/sshlisten.go and internal/server/sshtunnel). Only the remote
+// fleet surface has this mode — MCP and webhooks stay gateway-only.
+//
 // Only these fields are persisted here. The gateway-assigned "Public MCP URL" /
 // "Public GRPC URL" are deliberately NOT stored: they are runtime state the
 // server computes after it connects and pushes to the TUI over the Watch stream
@@ -27,10 +33,11 @@ type RemoteMcpSettings struct {
 	// "enabled but not yet configured"; the tunnel manager treats that as a no-op.
 	GatewayURL string `json:"gateway_url,omitempty"`
 
-	// FleetEnabled ("Enable Remote Fleet") exposes the daemon's gRPC server
-	// through the gateway so a remote `fleet` binary can control this instance.
-	// When off, fleetd does not negotiate the grpc tunnel feature, so the
-	// gateway rejects any incoming gRPC commands aimed at this daemon.
+	// FleetEnabled ("Enable Remote Fleet") exposes the daemon's gRPC server so a
+	// remote `fleet` binary can control this instance — through the gateway
+	// (FleetMode gateway, the default) or over an SSH tunnel (FleetMode ssh).
+	// When off, fleetd neither negotiates the grpc tunnel feature nor opens the
+	// SSH loopback listener.
 	FleetEnabled bool `json:"fleet_enabled,omitempty"`
 
 	// WebhookEnabled ("Enable Webhook") exposes this daemon's automation webhook
@@ -40,16 +47,46 @@ type RemoteMcpSettings struct {
 	// gateway does not serve the webhook route for this daemon. Independent of
 	// Enabled/FleetEnabled — all three ride the SAME outbound tunnel.
 	WebhookEnabled bool `json:"webhook_enabled,omitempty"`
+
+	// FleetMode selects HOW remote fleet control is reached: FleetModeGateway
+	// (the default; "" reads as gateway) rides the gateway tunnel, FleetModeSSH
+	// serves the token-gated gRPC server on a loopback port for an SSH tunnel.
+	// Stored explicitly rather than inferred from an empty GatewayURL, so an
+	// existing "enabled but unconfigured" gateway config keeps its documented
+	// no-op behaviour instead of silently opening a listener.
+	FleetMode string `json:"fleet_mode,omitempty"`
+}
+
+// The FleetMode values. An unknown value is treated as gateway (the default), so
+// a config written by a newer daemon never flips an older one into SSH mode.
+const (
+	FleetModeGateway = "gateway"
+	FleetModeSSH     = "ssh"
+)
+
+// FleetViaSSH reports whether remote fleet control is enabled AND set to the SSH
+// transport — the predicate the SSH loopback listener converges on.
+func (s RemoteMcpSettings) FleetViaSSH() bool {
+	return s.FleetEnabled && s.FleetMode == FleetModeSSH
+}
+
+// FleetViaGateway reports whether remote fleet control is enabled AND set to the
+// gateway transport — the predicate that makes the tunnel negotiate the grpc
+// feature. Exactly one of FleetViaSSH / FleetViaGateway is true while
+// FleetEnabled is on.
+func (s RemoteMcpSettings) FleetViaGateway() bool {
+	return s.FleetEnabled && !s.FleetViaSSH()
 }
 
 // TunnelDesired reports whether the outbound gateway tunnel should be up: any of
-// the three remote surfaces (MCP / gRPC / webhook) is enabled AND a gateway URL
-// is configured. It is the single source of truth for that predicate — the
-// manager's desiredState.on() (internal/server/remote/manager.go) delegates here
-// for the dial decision, and the TUI's remote-connection indicator uses it to
-// light exactly when the tunnel will actually dial. Without a gateway URL the
-// tunnel is a documented no-op, so the indicator stays dark rather than showing
-// a misleading "connecting" state forever.
+// the three gateway surfaces (MCP / gateway-mode gRPC / webhook) is enabled AND
+// a gateway URL is configured. It is the single source of truth for that
+// predicate — the manager's desiredState.on() (internal/server/remote/manager.go)
+// delegates here for the dial decision, and the TUI's remote-connection
+// indicator uses it to light exactly when the tunnel will actually dial. Without
+// a gateway URL the tunnel is a documented no-op, so the indicator stays dark
+// rather than showing a misleading "connecting" state forever. Remote fleet in
+// SSH mode does not want the tunnel at all.
 func (s RemoteMcpSettings) TunnelDesired() bool {
-	return (s.Enabled || s.FleetEnabled || s.WebhookEnabled) && strings.TrimSpace(s.GatewayURL) != ""
+	return (s.Enabled || s.FleetViaGateway() || s.WebhookEnabled) && strings.TrimSpace(s.GatewayURL) != ""
 }

--- a/internal/state/remote_mcp_settings_test.go
+++ b/internal/state/remote_mcp_settings_test.go
@@ -3,8 +3,9 @@ package state
 import "testing"
 
 // TestTunnelDesired pins the "tunnel should be up" predicate: any of the three
-// remote surfaces enabled AND a (non-blank) gateway URL set. It must mirror the
+// gateway surfaces enabled AND a (non-blank) gateway URL set. It must mirror the
 // manager's desiredState.on() so the TUI indicator and the actual dial agree.
+// Remote fleet in SSH mode is NOT a gateway surface.
 func TestTunnelDesired(t *testing.T) {
 	cases := []struct {
 		name string
@@ -19,12 +20,43 @@ func TestTunnelDesired(t *testing.T) {
 		{name: "blank url counts as unset", s: RemoteMcpSettings{Enabled: true, GatewayURL: "   "}, want: false},
 		{name: "mcp on + url", s: RemoteMcpSettings{Enabled: true, GatewayURL: "https://gw"}, want: true},
 		{name: "grpc on + url", s: RemoteMcpSettings{FleetEnabled: true, GatewayURL: "https://gw"}, want: true},
+		{name: "grpc on + explicit gateway mode + url", s: RemoteMcpSettings{FleetEnabled: true, FleetMode: FleetModeGateway, GatewayURL: "https://gw"}, want: true},
+		{name: "grpc on in ssh mode + url: no tunnel", s: RemoteMcpSettings{FleetEnabled: true, FleetMode: FleetModeSSH, GatewayURL: "https://gw"}, want: false},
+		{name: "ssh mode grpc + mcp on + url: tunnel for mcp", s: RemoteMcpSettings{Enabled: true, FleetEnabled: true, FleetMode: FleetModeSSH, GatewayURL: "https://gw"}, want: true},
 		{name: "webhook on + url", s: RemoteMcpSettings{WebhookEnabled: true, GatewayURL: "https://gw"}, want: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := tc.s.TunnelDesired(); got != tc.want {
 				t.Fatalf("TunnelDesired(%+v) = %v, want %v", tc.s, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFleetModePredicates pins the SSH/gateway split: exactly one of the two
+// predicates holds while FleetEnabled is on, neither while it is off, and an
+// unknown mode value falls back to gateway.
+func TestFleetModePredicates(t *testing.T) {
+	cases := []struct {
+		name        string
+		s           RemoteMcpSettings
+		ssh, gatewy bool
+	}{
+		{name: "off", s: RemoteMcpSettings{}, ssh: false, gatewy: false},
+		{name: "off in ssh mode", s: RemoteMcpSettings{FleetMode: FleetModeSSH}, ssh: false, gatewy: false},
+		{name: "on, default mode", s: RemoteMcpSettings{FleetEnabled: true}, ssh: false, gatewy: true},
+		{name: "on, gateway", s: RemoteMcpSettings{FleetEnabled: true, FleetMode: FleetModeGateway}, ssh: false, gatewy: true},
+		{name: "on, ssh", s: RemoteMcpSettings{FleetEnabled: true, FleetMode: FleetModeSSH}, ssh: true, gatewy: false},
+		{name: "on, unknown mode is gateway", s: RemoteMcpSettings{FleetEnabled: true, FleetMode: "carrier-pigeon"}, ssh: false, gatewy: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.s.FleetViaSSH(); got != tc.ssh {
+				t.Errorf("FleetViaSSH = %v, want %v", got, tc.ssh)
+			}
+			if got := tc.s.FleetViaGateway(); got != tc.gatewy {
+				t.Errorf("FleetViaGateway = %v, want %v", got, tc.gatewy)
 			}
 		})
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -61,12 +61,13 @@ type model struct {
 	armadaTickArmed bool
 
 	// bootGateway/bootToken capture FLEET_GATEWAY/FLEET_TOKEN as they were at
-	// startup, and bootServer captures FLEET_SERVER. A runtime armada switch
-	// rewrites the env vars, so these preserve the boot remote (and its token)
-	// as a dropdown entry the user can switch back to even when it isn't
-	// registered.
+	// startup, bootSSH captures FLEET_SSH, and bootServer captures FLEET_SERVER.
+	// A runtime armada switch rewrites the env vars, so these preserve the boot
+	// remote (and its token) as a dropdown entry the user can switch back to
+	// even when it isn't registered.
 	bootGateway string
 	bootToken   string
+	bootSSH     string
 	bootServer  string
 
 	// watchGen is the active Watch connection generation. The watch goroutine
@@ -198,6 +199,7 @@ func newModel() model {
 		copySessionAllow:   make(map[string]bool),
 		bootGateway:        os.Getenv(fleetclient.EnvGateway),
 		bootToken:          os.Getenv(fleetclient.EnvToken),
+		bootSSH:            os.Getenv(fleetclient.EnvSSH),
 		bootServer:         os.Getenv(fleetclient.EnvServer),
 	}
 

--- a/internal/tui/armada.go
+++ b/internal/tui/armada.go
@@ -24,9 +24,13 @@ import (
 // "local" and a registered remote (the border selector on the main page).
 //
 // Persistence always targets the LOCAL daemon (armada_client.go); the switch
-// itself works by swapping the FLEET_GATEWAY/FLEET_TOKEN env vars — every
-// fleetclient.Dial re-reads them, and spawned `fleet shell` children inherit
-// them — then bouncing each connection the TUI holds.
+// itself works by swapping the FLEET_GATEWAY/FLEET_TOKEN (gateway remote) or
+// FLEET_SSH (ssh:// remote) env vars — every fleetclient.Dial re-reads them,
+// and spawned `fleet shell` children inherit them — then bouncing each
+// connection the TUI holds. A remote's URL scheme decides its transport: a
+// gateway URL carries a token the user pasted; an ssh:// URL carries none (the
+// local daemon discovers it over SSH) and is dialed through a tunnel the local
+// daemon maintains (fleetclient.EnvSSH).
 
 // ===========================================
 // Connection status
@@ -212,7 +216,7 @@ func (m *model) handleArmadaMsg(msg tea.Msg) tea.Cmd {
 	case armadaPingResultMsg:
 		st := armadaStatus{state: armadaStatusConnected}
 		if msg.err != nil {
-			st = armadaStatus{state: armadaStatusError, err: armadaPingErrText(msg.err)}
+			st = armadaStatus{state: armadaStatusError, err: armadaPingErrText(msg.url, msg.err)}
 		}
 		m.armadaStatus[msg.url] = st
 		return nil
@@ -223,7 +227,7 @@ func (m *model) handleArmadaMsg(msg tea.Msg) tea.Cmd {
 		}
 		if msg.err != nil {
 			settingsPage.cancelArmadaAdd()
-			m.message = fmt.Sprintf("Connection test failed: %s", armadaPingErrText(msg.err))
+			m.message = fmt.Sprintf("Connection test failed: %s", armadaPingErrText(msg.url, msg.err))
 			return nil
 		}
 		m.armadaStatus[msg.url] = armadaStatus{state: armadaStatusConnected}
@@ -327,28 +331,23 @@ func (m *model) postSwitchFetchCmd() tea.Cmd {
 }
 
 // pingAllArmadaCmd marks every pingable remote (registered remotes plus an
-// unregistered gateway boot remote) as pinging and probes them concurrently.
-// Remotes already mid-ping are skipped so overlapping sweeps (tick + manual)
-// don't double-probe.
+// unregistered gateway/ssh boot remote) as pinging and probes them
+// concurrently. Remotes already mid-ping are skipped so overlapping sweeps
+// (tick + manual) don't double-probe. Pinging an ssh:// remote makes the local
+// daemon bring its tunnel up, so a later switch to it is instant.
 func (m *model) pingAllArmadaCmd() tea.Cmd {
 	type target struct{ url, token string }
 	var targets []target
 	for _, r := range m.armadaRemotes {
 		targets = append(targets, target{r.URL, r.Token})
 	}
-	// The gateway boot remote shows in the dropdown as "(env)" even when not
-	// registered, so give it a status too.
-	if m.bootGateway != "" {
-		registered := false
-		for _, r := range m.armadaRemotes {
-			if r.URL == m.bootGateway {
-				registered = true
-				break
-			}
+	// A boot remote shows in the dropdown as "(env)" even when not registered,
+	// so give it a status too.
+	for _, boot := range []target{{m.bootGateway, m.bootToken}, {m.bootSSH, ""}} {
+		if boot.url == "" || m.armadaRegistered(boot.url) {
+			continue
 		}
-		if !registered {
-			targets = append(targets, target{m.bootGateway, m.bootToken})
-		}
+		targets = append(targets, boot)
 	}
 
 	var cmds []tea.Cmd
@@ -365,18 +364,40 @@ func (m *model) pingAllArmadaCmd() tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
+// armadaRegistered reports whether url is in the registry.
+func (m *model) armadaRegistered(url string) bool {
+	for _, r := range m.armadaRemotes {
+		if r.URL == url {
+			return true
+		}
+	}
+	return false
+}
+
 // armadaPingErrText folds a ping error into a short human cause. The gRPC code
-// distinguishes where the chain broke (see fleetclient.Ping).
-func armadaPingErrText(err error) string {
+// distinguishes where the chain broke (see fleetclient.Ping); the URL's
+// transport words it (a gateway hop vs the local daemon's ssh tunnel).
+func armadaPingErrText(url string, err error) string {
+	ssh := fleetclient.IsSSHURL(url)
 	switch status.Code(err) {
 	case codes.Unauthenticated:
+		if ssh {
+			return "remote refused the discovered token"
+		}
 		return "invalid token"
 	case codes.NotFound:
 		return "unknown session — daemon offline or Remote Fleet disabled"
 	case codes.Unavailable:
+		if ssh {
+			return "ssh tunnel unreachable"
+		}
 		return "gateway unreachable"
 	case codes.DeadlineExceeded:
 		return "timed out"
+	case codes.FailedPrecondition:
+		// The local daemon could not bring the ssh tunnel up; its message is
+		// already user-facing (ssh's own diagnostic, or "SSH mode is off").
+		return status.Convert(err).Message()
 	default:
 		return err.Error()
 	}
@@ -387,16 +408,44 @@ func armadaPingErrText(err error) string {
 // ===========================================
 
 // armadaEntry is one row of the main-page Armada dropdown. Exactly one of url
-// (a gateway) / server (a plain FLEET_SERVER target) is set for a remote; both
-// empty means local. displayName is the short, user-facing name (hostname,
-// disambiguated by session id when two entries share a host).
+// (a gateway or ssh:// remote) / server (a plain FLEET_SERVER target) is set
+// for a remote; both empty means local. displayName is the short, user-facing
+// name (hostname, disambiguated when two entries share a host).
 type armadaEntry struct {
 	displayName string
-	url         string // gateway URL ("" unless a gateway entry)
+	url         string // gateway or ssh:// URL ("" unless a URL entry)
 	token       string
 	server      string // FLEET_SERVER host:port ("" unless a plain-TCP entry)
 	env         bool   // an unregistered boot endpoint (shown with "(env)")
 	current     bool
+}
+
+// Transport badges: every remote entry wears one so the connection mode is
+// always visible (the dropdown, the border selector, the settings rows).
+const (
+	armadaBadgeGateway = "[gtwy]"
+	armadaBadgeSSH     = "[ssh]"
+	armadaBadgeTCP     = "[tcp]"
+)
+
+// badge is the entry's transport badge ("" for local).
+func (e armadaEntry) badge() string {
+	return armadaURLBadge(e.url, e.server)
+}
+
+// armadaURLBadge picks the transport badge for a remote: ssh:// → [ssh], any
+// other URL → [gtwy], a plain FLEET_SERVER target → [tcp], nothing → "".
+func armadaURLBadge(url, server string) string {
+	switch {
+	case url != "" && fleetclient.IsSSHURL(url):
+		return armadaBadgeSSH
+	case url != "":
+		return armadaBadgeGateway
+	case server != "":
+		return armadaBadgeTCP
+	default:
+		return ""
+	}
 }
 
 // key uniquely identifies the endpoint an entry points at, matching
@@ -434,9 +483,11 @@ func (e armadaEntry) host() string {
 }
 
 // sessionID8 returns the first 8 characters of a gateway URL's session id (the
-// last path segment), used to disambiguate two gateways on the same host.
+// last path segment), used to disambiguate two gateways on the same host. An
+// ssh:// URL has no session id (it is disambiguated by its user/port instead —
+// see armadaDisplayName).
 func (e armadaEntry) sessionID8() string {
-	if e.url == "" {
+	if e.url == "" || fleetclient.IsSSHURL(e.url) {
 		return ""
 	}
 	u, err := url.Parse(e.url)
@@ -455,21 +506,20 @@ func (e armadaEntry) sessionID8() string {
 
 // armadaEntries builds the dropdown: local first, then every registered
 // remote, then — when the TUI was booted pointing at an UNREGISTERED remote
-// (FLEET_GATEWAY or FLEET_SERVER) — that boot remote, so the current selection
-// is always present and selectable. Each entry's displayName is its hostname,
-// suffixed with " - <sid8>" when another entry shares the same host.
+// (FLEET_GATEWAY, FLEET_SSH or FLEET_SERVER) — that boot remote, so the current
+// selection is always present and selectable. Each entry's displayName is its
+// hostname, disambiguated when another entry shares the same host.
 func (m *model) armadaEntries() []armadaEntry {
 	current := armadaCurrentKey()
 	entries := []armadaEntry{{}} // local
-	bootGatewaySeen := false
 	for _, r := range m.armadaRemotes {
-		if r.URL == m.bootGateway {
-			bootGatewaySeen = true
-		}
 		entries = append(entries, armadaEntry{url: r.URL, token: r.Token})
 	}
-	if m.bootGateway != "" && !bootGatewaySeen {
+	if m.bootGateway != "" && !m.armadaRegistered(m.bootGateway) {
 		entries = append(entries, armadaEntry{url: m.bootGateway, token: m.bootToken, env: true})
+	}
+	if m.bootSSH != "" && !m.armadaRegistered(m.bootSSH) {
+		entries = append(entries, armadaEntry{url: m.bootSSH, env: true})
 	}
 	if m.bootServer != "" {
 		// FLEET_SERVER targets aren't registrable (no token / gateway), so the
@@ -492,8 +542,9 @@ func (m *model) armadaEntries() []armadaEntry {
 }
 
 // armadaDisplayName renders the short name for an entry: "local" for the local
-// daemon, otherwise the hostname — suffixed with " - <sid8>" when another entry
-// shares the host, and with " (env)" for an unregistered boot endpoint.
+// daemon, otherwise the hostname — disambiguated when another entry shares the
+// host (a gateway by " - <sid8>", an ssh remote by its user@host[:port]
+// authority), and suffixed with " (env)" for an unregistered boot endpoint.
 func armadaDisplayName(e armadaEntry, hostCounts map[string]int) string {
 	h := e.host()
 	if h == "" {
@@ -503,12 +554,37 @@ func armadaDisplayName(e armadaEntry, hostCounts map[string]int) string {
 	if hostCounts[h] > 1 {
 		if sid := e.sessionID8(); sid != "" {
 			name = h + " - " + sid
+		} else if auth := e.sshAuthority(); auth != "" {
+			name = auth
 		}
 	}
 	if e.env {
 		name += " (env)"
 	}
 	return name
+}
+
+// sshAuthority returns an ssh:// entry's [user@]host[:port] (lower-cased host),
+// or "" for any other entry.
+func (e armadaEntry) sshAuthority() string {
+	if e.url == "" || !fleetclient.IsSSHURL(e.url) {
+		return ""
+	}
+	u, err := url.Parse(strings.TrimSpace(e.url))
+	if err != nil || u.Hostname() == "" {
+		return ""
+	}
+	auth := strings.ToLower(u.Host)
+	if u.User != nil && u.User.Username() != "" {
+		auth = u.User.Username() + "@" + auth
+	}
+	return auth
+}
+
+// armadaCurrentBadge is the active connection's transport badge for the border
+// selector ("" for local).
+func (m *model) armadaCurrentBadge() string {
+	return armadaURLBadge(os.Getenv(fleetclient.EnvGateway)+os.Getenv(fleetclient.EnvSSH), os.Getenv(fleetclient.EnvServer))
 }
 
 // armadaCurrentDisplay is the active connection's short name for the border
@@ -525,6 +601,9 @@ func (m *model) armadaCurrentDisplay() string {
 	if gw := os.Getenv(fleetclient.EnvGateway); gw != "" {
 		return (armadaEntry{url: gw}).host()
 	}
+	if ssh := os.Getenv(fleetclient.EnvSSH); ssh != "" {
+		return (armadaEntry{url: ssh}).host()
+	}
 	if srv := os.Getenv(fleetclient.EnvServer); srv != "" {
 		return (armadaEntry{server: srv}).host()
 	}
@@ -533,10 +612,14 @@ func (m *model) armadaCurrentDisplay() string {
 
 // armadaCurrentKey identifies the active connection from the live env (the env
 // IS the switch mechanism, so it's correct whether the connection came from
-// boot or a runtime switch). "" = local.
+// boot or a runtime switch). "" = local. Gateway and ssh remotes are both keyed
+// by their URL (the schemes never collide).
 func armadaCurrentKey() string {
 	if gw := os.Getenv(fleetclient.EnvGateway); gw != "" {
 		return gw
+	}
+	if ssh := os.Getenv(fleetclient.EnvSSH); ssh != "" {
+		return ssh
 	}
 	if srv := os.Getenv(fleetclient.EnvServer); srv != "" {
 		return "server:" + srv
@@ -557,16 +640,26 @@ func (m *model) switchArmada(entry armadaEntry) tea.Cmd {
 	// from here on inherit them. Swap them FIRST so any RPC that re-dials
 	// during the teardown below targets the NEW endpoint, never the old one.
 	switch {
+	case entry.url != "" && fleetclient.IsSSHURL(entry.url):
+		// The local daemon resolves the tunnel address + token per dial; no
+		// token env (the remote's token never leaves the daemons).
+		_ = os.Setenv(fleetclient.EnvSSH, entry.url)
+		_ = os.Unsetenv(fleetclient.EnvGateway)
+		_ = os.Unsetenv(fleetclient.EnvToken)
+		_ = os.Unsetenv(fleetclient.EnvServer)
 	case entry.url != "":
 		_ = os.Setenv(fleetclient.EnvGateway, entry.url)
 		_ = os.Setenv(fleetclient.EnvToken, entry.token)
+		_ = os.Unsetenv(fleetclient.EnvSSH)
 		_ = os.Unsetenv(fleetclient.EnvServer)
 	case entry.server != "":
 		_ = os.Setenv(fleetclient.EnvServer, entry.server)
 		_ = os.Unsetenv(fleetclient.EnvGateway)
+		_ = os.Unsetenv(fleetclient.EnvSSH)
 		_ = os.Unsetenv(fleetclient.EnvToken)
 	default: // local
 		_ = os.Unsetenv(fleetclient.EnvGateway)
+		_ = os.Unsetenv(fleetclient.EnvSSH)
 		_ = os.Unsetenv(fleetclient.EnvServer)
 		_ = os.Unsetenv(fleetclient.EnvToken)
 	}
@@ -631,16 +724,16 @@ func (m *model) switchArmada(entry armadaEntry) tea.Cmd {
 	return switchReloadCmd(entry.displayName, m.watchGen)
 }
 
-// syncTmuxArmadaEnv mirrors the FLEET_GATEWAY/FLEET_TOKEN/FLEET_SERVER env onto
-// the tmux server's global environment so panes tmux spawns AFTER a switch
-// (split-window, the bound %/" keys) inherit the new connection. tmux captures
-// its environment at session start, so an in-process os.Setenv alone never
-// reaches these children. No-op when not running inside tmux.
+// syncTmuxArmadaEnv mirrors the FLEET_GATEWAY/FLEET_TOKEN/FLEET_SSH/FLEET_SERVER
+// env onto the tmux server's global environment so panes tmux spawns AFTER a
+// switch (split-window, the bound %/" keys) inherit the new connection. tmux
+// captures its environment at session start, so an in-process os.Setenv alone
+// never reaches these children. No-op when not running inside tmux.
 func syncTmuxArmadaEnv(m *model) {
 	if !m.inHostTmux {
 		return
 	}
-	for _, name := range []string{fleetclient.EnvGateway, fleetclient.EnvToken, fleetclient.EnvServer} {
+	for _, name := range []string{fleetclient.EnvGateway, fleetclient.EnvToken, fleetclient.EnvSSH, fleetclient.EnvServer} {
 		if v := os.Getenv(name); v != "" {
 			_ = exec.Command("tmux", "set-environment", "-g", name, v).Run()
 		} else {
@@ -705,8 +798,11 @@ func (fleetPage *fleetPage) renderArmadaSelectDialog(m *model) string {
 	var opts strings.Builder
 	for i, e := range entries {
 		suffix := ""
+		if badge := e.badge(); badge != "" {
+			suffix = "  " + dimStyle.Render(badge)
+		}
 		if e.url != "" {
-			suffix = "  " + armadaStatusValue(m, e.url)
+			suffix += "  " + armadaStatusValue(m, e.url)
 		}
 		if e.current {
 			suffix += "  " + dimStyle.Render("(current)")

--- a/internal/tui/armada_test.go
+++ b/internal/tui/armada_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // armadaTestModel builds a model with the pieces the armada paths touch. The
@@ -581,5 +583,180 @@ func TestBounceWatchStreamBumpsGeneration(t *testing.T) {
 	// is a no-op returning the current gen (0).
 	if got := bounceWatchStream(); got != watchCtl.gen {
 		t.Fatalf("bounce no-op returned %d, want current gen %d", got, watchCtl.gen)
+	}
+}
+
+// ===========================================
+// ssh:// remotes
+// ===========================================
+
+// TestArmadaAddFlowSSHSkipsToken: an ssh:// URL needs no token (the local
+// daemon discovers it), so enter on the URL goes straight to the connection
+// test, and the saved entry carries an empty token.
+func TestArmadaAddFlowSSHSkipsToken(t *testing.T) {
+	pingedURL, pingedToken := "", "unset"
+	origPing := pingArmadaRemote
+	pingArmadaRemote = func(url, token string) error {
+		pingedURL, pingedToken = url, token
+		return nil
+	}
+	defer func() { pingArmadaRemote = origPing }()
+	var saved []configutil.ArmadaRemote
+	origSave := saveArmadaLocal
+	saveArmadaLocal = func(remotes []configutil.ArmadaRemote) error {
+		saved = remotes
+		return nil
+	}
+	defer func() { saveArmadaLocal = origSave }()
+
+	sp := newSettingsPage()
+	m := armadaTestModel(sp)
+	sp.cursor = settingsPositionOf(sp, m, settingsItemArmadaAdd)
+	sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	typeRunes(sp, m, "ssh://ben@desktop")
+	cmd := sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if sp.armadaAddStage != armadaAddTesting {
+		t.Fatalf("stage = %v, want testing (no token stage for ssh)", sp.armadaAddStage)
+	}
+	if cmd == nil {
+		t.Fatal("ssh URL commit should return the connection-test command")
+	}
+	testMsg := cmd().(armadaTestResultMsg)
+	if pingedURL != "ssh://ben@desktop" || pingedToken != "" {
+		t.Fatalf("connection test used %q/%q, want the ssh url with an empty token", pingedURL, pingedToken)
+	}
+	saveCmd := m.handleArmadaMsg(testMsg)
+	if saveCmd == nil {
+		t.Fatal("successful test should chain into the save command")
+	}
+	m.handleArmadaMsg(saveCmd())
+	if len(saved) != 1 || saved[0].URL != "ssh://ben@desktop" || saved[0].Token != "" {
+		t.Fatalf("persisted registry mismatch: %+v", saved)
+	}
+}
+
+// TestArmadaAddFlowRejectsMalformedSSH: an ssh URL without a host, or with a
+// path, is refused before any connection test.
+func TestArmadaAddFlowRejectsMalformedSSH(t *testing.T) {
+	origPing := pingArmadaRemote
+	pinged := false
+	pingArmadaRemote = func(string, string) error { pinged = true; return nil }
+	defer func() { pingArmadaRemote = origPing }()
+
+	for _, bad := range []string{"ssh://", "ssh://host/path"} {
+		sp := newSettingsPage()
+		m := armadaTestModel(sp)
+		sp.cursor = settingsPositionOf(sp, m, settingsItemArmadaAdd)
+		sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter})
+		typeRunes(sp, m, bad)
+		sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter})
+		if sp.armadaAddStage != armadaAddURLIn || !strings.Contains(m.message, "ssh://") {
+			t.Errorf("%q: stage %v, message %q — want to stay on the URL stage with a hint", bad, sp.armadaAddStage, m.message)
+		}
+	}
+	if pinged {
+		t.Fatal("a malformed ssh URL must not be tested")
+	}
+}
+
+// TestArmadaSSHBadgesAndNames: ssh remotes wear [ssh], gateway remotes [gtwy],
+// the plain-TCP boot [tcp], local none; two ssh remotes on one host are told
+// apart by user@host[:port].
+func TestArmadaSSHBadgesAndNames(t *testing.T) {
+	t.Setenv("FLEET_GATEWAY", "")
+	t.Setenv("FLEET_SSH", "")
+	t.Setenv("FLEET_SERVER", "")
+	m := armadaTestModel(nil)
+	m.armadaRemotes = []configutil.ArmadaRemote{
+		{URL: "https://gw.example.com/abc", Token: "t"},
+		{URL: "ssh://ben@desktop"},
+		{URL: "ssh://root@Desktop:2222"},
+	}
+	m.bootServer = "10.0.0.9:50051"
+	entries := m.armadaEntries()
+	got := make([]string, 0, len(entries))
+	for _, e := range entries {
+		got = append(got, e.displayName+"|"+e.badge())
+	}
+	want := []string{"local|", "gw.example.com|[gtwy]", "ben@desktop|[ssh]", "root@desktop:2222|[ssh]", "10.0.0.9 (env)|[tcp]"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("entries = %v, want %v", got, want)
+	}
+	// A lone ssh remote shows just its host.
+	m.armadaRemotes = m.armadaRemotes[1:2]
+	if e := m.armadaEntries()[1]; e.displayName != "desktop" {
+		t.Fatalf("lone ssh remote displayName = %q, want desktop", e.displayName)
+	}
+}
+
+// TestSwitchArmadaSSHSetsEnv: switching to an ssh remote sets FLEET_SSH (and
+// nothing else), is recognised as current, and shows the [ssh] badge in the
+// border; switching back to local clears it.
+func TestSwitchArmadaSSHSetsEnv(t *testing.T) {
+	t.Setenv("FLEET_GATEWAY", "https://old.example.com/abc")
+	t.Setenv("FLEET_TOKEN", "old")
+	t.Setenv("FLEET_SSH", "")
+	t.Setenv("FLEET_SERVER", "")
+	m := armadaTestModel(nil)
+	m.armadaRemotes = []configutil.ArmadaRemote{{URL: "ssh://ben@desktop"}}
+
+	entry := m.armadaEntries()[1]
+	if entry.badge() != armadaBadgeSSH {
+		t.Fatalf("entry badge = %q", entry.badge())
+	}
+	if cmd := m.switchArmada(entry); cmd == nil {
+		t.Fatal("switch should return the reload command")
+	}
+	if os.Getenv("FLEET_SSH") != "ssh://ben@desktop" || os.Getenv("FLEET_GATEWAY") != "" || os.Getenv("FLEET_TOKEN") != "" || os.Getenv("FLEET_SERVER") != "" {
+		t.Fatalf("env after ssh switch: SSH=%q GATEWAY=%q TOKEN=%q SERVER=%q",
+			os.Getenv("FLEET_SSH"), os.Getenv("FLEET_GATEWAY"), os.Getenv("FLEET_TOKEN"), os.Getenv("FLEET_SERVER"))
+	}
+	if armadaCurrentKey() != "ssh://ben@desktop" || !m.armadaEntries()[1].current {
+		t.Fatal("the ssh remote should now be the current connection")
+	}
+	if m.armadaCurrentDisplay() != "desktop" || m.armadaCurrentBadge() != armadaBadgeSSH {
+		t.Fatalf("current display/badge = %q/%q", m.armadaCurrentDisplay(), m.armadaCurrentBadge())
+	}
+	fp := newFleetPage()
+	border := ansi.Strip(fp.renderArmadaBorder(m, 80))
+	if !strings.Contains(border, "Armada [ desktop ] [ssh]") {
+		t.Fatalf("border = %q, want the [ssh] badge after the selector", border)
+	}
+
+	m.switchArmada(m.armadaEntries()[0]) // local
+	if os.Getenv("FLEET_SSH") != "" || armadaCurrentKey() != "" || m.armadaCurrentBadge() != "" {
+		t.Fatalf("local switch should clear FLEET_SSH: %q", os.Getenv("FLEET_SSH"))
+	}
+}
+
+// TestArmadaEntriesIncludesSSHBoot: a TUI booted with FLEET_SSH pointing at an
+// unregistered remote lists it as "(env)" and pings it.
+func TestArmadaEntriesIncludesSSHBoot(t *testing.T) {
+	t.Setenv("FLEET_GATEWAY", "")
+	t.Setenv("FLEET_SSH", "ssh://ben@laptop")
+	t.Setenv("FLEET_SERVER", "")
+	m := armadaTestModel(nil)
+	m.bootSSH = "ssh://ben@laptop"
+	entries := m.armadaEntries()
+	if len(entries) != 2 || entries[1].displayName != "laptop (env)" || !entries[1].current || entries[1].badge() != armadaBadgeSSH {
+		t.Fatalf("entries = %+v", entries)
+	}
+	if m.pingAllArmadaCmd() == nil || m.armadaStatus["ssh://ben@laptop"].state != armadaStatusPinging {
+		t.Fatal("the ssh boot remote should be pinged")
+	}
+}
+
+// TestArmadaPingErrTextSSH words tunnel failures for ssh remotes: the local
+// daemon's FailedPrecondition message verbatim, Unavailable as the tunnel.
+func TestArmadaPingErrTextSSH(t *testing.T) {
+	precond := status.Error(codes.FailedPrecondition, "ssh: Permission denied (publickey).")
+	if got := armadaPingErrText("ssh://desktop", precond); got != "ssh: Permission denied (publickey)." {
+		t.Fatalf("FailedPrecondition text = %q", got)
+	}
+	if got := armadaPingErrText("ssh://desktop", status.Error(codes.Unavailable, "x")); got != "ssh tunnel unreachable" {
+		t.Fatalf("Unavailable (ssh) text = %q", got)
+	}
+	if got := armadaPingErrText("https://gw/abc", status.Error(codes.Unavailable, "x")); got != "gateway unreachable" {
+		t.Fatalf("Unavailable (gateway) text = %q", got)
 	}
 }

--- a/internal/tui/page_fleet_view.go
+++ b/internal/tui/page_fleet_view.go
@@ -99,7 +99,13 @@ func (fleetPage *fleetPage) renderArmadaBorder(m *model, width int) string {
 	borderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("63"))
 
 	name := m.armadaCurrentDisplay()
-	frame := " Armada [  ] "
+	// The transport badge ([gtwy] / [ssh] / [tcp]) trails the selector so the
+	// connection mode is visible at a glance; local wears none.
+	badge := ""
+	if b := m.armadaCurrentBadge(); b != "" {
+		badge = b + " "
+	}
+	frame := " Armada [  ] " + badge
 	// Corners + 2 leading dashes + at least 2 trailing dashes must survive.
 	maxName := width - 6 - lipgloss.Width(frame)
 	if maxName < 1 {
@@ -111,7 +117,7 @@ func (fleetPage *fleetPage) renderArmadaBorder(m *model, width int) string {
 	}
 	// labelWidth drives layout + mouse hit-testing, so measure the PLAIN text;
 	// the ANSI styling applied below doesn't change the visible width.
-	label := " Armada [ " + name + " ] "
+	label := " Armada [ " + name + " ] " + badge
 	labelWidth := lipgloss.Width(label)
 
 	// "Armada" wears the same light-cyan→deep-blue gradient as the "fleet" logo
@@ -123,6 +129,9 @@ func (fleetPage *fleetPage) renderArmadaBorder(m *model, width int) string {
 		restStyle = selectedStyle
 	}
 	styledLabel := " " + renderGradient("Armada") + restStyle.Render(rest)
+	if badge != "" {
+		styledLabel += dimStyle.Render(badge)
+	}
 
 	fleetPage.armadaSel.x0 = 3
 	fleetPage.armadaSel.x1 = 3 + labelWidth

--- a/internal/tui/page_settings.go
+++ b/internal/tui/page_settings.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
@@ -50,6 +51,7 @@ const (
 	settingsItemRemoteMcpToken         = 707 // copy the bearer token (~/.fleet/mcp.token)
 	settingsItemRemoteWebhookEnabled   = 708 // expose the automation webhook endpoint through the gateway
 	settingsItemRemoteWebhookPublicURL = 709 // copy the gateway-assigned public webhook base URL
+	settingsItemRemoteFleetMode        = 710 // "Remote Fleet via" [Gateway] [SSH] segmented selector
 
 	// Fleet armada: the "+ Remote Fleet" button has a fixed id; registered
 	// remotes get base+i. The base is placed FAR above every other block (and
@@ -163,6 +165,7 @@ type remoteSettingsSnapshot struct {
 	fleetEnabled   bool
 	webhookEnabled bool
 	gatewayURL     string
+	fleetMode      string
 }
 
 // snapshotRemoteSettings extracts the tunnel-relevant settings from config.
@@ -175,6 +178,7 @@ func snapshotRemoteSettings(config *configutil.Config) remoteSettingsSnapshot {
 		fleetEnabled:   config.RemoteMcpSettings.FleetEnabled,
 		webhookEnabled: config.RemoteMcpSettings.WebhookEnabled,
 		gatewayURL:     config.RemoteMcpSettings.GatewayURL,
+		fleetMode:      config.RemoteMcpSettings.FleetMode,
 	}
 }
 
@@ -304,7 +308,14 @@ var settingsSections = []settingsSection{
 			if m.config != nil && m.config.RemoteMcpSettings.Enabled {
 				items = append(items, settingsItemRemoteMcpCopyRemote)
 			}
-			items = append(items, settingsItemRemoteMcpEnabled, settingsItemRemoteFleetEnabled, settingsItemRemoteWebhookEnabled, settingsItemRemoteMcpGatewayURL)
+			items = append(items, settingsItemRemoteMcpEnabled, settingsItemRemoteFleetEnabled)
+			// The transport selector appears only while remote fleet is on —
+			// it is the toggle's sub-setting, and hidden it can't confuse the
+			// gateway-only MCP/webhook rows around it.
+			if m.config != nil && m.config.RemoteMcpSettings.FleetEnabled {
+				items = append(items, settingsItemRemoteFleetMode)
+			}
+			items = append(items, settingsItemRemoteWebhookEnabled, settingsItemRemoteMcpGatewayURL)
 			if m.config != nil && m.config.RemoteMcpSettings.Enabled {
 				items = append(items, settingsItemRemoteMcpPublicURL)
 			}
@@ -584,6 +595,56 @@ func (settingsPage *settingsPage) toggleRemoteFleetEnabled(m *model) {
 		label = "on"
 	}
 	m.message = fmt.Sprintf("Remote Fleet set to %s", label)
+}
+
+// setRemoteFleetMode selects the remote-fleet transport ("Remote Fleet via"
+// Gateway / SSH) and saves. A no-op when already in that mode. Reverts on a
+// failed save unless the failure is the expected tunnel bounce from a remote
+// client (switching the mode moves the daemon's control surface, which can
+// drop the very connection this save rode in on). The row sits BELOW the toggle
+// and above the rows the mode swaps (Public GRPC URL ↔ SSH Listener), so its
+// index is preserved and no cursor re-pin is needed.
+func (settingsPage *settingsPage) setRemoteFleetMode(m *model, mode string) {
+	if m.config == nil {
+		m.config = configutil.DefaultConfig()
+	}
+	current := m.config.RemoteMcpSettings.FleetMode
+	if current == mode || (mode == configutil.FleetModeGateway && !m.config.RemoteMcpSettings.FleetViaSSH()) {
+		return
+	}
+	m.config.RemoteMcpSettings.FleetMode = mode
+	if err := setConfigRemote(m.config); err != nil {
+		if settingsPage.remoteSaveBounced(m, err) {
+			settingsPage.serverRemote = snapshotRemoteSettings(m.config)
+			m.message = remoteSettingsSavedMsg
+			return
+		}
+		m.config.RemoteMcpSettings.FleetMode = current
+		m.message = fmt.Sprintf("Failed to save settings: %v", err)
+		return
+	}
+	settingsPage.serverRemote = snapshotRemoteSettings(m.config)
+	label := "Gateway"
+	if mode == configutil.FleetModeSSH {
+		label = "SSH"
+	}
+	m.message = fmt.Sprintf("Remote Fleet via %s", label)
+}
+
+// remoteSSHStatusValue renders the "SSH Listener" line (the Public GRPC URL
+// row's stand-in while Remote Fleet is via SSH) from the pushed status: the
+// loopback address the daemon's token-gated server listens on, or why it
+// isn't. Independent of the gateway tunnel's state field.
+func remoteSSHStatusValue(m *model) string {
+	st := m.remoteMcpStatus
+	switch {
+	case st != nil && st.GetSshAddr() != "":
+		return statusRunningStyle.Render("listening") + "  " + st.GetSshAddr() + "  " + dimStyle.Render("clients add ssh://<user>@<this host> as a Remote Fleet")
+	case st != nil && st.GetSshError() != "":
+		return statusCreatingStyle.Render("error") + "  " + dimStyle.Render(st.GetSshError())
+	default:
+		return dimStyle.Render("(starting…)")
+	}
 }
 
 // toggleRemoteWebhookEnabled flips the "Enable Webhook" preference — exposing
@@ -905,6 +966,8 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 				settingsPage.toggleRemoteMcpEnabled(m)
 			} else if item == settingsItemRemoteFleetEnabled {
 				settingsPage.toggleRemoteFleetEnabled(m)
+			} else if item == settingsItemRemoteFleetMode {
+				settingsPage.setRemoteFleetMode(m, configutil.FleetModeGateway)
 			} else if item == settingsItemRemoteWebhookEnabled {
 				settingsPage.toggleRemoteWebhookEnabled(m)
 			} else if item == settingsItemCodespacesMachine {
@@ -935,6 +998,8 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 				settingsPage.toggleRemoteMcpEnabled(m)
 			} else if item == settingsItemRemoteFleetEnabled {
 				settingsPage.toggleRemoteFleetEnabled(m)
+			} else if item == settingsItemRemoteFleetMode {
+				settingsPage.setRemoteFleetMode(m, configutil.FleetModeSSH)
 			} else if item == settingsItemRemoteWebhookEnabled {
 				settingsPage.toggleRemoteWebhookEnabled(m)
 			} else if item == settingsItemCodespacesMachine {
@@ -980,6 +1045,14 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 				settingsPage.toggleRemoteFleetEnabled(m)
 				return nil
 			}
+			if item == settingsItemRemoteFleetMode {
+				next := configutil.FleetModeSSH
+				if m.config != nil && m.config.RemoteMcpSettings.FleetViaSSH() {
+					next = configutil.FleetModeGateway
+				}
+				settingsPage.setRemoteFleetMode(m, next)
+				return nil
+			}
 			if item == settingsItemRemoteWebhookEnabled {
 				settingsPage.toggleRemoteWebhookEnabled(m)
 				return nil
@@ -1007,6 +1080,12 @@ func (settingsPage *settingsPage) updateSettingsNav(m *model, msg tea.Msg) tea.C
 				return copyToClipboardCmd(url)
 			}
 			if item == settingsItemRemoteGrpcPublicURL {
+				if m.config != nil && m.config.RemoteMcpSettings.FleetViaSSH() {
+					// The SSH listener has no public URL: the client side registers
+					// ssh://<user>@<this host> and discovers the port itself.
+					m.message = "Nothing to copy — on the client, add ssh://<user>@<this host> as a Remote Fleet"
+					return nil
+				}
 				url := remoteGrpcPublicURL(m)
 				if url == "" {
 					m.message = "No public GRPC URL yet — connect to the gateway first"
@@ -1131,7 +1210,7 @@ func (settingsPage *settingsPage) beginArmadaAdd(m *model) tea.Cmd {
 	}
 	settingsPage.armadaAddStage = armadaAddURLIn
 	settingsPage.armadaAddURL = ""
-	settingsPage.input.Placeholder = "https://gateway.example.com/<session-id>"
+	settingsPage.input.Placeholder = "https://gateway.example.com/<session-id>  or  ssh://user@host"
 	settingsPage.input.EchoMode = textinput.EchoNormal
 	settingsPage.input.SetValue("")
 	settingsPage.input.Focus()
@@ -1207,6 +1286,19 @@ func (settingsPage *settingsPage) updateArmadaAdd(m *model, msg tea.Msg) tea.Cmd
 				}
 			}
 			settingsPage.armadaAddURL = url
+			if fleetclient.IsSSHURL(url) {
+				// An ssh:// remote needs no token from the user: the local daemon
+				// discovers it over SSH during the connection test (which also
+				// brings the tunnel up). Straight to testing.
+				if !sshURLLooksValid(url) {
+					m.message = "Enter an ssh://[user@]host[:port] URL"
+					return nil
+				}
+				settingsPage.armadaAddStage = armadaAddTesting
+				settingsPage.input.Blur()
+				m.message = ""
+				return testArmadaRemoteCmd(url, "")
+			}
 			settingsPage.armadaAddStage = armadaAddTokenIn
 			settingsPage.input.SetValue("")
 			settingsPage.input.Placeholder = "bearer token (~/.fleet/mcp.token on the remote)"
@@ -1236,6 +1328,17 @@ func (settingsPage *settingsPage) updateArmadaAdd(m *model, msg tea.Msg) tea.Cmd
 	var cmd tea.Cmd
 	settingsPage.input, cmd = settingsPage.input.Update(msg)
 	return cmd
+}
+
+// sshURLLooksValid is the client-side shape check for an ssh:// armada URL
+// (a host, no path/query). The local daemon parses it strictly when resolving;
+// this just stops an obviously broken entry from starting a connection test.
+func sshURLLooksValid(raw string) bool {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Hostname() == "" {
+		return false
+	}
+	return (u.Path == "" || u.Path == "/") && u.RawQuery == "" && u.Fragment == ""
 }
 
 // armadaStatusValue renders one remote's connection indicator from the latest
@@ -1510,9 +1613,37 @@ func (settingsPage *settingsPage) viewSettings(m *model) string {
 			if config.RemoteMcpSettings.FleetEnabled {
 				fleetEnabledValue = "[ on ]"
 			}
-			fleetEnabledValue += "\n" + strings.Repeat(" ", 21) + dimStyle.Render("Allow remote `fleet` binary to control this instance through the gateway public url")
+			fleetEnabledValue += "\n" + strings.Repeat(" ", 21) + dimStyle.Render("Allow a remote `fleet` binary to control this instance, via the gateway or an SSH tunnel")
 			recordRow(settingsItemRemoteFleetEnabled, settingsPage.renderSettingsRow(m, currentItem == settingsItemRemoteFleetEnabled, "Enable Remote Fleet", fleetEnabledValue))
 			listContent.WriteString("\n")
+
+			if config.RemoteMcpSettings.FleetEnabled {
+				// Transport selector: every mode bracketed, the active one
+				// highlighted (the Fleet Daemon "Logs" segmented control).
+				viaSSH := config.RemoteMcpSettings.FleetViaSSH()
+				var seg strings.Builder
+				for i, mode := range []struct {
+					label string
+					ssh   bool
+				}{{"Gateway", false}, {"SSH", true}} {
+					if i > 0 {
+						seg.WriteString(" ")
+					}
+					label := "[" + mode.label + "]"
+					if mode.ssh == viaSSH {
+						seg.WriteString(selectedStyle.Render(label))
+					} else {
+						seg.WriteString(dimStyle.Render(label))
+					}
+				}
+				hint := "Reached through the fleet gateway at the Gateway URL below"
+				if viaSSH {
+					hint = "Reached over an SSH tunnel — no gateway; the client registers ssh://<user>@<this host>"
+				}
+				modeValue := seg.String() + "\n" + strings.Repeat(" ", 21) + dimStyle.Render(hint)
+				recordRow(settingsItemRemoteFleetMode, settingsPage.renderSettingsRow(m, currentItem == settingsItemRemoteFleetMode, "Remote Fleet via", modeValue))
+				listContent.WriteString("\n")
+			}
 
 			webhookEnabledValue := "[ off ]"
 			if config.RemoteMcpSettings.WebhookEnabled {
@@ -1544,7 +1675,13 @@ func (settingsPage *settingsPage) viewSettings(m *model) string {
 				}
 				recordRow(settingsItemRemoteMcpPublicURL, settingsPage.renderSettingsRow(m, currentItem == settingsItemRemoteMcpPublicURL, "Public MCP URL", mcpValue))
 			}
-			if config.RemoteMcpSettings.FleetEnabled {
+			if config.RemoteMcpSettings.FleetViaSSH() {
+				// SSH mode: the row shows the loopback listener instead of a
+				// gateway URL (there is none). Same item id, so navigation and
+				// tests keyed on it keep working across a mode flip.
+				listContent.WriteString("\n")
+				recordRow(settingsItemRemoteGrpcPublicURL, settingsPage.renderSettingsRow(m, currentItem == settingsItemRemoteGrpcPublicURL, "SSH Listener", remoteSSHStatusValue(m)))
+			} else if config.RemoteMcpSettings.FleetEnabled {
 				listContent.WriteString("\n")
 				grpcValue := remoteGrpcStatusValue(m)
 				if remoteGrpcPublicURL(m) != "" {
@@ -1572,7 +1709,7 @@ func (settingsPage *settingsPage) viewSettings(m *model) string {
 			for i, remote := range m.armadaRemotes {
 				item := settingsItemArmadaBase + i
 				active := currentItem == item
-				value := remote.URL + "  " + armadaStatusValue(m, remote.URL) + "  " + settingsPage.renderArmadaDeleteButton(m, active)
+				value := dimStyle.Render(armadaURLBadge(remote.URL, "")) + " " + remote.URL + "  " + armadaStatusValue(m, remote.URL) + "  " + settingsPage.renderArmadaDeleteButton(m, active)
 				recordRow(item, settingsPage.renderSettingsRow(m, active, fmt.Sprintf("Remote %d", i+1), value))
 				listContent.WriteString("\n")
 			}

--- a/internal/tui/page_settings_test.go
+++ b/internal/tui/page_settings_test.go
@@ -2,6 +2,9 @@ package tui
 
 import (
 	"encoding/base64"
+	"errors"
+	"github.com/BenjaminBenetti/fleet-man/internal/configutil"
+	"github.com/charmbracelet/x/ansi"
 	"io"
 	"os"
 	"os/exec"
@@ -892,5 +895,119 @@ func TestSilenceStreamInterrupt(t *testing.T) {
 	// A clean exit stays nil.
 	if got := silenceStreamInterrupt(nil); got != nil {
 		t.Fatalf("nil error should stay nil, got %v", got)
+	}
+}
+
+// ===========================================
+// Remote Fleet via [Gateway] [SSH]
+// ===========================================
+
+// TestRemoteFleetModeRowFollowsToggle: the "Remote Fleet via" selector appears
+// only while Enable Remote Fleet is on, defaults to Gateway, and in SSH mode
+// the Public GRPC URL row becomes the SSH Listener row.
+func TestRemoteFleetModeRowFollowsToggle(t *testing.T) {
+	sp := newSettingsPage()
+	m := armadaTestModel(sp)
+
+	if slices.Contains(sp.visibleItems(m), settingsItemRemoteFleetMode) {
+		t.Fatal("mode row must be hidden while Remote Fleet is off")
+	}
+	m.config.RemoteMcpSettings.FleetEnabled = true
+	items := sp.visibleItems(m)
+	if i, j := slices.Index(items, settingsItemRemoteFleetEnabled), slices.Index(items, settingsItemRemoteFleetMode); j != i+1 {
+		t.Fatalf("mode row should directly follow the toggle: %v", items)
+	}
+	out := ansi.Strip(sp.View(m))
+	if !strings.Contains(out, "Remote Fleet via") || !strings.Contains(out, "[Gateway] [SSH]") || !strings.Contains(out, "Public GRPC URL") {
+		t.Fatalf("gateway-mode view missing rows:\n%s", out)
+	}
+
+	m.config.RemoteMcpSettings.FleetMode = configutil.FleetModeSSH
+	m.remoteMcpStatus = &fleetgrpc.RemoteMcpStatus{SshAddr: "127.0.0.1:41234"}
+	out = ansi.Strip(sp.View(m))
+	if strings.Contains(out, "Public GRPC URL") || !strings.Contains(out, "SSH Listener") || !strings.Contains(out, "listening  127.0.0.1:41234") {
+		t.Fatalf("ssh-mode view should show the listener instead of the gateway URL:\n%s", out)
+	}
+	m.remoteMcpStatus = &fleetgrpc.RemoteMcpStatus{SshError: "listen: boom"}
+	if out := ansi.Strip(sp.View(m)); !strings.Contains(out, "error  listen: boom") {
+		t.Fatalf("ssh listener error not rendered:\n%s", out)
+	}
+}
+
+// TestRemoteFleetModeKeysPersist: l selects SSH, h selects Gateway, enter
+// toggles; each change is saved through setConfigRemote, and a no-op key
+// (already in that mode) does not save.
+func TestRemoteFleetModeKeysPersist(t *testing.T) {
+	saves := 0
+	var lastMode string
+	orig := setConfigRemote
+	setConfigRemote = func(c *configutil.Config) error {
+		saves++
+		lastMode = c.RemoteMcpSettings.FleetMode
+		return nil
+	}
+	defer func() { setConfigRemote = orig }()
+
+	sp := newSettingsPage()
+	m := armadaTestModel(sp)
+	m.config.RemoteMcpSettings.FleetEnabled = true
+	sp.cursor = settingsPositionOf(sp, m, settingsItemRemoteFleetMode)
+
+	sp.Update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}}) // already gateway: no save
+	if saves != 0 {
+		t.Fatalf("h in gateway mode saved %d times, want 0", saves)
+	}
+	sp.Update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if saves != 1 || lastMode != configutil.FleetModeSSH || !m.config.RemoteMcpSettings.FleetViaSSH() {
+		t.Fatalf("l: saves=%d mode=%q", saves, lastMode)
+	}
+	if m.message != "Remote Fleet via SSH" {
+		t.Fatalf("message = %q", m.message)
+	}
+	sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter}) // toggles back to gateway
+	if saves != 2 || lastMode != configutil.FleetModeGateway || m.config.RemoteMcpSettings.FleetViaSSH() {
+		t.Fatalf("enter: saves=%d mode=%q", saves, lastMode)
+	}
+	sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter}) // and forward to ssh again
+	if saves != 3 || lastMode != configutil.FleetModeSSH {
+		t.Fatalf("enter again: saves=%d mode=%q", saves, lastMode)
+	}
+	// The mode row keeps its position across the flip (the rows it swaps sit
+	// below it), so the cursor still rests on it.
+	if sp.settingsCursorItem(m) != settingsItemRemoteFleetMode {
+		t.Fatalf("cursor drifted to item %d", sp.settingsCursorItem(m))
+	}
+}
+
+// TestRemoteFleetModeSaveFailureReverts: a failed save restores the previous
+// mode and reports the error.
+func TestRemoteFleetModeSaveFailureReverts(t *testing.T) {
+	orig := setConfigRemote
+	setConfigRemote = func(*configutil.Config) error { return errors.New("disk full") }
+	defer func() { setConfigRemote = orig }()
+
+	sp := newSettingsPage()
+	m := armadaTestModel(sp)
+	m.config.RemoteMcpSettings.FleetEnabled = true
+	sp.cursor = settingsPositionOf(sp, m, settingsItemRemoteFleetMode)
+	sp.Update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if m.config.RemoteMcpSettings.FleetViaSSH() || !strings.Contains(m.message, "disk full") {
+		t.Fatalf("mode=%q message=%q", m.config.RemoteMcpSettings.FleetMode, m.message)
+	}
+}
+
+// TestSSHListenerRowEnterExplains: enter on the SSH Listener row copies nothing
+// (there is no URL) and tells the user what to register on the client.
+func TestSSHListenerRowEnterExplains(t *testing.T) {
+	sp := newSettingsPage()
+	m := armadaTestModel(sp)
+	m.config.RemoteMcpSettings.FleetEnabled = true
+	m.config.RemoteMcpSettings.FleetMode = configutil.FleetModeSSH
+	sp.cursor = settingsPositionOf(sp, m, settingsItemRemoteGrpcPublicURL)
+	if cmd := sp.Update(m, tea.KeyMsg{Type: tea.KeyEnter}); cmd != nil {
+		t.Fatal("nothing should be copied in ssh mode")
+	}
+	if !strings.Contains(m.message, "ssh://") {
+		t.Fatalf("message = %q", m.message)
 	}
 }


### PR DESCRIPTION
## Summary

Remote fleet control **without a gateway**: if you can `ssh` to the box running a fleet, that is all you need.

- **Daemon side:** "Enable Remote Fleet" gains a **Remote Fleet via `[Gateway] [SSH]`** selector. In SSH mode the daemon serves the *same* token-gated `FleetService` on a loopback port (`127.0.0.1:0`, recorded in `~/.fleet/ssh.port`) instead of negotiating the gateway's grpc feature. An **SSH Listener** row replaces Public GRPC URL and shows the live address or the bind error.
- **Client side:** an armada remote can be an `ssh://[user@]host[:port]` URL. No token to paste (it is discovered over SSH), no session id. Every remote wears a `[gtwy]` / `[ssh]` / `[tcp]` badge in the Armada border selector, the dropdown, and the settings rows. `FLEET_SSH=ssh://user@host fleet ls` works from a plain shell too.
- **The local fleetd owns the tunnels** (`internal/server/sshtunnel`). A new **local-only** `ResolveArmadaRemote` RPC runs a small POSIX `sh` probe over the user's own `ssh` (so `~/.ssh/config`, keys, agents, ProxyJump apply; the script is fed on stdin so no remote `fleet` on PATH is needed), reads `ssh.port` + `mcp.token`, starts the remote daemon if it is down, keeps one `ssh -N -L` forward per remote, verifies it with a bearer Hello, and hands the TUI/CLI a loopback address + token. A stale forward (remote restarted on a new port) is rebuilt on the next dial; there is no reconnect loop to supervise.

### Why not spawn a local `fleet gateway`?
SSH already is the tunnel and already authenticates the user; the gateway's yamux/session-id/registration machinery buys nothing on a single-daemon direct hop and would need a supervised subprocess, a persisted session key, and two ports. The token-gated server already existed and only needed a TCP listener.

### Design notes
- The mode is an explicit `fleet_mode` config field (proto 5). An existing "enabled but no gateway URL" config keeps its documented no-op behaviour rather than silently opening a listener.
- The SSH listener's status rides `RemoteMcpStatus` (`ssh_addr` / `ssh_error`); the hub stamps those onto every status so the gateway manager's pushes cannot erase them.
- `ResolveArmadaRemote` joins `Get/SetArmada` in the tunnel-facing server's local-only deny list (it returns a remote's bearer token and drives the user's ssh).
- `ssh` runs in **BatchMode**: an unknown host key or a passphrase-locked key fails fast with ssh's own diagnostic in the remote's status column instead of hanging a daemon that has no TTY.
- Linux sets `Pdeathsig` on the ssh child so a SIGKILLed daemon cannot leave a forward squatting the port.

### Tests
- `internal/server/sshtunnel`: URL parsing/canonicalisation, the discovery script run under real `sh` across all three outcomes plus the auto-spawn branch (with a fake `fleet` shadowing the real one), manager bring-up / reuse / stale-rebuild / bind-collision / wrong-token / prune, and an **end-to-end test through the real `ssh` binary** against an in-process `x/crypto/ssh` server (discovery, `-L` forward, token Hello, remote-restart healing, SSH-mode-off detection, batch-mode auth failure). Skips when `ssh` is absent.
- `internal/server`: listener lifecycle (bind, `ssh.port`, token enforcement, stop removes the hint), local-only denial of the new RPC.
- `fleetclient`: `FLEET_SSH` endpoint selection, precedence, error surfacing.
- TUI: ssh add-flow skips the token stage, malformed ssh URLs rejected, badges/names/disambiguation, switch sets `FLEET_SSH` and the border badge, boot `FLEET_SSH` entry, mode row visibility/keys/persistence/revert, SSH Listener row.
- README + `doc/gateway.md` updated.

### Open follow-ups (not in this PR)
- Host-key policy: strict for now (user runs `ssh host` once). `StrictHostKeyChecking=accept-new` would be smoother but is a trust decision.
- Remote MCP and webhooks stay gateway-only.
- `ssh` inherits the daemon's environment, so an agent-only key setup needs `SSH_AUTH_SOCK` visible to fleetd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jcRHfzAXz2za5AhuvSTVc
